### PR TITLE
test: deploy contracts as part of docker compose pre requesite

### DIFF
--- a/tests-functional/Dockerfile
+++ b/tests-functional/Dockerfile
@@ -7,6 +7,7 @@ RUN mkdir -p /app/contracts
 COPY contracts/Multicall3.sol /app/contracts/
 
 COPY --chmod=0755 clone_and_run.sh /app
+COPY --chmod=0755 deploy_contracts.sh /app
 COPY --chmod=0755 entrypoint.sh /app
 
 ENTRYPOINT [ "/app/entrypoint.sh" ]

--- a/tests-functional/clients/contract_deployers/communities.py
+++ b/tests-functional/clients/contract_deployers/communities.py
@@ -17,15 +17,6 @@ class CommunitiesDeployer:
     @classmethod
     def from_file(cls, foundry: Foundry, container_file_path: str):
         """Load Communities contract addresses from a JSON file in the foundry container."""
-        import json
-
         instance = cls.__new__(cls)
-
-        # Read the JSON file from the container
-        host_file_path = foundry.get_archive(container_file_path)
-        with open(host_file_path, "r") as f:
-            deploy_output = json.load(f)
-
-        instance.deploy_output = deploy_output
-
+        instance.deploy_output = foundry.load_json(container_file_path)
         return instance

--- a/tests-functional/clients/contract_deployers/communities.py
+++ b/tests-functional/clients/contract_deployers/communities.py
@@ -13,3 +13,19 @@ class CommunitiesDeployer:
             private_key=DEPLOYER_ACCOUNT.private_key,
             sender_address=DEPLOYER_ACCOUNT.address,
         )
+
+    @classmethod
+    def from_file(cls, foundry: Foundry, container_file_path: str):
+        """Load Communities contract addresses from a JSON file in the foundry container."""
+        import json
+
+        instance = cls.__new__(cls)
+
+        # Read the JSON file from the container
+        host_file_path = foundry.get_archive(container_file_path)
+        with open(host_file_path, "r") as f:
+            deploy_output = json.load(f)
+
+        instance.deploy_output = deploy_output
+
+        return instance

--- a/tests-functional/clients/contract_deployers/snt.py
+++ b/tests-functional/clients/contract_deployers/snt.py
@@ -20,6 +20,24 @@ class SNTDeployer:
         self.snt_contract_address = self._get_snt_contract_address(self.deploy_output)
         self.snt_token_controller_address = self._get_snt_token_controller_address(self.deploy_output)
 
+    @classmethod
+    def from_file(cls, foundry: Foundry, container_file_path: str):
+        """Load SNT addresses from a JSON file in the foundry container."""
+        import json
+
+        instance = cls.__new__(cls)
+        instance.deploy_output = None
+
+        # Read the JSON file from the container
+        host_file_path = foundry.get_archive(container_file_path)
+        with open(host_file_path, "r") as f:
+            addresses = json.load(f)
+
+        instance.snt_contract_address = addresses["snt"]
+        instance.snt_token_controller_address = addresses["controller"]
+
+        return instance
+
     def _get_snt_contract_address(self, deploy_output):
         for deployment in deploy_output.values():
             if deployment["internal_type"] == "contract SNTV2":

--- a/tests-functional/clients/foundry.py
+++ b/tests-functional/clients/foundry.py
@@ -181,7 +181,7 @@ class Foundry:
         tar_bytes = io.BytesIO(b"".join(stream))
 
         with tarfile.open(fileobj=tar_bytes) as tar:
-            tar.extractall(path=temp_dir)
+            tar.extractall(path=temp_dir, filter="data")
             # If the tar contains a single file, return the path to that file
             # Otherwise it's a directory, just return temp_dir.
             if len(tar.getmembers()) == 1:

--- a/tests-functional/clients/foundry.py
+++ b/tests-functional/clients/foundry.py
@@ -220,3 +220,9 @@ class Foundry:
             return False
         code = result.output.decode().strip().lower()
         return code != "0x"
+
+    def load_json(self, container_path: str) -> dict:
+        """Load JSON file from container."""
+        host_path = self.get_archive(container_path)
+        with open(host_path, "r") as f:
+            return json.load(f)

--- a/tests-functional/clients/foundry.py
+++ b/tests-functional/clients/foundry.py
@@ -181,7 +181,7 @@ class Foundry:
         tar_bytes = io.BytesIO(b"".join(stream))
 
         with tarfile.open(fileobj=tar_bytes) as tar:
-            tar.extractall(path=temp_dir, filter="data")
+            tar.extractall(path=temp_dir)
             # If the tar contains a single file, return the path to that file
             # Otherwise it's a directory, just return temp_dir.
             if len(tar.getmembers()) == 1:

--- a/tests-functional/clients/services/wakuext.py
+++ b/tests-functional/clients/services/wakuext.py
@@ -311,6 +311,11 @@ class WakuextService(Service):
         response = self.rpc_request("fetchCommunity", params)
         return response
 
+    def spectate_community(self, community_id: str):
+        params = [community_id]
+        response = self.rpc_request("spectateCommunity", params)
+        return response
+
     def request_to_join_community(
         self,
         community_id: str,

--- a/tests-functional/deploy_contracts.sh
+++ b/tests-functional/deploy_contracts.sh
@@ -11,30 +11,16 @@ echo "Deploying SNT contracts..."
 # Extract SNT addresses from broadcast output
 SNT_BROADCAST_FILE="/app/status-network-token-v2/broadcast/Deploy.s.sol/31337/run-latest.json"
 if [ -f "$SNT_BROADCAST_FILE" ]; then
-    # Parse the broadcast JSON to extract contract addresses using Python
-    python3 << 'PYTHON_SCRIPT' > $CONTRACTS_PATH/snt_addresses.json
-import json
+    # Parse the broadcast JSON to extract contract addresses using grep/sed
+    SNT_ADDR=$(grep -A1 '"internal_type": "contract SNTV2"' "$SNT_BROADCAST_FILE" | grep '"value"' | sed 's/.*"value": "\([^"]*\)".*/\1/')
+    CONTROLLER_ADDR=$(grep -A1 '"internal_type": "contract SNTTokenController"' "$SNT_BROADCAST_FILE" | grep '"value"' | sed 's/.*"value": "\([^"]*\)".*/\1/')
 
-with open("/app/status-network-token-v2/broadcast/Deploy.s.sol/31337/run-latest.json", "r") as f:
-    data = json.load(f)
-
-returns = data.get("returns", {})
-snt_address = None
-controller_address = None
-
-for key, value in returns.items():
-    if value.get("internal_type") == "contract SNTV2":
-        snt_address = value.get("value")
-    elif value.get("internal_type") == "contract SNTTokenController":
-        controller_address = value.get("value")
-
-result = {
-    "snt": snt_address,
-    "controller": controller_address
+    cat > $CONTRACTS_PATH/snt_addresses.json << EOF
+{
+  "snt": "$SNT_ADDR",
+  "controller": "$CONTROLLER_ADDR"
 }
-
-print(json.dumps(result, indent=2))
-PYTHON_SCRIPT
+EOF
 
     echo "SNT deployed successfully"
     echo "Addresses saved to $CONTRACTS_PATH/snt_addresses.json"
@@ -50,8 +36,8 @@ echo "Deploying Communities contracts..."
 # Extract Communities addresses from broadcast output
 COMMUNITIES_BROADCAST_FILE="/app/communities-contracts/broadcast/DeployContracts.s.sol/31337/run-latest.json"
 if [ -f "$COMMUNITIES_BROADCAST_FILE" ]; then
-    # Save the entire returns object from the broadcast file
-    cat "$COMMUNITIES_BROADCAST_FILE" | python3 -c "import sys, json; data = json.load(sys.stdin); print(json.dumps(data.get('returns', {}), indent=2))" > $CONTRACTS_PATH/communities_addresses.json
+    # Extract returns section using sed
+    sed -n '/"returns":/,/^  },$/p' "$COMMUNITIES_BROADCAST_FILE" | sed '1s/"returns"://' | sed '$s/,$//' > $CONTRACTS_PATH/communities_addresses.json
 
     echo "Communities contracts deployed successfully"
     echo "Addresses saved to $CONTRACTS_PATH/communities_addresses.json"

--- a/tests-functional/deploy_contracts.sh
+++ b/tests-functional/deploy_contracts.sh
@@ -1,0 +1,63 @@
+#!/bin/sh
+
+set -e
+
+echo "Deploying SNT and Communities contracts..."
+
+# Deploy SNT contracts
+echo "Deploying SNT contracts..."
+/app/clone_and_run.sh status-im status-network-token-v2 script Deploy.s.sol $DEPLOYER_PRIVATE_KEY $DEPLOYER_ADDRESS
+
+# Extract SNT addresses from broadcast output
+SNT_BROADCAST_FILE="/app/status-network-token-v2/broadcast/Deploy.s.sol/31337/run-latest.json"
+if [ -f "$SNT_BROADCAST_FILE" ]; then
+    # Parse the broadcast JSON to extract contract addresses using Python
+    python3 << 'PYTHON_SCRIPT' > $CONTRACTS_PATH/snt_addresses.json
+import json
+
+with open("/app/status-network-token-v2/broadcast/Deploy.s.sol/31337/run-latest.json", "r") as f:
+    data = json.load(f)
+
+returns = data.get("returns", {})
+snt_address = None
+controller_address = None
+
+for key, value in returns.items():
+    if value.get("internal_type") == "contract SNTV2":
+        snt_address = value.get("value")
+    elif value.get("internal_type") == "contract SNTTokenController":
+        controller_address = value.get("value")
+
+result = {
+    "snt": snt_address,
+    "controller": controller_address
+}
+
+print(json.dumps(result, indent=2))
+PYTHON_SCRIPT
+
+    echo "SNT deployed successfully"
+    echo "Addresses saved to $CONTRACTS_PATH/snt_addresses.json"
+else
+    echo "Error: SNT broadcast file not found!"
+    exit 1
+fi
+
+# Deploy Communities contracts
+echo "Deploying Communities contracts..."
+/app/clone_and_run.sh status-im communities-contracts script DeployContracts.s.sol $DEPLOYER_PRIVATE_KEY $DEPLOYER_ADDRESS
+
+# Extract Communities addresses from broadcast output
+COMMUNITIES_BROADCAST_FILE="/app/communities-contracts/broadcast/DeployContracts.s.sol/31337/run-latest.json"
+if [ -f "$COMMUNITIES_BROADCAST_FILE" ]; then
+    # Save the entire returns object from the broadcast file
+    cat "$COMMUNITIES_BROADCAST_FILE" | python3 -c "import sys, json; data = json.load(sys.stdin); print(json.dumps(data.get('returns', {}), indent=2))" > $CONTRACTS_PATH/communities_addresses.json
+
+    echo "Communities contracts deployed successfully"
+    echo "Addresses saved to $CONTRACTS_PATH/communities_addresses.json"
+else
+    echo "Error: Communities broadcast file not found!"
+    exit 1
+fi
+
+echo "All contracts deployed successfully!"

--- a/tests-functional/entrypoint.sh
+++ b/tests-functional/entrypoint.sh
@@ -10,4 +10,7 @@ echo "Starting Foundry"
 echo "Deploying Multicall3"
 forge create $CONTRACTS_PATH/Multicall3.sol:Multicall3 --rpc-url $ANVIL_URL --private-key $DEPLOYER_PRIVATE_KEY --broadcast | tee $CONTRACTS_PATH/Multicall3.sol.log
 
+echo "Deploying SNT and Communities contracts"
+/app/deploy_contracts.sh
+
 tail -F /dev/null # Keep container running indefinitely

--- a/tests-functional/resources/constants.py
+++ b/tests-functional/resources/constants.py
@@ -142,3 +142,7 @@ STATUS_CONNECTOR_WS_PORT = 8586
 STATUS_MEDIA_SERVER_PORT = 8587
 
 NATIVE_TOKEN_ADDRESS = "0x0000000000000000000000000000000000000000"
+
+# Container paths for pre-deployed contracts
+SNT_ADDRESSES_CONTAINER_PATH = "/app/contracts/snt_addresses.json"
+COMMUNITIES_ADDRESSES_CONTAINER_PATH = "/app/contracts/communities_addresses.json"

--- a/tests-functional/tests/conftest.py
+++ b/tests-functional/tests/conftest.py
@@ -1,4 +1,3 @@
-import json
 import logging
 from uuid import uuid4
 
@@ -9,8 +8,14 @@ from clients.anvil import Anvil
 from clients.contract_deployers.multicall3 import Multicall3Deployer
 from clients.foundry import Foundry
 from clients.status_backend import StatusBackend
-from resources.constants import USE_IPV6
+from resources.constants import (
+    USE_IPV6,
+    SNT_ADDRESSES_CONTAINER_PATH,
+    COMMUNITIES_ADDRESSES_CONTAINER_PATH,
+)
 from utils import fake
+
+logger = logging.getLogger(__name__)
 
 
 @pytest.fixture(scope="function", autouse=False)
@@ -163,20 +168,13 @@ def multicall3_deployer(foundry_client):
 
 @pytest.fixture(scope="session")
 def snt_addresses(foundry_client):
-    logger = logging.getLogger(__name__)
-    container_file_path = "/app/contracts/snt_addresses.json"
-
     try:
-        # Read addresses from the pre-deployed contracts in the container
-        host_file_path = foundry_client.get_archive(container_file_path)
-        with open(host_file_path, "r") as f:
-            data = json.load(f)
-
+        data = foundry_client.load_json(SNT_ADDRESSES_CONTAINER_PATH)
         logger.info(f"Using pre-deployed SNT contracts: token={data['snt']}, controller={data['controller']}")
         return data
     except Exception as e:
         logger.error(f"Failed to load SNT addresses from container: {e}")
-        logger.info("SNT contracts should be deployed as part of docker-compose startup")
+        logger.error("SNT contracts should be deployed as part of docker-compose startup")
         raise RuntimeError(
             "SNT contracts not found. Make sure the foundry container has deployed contracts during startup. "
             "This should happen automatically in entrypoint.sh"
@@ -185,20 +183,13 @@ def snt_addresses(foundry_client):
 
 @pytest.fixture(scope="session")
 def communities_addresses(foundry_client):
-    logger = logging.getLogger(__name__)
-    container_file_path = "/app/contracts/communities_addresses.json"
-
     try:
-        # Read addresses from the pre-deployed contracts in the container
-        host_file_path = foundry_client.get_archive(container_file_path)
-        with open(host_file_path, "r") as f:
-            data = json.load(f)
-
+        data = foundry_client.load_json(COMMUNITIES_ADDRESSES_CONTAINER_PATH)
         logger.info("Using pre-deployed Communities contracts")
         return data
     except Exception as e:
         logger.error(f"Failed to load Communities addresses from container: {e}")
-        logger.info("Communities contracts should be deployed as part of docker-compose startup")
+        logger.error("Communities contracts should be deployed as part of docker-compose startup")
         raise RuntimeError(
             "Communities contracts not found. Make sure the foundry container has deployed contracts during startup. "
             "This should happen automatically in entrypoint.sh"

--- a/tests-functional/tests/conftest.py
+++ b/tests-functional/tests/conftest.py
@@ -1,15 +1,12 @@
 import json
 import logging
-import os
 from uuid import uuid4
 
 import pytest
-from filelock import FileLock
 from requests import ReadTimeout
 
 from clients.anvil import Anvil
 from clients.contract_deployers.multicall3 import Multicall3Deployer
-from clients.contract_deployers.snt import SNTDeployer
 from clients.foundry import Foundry
 from clients.status_backend import StatusBackend
 from resources.constants import USE_IPV6
@@ -167,35 +164,45 @@ def multicall3_deployer(foundry_client):
 @pytest.fixture(scope="session")
 def snt_addresses(foundry_client):
     logger = logging.getLogger(__name__)
-    addresses_file = os.path.join(os.path.dirname(os.path.dirname(__file__)), "snt_addresses.json")
-    lock_path = addresses_file + ".lock"  # Lock file next to JSON
+    container_file_path = "/app/contracts/snt_addresses.json"
 
-    with FileLock(lock_path, timeout=120):  # Acquire lock (120s timeout for deploy)
-        data = None
-        if os.path.exists(addresses_file):
-            try:
-                with open(addresses_file, "r") as f:
-                    data = json.load(f)
-                # Re-check contracts INSIDE lock (critical for races)
-                if foundry_client.check_contract_exists(data["snt"]) and foundry_client.check_contract_exists(data["controller"]):
-                    logger.info("Using existing SNT deployment addresses")
-                    return data
-                else:
-                    logger.warning("Existing SNT addresses invalid (no code), will redeploy")
-            except (json.JSONDecodeError, KeyError, IOError) as e:
-                logger.warning(f"Failed to load existing addresses: {e}, will redeploy")
+    try:
+        # Read addresses from the pre-deployed contracts in the container
+        host_file_path = foundry_client.get_archive(container_file_path)
+        with open(host_file_path, "r") as f:
+            data = json.load(f)
 
-        # Deploy (now EXCLUSIVE due to lock)
-        logger.info("Deploying new SNT token...")
-        deployer = SNTDeployer(foundry_client)
-        data = {
-            "snt": deployer.snt_contract_address,
-            "controller": deployer.snt_token_controller_address,
-        }
-        with open(addresses_file, "w") as f:
-            json.dump(data, f, indent=2)
-        logger.info(f"New SNT deployed: token={data['snt']}, controller={data['controller']}")
+        logger.info(f"Using pre-deployed SNT contracts: token={data['snt']}, controller={data['controller']}")
         return data
+    except Exception as e:
+        logger.error(f"Failed to load SNT addresses from container: {e}")
+        logger.info("SNT contracts should be deployed as part of docker-compose startup")
+        raise RuntimeError(
+            "SNT contracts not found. Make sure the foundry container has deployed contracts during startup. "
+            "This should happen automatically in entrypoint.sh"
+        ) from e
+
+
+@pytest.fixture(scope="session")
+def communities_addresses(foundry_client):
+    logger = logging.getLogger(__name__)
+    container_file_path = "/app/contracts/communities_addresses.json"
+
+    try:
+        # Read addresses from the pre-deployed contracts in the container
+        host_file_path = foundry_client.get_archive(container_file_path)
+        with open(host_file_path, "r") as f:
+            data = json.load(f)
+
+        logger.info("Using pre-deployed Communities contracts")
+        return data
+    except Exception as e:
+        logger.error(f"Failed to load Communities addresses from container: {e}")
+        logger.info("Communities contracts should be deployed as part of docker-compose startup")
+        raise RuntimeError(
+            "Communities contracts not found. Make sure the foundry container has deployed contracts during startup. "
+            "This should happen automatically in entrypoint.sh"
+        ) from e
 
 
 @pytest.fixture(scope="function")

--- a/tests-functional/tests/test_wakuext_community_token_permissions.py
+++ b/tests-functional/tests/test_wakuext_community_token_permissions.py
@@ -6,7 +6,7 @@ import pytest
 from tenacity import retry, stop_after_attempt, wait_fixed, retry_if_result
 
 from clients.services.wakuext import CommunityPermissionsAccess, CommunityTokenPermissionType, CommunityTokenType, CommunityRoles
-from clients.signals import SignalType
+from clients.signals import SignalType, WalletEventType
 from clients.status_backend import StatusBackend
 from resources.constants import user_1
 from steps.messenger import MessengerSteps
@@ -113,23 +113,6 @@ class TestCommunityTokenPermissions(MessengerSteps):
         assert balance_result.exit_code == 0, "Balance check command failed"
         balance = int(balance_result.output.decode().strip(), 16)
         assert balance >= min_wei, f"Insufficient SNT balance: {balance}, expected at least 1 token"
-
-    def _wait_for_permissions_satisfied(self, backend, community_id, member_address, attempts=3, wait_sec=2):
-        """Wait for permission check to see the balance and return satisfied response."""
-
-        @retry(
-            stop=stop_after_attempt(attempts),
-            wait=wait_fixed(wait_sec),
-            retry=retry_if_result(lambda r: not r or not r.get("satisfied")),
-        )
-        def _check():
-            # Force refresh wallet balances before checking permissions.
-            # Without this, check_permissions_to_join_community may use stale cached balances
-            # and not see tokens that were just minted in fund_backend_account_with_snt.
-            backend.wallet_service.fetch_or_get_cached_wallet_balances([member_address], True)
-            return backend.wakuext_service.check_permissions_to_join_community(community_id)
-
-        return _check()
 
     @pytest.mark.skip(reason="Pending on issue https://github.com/status-im/status-go/issues/7114")
     def test_membership_no_valid_tokens_fake_address(self, owner_backend, member_backend):
@@ -240,8 +223,16 @@ class TestCommunityTokenPermissions(MessengerSteps):
         assert response["tokenPermissions"], "No token permissions found"
         assert len(response["tokenPermissions"]) == 2, "Unexpected number of token permissions"
 
-        # Wait for permission check to see the balance
-        permissions_resp = self._wait_for_permissions_satisfied(member_with_snt_backend, community_id, member_address)
+        # Wait for balance to be fetched (request to join uses cached balances)
+        member_with_snt_backend.wallet_service.restart_wallet_reload_timer()  # Force balance fetch
+        member_with_snt_backend.wait_for_signal_predicate(
+            SignalType.WALLET,
+            lambda signal: signal["event"]["type"] == WalletEventType.WALLET_TICK_RELOAD.value,
+            timeout=20,  # 10 seconds backoff + timeout
+        )
+
+        permissions_resp = member_with_snt_backend.wakuext_service.check_permissions_to_join_community(community_id)
+        assert permissions_resp, "Failed to check permissions to join community"
         assert permissions_resp.get("satisfied"), "Permissions to join are not satisfied"
 
         # Member with tokens requests to join community

--- a/tests-functional/tests/test_wakuext_community_token_permissions.py
+++ b/tests-functional/tests/test_wakuext_community_token_permissions.py
@@ -4,8 +4,9 @@ from typing import Optional, List
 
 import pytest
 
+from clients.api import ApiResponseError
 from clients.services.wakuext import CommunityPermissionsAccess, CommunityTokenPermissionType, CommunityTokenType, CommunityRoles
-from clients.signals import SignalType, WalletEventType
+from clients.signals import SignalType
 from clients.status_backend import StatusBackend
 from resources.constants import user_1
 from steps.messenger import MessengerSteps
@@ -41,6 +42,24 @@ class TestCommunityTokenPermissions(MessengerSteps):
         if isinstance(communities_response, dict):
             return communities_response.get("communities", []) or []
         return communities_response or []
+
+    def _spectate_and_fetch_community(self, backend, community_id, attempts=10, delay=5):
+        """
+        Fetch community using polling approach with spectate subscription.
+        Each fetchCommunity call waits up to 60s for network response.
+        """
+        try:
+            backend.wakuext_service.spectate_community(community_id)
+        except ApiResponseError as exc:
+            logging.warning(f"Spectate community failed for {community_id}: {exc}")
+
+        for attempt in range(attempts):
+            community = self.fetch_community(backend, community_id)
+            if community:
+                return community
+            logging.info(f"Community {community_id} not found yet (attempt {attempt + 1}/{attempts})")
+            time.sleep(delay)
+        return None
 
     def create_token_gated_community(
         self,
@@ -152,7 +171,8 @@ class TestCommunityTokenPermissions(MessengerSteps):
         time.sleep(2)
 
         # Fetch community as member
-        self.fetch_community(member_with_snt_backend, community_id)
+        community = self._spectate_and_fetch_community(member_with_snt_backend, community_id)
+        assert community, f"Community {community_id} not found"
 
         # Member tries to join with their wallet address (should have tokens)
         join_req = request_to_join_with_signatures(member_with_snt_backend, community_id, [member_address])
@@ -166,7 +186,7 @@ class TestCommunityTokenPermissions(MessengerSteps):
         # Wait for the request to join to be received
         owner_backend.wait_for_signal_predicate(
             signal_type=SignalType.MESSAGES_NEW,
-            predicate=lambda s: (s.get("event", {})["requestsToJoinCommunity"][0]["id"] == req_id),
+            predicate=lambda s: ((s.get("event", {}).get("requestsToJoinCommunity") or [{}])[0].get("id") == req_id),
         )
 
         # Accept request to join
@@ -207,20 +227,21 @@ class TestCommunityTokenPermissions(MessengerSteps):
         time.sleep(2)
 
         # Fetch community as member
-        response = self.fetch_community(member_with_snt_backend, community_id)
+        response = self._spectate_and_fetch_community(member_with_snt_backend, community_id)
         assert response, "Community not found"
         assert response["tokenPermissions"], "No token permissions found"
         assert len(response["tokenPermissions"]) == 2, "Unexpected number of token permissions"
 
-        # Wait for balance to be fetched (request to join uses cached balances)
-        member_with_snt_backend.wallet_service.restart_wallet_reload_timer()  # Force balance fetch
-        member_with_snt_backend.wait_for_signal_predicate(
-            SignalType.WALLET,
-            lambda signal: signal["event"]["type"] == WalletEventType.WALLET_TICK_RELOAD.value,
-            timeout=20,  # 10 seconds backoff + timeout
-        )
+        # Trigger explicit refresh and wait until permission check sees the balance
+        member_with_snt_backend.wallet_service.fetch_or_get_cached_wallet_balances([member_address], True)
+        permissions_resp = None
+        for attempt in range(3):
+            time.sleep(2)
+            permissions_resp = member_with_snt_backend.wakuext_service.check_permissions_to_join_community(community_id)
+            if permissions_resp and permissions_resp.get("satisfied"):
+                break
+            member_with_snt_backend.wallet_service.fetch_or_get_cached_wallet_balances([member_address], True)
 
-        permissions_resp = member_with_snt_backend.wakuext_service.check_permissions_to_join_community(community_id)
         assert permissions_resp, "Failed to check permissions to join community"
         assert permissions_resp.get("satisfied"), "Permissions to join are not satisfied"
 
@@ -236,7 +257,7 @@ class TestCommunityTokenPermissions(MessengerSteps):
         # Wait for request to join to get received
         owner_backend.wait_for_signal_predicate(
             SignalType.MESSAGES_NEW,
-            lambda signal: (signal.get("event", {})["requestsToJoinCommunity"][0]["id"] == req_id),
+            lambda signal: ((signal.get("event", {}).get("requestsToJoinCommunity") or [{}])[0].get("id") == req_id),
         )
 
         accept_resp = owner_backend.wakuext_service.accept_request_to_join_community(req_id)

--- a/tests-functional/tests/test_wakuext_community_token_permissions.py
+++ b/tests-functional/tests/test_wakuext_community_token_permissions.py
@@ -5,7 +5,6 @@ from typing import Optional, List
 import pytest
 from tenacity import retry, stop_after_attempt, wait_fixed, retry_if_result
 
-from clients.api import ApiResponseError
 from clients.services.wakuext import CommunityPermissionsAccess, CommunityTokenPermissionType, CommunityTokenType, CommunityRoles
 from clients.signals import SignalType
 from clients.status_backend import StatusBackend
@@ -44,23 +43,14 @@ class TestCommunityTokenPermissions(MessengerSteps):
             return communities_response.get("communities", []) or []
         return communities_response or []
 
-    def _spectate_and_fetch_community(self, backend, community_id, attempts=10, delay=5):
-        """
-        Fetch community using polling approach with spectate subscription.
-        Each fetchCommunity call waits up to 60s for network response.
-        """
-        try:
-            backend.wakuext_service.spectate_community(community_id)
-        except ApiResponseError as exc:
-            logging.warning(f"Spectate community failed for {community_id}: {exc}")
-
-        for attempt in range(attempts):
-            community = self.fetch_community(backend, community_id)
-            if community:
-                return community
-            logging.info(f"Community {community_id} not found yet (attempt {attempt + 1}/{attempts})")
-            time.sleep(delay)
-        return None
+    @retry(
+        stop=stop_after_attempt(10),
+        wait=wait_fixed(5),
+        retry=retry_if_result(lambda r: r is None),
+    )
+    def _fetch_community_with_retry(self, backend, community_id):
+        """Fetch community with retry."""
+        return self.fetch_community(backend, community_id)
 
     def create_token_gated_community(
         self,
@@ -133,6 +123,9 @@ class TestCommunityTokenPermissions(MessengerSteps):
             retry=retry_if_result(lambda r: not r or not r.get("satisfied")),
         )
         def _check():
+            # Force refresh wallet balances before checking permissions.
+            # Without this, check_permissions_to_join_community may use stale cached balances
+            # and not see tokens that were just minted in fund_backend_account_with_snt.
             backend.wallet_service.fetch_or_get_cached_wallet_balances([member_address], True)
             return backend.wakuext_service.check_permissions_to_join_community(community_id)
 
@@ -186,7 +179,7 @@ class TestCommunityTokenPermissions(MessengerSteps):
         time.sleep(2)
 
         # Fetch community as member
-        community = self._spectate_and_fetch_community(member_with_snt_backend, community_id)
+        community = self._fetch_community_with_retry(member_with_snt_backend, community_id)
         assert community, f"Community {community_id} not found"
 
         # Member tries to join with their wallet address (should have tokens)
@@ -242,7 +235,7 @@ class TestCommunityTokenPermissions(MessengerSteps):
         time.sleep(2)
 
         # Fetch community as member
-        response = self._spectate_and_fetch_community(member_with_snt_backend, community_id)
+        response = self._fetch_community_with_retry(member_with_snt_backend, community_id)
         assert response, "Community not found"
         assert response["tokenPermissions"], "No token permissions found"
         assert len(response["tokenPermissions"]) == 2, "Unexpected number of token permissions"

--- a/tests-functional/tests/test_wakuext_community_token_permissions.py
+++ b/tests-functional/tests/test_wakuext_community_token_permissions.py
@@ -3,6 +3,7 @@ import time
 from typing import Optional, List
 
 import pytest
+from tenacity import retry, stop_after_attempt, wait_fixed, retry_if_result
 
 from clients.api import ApiResponseError
 from clients.services.wakuext import CommunityPermissionsAccess, CommunityTokenPermissionType, CommunityTokenType, CommunityRoles
@@ -123,6 +124,20 @@ class TestCommunityTokenPermissions(MessengerSteps):
         balance = int(balance_result.output.decode().strip(), 16)
         assert balance >= min_wei, f"Insufficient SNT balance: {balance}, expected at least 1 token"
 
+    def _wait_for_permissions_satisfied(self, backend, community_id, member_address, attempts=3, wait_sec=2):
+        """Wait for permission check to see the balance and return satisfied response."""
+
+        @retry(
+            stop=stop_after_attempt(attempts),
+            wait=wait_fixed(wait_sec),
+            retry=retry_if_result(lambda r: not r or not r.get("satisfied")),
+        )
+        def _check():
+            backend.wallet_service.fetch_or_get_cached_wallet_balances([member_address], True)
+            return backend.wakuext_service.check_permissions_to_join_community(community_id)
+
+        return _check()
+
     @pytest.mark.skip(reason="Pending on issue https://github.com/status-im/status-go/issues/7114")
     def test_membership_no_valid_tokens_fake_address(self, owner_backend, member_backend):
         """Test that join request with no tokens/fake address fails permission check (no request created)"""
@@ -232,17 +247,8 @@ class TestCommunityTokenPermissions(MessengerSteps):
         assert response["tokenPermissions"], "No token permissions found"
         assert len(response["tokenPermissions"]) == 2, "Unexpected number of token permissions"
 
-        # Trigger explicit refresh and wait until permission check sees the balance
-        member_with_snt_backend.wallet_service.fetch_or_get_cached_wallet_balances([member_address], True)
-        permissions_resp = None
-        for attempt in range(3):
-            time.sleep(2)
-            permissions_resp = member_with_snt_backend.wakuext_service.check_permissions_to_join_community(community_id)
-            if permissions_resp and permissions_resp.get("satisfied"):
-                break
-            member_with_snt_backend.wallet_service.fetch_or_get_cached_wallet_balances([member_address], True)
-
-        assert permissions_resp, "Failed to check permissions to join community"
+        # Wait for permission check to see the balance
+        permissions_resp = self._wait_for_permissions_satisfied(member_with_snt_backend, community_id, member_address)
         assert permissions_resp.get("satisfied"), "Permissions to join are not satisfied"
 
         # Member with tokens requests to join community

--- a/tests-functional/tests/test_wallet_activity_session.py
+++ b/tests-functional/tests/test_wallet_activity_session.py
@@ -4,7 +4,6 @@ import uuid as uuid_lib
 import pytest
 from web3 import Web3
 
-from clients.contract_deployers.communities import CommunitiesDeployer
 from clients.contract_deployers.snt import (
     SNTV2_ABI,
     SNT_TOKEN_CONTROLLER_ABI,
@@ -13,7 +12,6 @@ from resources.constants import (
     DEPLOYER_ACCOUNT,
     ANVIL_NETWORK_ID,
     NATIVE_TOKEN_ADDRESS,
-    COMMUNITIES_ADDRESSES_CONTAINER_PATH,
 )
 from resources.constants import user_1, user_2
 from utils import wallet_utils
@@ -58,13 +56,12 @@ class TestWalletActivitySession:
         self.anvil_client.eth.wait_for_transaction_receipt(tx_hash)
 
     @pytest.fixture(autouse=True)
-    def setup_backend(self, backend_recovered_profile, anvil_client, foundry_client, multicall3_deployer, snt_addresses, communities_addresses):
+    def setup_backend(self, backend_recovered_profile, anvil_client, multicall3_deployer, snt_addresses):
         # Setup contracts and deployers
         self.anvil_client = anvil_client
         self.anvil_client.eth.default_account = Web3.to_checksum_address(DEPLOYER_ACCOUNT.address)
         self.snt_address = snt_addresses["snt"]
         self.snt_controller_address = snt_addresses["controller"]
-        self.communities_deployer = CommunitiesDeployer.from_file(foundry_client, COMMUNITIES_ADDRESSES_CONTAINER_PATH)
         self.erc20_token_list = {ANVIL_NETWORK_ID: self.snt_address}
         token_overrides = self._token_list_to_token_overrides(self.erc20_token_list)
 

--- a/tests-functional/tests/test_wallet_activity_session.py
+++ b/tests-functional/tests/test_wallet_activity_session.py
@@ -9,7 +9,12 @@ from clients.contract_deployers.snt import (
     SNTV2_ABI,
     SNT_TOKEN_CONTROLLER_ABI,
 )
-from resources.constants import DEPLOYER_ACCOUNT, ANVIL_NETWORK_ID, NATIVE_TOKEN_ADDRESS
+from resources.constants import (
+    DEPLOYER_ACCOUNT,
+    ANVIL_NETWORK_ID,
+    NATIVE_TOKEN_ADDRESS,
+    COMMUNITIES_ADDRESSES_CONTAINER_PATH,
+)
 from resources.constants import user_1, user_2
 from utils import wallet_utils
 
@@ -59,7 +64,7 @@ class TestWalletActivitySession:
         self.anvil_client.eth.default_account = Web3.to_checksum_address(DEPLOYER_ACCOUNT.address)
         self.snt_address = snt_addresses["snt"]
         self.snt_controller_address = snt_addresses["controller"]
-        self.communities_deployer = CommunitiesDeployer.from_file(foundry_client, "/app/contracts/communities_addresses.json")
+        self.communities_deployer = CommunitiesDeployer.from_file(foundry_client, COMMUNITIES_ADDRESSES_CONTAINER_PATH)
         self.erc20_token_list = {ANVIL_NETWORK_ID: self.snt_address}
         token_overrides = self._token_list_to_token_overrides(self.erc20_token_list)
 

--- a/tests-functional/tests/test_wallet_activity_session.py
+++ b/tests-functional/tests/test_wallet_activity_session.py
@@ -53,13 +53,13 @@ class TestWalletActivitySession:
         self.anvil_client.eth.wait_for_transaction_receipt(tx_hash)
 
     @pytest.fixture(autouse=True)
-    def setup_backend(self, backend_recovered_profile, anvil_client, foundry_client, multicall3_deployer, snt_addresses):
+    def setup_backend(self, backend_recovered_profile, anvil_client, foundry_client, multicall3_deployer, snt_addresses, communities_addresses):
         # Setup contracts and deployers
         self.anvil_client = anvil_client
         self.anvil_client.eth.default_account = Web3.to_checksum_address(DEPLOYER_ACCOUNT.address)
         self.snt_address = snt_addresses["snt"]
         self.snt_controller_address = snt_addresses["controller"]
-        self.communities_deployer = CommunitiesDeployer(foundry_client)
+        self.communities_deployer = CommunitiesDeployer.from_file(foundry_client, "/app/contracts/communities_addresses.json")
         self.erc20_token_list = {ANVIL_NETWORK_ID: self.snt_address}
         token_overrides = self._token_list_to_token_overrides(self.erc20_token_list)
 


### PR DESCRIPTION
Moved contract deployment from test runtime to docker-compose startup to improve test performance and reliability.

Important changes:

**Infrastructure:**
- Added `deploy_contracts.sh` script that deploys SNT and Communities contracts during foundry container startup
- Updated `entrypoint.sh` to call deployment script after Multicall3
- Modified `Dockerfile` to include new deployment script

**Contract Deployers:**
- Added `SNTDeployer.from_file()` classmethod to load pre-deployed contract addresses from JSON
- Added `CommunitiesDeployer.from_file()` classmethod to load pre-deployed contract addresses from JSON

**Test Fixtures:**
- Updated `snt_addresses` fixture to read from `/app/contracts/snt_addresses.json` instead of deploying
- Added `communities_addresses` fixture to read from `/app/contracts/communities_addresses.json`
- Removed FileLock dependency and runtime deployment logic from fixtures

Closes #7087
