### PR TITLE
feat(wallet): introduce tokenhistoricalownership module

### DIFF
--- a/internal/db/walletdatabase/migrations/sql/1736449200_token_historical_ownership.up.sql
+++ b/internal/db/walletdatabase/migrations/sql/1736449200_token_historical_ownership.up.sql
@@ -1,0 +1,10 @@
+CREATE TABLE IF NOT EXISTS token_historical_ownership (
+    owner_address VARCHAR NOT NULL,
+    chain_id UNSIGNED BIGINT NOT NULL,
+    token_address VARCHAR NOT NULL,
+    first_detected_timestamp UNSIGNED BIGINT NOT NULL,
+    last_detected_timestamp UNSIGNED BIGINT NOT NULL,
+    PRIMARY KEY (owner_address, chain_id, token_address)
+);
+
+CREATE INDEX IF NOT EXISTS token_historical_ownership_owner_address ON token_historical_ownership(owner_address);

--- a/services/wallet/tokenhistoricalownership/doc.go
+++ b/services/wallet/tokenhistoricalownership/doc.go
@@ -1,0 +1,6 @@
+// Package tokenhistoricalownership implements persistent tracking of token ownership for wallet accounts.
+// Sources for determining ownership are:
+// - transferdetector events
+// - activityfetcher events
+// - Non-zero balances
+package tokenhistoricalownership

--- a/services/wallet/tokenhistoricalownership/service.go
+++ b/services/wallet/tokenhistoricalownership/service.go
@@ -1,0 +1,475 @@
+package tokenhistoricalownership
+
+//go:generate go tool mockgen -package=mock_tokenhistoricalownership -source=service.go -destination=mock/service.go
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"math/big"
+	"sync"
+
+	"go.uber.org/zap"
+
+	"github.com/ethereum/go-ethereum/common"
+
+	"github.com/status-im/go-wallet-sdk/pkg/contracts/erc1155"
+	"github.com/status-im/go-wallet-sdk/pkg/contracts/erc20"
+	"github.com/status-im/go-wallet-sdk/pkg/contracts/erc721"
+	"github.com/status-im/go-wallet-sdk/pkg/eventlog"
+
+	gocommon "github.com/status-im/status-go/common"
+	"github.com/status-im/status-go/internal/logutils"
+	"github.com/status-im/status-go/pkg/pubsub"
+	"github.com/status-im/status-go/services/accounts/accountsevent"
+	af "github.com/status-im/status-go/services/wallet/activityfetcher"
+	"github.com/status-im/status-go/services/wallet/tokenbalances"
+	"github.com/status-im/status-go/services/wallet/transferdetector"
+	"github.com/status-im/status-go/signal"
+)
+
+type TokenBalancesProvider interface {
+	GetAllBalancesForAccountAndChain(ctx context.Context, accountAddress tokenbalances.AccountAddress, chainID uint64) (map[tokenbalances.ContractAddress]*big.Int, tokenbalances.State, error)
+}
+
+type ActivityTokenProvider interface {
+	GetActivityTokens(chainID uint64, address common.Address) ([]af.ActivityToken, error)
+}
+
+// Service tracks historical token ownership for wallet accounts
+type Service struct {
+	db                        *sql.DB
+	storage                   StorageInterface
+	activityFetcherPublisher  *pubsub.Publisher
+	activityTokenProvider     ActivityTokenProvider
+	tokenBalancesProvider     TokenBalancesProvider
+	tokenBalancesPublisher    *pubsub.Publisher
+	transferDetectorPublisher *pubsub.Publisher
+	accountsPublisher         *pubsub.Publisher
+	publisher                 *pubsub.Publisher
+
+	stopCh  chan struct{}
+	started bool
+	mu      sync.Mutex
+}
+
+// NewService creates a new historical ownership tracking service
+func NewService(
+	db *sql.DB,
+	storage StorageInterface,
+	activityFetcherPublisher *pubsub.Publisher,
+	activityTokenProvider ActivityTokenProvider,
+	tokenBalancesProvider TokenBalancesProvider,
+	tokenBalancesPublisher *pubsub.Publisher,
+	transferDetectorPublisher *pubsub.Publisher,
+	accountsPublisher *pubsub.Publisher,
+) *Service {
+	return &Service{
+		db:                        db,
+		storage:                   storage,
+		activityFetcherPublisher:  activityFetcherPublisher,
+		activityTokenProvider:     activityTokenProvider,
+		tokenBalancesProvider:     tokenBalancesProvider,
+		tokenBalancesPublisher:    tokenBalancesPublisher,
+		transferDetectorPublisher: transferDetectorPublisher,
+		accountsPublisher:         accountsPublisher,
+		publisher:                 pubsub.NewPublisher(),
+	}
+}
+
+// GetPublisher returns the publisher for ownership change events
+func (s *Service) GetPublisher() *pubsub.Publisher {
+	return s.publisher
+}
+
+// Start begins tracking token ownership
+func (s *Service) Start() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.started {
+		return nil
+	}
+
+	s.stopCh = make(chan struct{})
+	s.started = true
+
+	// Start watching for activity fetcher events
+	go s.watchActivityFetcherEvents()
+
+	// Start watching for balance events
+	go s.watchTokenBalancesEvents()
+
+	// Start watching for transfer events
+	go s.watchTransferEvents()
+
+	// Start watching for account removal events
+	go s.watchAccountEvents()
+
+	return nil
+}
+
+// Stop stops the service
+func (s *Service) Stop() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if !s.started {
+		return
+	}
+
+	close(s.stopCh)
+	s.stopCh = nil
+	s.started = false
+}
+
+// MarkAsPreviouslyOwned manually marks a token as owned by an address
+// Returns true if this is a new entry, false if already existed
+func (s *Service) MarkAsPreviouslyOwned(ownerAddress common.Address, chainID uint64, tokenAddress common.Address) (bool, error) {
+	isNew, err := s.storage.MarkAsOwned(ownerAddress, chainID, tokenAddress)
+	if err != nil {
+		logutils.ZapLogger().Error("failed to mark token as owned",
+			zap.String("owner", ownerAddress.Hex()),
+			zap.Uint64("chainID", chainID),
+			zap.String("token", tokenAddress.Hex()),
+			zap.Error(err))
+		return false, err
+	}
+
+	if isNew {
+		logutils.ZapLogger().Debug("marked token as historically owned",
+			zap.String("owner", ownerAddress.Hex()),
+			zap.Uint64("chainID", chainID),
+			zap.String("token", tokenAddress.Hex()))
+
+		// Emit event and signal
+		s.emitOwnershipChanged(chainID, ownerAddress)
+	}
+
+	return isNew, nil
+}
+
+// GetOwnedTokens returns all tokens ever owned by an address
+func (s *Service) GetOwnedTokens(ownerAddress common.Address) ([]TokenOwnership, error) {
+	return s.storage.GetOwnedTokens(ownerAddress)
+}
+
+// GetOwnedTokensByChain returns all tokens ever owned by an address on a specific chain
+func (s *Service) GetOwnedTokensByChain(ownerAddress common.Address, chainID uint64) ([]TokenOwnership, error) {
+	return s.storage.GetOwnedTokensByChain(ownerAddress, chainID)
+}
+
+// IsOwned checks if a token was ever owned by an address
+func (s *Service) IsOwned(ownerAddress common.Address, chainID uint64, tokenAddress common.Address) (bool, error) {
+	return s.storage.IsOwned(ownerAddress, chainID, tokenAddress)
+}
+
+// GetOwnedTokenKeys returns token keys (formatted as "chainID-tokenAddress") for all tokens ever owned by an address
+func (s *Service) GetOwnedTokenKeys(ownerAddress common.Address) ([]string, error) {
+	ownedTokens, err := s.storage.GetOwnedTokens(ownerAddress)
+	if err != nil {
+		return nil, err
+	}
+
+	keys := make([]string, 0, len(ownedTokens))
+	for _, token := range ownedTokens {
+		// Format as "chainID-tokenAddress"
+		key := fmt.Sprintf("%d-%s", token.ChainID, token.TokenAddress.Hex())
+		keys = append(keys, key)
+	}
+
+	return keys, nil
+}
+
+// watchActivityFetcherEvents listens for activity detection events and fetches activity from storage
+func (s *Service) watchActivityFetcherEvents() {
+	defer gocommon.LogOnPanic()
+
+	if s.activityFetcherPublisher == nil {
+		logutils.ZapLogger().Warn("activityFetcherPublisher is nil, token ownership tracking from activities disabled")
+		return
+	}
+
+	ch, unsub := pubsub.Subscribe[af.EventActivityDetected](s.activityFetcherPublisher, 10)
+	defer unsub()
+
+	for {
+		select {
+		case <-s.stopCh:
+			return
+		case event, ok := <-ch:
+			if !ok {
+				return
+			}
+			s.handleActivityDetected(event)
+		}
+	}
+}
+
+// handleActivityDetected processes activity detection events and marks tokens as owned
+func (s *Service) handleActivityDetected(event af.EventActivityDetected) {
+	if s.activityTokenProvider == nil {
+		logutils.ZapLogger().Warn("activityTokenProvider is nil, cannot get activity tokens")
+		return
+	}
+
+	// Get tokens from activity provider
+	tokens, err := s.activityTokenProvider.GetActivityTokens(event.ChainID, event.Account)
+	if err != nil {
+		logutils.ZapLogger().Error("failed to get activity tokens",
+			zap.Uint64("chainID", event.ChainID),
+			zap.String("account", event.Account.Hex()),
+			zap.Error(err))
+		return
+	}
+
+	// Track if any new tokens were added
+	hasNewTokens := false
+
+	// Mark each token as owned
+	for _, token := range tokens {
+		isNew, err := s.storage.MarkAsOwned(event.Account, event.ChainID, token.Address)
+		if err != nil {
+			logutils.ZapLogger().Error("failed to mark token as owned from activity",
+				zap.String("account", event.Account.Hex()),
+				zap.Uint64("chainID", event.ChainID),
+				zap.String("token", token.Address.Hex()),
+				zap.Bool("isNative", token.IsNative),
+				zap.Error(err))
+			continue
+		}
+		if isNew {
+			hasNewTokens = true
+		}
+	}
+
+	// Emit event and signal if any new tokens were added
+	if hasNewTokens {
+		s.emitOwnershipChanged(event.ChainID, event.Account)
+	}
+}
+
+// watchBalanceEvents listens for balance events and marks tokens with balance > 0 as owned
+func (s *Service) watchTokenBalancesEvents() {
+	defer gocommon.LogOnPanic()
+
+	if s.tokenBalancesPublisher == nil {
+		logutils.ZapLogger().Warn("tokenBalancesPublisher is nil, token ownership tracking from token balances disabled")
+		return
+	}
+
+	ch, unsub := pubsub.Subscribe[tokenbalances.EventBalanceFetchFinished](s.tokenBalancesPublisher, 10)
+	defer unsub()
+
+	for {
+		select {
+		case <-s.stopCh:
+			return
+		case event, ok := <-ch:
+			if !ok {
+				return
+			}
+			s.handleBalanceFetchFinished(event)
+		}
+	}
+}
+
+// handleBalanceFetchFinished processes balance fetch finished events for Native and ERC20 tokens with balance > 0
+func (s *Service) handleBalanceFetchFinished(event tokenbalances.EventBalanceFetchFinished) {
+	// Only process if balance changed
+	if !event.BalanceChanged {
+		return
+	}
+
+	// Query storage to get all balances for this account on this chain
+	ctx := context.Background()
+	balances, _, err := s.tokenBalancesProvider.GetAllBalancesForAccountAndChain(ctx, event.Account, event.ChainID)
+	if err != nil {
+		logutils.ZapLogger().Error("failed to get balances from storage",
+			zap.String("account", event.Account.Hex()),
+			zap.Uint64("chainID", event.ChainID),
+			zap.Error(err))
+		return
+	}
+
+	// Track if any new tokens were added
+	hasNewTokens := false
+
+	// Mark tokens with balance > 0 as owned
+	for tokenAddress, balance := range balances {
+		if balance != nil && balance.Sign() > 0 {
+			isNew, err := s.storage.MarkAsOwned(event.Account, event.ChainID, tokenAddress)
+			if err != nil {
+				logutils.ZapLogger().Error("failed to mark token as owned from balance event",
+					zap.String("account", event.Account.Hex()),
+					zap.Uint64("chainID", event.ChainID),
+					zap.String("token", tokenAddress.Hex()),
+					zap.Error(err))
+				continue
+			}
+			if isNew {
+				hasNewTokens = true
+			}
+		}
+	}
+
+	// Emit event and signal if any new tokens were added
+	if hasNewTokens {
+		s.emitOwnershipChanged(event.ChainID, event.Account)
+	}
+}
+
+// watchTransferEvents listens for transfer detection events to track token ownership
+func (s *Service) watchTransferEvents() {
+	defer gocommon.LogOnPanic()
+
+	if s.transferDetectorPublisher == nil {
+		logutils.ZapLogger().Warn("transferDetectorPublisher is nil, token ownership tracking from transfers disabled")
+		return
+	}
+
+	ch, unsub := pubsub.Subscribe[transferdetector.EventTransferDetectionFinished](s.transferDetectorPublisher, 10)
+	defer unsub()
+
+	for {
+		select {
+		case <-s.stopCh:
+			return
+		case msg, ok := <-ch:
+			if !ok {
+				return
+			}
+			s.handleTransferDetection(msg)
+		}
+	}
+}
+
+// handleTransferDetection processes transfer events to track token ownership
+func (s *Service) handleTransferDetection(msg transferdetector.EventTransferDetectionFinished) {
+	// Track which accounts had new tokens added
+	accountsWithNewTokens := make(map[common.Address]bool)
+
+	for _, event := range msg.Events {
+		// Extract recipient address and token address based on event type
+		var recipient common.Address
+		var tokenAddress common.Address
+
+		switch event.EventKey {
+		case eventlog.ERC20Transfer:
+			unpackedEvent, ok := event.Unpacked.(erc20.Erc20Transfer)
+			if !ok {
+				logutils.ZapLogger().Error("failed to unpack ERC20Transfer event")
+				continue
+			}
+			recipient = unpackedEvent.To
+			tokenAddress = unpackedEvent.Raw.Address
+
+		case eventlog.ERC721Transfer:
+			unpackedEvent, ok := event.Unpacked.(erc721.Erc721Transfer)
+			if !ok {
+				logutils.ZapLogger().Error("failed to unpack ERC721Transfer event")
+				continue
+			}
+			recipient = unpackedEvent.To
+			tokenAddress = unpackedEvent.Raw.Address
+
+		case eventlog.ERC1155TransferSingle:
+			unpackedEvent, ok := event.Unpacked.(erc1155.Erc1155TransferSingle)
+			if !ok {
+				logutils.ZapLogger().Error("failed to unpack ERC1155TransferSingle event")
+				continue
+			}
+			recipient = unpackedEvent.To
+			tokenAddress = unpackedEvent.Raw.Address
+
+		case eventlog.ERC1155TransferBatch:
+			unpackedEvent, ok := event.Unpacked.(erc1155.Erc1155TransferBatch)
+			if !ok {
+				logutils.ZapLogger().Error("failed to unpack ERC1155TransferBatch event")
+				continue
+			}
+			recipient = unpackedEvent.To
+			tokenAddress = unpackedEvent.Raw.Address
+
+		default:
+			// Not a token transfer event, skip
+			continue
+		}
+
+		// Record the token ownership for the recipient
+		isNew, err := s.storage.MarkAsOwned(recipient, msg.ChainID, tokenAddress)
+		if err != nil {
+			logutils.ZapLogger().Error("failed to mark token as owned from transfer event",
+				zap.String("recipient", recipient.Hex()),
+				zap.Uint64("chainID", msg.ChainID),
+				zap.String("token", tokenAddress.Hex()),
+				zap.Error(err))
+			continue
+		}
+		if isNew {
+			accountsWithNewTokens[recipient] = true
+		}
+	}
+
+	// Emit events and signals for accounts that had new tokens added
+	for account := range accountsWithNewTokens {
+		s.emitOwnershipChanged(msg.ChainID, account)
+	}
+}
+
+// watchAccountEvents listens for account removal events to cleanup ownership records
+func (s *Service) watchAccountEvents() {
+	defer gocommon.LogOnPanic()
+
+	if s.accountsPublisher == nil {
+		logutils.ZapLogger().Warn("accountsPublisher is nil, account cleanup disabled")
+		return
+	}
+
+	ch, unsub := pubsub.Subscribe[accountsevent.AccountsRemovedEvent](s.accountsPublisher, 10)
+	defer unsub()
+
+	for {
+		select {
+		case <-s.stopCh:
+			return
+		case event, ok := <-ch:
+			if !ok {
+				return
+			}
+			s.handleAccountsRemoved(event)
+		}
+	}
+}
+
+// handleAccountsRemoved cleans up ownership records for removed accounts
+func (s *Service) handleAccountsRemoved(event accountsevent.AccountsRemovedEvent) {
+	for _, address := range event.Accounts {
+		err := s.storage.RemoveOwnerRecords(address)
+		if err != nil {
+			logutils.ZapLogger().Error("failed to remove ownership records for account",
+				zap.String("address", address.Hex()),
+				zap.Error(err))
+		} else {
+			logutils.ZapLogger().Debug("removed ownership records for account",
+				zap.String("address", address.Hex()))
+		}
+	}
+}
+
+// emitOwnershipChanged emits event and sends signal when ownership changes for an account/chain
+func (s *Service) emitOwnershipChanged(chainID uint64, account common.Address) {
+	// Emit event to publisher
+	if s.publisher != nil {
+		pubsub.Publish(s.publisher, EventOwnershipChanged{
+			ChainID: chainID,
+			Account: account,
+		})
+	}
+
+	// Send wallet signal
+	signal.SendWalletEvent(SignalOwnershipChanged, SignalOwnershipChangedPayload{
+		ChainID: chainID,
+		Account: account,
+	})
+}

--- a/services/wallet/tokenhistoricalownership/service_test.go
+++ b/services/wallet/tokenhistoricalownership/service_test.go
@@ -1,0 +1,661 @@
+package tokenhistoricalownership_test
+
+import (
+	"database/sql"
+	"math/big"
+	"testing"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+
+	"github.com/status-im/status-go/internal/db/walletdatabase"
+	"github.com/status-im/status-go/internal/testutils"
+	"github.com/status-im/status-go/pkg/pubsub"
+	"github.com/status-im/status-go/services/accounts/accountsevent"
+	af "github.com/status-im/status-go/services/wallet/activityfetcher"
+	"github.com/status-im/status-go/services/wallet/tokenbalances"
+	"github.com/status-im/status-go/services/wallet/tokenhistoricalownership"
+	mock "github.com/status-im/status-go/services/wallet/tokenhistoricalownership/mock"
+	"github.com/status-im/status-go/services/wallet/transferdetector"
+
+	gethTypes "github.com/ethereum/go-ethereum/core/types"
+	"github.com/status-im/go-wallet-sdk/pkg/contracts/erc20"
+	"github.com/status-im/go-wallet-sdk/pkg/contracts/erc721"
+	"github.com/status-im/go-wallet-sdk/pkg/eventlog"
+)
+
+func setupTestDB(t *testing.T) (*sql.DB, func()) {
+	db, err := testutils.SetupTestMemorySQLDB(walletdatabase.DbInitializer{})
+	require.NoError(t, err)
+	return db, func() {
+		require.NoError(t, db.Close())
+	}
+}
+
+func TestServiceLifecycle(t *testing.T) {
+	db, close := setupTestDB(t)
+	defer close()
+
+	storage := tokenhistoricalownership.NewStorage(db)
+	activityPublisher := pubsub.NewPublisher()
+	balancesPublisher := pubsub.NewPublisher()
+	transferPublisher := pubsub.NewPublisher()
+	accountsPublisher := pubsub.NewPublisher()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockActivityProvider := mock.NewMockActivityTokenProvider(ctrl)
+	mockBalancesProvider := mock.NewMockTokenBalancesProvider(ctrl)
+
+	service := tokenhistoricalownership.NewService(
+		db,
+		storage,
+		activityPublisher,
+		mockActivityProvider,
+		mockBalancesProvider,
+		balancesPublisher,
+		transferPublisher,
+		accountsPublisher,
+	)
+
+	// Test Start
+	err := service.Start()
+	require.NoError(t, err)
+	// Note: We can't access private fields (started, stopCh) from _test package
+	// These assertions would need to be removed or tested indirectly
+
+	// Test double Start (should be idempotent)
+	err = service.Start()
+	require.NoError(t, err)
+
+	// Test Stop
+	service.Stop()
+
+	// Test double Stop (should be idempotent)
+	service.Stop()
+}
+
+func TestGetPublisher(t *testing.T) {
+	db, close := setupTestDB(t)
+	defer close()
+
+	storage := tokenhistoricalownership.NewStorage(db)
+	service := tokenhistoricalownership.NewService(
+		db,
+		storage,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+	)
+
+	pub := service.GetPublisher()
+	assert.NotNil(t, pub)
+}
+
+func TestMarkAsPreviouslyOwned(t *testing.T) {
+	db, close := setupTestDB(t)
+	defer close()
+
+	storage := tokenhistoricalownership.NewStorage(db)
+	service := tokenhistoricalownership.NewService(
+		db,
+		storage,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+	)
+
+	address := common.HexToAddress("0x1234567890123456789012345678901234567890")
+	tokenAddress := common.HexToAddress("0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48")
+	chainID := uint64(1)
+
+	// First call should return true (new entry)
+	isNew, err := service.MarkAsPreviouslyOwned(address, chainID, tokenAddress)
+	require.NoError(t, err)
+	assert.True(t, isNew)
+
+	// Second call should return false (already exists)
+	isNew, err = service.MarkAsPreviouslyOwned(address, chainID, tokenAddress)
+	require.NoError(t, err)
+	assert.False(t, isNew)
+
+	// Verify it's stored
+	isOwned, err := service.IsOwned(address, chainID, tokenAddress)
+	require.NoError(t, err)
+	assert.True(t, isOwned)
+}
+
+func TestGetOwnedTokens(t *testing.T) {
+	db, close := setupTestDB(t)
+	defer close()
+
+	storage := tokenhistoricalownership.NewStorage(db)
+	service := tokenhistoricalownership.NewService(
+		db,
+		storage,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+	)
+
+	address := common.HexToAddress("0x1234567890123456789012345678901234567890")
+	token1 := common.HexToAddress("0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48")
+	token2 := common.HexToAddress("0xdAC17F958D2ee523a2206206994597C13D831ec7")
+	chainID1 := uint64(1)
+	chainID2 := uint64(5)
+
+	// Mark some tokens as owned
+	_, err := service.MarkAsPreviouslyOwned(address, chainID1, token1)
+	require.NoError(t, err)
+
+	_, err = service.MarkAsPreviouslyOwned(address, chainID2, token2)
+	require.NoError(t, err)
+
+	// Get all owned tokens
+	tokens, err := service.GetOwnedTokens(address)
+	require.NoError(t, err)
+	assert.Len(t, tokens, 2)
+
+	// Verify token addresses are in the result
+	addresses := []common.Address{tokens[0].TokenAddress, tokens[1].TokenAddress}
+	assert.Contains(t, addresses, token1)
+	assert.Contains(t, addresses, token2)
+}
+
+func TestGetOwnedTokensByChain(t *testing.T) {
+	db, close := setupTestDB(t)
+	defer close()
+
+	storage := tokenhistoricalownership.NewStorage(db)
+	service := tokenhistoricalownership.NewService(
+		db,
+		storage,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+	)
+
+	address := common.HexToAddress("0x1234567890123456789012345678901234567890")
+	token1 := common.HexToAddress("0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48")
+	token2 := common.HexToAddress("0xdAC17F958D2ee523a2206206994597C13D831ec7")
+	token3 := common.HexToAddress("0x6B175474E89094C44Da98b954EedeAC495271d0F")
+	chainID1 := uint64(1)
+	chainID2 := uint64(5)
+
+	// Mark tokens as owned on different chains
+	_, err := service.MarkAsPreviouslyOwned(address, chainID1, token1)
+	require.NoError(t, err)
+
+	_, err = service.MarkAsPreviouslyOwned(address, chainID1, token2)
+	require.NoError(t, err)
+
+	_, err = service.MarkAsPreviouslyOwned(address, chainID2, token3)
+	require.NoError(t, err)
+
+	// Get tokens for chain 1
+	tokens, err := service.GetOwnedTokensByChain(address, chainID1)
+	require.NoError(t, err)
+	assert.Len(t, tokens, 2)
+
+	// Verify token addresses
+	addresses := []common.Address{tokens[0].TokenAddress, tokens[1].TokenAddress}
+	assert.Contains(t, addresses, token1)
+	assert.Contains(t, addresses, token2)
+
+	// Get tokens for chain 2
+	tokens, err = service.GetOwnedTokensByChain(address, chainID2)
+	require.NoError(t, err)
+	assert.Len(t, tokens, 1)
+	assert.Equal(t, token3, tokens[0].TokenAddress)
+}
+
+func TestGetOwnedTokenKeys(t *testing.T) {
+	db, close := setupTestDB(t)
+	defer close()
+
+	storage := tokenhistoricalownership.NewStorage(db)
+	service := tokenhistoricalownership.NewService(
+		db,
+		storage,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+	)
+
+	address := common.HexToAddress("0x1234567890123456789012345678901234567890")
+	token1 := common.HexToAddress("0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48")
+	chainID := uint64(1)
+
+	// Mark token as owned
+	_, err := service.MarkAsPreviouslyOwned(address, chainID, token1)
+	require.NoError(t, err)
+
+	// Get token keys
+	keys, err := service.GetOwnedTokenKeys(address)
+	require.NoError(t, err)
+	assert.Len(t, keys, 1)
+	assert.Equal(t, "1-0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48", keys[0])
+}
+
+func TestHandleActivityDetected(t *testing.T) {
+	db, close := setupTestDB(t)
+	defer close()
+
+	storage := tokenhistoricalownership.NewStorage(db)
+	activityPublisher := pubsub.NewPublisher()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockActivityProvider := mock.NewMockActivityTokenProvider(ctrl)
+
+	service := tokenhistoricalownership.NewService(
+		db,
+		storage,
+		activityPublisher,
+		mockActivityProvider,
+		nil,
+		nil,
+		nil,
+		nil,
+	)
+
+	address := common.HexToAddress("0x1234567890123456789012345678901234567890")
+	nativeToken := common.HexToAddress("0x0000000000000000000000000000000000000000")
+	erc20Token := common.HexToAddress("0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48")
+	chainID := uint64(1)
+
+	// Mock GetActivityTokens to return some tokens
+	mockActivityProvider.EXPECT().
+		GetActivityTokens(chainID, address).
+		Return([]af.ActivityToken{
+			{Address: nativeToken, IsNative: true},
+			{Address: erc20Token, IsNative: false},
+		}, nil)
+
+	// Subscribe to ownership changed events
+	pub := service.GetPublisher()
+	ch, unsub := pubsub.Subscribe[tokenhistoricalownership.EventOwnershipChanged](pub, 10)
+	defer unsub()
+
+	// Start service to enable event processing
+	err := service.Start()
+	require.NoError(t, err)
+	defer service.Stop()
+
+	// Give service time to start goroutines
+	time.Sleep(10 * time.Millisecond)
+
+	// Publish activity detected event (will be processed by handleActivityDetected)
+	event := af.EventActivityDetected{
+		ChainID: chainID,
+		Account: address,
+	}
+	pubsub.Publish(activityPublisher, event)
+
+	// Give it time to process
+	time.Sleep(200 * time.Millisecond)
+
+	// Verify tokens were marked as owned
+	isOwned, err := service.IsOwned(address, chainID, nativeToken)
+	require.NoError(t, err)
+	assert.True(t, isOwned)
+
+	isOwned, err = service.IsOwned(address, chainID, erc20Token)
+	require.NoError(t, err)
+	assert.True(t, isOwned)
+
+	// Verify ownership changed event was published
+	select {
+	case publishedEvent := <-ch:
+		assert.Equal(t, chainID, publishedEvent.ChainID)
+		assert.Equal(t, address, publishedEvent.Account)
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("Event was not published")
+	}
+}
+
+func TestHandleBalanceFetchFinished(t *testing.T) {
+	db, close := setupTestDB(t)
+	defer close()
+
+	storage := tokenhistoricalownership.NewStorage(db)
+	balancesPublisher := pubsub.NewPublisher()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockBalancesProvider := mock.NewMockTokenBalancesProvider(ctrl)
+
+	service := tokenhistoricalownership.NewService(
+		db,
+		storage,
+		nil,
+		nil,
+		mockBalancesProvider,
+		balancesPublisher,
+		nil,
+		nil,
+	)
+
+	address := common.HexToAddress("0x1234567890123456789012345678901234567890")
+	nativeToken := common.HexToAddress("0x0000000000000000000000000000000000000000")
+	erc20Token := common.HexToAddress("0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48")
+	chainID := uint64(1)
+
+	// Mock GetAllBalancesForAccountAndChain to return some balances
+	balances := map[tokenbalances.ContractAddress]*big.Int{
+		tokenbalances.ContractAddress(nativeToken): big.NewInt(1000000000000000000), // 1 ETH
+		tokenbalances.ContractAddress(erc20Token):  big.NewInt(1000000),             // 1 USDC
+	}
+	mockBalancesProvider.EXPECT().
+		GetAllBalancesForAccountAndChain(gomock.Any(), tokenbalances.AccountAddress(address), chainID).
+		Return(balances, tokenbalances.State{}, nil)
+
+	// Subscribe to ownership changed events
+	pub := service.GetPublisher()
+	ch, unsub := pubsub.Subscribe[tokenhistoricalownership.EventOwnershipChanged](pub, 10)
+	defer unsub()
+
+	err := service.Start()
+	require.NoError(t, err)
+	defer service.Stop()
+
+	// Give service time to start goroutines
+	time.Sleep(10 * time.Millisecond)
+
+	// Publish balance fetch finished event
+	event := tokenbalances.EventBalanceFetchFinished{
+		ChainID:        chainID,
+		Account:        address,
+		BalanceChanged: true,
+	}
+	pubsub.Publish(balancesPublisher, event)
+
+	// Give it time to process
+	time.Sleep(200 * time.Millisecond)
+
+	// Verify tokens with balance > 0 were marked as owned
+	isOwned, err := service.IsOwned(address, chainID, nativeToken)
+	require.NoError(t, err)
+	assert.True(t, isOwned)
+
+	isOwned, err = service.IsOwned(address, chainID, erc20Token)
+	require.NoError(t, err)
+	assert.True(t, isOwned)
+
+	// Verify ownership changed event was published
+	select {
+	case publishedEvent := <-ch:
+		assert.Equal(t, chainID, publishedEvent.ChainID)
+		assert.Equal(t, address, publishedEvent.Account)
+	case <-time.After(200 * time.Millisecond):
+		t.Fatal("Event was not published")
+	}
+}
+
+func TestHandleBalanceFetchFinished_NoChange(t *testing.T) {
+	db, close := setupTestDB(t)
+	defer close()
+
+	storage := tokenhistoricalownership.NewStorage(db)
+	balancesPublisher := pubsub.NewPublisher()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockBalancesProvider := mock.NewMockTokenBalancesProvider(ctrl)
+
+	service := tokenhistoricalownership.NewService(
+		db,
+		storage,
+		nil,
+		nil,
+		mockBalancesProvider,
+		balancesPublisher,
+		nil,
+		nil,
+	)
+
+	address := common.HexToAddress("0x1234567890123456789012345678901234567890")
+	chainID := uint64(1)
+
+	// Balance didn't change, so GetAllBalancesForAccountAndChain should NOT be called
+	mockBalancesProvider.EXPECT().
+		GetAllBalancesForAccountAndChain(gomock.Any(), gomock.Any(), gomock.Any()).
+		Times(0)
+
+	err := service.Start()
+	require.NoError(t, err)
+	defer service.Stop()
+
+	// Publish balance fetch finished event with BalanceChanged = false
+	event := tokenbalances.EventBalanceFetchFinished{
+		ChainID:        chainID,
+		Account:        address,
+		BalanceChanged: false,
+	}
+	pubsub.Publish(balancesPublisher, event)
+
+	// Give it time to process
+	time.Sleep(50 * time.Millisecond)
+}
+
+func TestHandleTransferDetection_ERC20(t *testing.T) {
+	db, close := setupTestDB(t)
+	defer close()
+
+	storage := tokenhistoricalownership.NewStorage(db)
+	transferPublisher := pubsub.NewPublisher()
+
+	service := tokenhistoricalownership.NewService(
+		db,
+		storage,
+		nil,
+		nil,
+		nil,
+		nil,
+		transferPublisher,
+		nil,
+	)
+
+	recipient := common.HexToAddress("0x1234567890123456789012345678901234567890")
+	tokenAddress := common.HexToAddress("0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48")
+	chainID := uint64(1)
+
+	// Subscribe to ownership changed events
+	pub := service.GetPublisher()
+	ch, unsub := pubsub.Subscribe[tokenhistoricalownership.EventOwnershipChanged](pub, 10)
+	defer unsub()
+
+	err := service.Start()
+	require.NoError(t, err)
+	defer service.Stop()
+
+	// Give service time to start goroutines
+	time.Sleep(10 * time.Millisecond)
+
+	// Create ERC20 transfer event
+	transferEvent := erc20.Erc20Transfer{
+		From:  common.HexToAddress("0x0000000000000000000000000000000000000000"),
+		To:    recipient,
+		Value: big.NewInt(1000000),
+		Raw: gethTypes.Log{
+			Address: tokenAddress,
+		},
+	}
+
+	// Publish transfer detection finished event
+	event := transferdetector.EventTransferDetectionFinished{
+		ChainID: chainID,
+		Events: []eventlog.Event{
+			{
+				EventKey: eventlog.ERC20Transfer,
+				Unpacked: transferEvent,
+			},
+		},
+	}
+	pubsub.Publish(transferPublisher, event)
+
+	// Give it time to process
+	time.Sleep(200 * time.Millisecond)
+
+	// Verify token was marked as owned
+	isOwned, err := service.IsOwned(recipient, chainID, tokenAddress)
+	require.NoError(t, err)
+	assert.True(t, isOwned)
+
+	// Verify ownership changed event was published
+	select {
+	case publishedEvent := <-ch:
+		assert.Equal(t, chainID, publishedEvent.ChainID)
+		assert.Equal(t, recipient, publishedEvent.Account)
+	case <-time.After(200 * time.Millisecond):
+		t.Fatal("Event was not published")
+	}
+}
+
+func TestHandleTransferDetection_ERC721(t *testing.T) {
+	db, close := setupTestDB(t)
+	defer close()
+
+	storage := tokenhistoricalownership.NewStorage(db)
+	transferPublisher := pubsub.NewPublisher()
+
+	service := tokenhistoricalownership.NewService(
+		db,
+		storage,
+		nil,
+		nil,
+		nil,
+		nil,
+		transferPublisher,
+		nil,
+	)
+
+	recipient := common.HexToAddress("0x1234567890123456789012345678901234567890")
+	tokenAddress := common.HexToAddress("0xBC4CA0EdA7647A8aB7C2061c2E118A18a936f13D")
+	chainID := uint64(1)
+
+	err := service.Start()
+	require.NoError(t, err)
+	defer service.Stop()
+
+	// Give service time to start goroutines
+	time.Sleep(10 * time.Millisecond)
+
+	// Create ERC721 transfer event
+	transferEvent := erc721.Erc721Transfer{
+		From:    common.HexToAddress("0x0000000000000000000000000000000000000000"),
+		To:      recipient,
+		TokenId: big.NewInt(1),
+		Raw: gethTypes.Log{
+			Address: tokenAddress,
+		},
+	}
+
+	// Publish transfer detection finished event
+	event := transferdetector.EventTransferDetectionFinished{
+		ChainID: chainID,
+		Events: []eventlog.Event{
+			{
+				EventKey: eventlog.ERC721Transfer,
+				Unpacked: transferEvent,
+			},
+		},
+	}
+	pubsub.Publish(transferPublisher, event)
+
+	// Give it time to process
+	time.Sleep(200 * time.Millisecond)
+
+	// Verify token was marked as owned
+	isOwned, err := service.IsOwned(recipient, chainID, tokenAddress)
+	require.NoError(t, err)
+	assert.True(t, isOwned)
+}
+
+func TestHandleAccountsRemoved(t *testing.T) {
+	db, close := setupTestDB(t)
+	defer close()
+
+	storage := tokenhistoricalownership.NewStorage(db)
+	accountsPublisher := pubsub.NewPublisher()
+
+	service := tokenhistoricalownership.NewService(
+		db,
+		storage,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		accountsPublisher,
+	)
+
+	address1 := common.HexToAddress("0x1234567890123456789012345678901234567890")
+	address2 := common.HexToAddress("0x2234567890123456789012345678901234567890")
+	tokenAddress := common.HexToAddress("0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48")
+	chainID := uint64(1)
+
+	// Mark tokens as owned for both addresses
+	_, err := service.MarkAsPreviouslyOwned(address1, chainID, tokenAddress)
+	require.NoError(t, err)
+
+	_, err = service.MarkAsPreviouslyOwned(address2, chainID, tokenAddress)
+	require.NoError(t, err)
+
+	// Verify both are owned
+	isOwned, err := service.IsOwned(address1, chainID, tokenAddress)
+	require.NoError(t, err)
+	assert.True(t, isOwned)
+
+	isOwned, err = service.IsOwned(address2, chainID, tokenAddress)
+	require.NoError(t, err)
+	assert.True(t, isOwned)
+
+	err = service.Start()
+	require.NoError(t, err)
+	defer service.Stop()
+
+	// Give service time to start goroutines
+	time.Sleep(10 * time.Millisecond)
+
+	// Publish account removed event
+	event := accountsevent.AccountsRemovedEvent{
+		Accounts: []common.Address{address1},
+	}
+	pubsub.Publish(accountsPublisher, event)
+
+	// Give it time to process
+	time.Sleep(200 * time.Millisecond)
+
+	// Verify address1 tokens were removed
+	isOwned, err = service.IsOwned(address1, chainID, tokenAddress)
+	require.NoError(t, err)
+	assert.False(t, isOwned)
+
+	// Verify address2 tokens still exist
+	isOwned, err = service.IsOwned(address2, chainID, tokenAddress)
+	require.NoError(t, err)
+	assert.True(t, isOwned)
+}

--- a/services/wallet/tokenhistoricalownership/signals.go
+++ b/services/wallet/tokenhistoricalownership/signals.go
@@ -1,0 +1,22 @@
+package tokenhistoricalownership
+
+import (
+	"github.com/ethereum/go-ethereum/common"
+
+	"github.com/status-im/status-go/signal"
+)
+
+const (
+	SignalOwnershipChanged = signal.SignalType("wallet.token-historical-ownership.changed")
+)
+
+type SignalOwnershipChangedPayload struct {
+	ChainID uint64         `json:"chainId"`
+	Account common.Address `json:"account"`
+}
+
+// Event types for publisher
+type EventOwnershipChanged struct {
+	ChainID uint64
+	Account common.Address
+}

--- a/services/wallet/tokenhistoricalownership/storage.go
+++ b/services/wallet/tokenhistoricalownership/storage.go
@@ -1,0 +1,189 @@
+package tokenhistoricalownership
+
+//go:generate go tool mockgen -package=mock_tokenhistoricalownership -destination=mock/storage.go . StorageInterface
+
+import (
+	"database/sql"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common"
+)
+
+// TokenOwnership represents a historical token ownership record
+type TokenOwnership struct {
+	OwnerAddress common.Address
+	ChainID      uint64
+	TokenAddress common.Address
+	Timestamp    int64
+}
+
+// StorageInterface defines the interface for historical token ownership storage
+type StorageInterface interface {
+	MarkAsOwned(ownerAddress common.Address, chainID uint64, tokenAddress common.Address) (bool, error)
+	GetOwnedTokens(ownerAddress common.Address) ([]TokenOwnership, error)
+	GetOwnedTokensByChain(ownerAddress common.Address, chainID uint64) ([]TokenOwnership, error)
+	IsOwned(ownerAddress common.Address, chainID uint64, tokenAddress common.Address) (bool, error)
+	RemoveOwnerRecords(ownerAddress common.Address) error
+}
+
+// Storage handles persistence of historical token ownership
+type Storage struct {
+	db *sql.DB
+}
+
+// NewStorage creates a new storage instance
+func NewStorage(db *sql.DB) *Storage {
+	return &Storage{db: db}
+}
+
+// MarkAsOwned records a token as owned by an address
+// Returns true if this is a new entry, false if it already existed
+func (s *Storage) MarkAsOwned(ownerAddress common.Address, chainID uint64, tokenAddress common.Address) (bool, error) {
+	timestamp := time.Now().Unix()
+
+	// Check if the record already exists
+	var count int
+	checkQuery := `
+		SELECT COUNT(*) FROM token_historical_ownership
+		WHERE owner_address = ? AND chain_id = ? AND token_address = ?
+	`
+	err := s.db.QueryRow(checkQuery, ownerAddress.Hex(), chainID, tokenAddress.Hex()).Scan(&count)
+	if err != nil {
+		return false, err
+	}
+
+	if count > 0 {
+		// Record exists, update last_detected_timestamp
+		updateQuery := `
+			UPDATE token_historical_ownership
+			SET last_detected_timestamp = ?
+			WHERE owner_address = ? AND chain_id = ? AND token_address = ?
+		`
+		_, err := s.db.Exec(updateQuery, timestamp, ownerAddress.Hex(), chainID, tokenAddress.Hex())
+		if err != nil {
+			return false, err
+		}
+		return false, nil // Existing entry
+	}
+
+	// Record doesn't exist, insert it
+	insertQuery := `
+		INSERT INTO token_historical_ownership (owner_address, chain_id, token_address, first_detected_timestamp, last_detected_timestamp)
+		VALUES (?, ?, ?, ?, ?)
+	`
+	_, err = s.db.Exec(insertQuery, ownerAddress.Hex(), chainID, tokenAddress.Hex(), timestamp, timestamp)
+	if err != nil {
+		return false, err
+	}
+
+	return true, nil // New entry
+}
+
+// GetOwnedTokens returns all tokens ever owned by an address
+func (s *Storage) GetOwnedTokens(ownerAddress common.Address) ([]TokenOwnership, error) {
+	query := `
+		SELECT owner_address, chain_id, token_address, last_detected_timestamp
+		FROM token_historical_ownership
+		WHERE owner_address = ?
+		ORDER BY last_detected_timestamp DESC
+	`
+
+	rows, err := s.db.Query(query, ownerAddress.Hex())
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var tokens []TokenOwnership
+	for rows.Next() {
+		var (
+			ownerHex string
+			chainID  uint64
+			tokenHex string
+			ts       int64
+		)
+
+		if err := rows.Scan(&ownerHex, &chainID, &tokenHex, &ts); err != nil {
+			return nil, err
+		}
+
+		tokens = append(tokens, TokenOwnership{
+			OwnerAddress: common.HexToAddress(ownerHex),
+			ChainID:      chainID,
+			TokenAddress: common.HexToAddress(tokenHex),
+			Timestamp:    ts,
+		})
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+
+	return tokens, nil
+}
+
+// GetOwnedTokensByChain returns all tokens ever owned by an address on a specific chain
+func (s *Storage) GetOwnedTokensByChain(ownerAddress common.Address, chainID uint64) ([]TokenOwnership, error) {
+	query := `
+		SELECT owner_address, chain_id, token_address, last_detected_timestamp
+		FROM token_historical_ownership
+		WHERE owner_address = ? AND chain_id = ?
+		ORDER BY last_detected_timestamp DESC
+	`
+
+	rows, err := s.db.Query(query, ownerAddress.Hex(), chainID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var tokens []TokenOwnership
+	for rows.Next() {
+		var (
+			ownerHex string
+			chainID  uint64
+			tokenHex string
+			ts       int64
+		)
+
+		if err := rows.Scan(&ownerHex, &chainID, &tokenHex, &ts); err != nil {
+			return nil, err
+		}
+
+		tokens = append(tokens, TokenOwnership{
+			OwnerAddress: common.HexToAddress(ownerHex),
+			ChainID:      chainID,
+			TokenAddress: common.HexToAddress(tokenHex),
+			Timestamp:    ts,
+		})
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+
+	return tokens, nil
+}
+
+// IsOwned checks if a token was ever owned by an address
+func (s *Storage) IsOwned(ownerAddress common.Address, chainID uint64, tokenAddress common.Address) (bool, error) {
+	query := `
+		SELECT COUNT(*) FROM token_historical_ownership
+		WHERE owner_address = ? AND chain_id = ? AND token_address = ?
+	`
+
+	var count int
+	err := s.db.QueryRow(query, ownerAddress.Hex(), chainID, tokenAddress.Hex()).Scan(&count)
+	if err != nil {
+		return false, err
+	}
+
+	return count > 0, nil
+}
+
+// RemoveOwnerRecords removes all ownership records for an address (used when account is removed)
+func (s *Storage) RemoveOwnerRecords(ownerAddress common.Address) error {
+	query := `DELETE FROM token_historical_ownership WHERE owner_address = ?`
+	_, err := s.db.Exec(query, ownerAddress.Hex())
+	return err
+}

--- a/services/wallet/tokenhistoricalownership/storage_test.go
+++ b/services/wallet/tokenhistoricalownership/storage_test.go
@@ -1,0 +1,319 @@
+package tokenhistoricalownership
+
+import (
+	"database/sql"
+	"testing"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/status-im/status-go/internal/db/walletdatabase"
+	"github.com/status-im/status-go/internal/testutils"
+)
+
+func setupTestDB(t *testing.T) (*sql.DB, func()) {
+	db, err := testutils.SetupTestMemorySQLDB(walletdatabase.DbInitializer{})
+	require.NoError(t, err)
+	return db, func() {
+		require.NoError(t, db.Close())
+	}
+}
+
+func TestStorage_MarkAsOwned(t *testing.T) {
+	db, close := setupTestDB(t)
+	defer close()
+
+	storage := NewStorage(db)
+
+	address := common.HexToAddress("0x1234567890123456789012345678901234567890")
+	tokenAddress := common.HexToAddress("0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48")
+	chainID := uint64(1)
+
+	// First call should return true (new entry)
+	isNew, err := storage.MarkAsOwned(address, chainID, tokenAddress)
+	require.NoError(t, err)
+	assert.True(t, isNew)
+
+	// Second call should return false (already exists)
+	isNew, err = storage.MarkAsOwned(address, chainID, tokenAddress)
+	require.NoError(t, err)
+	assert.False(t, isNew)
+
+	// Different token should return true
+	tokenAddress2 := common.HexToAddress("0xdAC17F958D2ee523a2206206994597C13D831ec7")
+	isNew, err = storage.MarkAsOwned(address, chainID, tokenAddress2)
+	require.NoError(t, err)
+	assert.True(t, isNew)
+
+	// Same token on different chain should return true
+	chainID2 := uint64(5)
+	isNew, err = storage.MarkAsOwned(address, chainID2, tokenAddress)
+	require.NoError(t, err)
+	assert.True(t, isNew)
+}
+
+func TestStorage_GetOwnedTokens(t *testing.T) {
+	db, close := setupTestDB(t)
+	defer close()
+
+	storage := NewStorage(db)
+
+	address := common.HexToAddress("0x1234567890123456789012345678901234567890")
+	token1 := common.HexToAddress("0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48")
+	token2 := common.HexToAddress("0xdAC17F958D2ee523a2206206994597C13D831ec7")
+	chainID1 := uint64(1)
+	chainID2 := uint64(5)
+
+	// Initially should be empty
+	tokens, err := storage.GetOwnedTokens(address)
+	require.NoError(t, err)
+	assert.Empty(t, tokens)
+
+	// Mark some tokens as owned
+	_, err = storage.MarkAsOwned(address, chainID1, token1)
+	require.NoError(t, err)
+
+	time.Sleep(10 * time.Millisecond) // Ensure different timestamps
+
+	_, err = storage.MarkAsOwned(address, chainID2, token2)
+	require.NoError(t, err)
+
+	// Get all owned tokens
+	tokens, err = storage.GetOwnedTokens(address)
+	require.NoError(t, err)
+	assert.Len(t, tokens, 2)
+
+	// Verify token addresses are in the result
+	addresses := []common.Address{tokens[0].TokenAddress, tokens[1].TokenAddress}
+	assert.Contains(t, addresses, token1)
+	assert.Contains(t, addresses, token2)
+
+	// Verify all fields are set correctly
+	for _, token := range tokens {
+		assert.Equal(t, address, token.OwnerAddress)
+		assert.Contains(t, []uint64{chainID1, chainID2}, token.ChainID)
+		assert.Greater(t, token.Timestamp, int64(0))
+	}
+
+	// Different address should return empty
+	address2 := common.HexToAddress("0x2234567890123456789012345678901234567890")
+	tokens, err = storage.GetOwnedTokens(address2)
+	require.NoError(t, err)
+	assert.Empty(t, tokens)
+}
+
+func TestStorage_GetOwnedTokensByChain(t *testing.T) {
+	db, close := setupTestDB(t)
+	defer close()
+
+	storage := NewStorage(db)
+
+	address := common.HexToAddress("0x1234567890123456789012345678901234567890")
+	token1 := common.HexToAddress("0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48")
+	token2 := common.HexToAddress("0xdAC17F958D2ee523a2206206994597C13D831ec7")
+	token3 := common.HexToAddress("0x6B175474E89094C44Da98b954EedeAC495271d0F")
+	chainID1 := uint64(1)
+	chainID2 := uint64(5)
+
+	// Mark tokens as owned on different chains
+	_, err := storage.MarkAsOwned(address, chainID1, token1)
+	require.NoError(t, err)
+
+	time.Sleep(10 * time.Millisecond)
+
+	_, err = storage.MarkAsOwned(address, chainID1, token2)
+	require.NoError(t, err)
+
+	time.Sleep(10 * time.Millisecond)
+
+	_, err = storage.MarkAsOwned(address, chainID2, token3)
+	require.NoError(t, err)
+
+	// Get tokens for chain 1
+	tokens, err := storage.GetOwnedTokensByChain(address, chainID1)
+	require.NoError(t, err)
+	assert.Len(t, tokens, 2)
+
+	// Verify token addresses
+	addresses := []common.Address{tokens[0].TokenAddress, tokens[1].TokenAddress}
+	assert.Contains(t, addresses, token1)
+	assert.Contains(t, addresses, token2)
+
+	// Verify all are on chain 1
+	for _, token := range tokens {
+		assert.Equal(t, chainID1, token.ChainID)
+		assert.Equal(t, address, token.OwnerAddress)
+	}
+
+	// Get tokens for chain 2
+	tokens, err = storage.GetOwnedTokensByChain(address, chainID2)
+	require.NoError(t, err)
+	assert.Len(t, tokens, 1)
+	assert.Equal(t, token3, tokens[0].TokenAddress)
+	assert.Equal(t, chainID2, tokens[0].ChainID)
+	assert.Equal(t, address, tokens[0].OwnerAddress)
+
+	// Get tokens for non-existent chain
+	tokens, err = storage.GetOwnedTokensByChain(address, uint64(999))
+	require.NoError(t, err)
+	assert.Empty(t, tokens)
+}
+
+func TestStorage_IsOwned(t *testing.T) {
+	db, close := setupTestDB(t)
+	defer close()
+
+	storage := NewStorage(db)
+
+	address := common.HexToAddress("0x1234567890123456789012345678901234567890")
+	tokenAddress := common.HexToAddress("0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48")
+	chainID := uint64(1)
+
+	// Initially should not be owned
+	isOwned, err := storage.IsOwned(address, chainID, tokenAddress)
+	require.NoError(t, err)
+	assert.False(t, isOwned)
+
+	// Mark as owned
+	_, err = storage.MarkAsOwned(address, chainID, tokenAddress)
+	require.NoError(t, err)
+
+	// Now should be owned
+	isOwned, err = storage.IsOwned(address, chainID, tokenAddress)
+	require.NoError(t, err)
+	assert.True(t, isOwned)
+
+	// Different token should not be owned
+	tokenAddress2 := common.HexToAddress("0xdAC17F958D2ee523a2206206994597C13D831ec7")
+	isOwned, err = storage.IsOwned(address, chainID, tokenAddress2)
+	require.NoError(t, err)
+	assert.False(t, isOwned)
+
+	// Same token on different chain should not be owned
+	chainID2 := uint64(5)
+	isOwned, err = storage.IsOwned(address, chainID2, tokenAddress)
+	require.NoError(t, err)
+	assert.False(t, isOwned)
+
+	// Mark it on different chain
+	_, err = storage.MarkAsOwned(address, chainID2, tokenAddress)
+	require.NoError(t, err)
+
+	// Now should be owned on both chains
+	isOwned, err = storage.IsOwned(address, chainID, tokenAddress)
+	require.NoError(t, err)
+	assert.True(t, isOwned)
+
+	isOwned, err = storage.IsOwned(address, chainID2, tokenAddress)
+	require.NoError(t, err)
+	assert.True(t, isOwned)
+}
+
+func TestStorage_RemoveOwnerRecords(t *testing.T) {
+	db, close := setupTestDB(t)
+	defer close()
+
+	storage := NewStorage(db)
+
+	address1 := common.HexToAddress("0x1234567890123456789012345678901234567890")
+	address2 := common.HexToAddress("0x2234567890123456789012345678901234567890")
+	tokenAddress := common.HexToAddress("0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48")
+	chainID1 := uint64(1)
+	chainID2 := uint64(5)
+
+	// Mark tokens as owned for both addresses
+	_, err := storage.MarkAsOwned(address1, chainID1, tokenAddress)
+	require.NoError(t, err)
+
+	_, err = storage.MarkAsOwned(address1, chainID2, tokenAddress)
+	require.NoError(t, err)
+
+	_, err = storage.MarkAsOwned(address2, chainID1, tokenAddress)
+	require.NoError(t, err)
+
+	// Verify both are owned
+	isOwned, err := storage.IsOwned(address1, chainID1, tokenAddress)
+	require.NoError(t, err)
+	assert.True(t, isOwned)
+
+	isOwned, err = storage.IsOwned(address1, chainID2, tokenAddress)
+	require.NoError(t, err)
+	assert.True(t, isOwned)
+
+	isOwned, err = storage.IsOwned(address2, chainID1, tokenAddress)
+	require.NoError(t, err)
+	assert.True(t, isOwned)
+
+	// Remove records for address1
+	err = storage.RemoveOwnerRecords(address1)
+	require.NoError(t, err)
+
+	// Verify address1 tokens were removed
+	isOwned, err = storage.IsOwned(address1, chainID1, tokenAddress)
+	require.NoError(t, err)
+	assert.False(t, isOwned)
+
+	isOwned, err = storage.IsOwned(address1, chainID2, tokenAddress)
+	require.NoError(t, err)
+	assert.False(t, isOwned)
+
+	// Verify address2 tokens still exist
+	isOwned, err = storage.IsOwned(address2, chainID1, tokenAddress)
+	require.NoError(t, err)
+	assert.True(t, isOwned)
+
+	// Verify GetOwnedTokens returns empty for address1
+	tokens, err := storage.GetOwnedTokens(address1)
+	require.NoError(t, err)
+	assert.Empty(t, tokens)
+
+	// Verify GetOwnedTokens still returns tokens for address2
+	tokens, err = storage.GetOwnedTokens(address2)
+	require.NoError(t, err)
+	assert.Len(t, tokens, 1)
+	assert.Equal(t, tokenAddress, tokens[0].TokenAddress)
+}
+
+func TestStorage_GetOwnedTokens_Ordering(t *testing.T) {
+	db, close := setupTestDB(t)
+	defer close()
+
+	storage := NewStorage(db)
+
+	address := common.HexToAddress("0x1234567890123456789012345678901234567890")
+	token1 := common.HexToAddress("0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48")
+	token2 := common.HexToAddress("0xdAC17F958D2ee523a2206206994597C13D831ec7")
+	token3 := common.HexToAddress("0x6B175474E89094C44Da98b954EedeAC495271d0F")
+	chainID := uint64(1)
+
+	// Mark tokens with delays to ensure different timestamps
+	// Use 1 second delays since time.Now().Unix() has second precision
+	_, err := storage.MarkAsOwned(address, chainID, token1)
+	require.NoError(t, err)
+
+	time.Sleep(1100 * time.Millisecond) // 1.1 seconds to ensure different timestamp
+
+	_, err = storage.MarkAsOwned(address, chainID, token2)
+	require.NoError(t, err)
+
+	time.Sleep(1100 * time.Millisecond) // 1.1 seconds to ensure different timestamp
+
+	_, err = storage.MarkAsOwned(address, chainID, token3)
+	require.NoError(t, err)
+
+	// Get tokens - should be ordered by timestamp DESC (newest first)
+	tokens, err := storage.GetOwnedTokens(address)
+	require.NoError(t, err)
+	assert.Len(t, tokens, 3)
+
+	// Verify ordering (newest first) - token3 was last, so should be first
+	assert.Equal(t, token3, tokens[0].TokenAddress)
+	assert.Equal(t, token2, tokens[1].TokenAddress)
+	assert.Equal(t, token1, tokens[2].TokenAddress)
+
+	// Verify timestamps are in descending order
+	assert.GreaterOrEqual(t, tokens[0].Timestamp, tokens[1].Timestamp)
+	assert.GreaterOrEqual(t, tokens[1].Timestamp, tokens[2].Timestamp)
+}


### PR DESCRIPTION
Add new tokenhistoricalownership service to track tokens that have been previously owned by wallet addresses. 

Changes:
- Add tokenhistoricalownership service with storage layer
- Track tokens from activity history, balance changes, and transfers
- Add database migration for token_historical_ownership table
- Implement MarkAsPreviouslyOwned and GetOwnedTokenKeys methods
- Add publisher for ownership change events
- Include comprehensive unit tests with gomock mocks

The service aggregates token ownership data from:
1. Activity events (via ActivityTokenProvider)
2. Balance changes (via TokenBalancesProvider)
3. Transfer events (via TransferDetectorProvider)

This module will be integrated into wallet service in a future commit.

