### PR TITLE
fix: improvements on swap and tokens for the active mode preparation

### DIFF
--- a/services/wallet/router/pathprocessor/processor_swap_paraswap.go
+++ b/services/wallet/router/pathprocessor/processor_swap_paraswap.go
@@ -35,6 +35,10 @@ const (
 	ParaswapPartnerID = "status.app"
 )
 
+var (
+	paraswapNativeTokenAddress = common.HexToAddress("0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee")
+)
+
 func getPartnerAddressAndFeePcnt(chainID uint64) (common.Address, float64) {
 	const partnerFeePcnt = 0.7
 
@@ -134,22 +138,28 @@ func (s *SwapParaswapProcessor) CalculateFees(params ProcessorInputParams) (*big
 	return walletCommon.ZeroBigIntValue(), walletCommon.ZeroBigIntValue(), nil
 }
 
+func getFromAndToTokenAddresses(params ProcessorInputParams) (common.Address, common.Address) {
+	fromTokenAddress := params.FromToken.Address
+	toTokenAddress := params.ToToken.Address
+	if params.FromToken.IsNative() {
+		fromTokenAddress = paraswapNativeTokenAddress
+	}
+	if params.ToToken.IsNative() {
+		toTokenAddress = paraswapNativeTokenAddress
+	}
+	return fromTokenAddress, toTokenAddress
+}
+
 func (s *SwapParaswapProcessor) fetchAndStorePriceRoute(params ProcessorInputParams) (*paraswap.Route, error) {
 	swapSide := paraswap.SellSide
 	if params.AmountOut != nil && params.AmountOut.Cmp(walletCommon.ZeroBigIntValue()) > 0 {
 		swapSide = paraswap.BuySide
 	}
 
-	// TODO: this is an extra check, we should remove it once we set the proper address for the native (ETH/BNB) token
-	if params.FromToken.IsNative() {
-		params.FromToken.Address = common.HexToAddress("0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee") // ETH address across all chains that we support
-	}
-	if params.ToToken.IsNative() {
-		params.ToToken.Address = common.HexToAddress("0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee") // ETH address across all chains that we support
-	}
+	fromTokenAddress, toTokenAddress := getFromAndToTokenAddresses(params)
 
-	priceRoute, err := s.paraswapClient.FetchPriceRoute(context.Background(), params.FromToken.Address, params.FromToken.Decimals,
-		params.ToToken.Address, params.ToToken.Decimals, params.AmountIn, params.FromAddr, params.ToAddr, swapSide)
+	priceRoute, err := s.paraswapClient.FetchPriceRoute(context.Background(), fromTokenAddress, params.FromToken.Decimals,
+		toTokenAddress, params.ToToken.Decimals, params.AmountIn, params.FromAddr, params.ToAddr, swapSide)
 	if err != nil {
 		return nil, createSwapParaswapErrorResponse(err)
 	}

--- a/services/wallet/token/token.go
+++ b/services/wallet/token/token.go
@@ -396,6 +396,53 @@ func (tm *Manager) GetTokensForActiveNetworksMode() ([]*tokentypes.Token, error)
 	return tm.GetTokensByChains(chainIDs)
 }
 
+// addTokensSharingCrossChainIDsToUsedTokenKeys adds all tokens that share the same cross chain id to the used tokens keys.
+func (tm *Manager) addTokensSharingCrossChainIDsToUsedTokenKeys(usedTokensKeys map[string]interface{}, testnetMode bool) error {
+	tokens, err := tm.GetTokensByKeys(maps.Keys(usedTokensKeys))
+	if err != nil {
+		return err
+	}
+
+	crossChainIDs := make([]string, 0)
+	for _, token := range tokens {
+		if token.CrossChainID == "" {
+			continue
+		}
+		crossChainIDs = append(crossChainIDs, token.CrossChainID)
+	}
+
+	if len(crossChainIDs) == 0 {
+		return nil
+	}
+
+	tokensByCrossChainIDs := make(map[string][]*tokentypes.Token)
+	wsdkTokens := tm.tokensManager.UniqueTokens()
+
+	for _, token := range wsdkTokens {
+		if token.CrossChainID == "" ||
+			testnetMode && walletcommon.ChainID(token.ChainID).IsMainnet() ||
+			!testnetMode && !walletcommon.ChainID(token.ChainID).IsMainnet() {
+			continue
+		}
+		tokensByCrossChainIDs[token.CrossChainID] = append(tokensByCrossChainIDs[token.CrossChainID], &tokentypes.Token{Token: token})
+	}
+
+	for _, crossChainID := range crossChainIDs {
+		tokens, ok := tokensByCrossChainIDs[crossChainID]
+		if !ok {
+			continue
+		}
+		for _, token := range tokens {
+			if _, ok := usedTokensKeys[token.Key()]; ok {
+				continue
+			}
+			usedTokensKeys[token.Key()] = nil
+		}
+	}
+
+	return nil
+}
+
 // getTokenKeysForTokensOfInterestForActiveNetworksMode returns the token keys for the tokens of interest for the active networks mode (testnet or mainnet)
 // On top of the used tokens keys, it adds all tokens that share the same cross chain id (because of grouping) and all mandatory tokens.
 func (tm *Manager) getTokenKeysForTokensOfInterestForActiveNetworksMode() ([]string, error) {
@@ -409,17 +456,10 @@ func (tm *Manager) getTokenKeysForTokensOfInterestForActiveNetworksMode() ([]str
 		return nil, err
 	}
 
-	tokens, err := tm.GetTokensByKeys(maps.Keys(usedTokensKeys))
+	// Because of grouping it's important to add all tokens that share the same cross chain id to the used tokens keys.
+	err = tm.addTokensSharingCrossChainIDsToUsedTokenKeys(usedTokensKeys, testnetMode)
 	if err != nil {
 		return nil, err
-	}
-
-	// Because of grouping it's important to add all tokens that share the same cross chain id to the used tokens keys
-	for _, token := range tokens {
-		if token.CrossChainID == "" {
-			continue
-		}
-		usedTokensKeys[token.Key()] = nil
 	}
 
 	// It's also important to add all mandatory tokens to the used tokens keys

--- a/services/wallet/token/token_test.go
+++ b/services/wallet/token/token_test.go
@@ -2,6 +2,7 @@ package token
 
 import (
 	"context"
+	"math/big"
 	"sync"
 	"testing"
 	"time"
@@ -330,6 +331,91 @@ func Test_tokensListsValidity(t *testing.T) {
 				}
 			}
 			require.Equal(t, 1, numOfOccurrences)
+		}
+	}
+}
+
+func TestGetTokensOfInterestForActiveNetworksMode_AddsCrossChainAndMandatoryTokens(t *testing.T) {
+	manager, _, stop := setupTestTokenManager(t)
+	defer stop()
+
+	require.NoError(t, manager.Start(context.Background()))
+	defer manager.Stop()
+
+	testnetMode, err := manager.settings.GetTestNetworksEnabled()
+	require.NoError(t, err)
+	require.False(t, testnetMode)
+
+	// Cache some tokens that are not among mandatory tokens and have cross chain id
+	err = manager.CacheBalances(map[common.Address][]tokentypes.StorageToken{
+		common.HexToAddress("0x0000000000000000000000000000000000000001"): {
+			{
+				TokenAddress: common.HexToAddress("0x514910771af9ca656af840dff83e8264ecf986ca"), // chainlink
+				TokenChainID: 1,
+				RawBalance:   "1000000000000000000",
+				Balance:      big.NewFloat(1),
+				HasError:     false,
+			},
+			{
+				TokenAddress: common.HexToAddress("0x6fd9d7ad17242c41f7131d257212c54a0e816691"), // uniswap
+				TokenChainID: 10,
+				RawBalance:   "1000000000000000000",
+				Balance:      big.NewFloat(1),
+				HasError:     false,
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	// token keys from cache, all of them have cross chain id
+	cachedTokenKeys := []string{
+		types.TokenKey(1, common.HexToAddress("0x514910771af9ca656af840dff83e8264ecf986ca")),
+		types.TokenKey(10, common.HexToAddress("0x6fd9d7ad17242c41f7131d257212c54a0e816691")),
+	}
+
+	// mandatory token keys for the active networks mode, all of them have cross chain id
+	mandatoryTokenKeysForMode := []string{}
+	for _, tokenKey := range walletcommon.MandatoryTokens() {
+		chainID, _, ok := types.ChainAndAddressFromTokenKey(tokenKey)
+		if !ok {
+			continue
+		}
+		if walletcommon.ChainID(chainID).IsMainnet() == testnetMode {
+			continue
+		}
+		mandatoryTokenKeysForMode = append(mandatoryTokenKeysForMode, tokenKey)
+	}
+
+	tokens, err := manager.GetTokensByKeys(append(cachedTokenKeys, mandatoryTokenKeysForMode...))
+	require.NoError(t, err)
+	require.NotEmpty(t, tokens)
+	require.Equal(t, len(cachedTokenKeys)+len(mandatoryTokenKeysForMode), len(tokens))
+
+	expectedCrossChainIDs := make(map[string]int)
+	for _, token := range tokens {
+		expectedCrossChainIDs[token.CrossChainID] = 0
+	}
+
+	tokensForActiveNetworksMode, err := manager.GetTokensOfInterestForActiveNetworksMode()
+	require.NoError(t, err)
+	require.NotEmpty(t, tokensForActiveNetworksMode)
+
+	for _, token := range tokensForActiveNetworksMode {
+		_, ok := expectedCrossChainIDs[token.CrossChainID]
+		require.True(t, ok, "token with cross chain id %s is not in the expected cross chain ids", token.CrossChainID)
+		expectedCrossChainIDs[token.CrossChainID]++
+	}
+
+	const (
+		bscNativeTokenCrossChainID = "bsc-native"   // nolint: gosec
+		bscUsdcTokenCrossChainID   = "usd-coin-bsc" // nolint: gosec
+	)
+	for crossChainID, count := range expectedCrossChainIDs {
+		switch crossChainID {
+		case bscNativeTokenCrossChainID, bscUsdcTokenCrossChainID:
+			require.Equal(t, count, 1, "expected 1 token with cross chain id %s, got %d", crossChainID, count)
+		default:
+			require.Greater(t, count, 1, "expected more than 1 token with cross chain id %s, got %d", crossChainID, count)
 		}
 	}
 }


### PR DESCRIPTION
- Paraswap processor updated to handle native token address without updating the token address of the ProcessorInputParams.
- When preparing tokens of interest, all tokens that share the same cross chain id are used now.
- Added tests to validate the inclusion of cross-chain and mandatory tokens in active networks mode.

Closes https://github.com/status-im/status-app/issues/19769