### PR TITLE
chore: use chronos shutdown in nim-sds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -269,7 +269,7 @@ ifeq ($(NIM_SDS_BUILD_FROM_SOURCE),true)
 	else \
 		cd $(NIM_SDS_SOURCE_DIR) && git fetch --all --tags; \
 	fi
-	cd $(NIM_SDS_SOURCE_DIR) && git fetch origin && git checkout $(NIM_SDS_VERSION)
+	cd $(NIM_SDS_SOURCE_DIR) && git checkout $(NIM_SDS_VERSION)
 endif
 
 $(LIBSDS): clone-nim-sds

--- a/Makefile
+++ b/Makefile
@@ -109,7 +109,7 @@ endif
 # `nim-sds` variables
 
 # Pin nim-sds revision here. Can be a tag (default) or commit hash.
-NIM_SDS_VERSION ?= v0.2.4
+NIM_SDS_VERSION ?= use-chronos-shutdown
 
 # Option 1: Provide NIM_SDS_SOURCE_DIR. Make clones it if missing.
 NIM_SDS_SOURCE_DIR ?= $(GIT_ROOT)/../nim-sds

--- a/Makefile
+++ b/Makefile
@@ -267,7 +267,7 @@ ifeq ($(NIM_SDS_BUILD_FROM_SOURCE),true)
 	if [ ! -d "$(NIM_SDS_SOURCE_DIR)" ]; then \
 		git clone https://github.com/waku-org/nim-sds.git $(NIM_SDS_SOURCE_DIR); \
 	else \
-		cd $(NIM_SDS_SOURCE_DIR) && git fetch --tags; \
+		cd $(NIM_SDS_SOURCE_DIR) && git fetch --all --tags; \
 	fi
 	cd $(NIM_SDS_SOURCE_DIR) && git checkout $(NIM_SDS_VERSION)
 endif

--- a/Makefile
+++ b/Makefile
@@ -269,7 +269,7 @@ ifeq ($(NIM_SDS_BUILD_FROM_SOURCE),true)
 	else \
 		cd $(NIM_SDS_SOURCE_DIR) && git fetch --all --tags; \
 	fi
-	cd $(NIM_SDS_SOURCE_DIR) && git checkout $(NIM_SDS_VERSION)
+	cd $(NIM_SDS_SOURCE_DIR) && git fetch origin && git checkout $(NIM_SDS_VERSION)
 endif
 
 $(LIBSDS): clone-nim-sds


### PR DESCRIPTION
Uses new `shutdown` proc exposed/created in `nim-chronos`.
The idea is that this will help properly free sds resources without leaking and sds will operate without crashing.

Important changes:
- [x] Chain of vendor updates: nim-sds -> nim-chronos


