### PR TITLE
chore: update go-wallet-sdk dependency and improve on token manager initialisation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -101,7 +101,7 @@ require (
 	github.com/prometheus/client_model v0.6.1
 	github.com/schollz/peerdiscovery v1.7.0
 	github.com/status-im/extkeys v1.4.0
-	github.com/status-im/go-wallet-sdk v0.0.0-20260108075629-2691c53cc1dc
+	github.com/status-im/go-wallet-sdk v0.0.0-20260126140800-7bb3ccf032ab
 	github.com/waku-org/go-waku v0.10.1
 	github.com/waku-org/sds-go-bindings v0.0.0-20251222164514-d5b47a911904
 	github.com/waku-org/waku-go-bindings v0.0.0-20251202095947-63b01b7d0ca9

--- a/go.sum
+++ b/go.sum
@@ -2281,8 +2281,8 @@ github.com/status-im/go-generate-fast v0.0.0-20250916164518-c78009bcfa9e h1:GV7a
 github.com/status-im/go-generate-fast v0.0.0-20250916164518-c78009bcfa9e/go.mod h1:iktiTcPdK+nuL47hn+7UL12uIkgJYyOAh99jdA6ruGw=
 github.com/status-im/go-sqlcipher/v4 v4.5.4-status.3 h1:/73h1w1hUfb3wVyTlNrUIwahZxatgesCHa6lwO57C2M=
 github.com/status-im/go-sqlcipher/v4 v4.5.4-status.3/go.mod h1:mF2UmIpBnzFeBdu/ypTDb/LdbS0nk0dfSN1WUsWTjMA=
-github.com/status-im/go-wallet-sdk v0.0.0-20260108075629-2691c53cc1dc h1:zQ1OeaKemSnxyK+bVvVDAMGR+Xq3xB2K//tfT4dqwiA=
-github.com/status-im/go-wallet-sdk v0.0.0-20260108075629-2691c53cc1dc/go.mod h1:E4E1D0mflc2pcjsutZpvMYSjI+a231uBHQf8UjdT1Ug=
+github.com/status-im/go-wallet-sdk v0.0.0-20260126140800-7bb3ccf032ab h1:4kkP4AmhEL/sgEDoU92r/ZM10xJj7bjk9jybs+vpMY8=
+github.com/status-im/go-wallet-sdk v0.0.0-20260126140800-7bb3ccf032ab/go.mod h1:E4E1D0mflc2pcjsutZpvMYSjI+a231uBHQf8UjdT1Ug=
 github.com/status-im/gomoji v1.1.3-0.20220213022530-e5ac4a8732d4 h1:CtobZoiNdHpx+xurFxnuJ1xsGm3oKMfcZkB3vmomJmA=
 github.com/status-im/gomoji v1.1.3-0.20220213022530-e5ac4a8732d4/go.mod h1:hmpnZzkzSZJbFYWAUkrPV8I36x7mdYiPhPqnALP4fKA=
 github.com/status-im/goroutine-defer-guard v0.3.1 h1:cZhcJ3gO6OgMYBOfEaAAUZaZgKZeSzMlGNEjMyejuRo=

--- a/internal/rpc/network/testutil/testutil.go
+++ b/internal/rpc/network/testutil/testutil.go
@@ -118,3 +118,17 @@ func ConvertNetworksToPointers(networks []params.Network) []*params.Network {
 	}
 	return result
 }
+
+func MinimalActiveNetworks() []params.Network {
+	return []params.Network{
+		*CreateNetwork(common.EthereumMainnet, "Ethereum Mainnet", []params.RpcProvider{
+			CreateProvider(
+				common.EthereumMainnet,
+				"Dummy Provider",
+				params.EmbeddedProxyProviderType,
+				true,
+				security.NewSensitiveString("http://localhost:0"),
+			),
+		}),
+	}
+}

--- a/nix/pkgs/status-go/library/default.nix
+++ b/nix/pkgs/status-go/library/default.nix
@@ -11,7 +11,7 @@ let
 in pkgs.buildGoModule {
   pname = "status-go";
   src = builtins.path { path = ./../../../..; name = "status-go-library"; };
-  vendorHash = "sha256-O2hS/NtjbU4QVPjsu3xh/BScRY+qqydMUdl+uo++OZs=";
+  vendorHash = "sha256-is6SmKVHD5SX+5WKPxOjXS7i53xzAr994Pb2m1PWAZs=";
 
   inherit meta version;
 

--- a/pkg/backend/node/geth_status_node_test.go
+++ b/pkg/backend/node/geth_status_node_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/status-im/status-go/internal/rpc/network/testutil"
 	"github.com/status-im/status-go/internal/testutils"
 	"github.com/status-im/status-go/params"
 )
@@ -16,6 +17,10 @@ import (
 func TestStatusNodeStart(t *testing.T) {
 	config, err := params.NewNodeConfig("", params.StatusChainNetworkID)
 	require.NoError(t, err)
+
+	// StatusNode startup always creates & starts TokenManager, which requires at least one active network.
+	config.Networks = testutil.MinimalActiveNetworks()
+
 	n := New(nil, nil, testutils.MustCreateTestLogger())
 
 	// checks before node is started
@@ -61,8 +66,10 @@ func TestStatusNodeWithDataDir(t *testing.T) {
 	err := os.MkdirAll(keyStoreDir, os.ModePerm)
 	require.NoError(t, err)
 
+	// Start requires at least one active network because TokenManager is started during node startup.
 	config := params.NodeConfig{
 		RootDataDir: dir,
+		Networks:    testutil.MinimalActiveNetworks(),
 	}
 
 	n, stop1, stop2, err := createStatusNode()

--- a/pkg/backend/test_helpers.go
+++ b/pkg/backend/test_helpers.go
@@ -11,6 +11,7 @@ import (
 	"github.com/status-im/status-go/internal/crypto/types"
 	"github.com/status-im/status-go/internal/db/multiaccounts"
 	"github.com/status-im/status-go/internal/db/multiaccounts/settings"
+	networktestutil "github.com/status-im/status-go/internal/rpc/network/testutil"
 	"github.com/status-im/status-go/internal/testutils"
 	"github.com/status-im/status-go/params"
 	"github.com/status-im/status-go/pkg/messaging"
@@ -143,6 +144,10 @@ func setupTestContext(t *testing.T, password string, storeProfile bool, storeMul
 			WalletRootAddress: derivedAccs[accscommon.PathWalletRoot].Address(),
 		}
 	}
+
+	// Node startup initializes TokenManager even when WalletConfig.Enabled is false,
+	// and TokenManager requires at least one active network.
+	data.config.Networks = networktestutil.MinimalActiveNetworks()
 
 	data.backend = NewStatusBackend(testutils.MustCreateTestLogger())
 	data.backend.UpdateRootDataDir(tmpdir)

--- a/pkg/backend/test_utils_test.go
+++ b/pkg/backend/test_utils_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/status-im/status-go/common"
+	networktestutil "github.com/status-im/status-go/internal/rpc/network/testutil"
 	"github.com/status-im/status-go/params"
 )
 
@@ -47,6 +48,10 @@ func makeTestNodeConfig(t *testing.T) (*params.NodeConfig, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	// Node startup always initializes TokenManager (even when WalletConfig.Enabled is false),
+	// and TokenManager requires at least one active network.
+	nodeConfig.Networks = networktestutil.MinimalActiveNetworks()
 
 	return nodeConfig, nil
 }

--- a/protocol/messenger_builder_test.go
+++ b/protocol/messenger_builder_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/status-im/status-go/internal/db/walletdatabase"
 	"github.com/status-im/status-go/internal/instrumentation/trace"
 	"github.com/status-im/status-go/internal/rpc/network"
+	networktestutil "github.com/status-im/status-go/internal/rpc/network/testutil"
 	"github.com/status-im/status-go/internal/testutils"
 	"github.com/status-im/status-go/params"
 	messaging2 "github.com/status-im/status-go/pkg/messaging"
@@ -166,7 +167,14 @@ func newTestMessenger(t *testing.T, messagingEnv *messaging2.TestMessagingEnviro
 		"",
 	)
 
-	tokenManager, err := token.NewTokenManager(walletDb, nil, nil, network.NewManager(appDb, nil), appDb, nil, nil, nil,
+	// TokenManager requires at least one active network.
+	nm := network.NewManager(appDb, nil)
+	err = nm.InitEmbeddedNetworks(networktestutil.MinimalActiveNetworks())
+	if err != nil {
+		return nil, err
+	}
+
+	tokenManager, err := token.NewTokenManager(walletDb, nil, nil, nm, appDb, nil, nil, nil,
 		nil, time.Hour, time.Hour)
 	if err != nil {
 		return nil, err

--- a/services/wallet/api_impl_test.go
+++ b/services/wallet/api_impl_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/status-im/status-go/internal/db/multiaccounts/accounts"
 	"github.com/status-im/status-go/internal/db/walletdatabase"
 	"github.com/status-im/status-go/internal/rpc"
+	network_mock "github.com/status-im/status-go/internal/rpc/network/mock"
 	"github.com/status-im/status-go/internal/rpc/network/testutil"
 	"github.com/status-im/status-go/internal/testutils"
 	"github.com/status-im/status-go/params"
@@ -74,13 +75,24 @@ func TestAPI_GetAddressDetails(t *testing.T) {
 	c, err := rpc.NewClient(config)
 	require.NoError(t, err)
 
-	tokenManager, err := token.NewTokenManager(db, c, nil, nil, appDB, nil, nil, nil, accountsDb, 0, 0)
+	mockCtrl := gomock.NewController(t)
+	mockNetworkManager := network_mock.NewMockManagerInterface(mockCtrl)
+	mockNetworkManager.EXPECT().GetActiveNetworks().DoAndReturn(func() ([]*params.Network, error) {
+		active := make([]*params.Network, 0, len(networks))
+		for i := range networks {
+			active = append(active, &networks[i])
+		}
+		return active, nil
+	}).AnyTimes()
+	mockNetworkManager.EXPECT().GetPublisher().Return(pubsub.NewPublisher()).AnyTimes()
+	mockNetworkManager.EXPECT().GetTestNetworksEnabled().Return(false, nil).AnyTimes()
+
+	tokenManager, err := token.NewTokenManager(db, c, nil, mockNetworkManager, appDB, nil, nil, nil, accountsDb, 0, 0)
 	require.NoError(t, err)
 
 	service, err := NewService(db, accountsDb, appDB, c, accountsPublisher, nil, nil, &params.NodeConfig{}, nil, nil, nil, nil, tokenManager, "")
 	require.NoError(t, err)
 
-	mockCtrl := gomock.NewController(t)
 	tokenbalancesFetcher := mock_tokenbalances.NewMockFetcherIface(mockCtrl)
 
 	service.tokenBalancesFetcher = tokenbalancesFetcher

--- a/services/wallet/token/token.go
+++ b/services/wallet/token/token.go
@@ -135,7 +135,13 @@ func NewTokenManager(
 		tokenBalancesStorage:       balanceStorage{walletDB: walletDB},
 	}
 
-	tokensManager, err := setUpTokenListsManager(manager, walletDB, lastTokensUpdate, autoRefreshInterval, autoRefreshCheckInterval)
+	enabledChains, err := getEnabledChains(networkManager)
+	if err != nil {
+		return nil, err
+	}
+
+	tokensManager, err := setUpTokenListsManager(manager, walletDB, enabledChains, lastTokensUpdate, autoRefreshInterval,
+		autoRefreshCheckInterval)
 	if err != nil {
 		logutils.ZapLogger().Error("Failed to create token lists manager", zap.Error(err))
 		return nil, err
@@ -147,8 +153,58 @@ func NewTokenManager(
 
 }
 
-func setUpTokenListsManager(mng *Manager, walletDB *sql.DB, lastUpdate time.Time, autoRefreshInterval time.Duration,
-	autoRefreshCheckInterval time.Duration) (manager.Manager, error) {
+func getEnabledChains(networkManager network.ManagerInterface) ([]uint64, error) {
+	if networkManager == nil {
+		return walletcommon.AllChainIDsAsUint64(), nil
+	}
+
+	enabledNetworks, err := networkManager.GetActiveNetworks()
+	if err != nil {
+		return nil, err
+	}
+	enabledChains := make([]uint64, 0)
+	for _, network := range enabledNetworks {
+		enabledChains = append(enabledChains, network.ChainID)
+	}
+	return enabledChains, nil
+}
+
+func initialListProviderFromEmbedded(id string) ([]byte, error) {
+	var data []byte
+
+	switch id {
+	case walletcommon.StatusTokenListID:
+		data = defaulttokenlists.StatusTokenList.JsonData
+	case walletcommon.UniswapTokenListID:
+		data = defaulttokenlists.UniswapTokenList.JsonData
+	case walletcommon.CoingeckoEthereumTokenListID:
+		data = defaulttokenlists.CoingeckoEthereumTokenList.JsonData
+	case walletcommon.CoingeckoOptimismTokenListID:
+		data = defaulttokenlists.CoingeckoOptimismTokenList.JsonData
+	case walletcommon.CoingeckoArbitrumTokenListID:
+		data = defaulttokenlists.CoingeckoArbitrumTokenList.JsonData
+	case walletcommon.CoingeckoBSCTokenListID:
+		data = defaulttokenlists.CoingeckoBscTokenList.JsonData
+	case walletcommon.CoingeckoBaseTokenListID:
+		data = defaulttokenlists.CoingeckoBaseTokenList.JsonData
+	case walletcommon.CoingeckoLineaTokenListID:
+		data = defaulttokenlists.CoingeckoLineaTokenList.JsonData
+	default:
+		return nil, fmt.Errorf("initial token list %q not found", id)
+	}
+
+	if len(data) == 0 {
+		return nil, fmt.Errorf("initial token list %q is empty", id)
+	}
+	return data, nil
+}
+
+func initialListIDsFromEmbedded() []string {
+	return maps.Keys(defaulttokenlists.TokensSources)
+}
+
+func setUpTokenListsManager(mng *Manager, walletDB *sql.DB, enabledChains []uint64, lastUpdate time.Time,
+	autoRefreshInterval time.Duration, autoRefreshCheckInterval time.Duration) (manager.Manager, error) {
 
 	wsdkFetcher := fetcher.New(fetcher.DefaultConfig())
 
@@ -173,29 +229,16 @@ func setUpTokenListsManager(mng *Manager, walletDB *sql.DB, lastUpdate time.Time
 
 		MainListID: walletcommon.StatusTokenListID,
 
-		InitialLists: map[string][]byte{
-			walletcommon.StatusTokenListID:            defaulttokenlists.StatusTokenList.JsonData,
-			walletcommon.UniswapTokenListID:           defaulttokenlists.UniswapTokenList.JsonData,
-			walletcommon.CoingeckoEthereumTokenListID: defaulttokenlists.CoingeckoEthereumTokenList.JsonData,
-			walletcommon.CoingeckoOptimismTokenListID: defaulttokenlists.CoingeckoOptimismTokenList.JsonData,
-			walletcommon.CoingeckoArbitrumTokenListID: defaulttokenlists.CoingeckoArbitrumTokenList.JsonData,
-			walletcommon.CoingeckoBSCTokenListID:      defaulttokenlists.CoingeckoBscTokenList.JsonData,
-			walletcommon.CoingeckoBaseTokenListID:     defaulttokenlists.CoingeckoBaseTokenList.JsonData,
-			walletcommon.CoingeckoLineaTokenListID:    defaulttokenlists.CoingeckoLineaTokenList.JsonData,
-		},
+		InitialListIDs:      initialListIDsFromEmbedded(),
+		InitialListProvider: initialListProviderFromEmbedded,
+
 		CustomParsers: map[string]parsers.TokenListParser{
 			walletcommon.StatusTokenListID: &parsers.StatusTokenListParser{},
 		},
 
-		Chains: walletcommon.AllChainIDsAsUint64(),
+		Chains: enabledChains,
 
 		SkippedTokenKeys: walletcommon.SkippedTokenKeys(),
-	}
-
-	for key, data := range config.InitialLists {
-		if len(data) == 0 {
-			delete(config.InitialLists, key)
-		}
 	}
 
 	return manager.New(config, wsdkFetcher, contentStore, customTokenStore)
@@ -204,6 +247,7 @@ func setUpTokenListsManager(mng *Manager, walletDB *sql.DB, lastUpdate time.Time
 func (tm *Manager) Start(ctx context.Context) error {
 	tm.stopCh = make(chan struct{})
 	tm.startAccountsWatcher()
+	tm.startNetworksWatcher()
 
 	tm.notifyCh = make(chan struct{})
 	return tm.startTokenListsNotifier(ctx)
@@ -273,6 +317,43 @@ func (tm *Manager) startAccountsWatcher() {
 			}
 		}
 	}()
+}
+
+func (tm *Manager) startNetworksWatcher() {
+	if tm.networkManager == nil {
+		return
+	}
+
+	ch, unsubFn := pubsub.Subscribe[network.EventActiveNetworksChanged](tm.networkManager.GetPublisher(), 10)
+
+	go func() {
+		defer gocommon.LogOnPanic()
+		defer unsubFn()
+		for {
+			select {
+			case <-tm.stopCh:
+				return
+			case _, ok := <-ch:
+				if !ok {
+					return
+				}
+				tm.onActiveNetworksChanged()
+			}
+		}
+	}()
+}
+
+func (tm *Manager) onActiveNetworksChanged() {
+	enabledChains, err := getEnabledChains(tm.networkManager)
+	if err != nil {
+		logutils.ZapLogger().Error("failed to get enabled chains", zap.Error(err))
+		return
+	}
+
+	err = tm.tokensManager.SetChains(enabledChains)
+	if err != nil {
+		logutils.ZapLogger().Error("failed to set chains", zap.Error(err))
+	}
 }
 
 func (tm *Manager) Stop() {
@@ -380,17 +461,17 @@ func (tm *Manager) GetTokensByChains(chainIDs []uint64) ([]*tokentypes.Token, er
 }
 
 func (tm *Manager) GetTokensForActiveNetworksMode() ([]*tokentypes.Token, error) {
-	testnetMode, err := tm.settings.GetTestNetworksEnabled()
+	if tm.networkManager == nil {
+		return nil, fmt.Errorf("network manager is nil")
+	}
+	enabledNetworks, err := tm.networkManager.GetActiveNetworks()
 	if err != nil {
 		return nil, err
 	}
 
 	chainIDs := make([]uint64, 0)
-	for _, chainID := range walletcommon.AllChainIDs() {
-		if chainID.IsMainnet() == testnetMode {
-			continue
-		}
-		chainIDs = append(chainIDs, uint64(chainID))
+	for _, network := range enabledNetworks {
+		chainIDs = append(chainIDs, network.ChainID)
 	}
 
 	return tm.GetTokensByChains(chainIDs)

--- a/services/wallet/token/token_test.go
+++ b/services/wallet/token/token_test.go
@@ -3,6 +3,7 @@ package token
 import (
 	"context"
 	"math/big"
+	"slices"
 	"sync"
 	"testing"
 	"time"
@@ -13,13 +14,16 @@ import (
 
 	"github.com/status-im/go-wallet-sdk/pkg/tokens/types"
 
+	"go.uber.org/mock/gomock"
+
 	"github.com/status-im/status-go/internal/contracts/snt"
 	"github.com/status-im/status-go/internal/db/appdatabase"
 	"github.com/status-im/status-go/internal/db/multiaccounts/accounts"
 	"github.com/status-im/status-go/internal/db/walletdatabase"
 	"github.com/status-im/status-go/internal/rpc"
-	"github.com/status-im/status-go/internal/rpc/network"
+	network_mock "github.com/status-im/status-go/internal/rpc/network/mock"
 	"github.com/status-im/status-go/internal/testutils"
+	"github.com/status-im/status-go/params"
 	"github.com/status-im/status-go/pkg/pubsub"
 	protocolsqlite "github.com/status-im/status-go/protocol/sqlite"
 	"github.com/status-im/status-go/services/accounts/accountsevent"
@@ -72,7 +76,17 @@ func setupTestTokenManager(t *testing.T) (*Manager, *pubsub.Publisher, func()) {
 	}
 	rpcClient, _ := rpc.NewClient(config)
 
-	nm := network.NewManager(appDB, nil)
+	mockCtrl := gomock.NewController(t)
+	nm := network_mock.NewMockManagerInterface(mockCtrl)
+	nm.EXPECT().GetActiveNetworks().Return([]*params.Network{
+		{ChainID: walletcommon.EthereumMainnet},
+		{ChainID: walletcommon.OptimismMainnet},
+		{ChainID: walletcommon.ArbitrumMainnet},
+		{ChainID: walletcommon.BaseMainnet},
+		{ChainID: walletcommon.BSCMainnet},
+	}, nil).AnyTimes()
+	nm.EXPECT().GetPublisher().Return(pubsub.NewPublisher()).AnyTimes()
+	nm.EXPECT().GetTestNetworksEnabled().Return(false, nil).AnyTimes()
 
 	manager, err := NewTokenManager(walletDB, rpcClient, nil, nm, appDB, nil, nil, accountsPublisher,
 		accountsDB, 1*time.Hour, 1*time.Hour)
@@ -80,11 +94,14 @@ func setupTestTokenManager(t *testing.T) (*Manager, *pubsub.Publisher, func()) {
 
 	lastTokensUpdate := time.Time{}
 
-	tokensManager, err := setUpTokenListsManager(manager, walletDB, lastTokensUpdate, 1*time.Hour, 1*time.Hour)
+	activeChains, err := getEnabledChains(nm)
+	require.NoError(t, err)
+	tokensManager, err := setUpTokenListsManager(manager, walletDB, activeChains, lastTokensUpdate, 1*time.Hour, 1*time.Hour)
 	require.NoError(t, err)
 	manager.tokensManager = tokensManager
 
 	return manager, accountsPublisher, func() {
+		mockCtrl.Finish()
 		require.NoError(t, appDB.Close())
 		require.NoError(t, walletDB.Close())
 	}
@@ -373,6 +390,9 @@ func TestGetTokensOfInterestForActiveNetworksMode_AddsCrossChainAndMandatoryToke
 		types.TokenKey(10, common.HexToAddress("0x6fd9d7ad17242c41f7131d257212c54a0e816691")),
 	}
 
+	activeNetworks, err := manager.networkManager.GetActiveNetworks()
+	require.NoError(t, err)
+
 	// mandatory token keys for the active networks mode, all of them have cross chain id
 	mandatoryTokenKeysForMode := []string{}
 	for _, tokenKey := range walletcommon.MandatoryTokens() {
@@ -381,6 +401,11 @@ func TestGetTokensOfInterestForActiveNetworksMode_AddsCrossChainAndMandatoryToke
 			continue
 		}
 		if walletcommon.ChainID(chainID).IsMainnet() == testnetMode {
+			continue
+		}
+		if !slices.ContainsFunc(activeNetworks, func(network *params.Network) bool {
+			return network.ChainID == chainID
+		}) {
 			continue
 		}
 		mandatoryTokenKeysForMode = append(mandatoryTokenKeysForMode, tokenKey)

--- a/tests-functional/clients/status_backend.py
+++ b/tests-functional/clients/status_backend.py
@@ -191,6 +191,13 @@ class StatusBackend(RpcClient, SignalClient, ApiClient):
 
     def _set_networks(self, data, **kwargs):
         self.network_id = kwargs.get("network_id", ANVIL_NETWORK_ID)
+
+        # Allow callers (fixtures/tests) to add additional networks on top of the default Anvil network.
+        # - networks_override: full replacement for networksOverride (list[dict])
+        # - extra_networks_override: appended to the default Anvil network (list[dict])
+        networks_override = kwargs.get("networks_override", None)
+        extra_networks_override = kwargs.get("extra_networks_override", []) or []
+
         anvil_network = {
             "chainID": self.network_id,
             "chainName": "Anvil",
@@ -219,7 +226,10 @@ class StatusBackend(RpcClient, SignalClient, ApiClient):
 
         data["testNetworksEnabled"] = False
         data["networkId"] = self.network_id
-        data["networksOverride"] = [anvil_network]
+        if networks_override is not None:
+            data["networksOverride"] = networks_override
+        else:
+            data["networksOverride"] = [anvil_network, *extra_networks_override]
 
     def _set_proxy_credentials(self, data):
         if "STATUS_BUILD_PROXY_USER" not in os.environ:

--- a/tests-functional/tests/test_wallet_rpc.py
+++ b/tests-functional/tests/test_wallet_rpc.py
@@ -14,8 +14,42 @@ TOKENS_KEYS = [
 @pytest.mark.rpc
 class TestRpc:
     @pytest.fixture(autouse=True)
-    def setup_backend(self, backend_recovered_profile):
-        self.rpc_client = backend_recovered_profile(name="main_user", user=user_1)
+    def setup_backend(self, request, backend_recovered_profile):
+        # Add Ethereum mainnet alongside Anvil so token keys like `1-0x...` can be resolved by the token manager.
+        extra_kwargs = {}
+        if request.node.name in (
+            "test_fetch_prices",
+            "test_fetch_market_values",
+            "test_fetch_token_details",
+        ):
+            extra_kwargs["extra_networks_override"] = [
+                {
+                    "chainID": 1,
+                    "chainName": "Ethereum Mainnet",
+                    "rpcProviders": [
+                        {
+                            "chainId": 1,
+                            "name": "Mainnet Dummy",
+                            "url": "http://localhost:0",
+                            "enableRpsLimiter": False,
+                            "type": "embedded-direct",
+                            "enabled": True,
+                            "authType": "no-auth",
+                        }
+                    ],
+                    "shortName": "eth",
+                    "nativeCurrencyName": "Ether",
+                    "nativeCurrencySymbol": "ETH",
+                    "nativeCurrencyDecimals": 18,
+                    "isTest": False,
+                    "layer": 1,
+                    "enabled": True,
+                    "isActive": True,
+                    "isDeactivatable": True,
+                }
+            ]
+
+        self.rpc_client = backend_recovered_profile(name="main_user", user=user_1, **extra_kwargs)
 
     def test_start_wallet(self):
         result = self.rpc_client.wallet_service.start_wallet()

--- a/tests-unit-network/cryptocompare/cryptocompare_test.go
+++ b/tests-unit-network/cryptocompare/cryptocompare_test.go
@@ -14,6 +14,8 @@ import (
 	mock_network "github.com/status-im/status-go/internal/rpc/network/mock"
 	"github.com/status-im/status-go/internal/testutils"
 	"github.com/status-im/status-go/params"
+	"github.com/status-im/status-go/pkg/pubsub"
+	protocolsqlite "github.com/status-im/status-go/protocol/sqlite"
 	w_common "github.com/status-im/status-go/services/wallet/common"
 	"github.com/status-im/status-go/services/wallet/thirdparty/market/cryptocompare"
 	"github.com/status-im/status-go/services/wallet/token"
@@ -23,6 +25,7 @@ import (
 func getTokenSymbols(t *testing.T) []*tokentypes.Token {
 	appDB, err := testutils.SetupTestMemorySQLDB(appdatabase.DbInitializer{})
 	require.NoError(t, err)
+	require.NoError(t, protocolsqlite.Migrate(appDB))
 
 	walletDB, err := testutils.SetupTestMemorySQLDB(walletdatabase.DbInitializer{})
 	require.NoError(t, err)
@@ -56,6 +59,9 @@ func getTokenSymbols(t *testing.T) []*tokentypes.Token {
 	networkManager.EXPECT().Get(gomock.Any()).Return(ptrNetworkList, nil).AnyTimes()
 	networkManager.EXPECT().GetAll().Return(ptrNetworkList, nil).AnyTimes()
 	networkManager.EXPECT().GetEmbeddedNetworks().Return(networksList).AnyTimes()
+	networkManager.EXPECT().GetActiveNetworks().Return(ptrNetworkList, nil).AnyTimes()
+	networkManager.EXPECT().GetPublisher().Return(pubsub.NewPublisher()).AnyTimes()
+	networkManager.EXPECT().GetTestNetworksEnabled().Return(false, nil).AnyTimes()
 
 	// Skeleton token store to get full list of tokens
 	tm, err := token.NewTokenManager(walletDB, nil, nil, networkManager, appDB, nil, nil, nil, nil, time.Hour, time.Hour)


### PR DESCRIPTION
Corresponding `go-wallet-sdk` PRs:
- https://github.com/status-im/go-wallet-sdk/pull/37
- https://github.com/status-im/go-wallet-sdk/pull/38

Changes done here:
- Updated go-wallet-sdk version in go.mod and go.sum.
- Improved on token manager initialization to use enabled chains from the network manager.
- Added functionality to watch for changes in active networks and update token manager accordingly.