### PR TITLE
chore: Adapt lmn to nim ffi

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -99,7 +99,7 @@ BUILD_TAGS ?= gowaku_no_rln
 
 ifeq ($(USE_NWAKU), true)
     BUILD_TAGS += use_nwaku
-    NWAKU_VERSION ?= v0.37.0-rc.3
+    NWAKU_VERSION ?= v0.37-with-ffi
     NWAKU_SOURCE_DIR ?= $(GIT_ROOT)/../nwaku
     LIBWAKU := $(NWAKU_SOURCE_DIR)/build/libwaku.$(LIB_EXT)
     CGO_CFLAGS+=-I$(NWAKU_SOURCE_DIR)/library

--- a/flake.lock
+++ b/flake.lock
@@ -7,7 +7,7 @@
       },
       "locked": {
         "lastModified": 1767692116,
-        "narHash": "sha256-7WYAk9I8tuFEU0RQqIIXMpanfriUIbdhXQlag2cwj7s=",
+        "narHash": "sha256-7Ac8t+MAIDnFjnSG13xqgWaGQFAc6POp+G0ofnrpx+E=",
         "rev": "a4e44dbe05347197ba367f967aa99078814a80fc",
         "revCount": 2197,
         "submodules": true,

--- a/flake.lock
+++ b/flake.lock
@@ -7,7 +7,7 @@
       },
       "locked": {
         "lastModified": 1769109744,
-        "narHash": "sha256-vaBAz+iyyf2AhetJ74s+m8xBQUbDziAcYduM0z3hIY8=",
+        "narHash": "sha256-Nvu4gosma1gte7m2DDcidiWgdpMQZYIbmMfRncln9HA=",
         "ref": "v0.37.0-beta-with-nim-ffi",
         "rev": "20c3b97950fb365e2949c9f1e7e483dc6cd89b66",
         "revCount": 2198,
@@ -30,6 +30,7 @@
       "locked": {
         "lastModified": 1766504822,
         "narHash": "sha256-tWVLbYoi8/xNzsbJmzMBnuc4GsB7/4oH05yCwuokKT8=",
+        "ref": "refs/heads/master",
         "rev": "fb8039c5a56086ec7fb3e5e1a5a593bb3756ccb6",
         "revCount": 76,
         "submodules": true,

--- a/flake.lock
+++ b/flake.lock
@@ -6,16 +6,18 @@
         "zerokit": "zerokit"
       },
       "locked": {
-        "lastModified": 1767692116,
-        "narHash": "sha256-7WYAk9I8tuFEU0RQqIIXMpanfriUIbdhXQlag2cwj7s=",
-        "rev": "a4e44dbe05347197ba367f967aa99078814a80fc",
-        "revCount": 2197,
+        "lastModified": 1769109744,
+        "narHash": "sha256-vaBAz+iyyf2AhetJ74s+m8xBQUbDziAcYduM0z3hIY8=",
+        "ref": "v0.37.0-beta-with-nim-ffi",
+        "rev": "20c3b97950fb365e2949c9f1e7e483dc6cd89b66",
+        "revCount": 2198,
         "submodules": true,
         "type": "git",
         "url": "https://github.com/logos-messaging/logos-messaging-nim"
       },
       "original": {
-        "rev": "a4e44dbe05347197ba367f967aa99078814a80fc",
+        "ref": "v0.37.0-beta-with-nim-ffi",
+        "rev": "20c3b97950fb365e2949c9f1e7e483dc6cd89b66",
         "submodules": true,
         "type": "git",
         "url": "https://github.com/logos-messaging/logos-messaging-nim"

--- a/flake.lock
+++ b/flake.lock
@@ -6,17 +6,16 @@
         "zerokit": "zerokit"
       },
       "locked": {
-        "lastModified": 1767020554,
-        "narHash": "sha256-LvnMp8dcmznNk6rb8cVfqWmZCga9UG/NCMQxrj3riMQ=",
-        "ref": "refs/heads/master",
-        "rev": "33383fee2d1e5444947acbe7316d5d31221d2852",
-        "revCount": 2196,
+        "lastModified": 1767692116,
+        "narHash": "sha256-7WYAk9I8tuFEU0RQqIIXMpanfriUIbdhXQlag2cwj7s=",
+        "rev": "a4e44dbe05347197ba367f967aa99078814a80fc",
+        "revCount": 2197,
         "submodules": true,
         "type": "git",
         "url": "https://github.com/logos-messaging/logos-messaging-nim"
       },
       "original": {
-        "rev": "33383fee2d1e5444947acbe7316d5d31221d2852",
+        "rev": "a4e44dbe05347197ba367f967aa99078814a80fc",
         "submodules": true,
         "type": "git",
         "url": "https://github.com/logos-messaging/logos-messaging-nim"
@@ -29,7 +28,6 @@
       "locked": {
         "lastModified": 1766504822,
         "narHash": "sha256-tWVLbYoi8/xNzsbJmzMBnuc4GsB7/4oH05yCwuokKT8=",
-        "ref": "refs/heads/master",
         "rev": "fb8039c5a56086ec7fb3e5e1a5a593bb3756ccb6",
         "revCount": 76,
         "submodules": true,

--- a/flake.lock
+++ b/flake.lock
@@ -7,7 +7,7 @@
       },
       "locked": {
         "lastModified": 1767692116,
-        "narHash": "sha256-7Ac8t+MAIDnFjnSG13xqgWaGQFAc6POp+G0ofnrpx+E=",
+        "narHash": "sha256-7WYAk9I8tuFEU0RQqIIXMpanfriUIbdhXQlag2cwj7s=",
         "rev": "a4e44dbe05347197ba367f967aa99078814a80fc",
         "revCount": 2197,
         "submodules": true,

--- a/flake.nix
+++ b/flake.nix
@@ -17,7 +17,7 @@
     # A commit from nixpkgs 24.11 release : https://github.com/NixOS/nixpkgs/tree/release-24.11
     nixpkgs.url = "github:NixOS/nixpkgs/0ef228213045d2cdb5a169a95d63ded38670b293";
     # We cannot do follows since the nim-unwrapped-2_0 doesn't exist in this nixpkgs version above
-    lmn.url = "git+https://github.com/logos-messaging/logos-messaging-nim?submodules=1&rev=c27405b19c62bd06ccf5a322590fc55ffa172ea3";
+    lmn.url = "git+https://github.com/logos-messaging/logos-messaging-nim?submodules=1&rev=a4e44dbe05347197ba367f967aa99078814a80fc";
     nim-sds.url = "git+https://github.com/logos-messaging/nim-sds?submodules=1&rev=fb8039c5a56086ec7fb3e5e1a5a593bb3756ccb6";
   };
 

--- a/flake.nix
+++ b/flake.nix
@@ -17,7 +17,7 @@
     # A commit from nixpkgs 24.11 release : https://github.com/NixOS/nixpkgs/tree/release-24.11
     nixpkgs.url = "github:NixOS/nixpkgs/0ef228213045d2cdb5a169a95d63ded38670b293";
     # We cannot do follows since the nim-unwrapped-2_0 doesn't exist in this nixpkgs version above
-    lmn.url = "git+https://github.com/logos-messaging/logos-messaging-nim?submodules=1&rev=fb4a112407460534a9154f3aaee8888045dc6852";
+    lmn.url = "git+https://github.com/logos-messaging/logos-messaging-nim?submodules=1&rev=c27405b19c62bd06ccf5a322590fc55ffa172ea3";
     nim-sds.url = "git+https://github.com/logos-messaging/nim-sds?submodules=1&rev=fb8039c5a56086ec7fb3e5e1a5a593bb3756ccb6";
   };
 

--- a/flake.nix
+++ b/flake.nix
@@ -17,7 +17,7 @@
     # A commit from nixpkgs 24.11 release : https://github.com/NixOS/nixpkgs/tree/release-24.11
     nixpkgs.url = "github:NixOS/nixpkgs/0ef228213045d2cdb5a169a95d63ded38670b293";
     # We cannot do follows since the nim-unwrapped-2_0 doesn't exist in this nixpkgs version above
-    lmn.url = "git+https://github.com/logos-messaging/logos-messaging-nim?submodules=1&rev=a4e44dbe05347197ba367f967aa99078814a80fc";
+    lmn.url = "git+https://github.com/logos-messaging/logos-messaging-nim?submodules=1&ref=v0.37.0-beta-with-nim-ffi&rev=20c3b97950fb365e2949c9f1e7e483dc6cd89b66";
     nim-sds.url = "git+https://github.com/logos-messaging/nim-sds?submodules=1&rev=fb8039c5a56086ec7fb3e5e1a5a593bb3756ccb6";
   };
 

--- a/go.mod
+++ b/go.mod
@@ -115,7 +115,7 @@ require (
 )
 
 require (
-	github.com/logos-messaging/logos-messaging-go-bindings v0.0.0-20251212215600-de7d4cf3c9e4
+	github.com/logos-messaging/logos-messaging-go-bindings v0.0.0-20260108175826-d29cc2c463e5
 	go.opentelemetry.io/otel v1.26.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.26.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.26.0

--- a/go.mod
+++ b/go.mod
@@ -104,7 +104,6 @@ require (
 	github.com/status-im/go-wallet-sdk v0.0.0-20260108075629-2691c53cc1dc
 	github.com/waku-org/go-waku v0.10.1
 	github.com/waku-org/sds-go-bindings v0.0.0-20251222164514-d5b47a911904
-	github.com/waku-org/waku-go-bindings v0.0.0-20251202095947-63b01b7d0ca9
 	github.com/wk8/go-ordered-map/v2 v2.1.7
 	go.uber.org/atomic v1.11.0
 	go.uber.org/mock v0.6.0
@@ -318,6 +317,7 @@ require (
 	github.com/libp2p/go-netroute v0.2.2 // indirect
 	github.com/libp2p/go-reuseport v0.4.0 // indirect
 	github.com/libp2p/go-yamux/v4 v4.0.2 // indirect
+	github.com/logos-messaging/logos-messaging-go-bindings v0.0.0-20251212212702-9a9a9e5c88c8 // indirect
 	github.com/lufeee/execinquery v1.2.1 // indirect
 	github.com/magiconair/properties v1.8.7 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect

--- a/go.mod
+++ b/go.mod
@@ -115,6 +115,7 @@ require (
 )
 
 require (
+	github.com/logos-messaging/logos-messaging-go-bindings v0.0.0-20251212215600-de7d4cf3c9e4
 	go.opentelemetry.io/otel v1.26.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.26.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.26.0
@@ -317,7 +318,6 @@ require (
 	github.com/libp2p/go-netroute v0.2.2 // indirect
 	github.com/libp2p/go-reuseport v0.4.0 // indirect
 	github.com/libp2p/go-yamux/v4 v4.0.2 // indirect
-	github.com/logos-messaging/logos-messaging-go-bindings v0.0.0-20251212212702-9a9a9e5c88c8 // indirect
 	github.com/lufeee/execinquery v1.2.1 // indirect
 	github.com/magiconair/properties v1.8.7 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1547,6 +1547,8 @@ github.com/libp2p/go-yamux/v4 v4.0.2/go.mod h1:C808cCRgOs1iBwY4S71T5oxgMxgLmqUw5
 github.com/lightstep/lightstep-tracer-common/golang/gogo v0.0.0-20190605223551-bc2310a04743/go.mod h1:qklhhLq1aX+mtWk9cPHPzaBjWImj5ULL6C7HFJtXQMM=
 github.com/lightstep/lightstep-tracer-go v0.18.1/go.mod h1:jlF1pusYV4pidLvZ+XD0UBX0ZE6WURAspgAczcDHrL4=
 github.com/linuxkit/virtsock v0.0.0-20201010232012-f8cee7dfc7a3/go.mod h1:3r6x7q95whyfWQpmGZTu3gk3v2YkMi05HEzl7Tf7YEo=
+github.com/logos-messaging/logos-messaging-go-bindings v0.0.0-20251212212702-9a9a9e5c88c8 h1:MP7gsVyyY9mpRUayfA1TYfAS/6gROqzvah++Q2TyivE=
+github.com/logos-messaging/logos-messaging-go-bindings v0.0.0-20251212212702-9a9a9e5c88c8/go.mod h1:Xx5gcSL5nKeRaZ1iZI88KsoLtGJPKf0et5Ajc1rL68c=
 github.com/lucas-clemente/quic-go v0.7.1-0.20190401152353-907071221cf9/go.mod h1:PpMmPfPKO9nKJ/psF49ESTAGQSdfXxlg1otPbEB2nOw=
 github.com/lucas-clemente/quic-go v0.18.0/go.mod h1:yXttHsSNxQi8AWijC/vLP+OJczXqzHSOcJrM5ITUlCg=
 github.com/lucas-clemente/quic-go v0.19.3/go.mod h1:ADXpNbTQjq1hIzCpB+y/k5iz4n4z4IwqoLb94Kh5Hu8=
@@ -2423,8 +2425,6 @@ github.com/waku-org/go-zerokit-rln-x86_64 v0.0.0-20230916171518-2a77c3734dd1 h1:
 github.com/waku-org/go-zerokit-rln-x86_64 v0.0.0-20230916171518-2a77c3734dd1/go.mod h1:+LeEYoW5/uBUTVjtBGLEVCUe9mOYAlu5ZPkIxLOSr5Y=
 github.com/waku-org/sds-go-bindings v0.0.0-20251222164514-d5b47a911904 h1:V6nJsnNpSl822Z013bYzh9lXnTfwBdQHptIOd3AVwXc=
 github.com/waku-org/sds-go-bindings v0.0.0-20251222164514-d5b47a911904/go.mod h1:GW6bN8Ski1GCOb2f5JbKKstH70wlPen1h8f1nzSDfSI=
-github.com/waku-org/waku-go-bindings v0.0.0-20251202095947-63b01b7d0ca9 h1:x4SKQ8zceFNhSBG02yULii7m/bFtGDuqX5XuahpSTCo=
-github.com/waku-org/waku-go-bindings v0.0.0-20251202095947-63b01b7d0ca9/go.mod h1:v6ogkMCyQRUTazRyQR5LIouukY4/2bkjjHpnBKBxcAY=
 github.com/wealdtech/go-ens/v3 v3.6.0 h1:EAByZlHRQ3vxqzzwNi0GvEq1AjVozfWO4DMldHcoVg8=
 github.com/wealdtech/go-ens/v3 v3.6.0/go.mod h1:hcmMr9qPoEgVSEXU2Bwzrn/9NczTWZ1rE53jIlqUpzw=
 github.com/wealdtech/go-multicodec v1.4.0 h1:iq5PgxwssxnXGGPTIK1srvt6U5bJwIp7k6kBrudIWxg=

--- a/go.sum
+++ b/go.sum
@@ -1547,8 +1547,8 @@ github.com/libp2p/go-yamux/v4 v4.0.2/go.mod h1:C808cCRgOs1iBwY4S71T5oxgMxgLmqUw5
 github.com/lightstep/lightstep-tracer-common/golang/gogo v0.0.0-20190605223551-bc2310a04743/go.mod h1:qklhhLq1aX+mtWk9cPHPzaBjWImj5ULL6C7HFJtXQMM=
 github.com/lightstep/lightstep-tracer-go v0.18.1/go.mod h1:jlF1pusYV4pidLvZ+XD0UBX0ZE6WURAspgAczcDHrL4=
 github.com/linuxkit/virtsock v0.0.0-20201010232012-f8cee7dfc7a3/go.mod h1:3r6x7q95whyfWQpmGZTu3gk3v2YkMi05HEzl7Tf7YEo=
-github.com/logos-messaging/logos-messaging-go-bindings v0.0.0-20251212215600-de7d4cf3c9e4 h1:lKvK7IafMwyn16uaKw0zaAIT353tQ0Lndpk+qYGdO10=
-github.com/logos-messaging/logos-messaging-go-bindings v0.0.0-20251212215600-de7d4cf3c9e4/go.mod h1:Xx5gcSL5nKeRaZ1iZI88KsoLtGJPKf0et5Ajc1rL68c=
+github.com/logos-messaging/logos-messaging-go-bindings v0.0.0-20260108175826-d29cc2c463e5 h1:rfscMW0+i8v2hih0s1hjR6NqIHizgzUdU01VU7wm8gs=
+github.com/logos-messaging/logos-messaging-go-bindings v0.0.0-20260108175826-d29cc2c463e5/go.mod h1:i4rL328Q++wR+M+7x7Nqzgnzb4zDuSXLcX0AB5yRMR4=
 github.com/lucas-clemente/quic-go v0.7.1-0.20190401152353-907071221cf9/go.mod h1:PpMmPfPKO9nKJ/psF49ESTAGQSdfXxlg1otPbEB2nOw=
 github.com/lucas-clemente/quic-go v0.18.0/go.mod h1:yXttHsSNxQi8AWijC/vLP+OJczXqzHSOcJrM5ITUlCg=
 github.com/lucas-clemente/quic-go v0.19.3/go.mod h1:ADXpNbTQjq1hIzCpB+y/k5iz4n4z4IwqoLb94Kh5Hu8=

--- a/go.sum
+++ b/go.sum
@@ -1547,8 +1547,8 @@ github.com/libp2p/go-yamux/v4 v4.0.2/go.mod h1:C808cCRgOs1iBwY4S71T5oxgMxgLmqUw5
 github.com/lightstep/lightstep-tracer-common/golang/gogo v0.0.0-20190605223551-bc2310a04743/go.mod h1:qklhhLq1aX+mtWk9cPHPzaBjWImj5ULL6C7HFJtXQMM=
 github.com/lightstep/lightstep-tracer-go v0.18.1/go.mod h1:jlF1pusYV4pidLvZ+XD0UBX0ZE6WURAspgAczcDHrL4=
 github.com/linuxkit/virtsock v0.0.0-20201010232012-f8cee7dfc7a3/go.mod h1:3r6x7q95whyfWQpmGZTu3gk3v2YkMi05HEzl7Tf7YEo=
-github.com/logos-messaging/logos-messaging-go-bindings v0.0.0-20251212212702-9a9a9e5c88c8 h1:MP7gsVyyY9mpRUayfA1TYfAS/6gROqzvah++Q2TyivE=
-github.com/logos-messaging/logos-messaging-go-bindings v0.0.0-20251212212702-9a9a9e5c88c8/go.mod h1:Xx5gcSL5nKeRaZ1iZI88KsoLtGJPKf0et5Ajc1rL68c=
+github.com/logos-messaging/logos-messaging-go-bindings v0.0.0-20251212215600-de7d4cf3c9e4 h1:lKvK7IafMwyn16uaKw0zaAIT353tQ0Lndpk+qYGdO10=
+github.com/logos-messaging/logos-messaging-go-bindings v0.0.0-20251212215600-de7d4cf3c9e4/go.mod h1:Xx5gcSL5nKeRaZ1iZI88KsoLtGJPKf0et5Ajc1rL68c=
 github.com/lucas-clemente/quic-go v0.7.1-0.20190401152353-907071221cf9/go.mod h1:PpMmPfPKO9nKJ/psF49ESTAGQSdfXxlg1otPbEB2nOw=
 github.com/lucas-clemente/quic-go v0.18.0/go.mod h1:yXttHsSNxQi8AWijC/vLP+OJczXqzHSOcJrM5ITUlCg=
 github.com/lucas-clemente/quic-go v0.19.3/go.mod h1:ADXpNbTQjq1hIzCpB+y/k5iz4n4z4IwqoLb94Kh5Hu8=

--- a/nix/pkgs/status-go/library/default.nix
+++ b/nix/pkgs/status-go/library/default.nix
@@ -11,7 +11,7 @@ let
 in pkgs.buildGoModule {
   pname = "status-go";
   src = builtins.path { path = ./../../../..; name = "status-go-library"; };
-  vendorHash = "sha256-O2hS/NtjbU4QVPjsu3xh/BScRY+qqydMUdl+uo++OZs=";
+  vendorHash = "sha256-C4wOMel/1yqd3SFt5hO+t8gH3lJ5/XhBHodBs33bM34=";
 
   inherit meta version;
 

--- a/pkg/messaging/waku/config.go
+++ b/pkg/messaging/waku/config.go
@@ -25,7 +25,7 @@ import (
 
 	ethdisc "github.com/ethereum/go-ethereum/p2p/dnsdisc"
 
-	bindingscommon "github.com/waku-org/waku-go-bindings/waku/common"
+	bindingscommon "github.com/logos-messaging/logos-messaging-go-bindings/waku/common"
 
 	"github.com/status-im/status-go/pkg/messaging/waku/common"
 )

--- a/pkg/messaging/waku/nwaku.go
+++ b/pkg/messaging/waku/nwaku.go
@@ -54,9 +54,9 @@ import (
 	"github.com/waku-org/go-waku/waku/v2/protocol/relay"
 	"github.com/waku-org/go-waku/waku/v2/protocol/store"
 
-	"github.com/waku-org/waku-go-bindings/waku"
-	bindingscommon "github.com/waku-org/waku-go-bindings/waku/common"
-	wakutimesource "github.com/waku-org/waku-go-bindings/waku/timesource"
+	"github.com/logos-messaging/logos-messaging-go-bindings/waku"
+	bindingscommon "github.com/logos-messaging/logos-messaging-go-bindings/waku/common"
+	wakutimesource "github.com/logos-messaging/logos-messaging-go-bindings/waku/timesource"
 
 	gocommon "github.com/status-im/status-go/common"
 	"github.com/status-im/status-go/internal/connection"

--- a/pkg/messaging/waku/nwaku_test.go
+++ b/pkg/messaging/waku/nwaku_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/libp2p/go-libp2p/core/peer"
 	"go.uber.org/zap"
 
-	"github.com/waku-org/waku-go-bindings/waku"
+	"github.com/logos-messaging/logos-messaging-go-bindings/waku"
 
 	"github.com/waku-org/go-waku/waku/v2/api/history"
 	"github.com/waku-org/go-waku/waku/v2/protocol/store"

--- a/pkg/messaging/waku/nwaku_utils.go
+++ b/pkg/messaging/waku/nwaku_utils.go
@@ -5,7 +5,7 @@ package wakuv2
 
 // TODO-nwaku remove this entire file once go-waku is removed from status-go
 import (
-	bindings "github.com/waku-org/waku-go-bindings/waku/common"
+	bindings "github.com/logos-messaging/logos-messaging-go-bindings/waku/common"
 
 	"github.com/waku-org/go-waku/waku/v2/protocol/pb"
 	storepb "github.com/waku-org/go-waku/waku/v2/protocol/store/pb"

--- a/pkg/messaging/waku/pinger.go
+++ b/pkg/messaging/waku/pinger.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/libp2p/go-libp2p/core/peer"
 
-	"github.com/waku-org/waku-go-bindings/waku"
+	"github.com/logos-messaging/logos-messaging-go-bindings/waku"
 
 	commonapi "github.com/waku-org/go-waku/waku/v2/api/common"
 )

--- a/pkg/messaging/waku/publisher.go
+++ b/pkg/messaging/waku/publisher.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/libp2p/go-libp2p/core/peer"
 
-	"github.com/waku-org/waku-go-bindings/waku"
+	"github.com/logos-messaging/logos-messaging-go-bindings/waku"
 
 	"github.com/waku-org/go-waku/waku/v2/api/publish"
 	"github.com/waku-org/go-waku/waku/v2/protocol/pb"

--- a/pkg/messaging/waku/result.go
+++ b/pkg/messaging/waku/result.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/libp2p/go-libp2p/core/peer"
 
-	"github.com/waku-org/waku-go-bindings/waku"
+	"github.com/logos-messaging/logos-messaging-go-bindings/waku"
 
 	"github.com/waku-org/go-waku/waku/v2/protocol"
 	"github.com/waku-org/go-waku/waku/v2/protocol/store"

--- a/pkg/messaging/waku/store_message_verifier.go
+++ b/pkg/messaging/waku/store_message_verifier.go
@@ -12,8 +12,8 @@ import (
 	"github.com/golang/protobuf/proto"
 	"github.com/libp2p/go-libp2p/core/peer"
 
-	"github.com/waku-org/waku-go-bindings/waku"
-	"github.com/waku-org/waku-go-bindings/waku/common"
+	"github.com/logos-messaging/logos-messaging-go-bindings/waku"
+	"github.com/logos-messaging/logos-messaging-go-bindings/waku/common"
 
 	"github.com/waku-org/go-waku/waku/v2/api/publish"
 	"github.com/waku-org/go-waku/waku/v2/protocol/pb"

--- a/pkg/messaging/waku/storenode_requestor.go
+++ b/pkg/messaging/waku/storenode_requestor.go
@@ -13,7 +13,7 @@ import (
 	"github.com/libp2p/go-libp2p/core/peer"
 	"go.uber.org/zap"
 
-	"github.com/waku-org/waku-go-bindings/waku"
+	"github.com/logos-messaging/logos-messaging-go-bindings/waku"
 
 	commonapi "github.com/waku-org/go-waku/waku/v2/api/common"
 	"github.com/waku-org/go-waku/waku/v2/protocol"


### PR DESCRIPTION
@AlbertoSoutullo informed that `USE_NWAKU=true make docker-image` was not working.
This PR fixes that and also migrates former `waku-go-bindings` into current `logos-messaging-go-bindings` references.