### PR TITLE
chore: Adapt code to use logos-messaging-go-bindings with nim-ffi

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -99,7 +99,7 @@ BUILD_TAGS ?= gowaku_no_rln
 
 ifeq ($(USE_NWAKU), true)
     BUILD_TAGS += use_nwaku
-    NWAKU_VERSION ?= v0.37.0-rc.3
+    NWAKU_VERSION ?= v0.37-with-ffi
     NWAKU_SOURCE_DIR ?= $(GIT_ROOT)/../nwaku
     LIBWAKU := $(NWAKU_SOURCE_DIR)/build/libwaku.$(LIB_EXT)
     CGO_CFLAGS+=-I$(NWAKU_SOURCE_DIR)/library

--- a/flake.lock
+++ b/flake.lock
@@ -31,7 +31,6 @@
       "locked": {
         "lastModified": 1766504822,
         "narHash": "sha256-tWVLbYoi8/xNzsbJmzMBnuc4GsB7/4oH05yCwuokKT8=",
-        "ref": "refs/heads/master",
         "rev": "fb8039c5a56086ec7fb3e5e1a5a593bb3756ccb6",
         "revCount": 76,
         "submodules": true,

--- a/flake.lock
+++ b/flake.lock
@@ -31,6 +31,7 @@
       "locked": {
         "lastModified": 1766504822,
         "narHash": "sha256-tWVLbYoi8/xNzsbJmzMBnuc4GsB7/4oH05yCwuokKT8=",
+        "ref": "refs/heads/master",
         "rev": "fb8039c5a56086ec7fb3e5e1a5a593bb3756ccb6",
         "revCount": 76,
         "submodules": true,

--- a/go.mod
+++ b/go.mod
@@ -115,7 +115,7 @@ require (
 )
 
 require (
-	github.com/logos-messaging/logos-messaging-go-bindings v0.0.0-20260206093723-95be7e9319be
+	github.com/logos-messaging/logos-messaging-go-bindings v0.0.0-20260207154548-84c0d57ed4ac
 	go.opentelemetry.io/otel v1.26.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.26.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.26.0

--- a/go.mod
+++ b/go.mod
@@ -115,7 +115,7 @@ require (
 )
 
 require (
-	github.com/logos-messaging/logos-messaging-go-bindings v0.0.0-20260125193545-66722e0a356b
+	github.com/logos-messaging/logos-messaging-go-bindings v0.0.0-20260125222137-088cc0f11b25
 	go.opentelemetry.io/otel v1.26.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.26.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.26.0

--- a/go.mod
+++ b/go.mod
@@ -115,7 +115,7 @@ require (
 )
 
 require (
-	github.com/logos-messaging/logos-messaging-go-bindings v0.0.0-20260207154548-84c0d57ed4ac
+	github.com/logos-messaging/logos-messaging-go-bindings v0.0.0-20260207160840-17fc5e00eef1
 	go.opentelemetry.io/otel v1.26.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.26.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.26.0

--- a/go.mod
+++ b/go.mod
@@ -115,7 +115,7 @@ require (
 )
 
 require (
-	github.com/logos-messaging/logos-messaging-go-bindings v0.0.0-20260125222137-088cc0f11b25
+	github.com/logos-messaging/logos-messaging-go-bindings v0.0.0-20260206093723-95be7e9319be
 	go.opentelemetry.io/otel v1.26.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.26.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.26.0

--- a/go.mod
+++ b/go.mod
@@ -115,7 +115,7 @@ require (
 )
 
 require (
-	github.com/logos-messaging/logos-messaging-go-bindings v0.0.0-20260108175826-d29cc2c463e5
+	github.com/logos-messaging/logos-messaging-go-bindings v0.0.0-20260125181314-e6dcad2b58b8
 	go.opentelemetry.io/otel v1.26.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.26.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.26.0

--- a/go.mod
+++ b/go.mod
@@ -115,7 +115,7 @@ require (
 )
 
 require (
-	github.com/logos-messaging/logos-messaging-go-bindings v0.0.0-20260125181314-e6dcad2b58b8
+	github.com/logos-messaging/logos-messaging-go-bindings v0.0.0-20260125193545-66722e0a356b
 	go.opentelemetry.io/otel v1.26.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.26.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.26.0

--- a/go.mod
+++ b/go.mod
@@ -318,6 +318,7 @@ require (
 	github.com/libp2p/go-netroute v0.2.2 // indirect
 	github.com/libp2p/go-reuseport v0.4.0 // indirect
 	github.com/libp2p/go-yamux/v4 v4.0.2 // indirect
+	github.com/logos-messaging/logos-messaging-go-bindings v0.0.0-20260108175826-d29cc2c463e5 // indirect
 	github.com/lufeee/execinquery v1.2.1 // indirect
 	github.com/magiconair/properties v1.8.7 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect

--- a/go.mod
+++ b/go.mod
@@ -104,7 +104,6 @@ require (
 	github.com/status-im/go-wallet-sdk v0.0.0-20260126140800-7bb3ccf032ab
 	github.com/waku-org/go-waku v0.10.1
 	github.com/waku-org/sds-go-bindings v0.0.0-20251222164514-d5b47a911904
-	github.com/waku-org/waku-go-bindings v0.0.0-20251202095947-63b01b7d0ca9
 	github.com/wk8/go-ordered-map/v2 v2.1.7
 	go.uber.org/atomic v1.11.0
 	go.uber.org/mock v0.6.0
@@ -116,6 +115,7 @@ require (
 )
 
 require (
+	github.com/logos-messaging/logos-messaging-go-bindings v0.0.0-20260108175826-d29cc2c463e5
 	go.opentelemetry.io/otel v1.26.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.26.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.26.0
@@ -318,7 +318,6 @@ require (
 	github.com/libp2p/go-netroute v0.2.2 // indirect
 	github.com/libp2p/go-reuseport v0.4.0 // indirect
 	github.com/libp2p/go-yamux/v4 v4.0.2 // indirect
-	github.com/logos-messaging/logos-messaging-go-bindings v0.0.0-20260108175826-d29cc2c463e5 // indirect
 	github.com/lufeee/execinquery v1.2.1 // indirect
 	github.com/magiconair/properties v1.8.7 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1547,8 +1547,8 @@ github.com/libp2p/go-yamux/v4 v4.0.2/go.mod h1:C808cCRgOs1iBwY4S71T5oxgMxgLmqUw5
 github.com/lightstep/lightstep-tracer-common/golang/gogo v0.0.0-20190605223551-bc2310a04743/go.mod h1:qklhhLq1aX+mtWk9cPHPzaBjWImj5ULL6C7HFJtXQMM=
 github.com/lightstep/lightstep-tracer-go v0.18.1/go.mod h1:jlF1pusYV4pidLvZ+XD0UBX0ZE6WURAspgAczcDHrL4=
 github.com/linuxkit/virtsock v0.0.0-20201010232012-f8cee7dfc7a3/go.mod h1:3r6x7q95whyfWQpmGZTu3gk3v2YkMi05HEzl7Tf7YEo=
-github.com/logos-messaging/logos-messaging-go-bindings v0.0.0-20260125181314-e6dcad2b58b8 h1:U9cUrZ+izSQ4WaP5xKCp8yNRqGQcmevgFQ5A1Azp8d8=
-github.com/logos-messaging/logos-messaging-go-bindings v0.0.0-20260125181314-e6dcad2b58b8/go.mod h1:i4rL328Q++wR+M+7x7Nqzgnzb4zDuSXLcX0AB5yRMR4=
+github.com/logos-messaging/logos-messaging-go-bindings v0.0.0-20260125193545-66722e0a356b h1:ZCB+oDME4YVwExdXyB+O5woHU77ZzTCp8bGXOJgIsfk=
+github.com/logos-messaging/logos-messaging-go-bindings v0.0.0-20260125193545-66722e0a356b/go.mod h1:i4rL328Q++wR+M+7x7Nqzgnzb4zDuSXLcX0AB5yRMR4=
 github.com/lucas-clemente/quic-go v0.7.1-0.20190401152353-907071221cf9/go.mod h1:PpMmPfPKO9nKJ/psF49ESTAGQSdfXxlg1otPbEB2nOw=
 github.com/lucas-clemente/quic-go v0.18.0/go.mod h1:yXttHsSNxQi8AWijC/vLP+OJczXqzHSOcJrM5ITUlCg=
 github.com/lucas-clemente/quic-go v0.19.3/go.mod h1:ADXpNbTQjq1hIzCpB+y/k5iz4n4z4IwqoLb94Kh5Hu8=

--- a/go.sum
+++ b/go.sum
@@ -1547,8 +1547,8 @@ github.com/libp2p/go-yamux/v4 v4.0.2/go.mod h1:C808cCRgOs1iBwY4S71T5oxgMxgLmqUw5
 github.com/lightstep/lightstep-tracer-common/golang/gogo v0.0.0-20190605223551-bc2310a04743/go.mod h1:qklhhLq1aX+mtWk9cPHPzaBjWImj5ULL6C7HFJtXQMM=
 github.com/lightstep/lightstep-tracer-go v0.18.1/go.mod h1:jlF1pusYV4pidLvZ+XD0UBX0ZE6WURAspgAczcDHrL4=
 github.com/linuxkit/virtsock v0.0.0-20201010232012-f8cee7dfc7a3/go.mod h1:3r6x7q95whyfWQpmGZTu3gk3v2YkMi05HEzl7Tf7YEo=
-github.com/logos-messaging/logos-messaging-go-bindings v0.0.0-20260125222137-088cc0f11b25 h1:z8+DTyFEGJlPf1dtRiORw4wx+Oqw4CwT7bdaTMM9Kag=
-github.com/logos-messaging/logos-messaging-go-bindings v0.0.0-20260125222137-088cc0f11b25/go.mod h1:i4rL328Q++wR+M+7x7Nqzgnzb4zDuSXLcX0AB5yRMR4=
+github.com/logos-messaging/logos-messaging-go-bindings v0.0.0-20260206093723-95be7e9319be h1:Q/L25SVyf01t/3lGo/5NITuwVPJyp4ddqrP2T/zbXPw=
+github.com/logos-messaging/logos-messaging-go-bindings v0.0.0-20260206093723-95be7e9319be/go.mod h1:i4rL328Q++wR+M+7x7Nqzgnzb4zDuSXLcX0AB5yRMR4=
 github.com/lucas-clemente/quic-go v0.7.1-0.20190401152353-907071221cf9/go.mod h1:PpMmPfPKO9nKJ/psF49ESTAGQSdfXxlg1otPbEB2nOw=
 github.com/lucas-clemente/quic-go v0.18.0/go.mod h1:yXttHsSNxQi8AWijC/vLP+OJczXqzHSOcJrM5ITUlCg=
 github.com/lucas-clemente/quic-go v0.19.3/go.mod h1:ADXpNbTQjq1hIzCpB+y/k5iz4n4z4IwqoLb94Kh5Hu8=

--- a/go.sum
+++ b/go.sum
@@ -1547,8 +1547,8 @@ github.com/libp2p/go-yamux/v4 v4.0.2/go.mod h1:C808cCRgOs1iBwY4S71T5oxgMxgLmqUw5
 github.com/lightstep/lightstep-tracer-common/golang/gogo v0.0.0-20190605223551-bc2310a04743/go.mod h1:qklhhLq1aX+mtWk9cPHPzaBjWImj5ULL6C7HFJtXQMM=
 github.com/lightstep/lightstep-tracer-go v0.18.1/go.mod h1:jlF1pusYV4pidLvZ+XD0UBX0ZE6WURAspgAczcDHrL4=
 github.com/linuxkit/virtsock v0.0.0-20201010232012-f8cee7dfc7a3/go.mod h1:3r6x7q95whyfWQpmGZTu3gk3v2YkMi05HEzl7Tf7YEo=
-github.com/logos-messaging/logos-messaging-go-bindings v0.0.0-20260108175826-d29cc2c463e5 h1:rfscMW0+i8v2hih0s1hjR6NqIHizgzUdU01VU7wm8gs=
-github.com/logos-messaging/logos-messaging-go-bindings v0.0.0-20260108175826-d29cc2c463e5/go.mod h1:i4rL328Q++wR+M+7x7Nqzgnzb4zDuSXLcX0AB5yRMR4=
+github.com/logos-messaging/logos-messaging-go-bindings v0.0.0-20260125181314-e6dcad2b58b8 h1:U9cUrZ+izSQ4WaP5xKCp8yNRqGQcmevgFQ5A1Azp8d8=
+github.com/logos-messaging/logos-messaging-go-bindings v0.0.0-20260125181314-e6dcad2b58b8/go.mod h1:i4rL328Q++wR+M+7x7Nqzgnzb4zDuSXLcX0AB5yRMR4=
 github.com/lucas-clemente/quic-go v0.7.1-0.20190401152353-907071221cf9/go.mod h1:PpMmPfPKO9nKJ/psF49ESTAGQSdfXxlg1otPbEB2nOw=
 github.com/lucas-clemente/quic-go v0.18.0/go.mod h1:yXttHsSNxQi8AWijC/vLP+OJczXqzHSOcJrM5ITUlCg=
 github.com/lucas-clemente/quic-go v0.19.3/go.mod h1:ADXpNbTQjq1hIzCpB+y/k5iz4n4z4IwqoLb94Kh5Hu8=

--- a/go.sum
+++ b/go.sum
@@ -1547,6 +1547,8 @@ github.com/libp2p/go-yamux/v4 v4.0.2/go.mod h1:C808cCRgOs1iBwY4S71T5oxgMxgLmqUw5
 github.com/lightstep/lightstep-tracer-common/golang/gogo v0.0.0-20190605223551-bc2310a04743/go.mod h1:qklhhLq1aX+mtWk9cPHPzaBjWImj5ULL6C7HFJtXQMM=
 github.com/lightstep/lightstep-tracer-go v0.18.1/go.mod h1:jlF1pusYV4pidLvZ+XD0UBX0ZE6WURAspgAczcDHrL4=
 github.com/linuxkit/virtsock v0.0.0-20201010232012-f8cee7dfc7a3/go.mod h1:3r6x7q95whyfWQpmGZTu3gk3v2YkMi05HEzl7Tf7YEo=
+github.com/logos-messaging/logos-messaging-go-bindings v0.0.0-20260108175826-d29cc2c463e5 h1:rfscMW0+i8v2hih0s1hjR6NqIHizgzUdU01VU7wm8gs=
+github.com/logos-messaging/logos-messaging-go-bindings v0.0.0-20260108175826-d29cc2c463e5/go.mod h1:i4rL328Q++wR+M+7x7Nqzgnzb4zDuSXLcX0AB5yRMR4=
 github.com/lucas-clemente/quic-go v0.7.1-0.20190401152353-907071221cf9/go.mod h1:PpMmPfPKO9nKJ/psF49ESTAGQSdfXxlg1otPbEB2nOw=
 github.com/lucas-clemente/quic-go v0.18.0/go.mod h1:yXttHsSNxQi8AWijC/vLP+OJczXqzHSOcJrM5ITUlCg=
 github.com/lucas-clemente/quic-go v0.19.3/go.mod h1:ADXpNbTQjq1hIzCpB+y/k5iz4n4z4IwqoLb94Kh5Hu8=

--- a/go.sum
+++ b/go.sum
@@ -1547,8 +1547,8 @@ github.com/libp2p/go-yamux/v4 v4.0.2/go.mod h1:C808cCRgOs1iBwY4S71T5oxgMxgLmqUw5
 github.com/lightstep/lightstep-tracer-common/golang/gogo v0.0.0-20190605223551-bc2310a04743/go.mod h1:qklhhLq1aX+mtWk9cPHPzaBjWImj5ULL6C7HFJtXQMM=
 github.com/lightstep/lightstep-tracer-go v0.18.1/go.mod h1:jlF1pusYV4pidLvZ+XD0UBX0ZE6WURAspgAczcDHrL4=
 github.com/linuxkit/virtsock v0.0.0-20201010232012-f8cee7dfc7a3/go.mod h1:3r6x7q95whyfWQpmGZTu3gk3v2YkMi05HEzl7Tf7YEo=
-github.com/logos-messaging/logos-messaging-go-bindings v0.0.0-20260206093723-95be7e9319be h1:Q/L25SVyf01t/3lGo/5NITuwVPJyp4ddqrP2T/zbXPw=
-github.com/logos-messaging/logos-messaging-go-bindings v0.0.0-20260206093723-95be7e9319be/go.mod h1:i4rL328Q++wR+M+7x7Nqzgnzb4zDuSXLcX0AB5yRMR4=
+github.com/logos-messaging/logos-messaging-go-bindings v0.0.0-20260207154548-84c0d57ed4ac h1:VHc+mG2KDah6ps8zQa2xqCPCogdult0fZEwchdNCvOQ=
+github.com/logos-messaging/logos-messaging-go-bindings v0.0.0-20260207154548-84c0d57ed4ac/go.mod h1:i4rL328Q++wR+M+7x7Nqzgnzb4zDuSXLcX0AB5yRMR4=
 github.com/lucas-clemente/quic-go v0.7.1-0.20190401152353-907071221cf9/go.mod h1:PpMmPfPKO9nKJ/psF49ESTAGQSdfXxlg1otPbEB2nOw=
 github.com/lucas-clemente/quic-go v0.18.0/go.mod h1:yXttHsSNxQi8AWijC/vLP+OJczXqzHSOcJrM5ITUlCg=
 github.com/lucas-clemente/quic-go v0.19.3/go.mod h1:ADXpNbTQjq1hIzCpB+y/k5iz4n4z4IwqoLb94Kh5Hu8=

--- a/go.sum
+++ b/go.sum
@@ -1547,8 +1547,8 @@ github.com/libp2p/go-yamux/v4 v4.0.2/go.mod h1:C808cCRgOs1iBwY4S71T5oxgMxgLmqUw5
 github.com/lightstep/lightstep-tracer-common/golang/gogo v0.0.0-20190605223551-bc2310a04743/go.mod h1:qklhhLq1aX+mtWk9cPHPzaBjWImj5ULL6C7HFJtXQMM=
 github.com/lightstep/lightstep-tracer-go v0.18.1/go.mod h1:jlF1pusYV4pidLvZ+XD0UBX0ZE6WURAspgAczcDHrL4=
 github.com/linuxkit/virtsock v0.0.0-20201010232012-f8cee7dfc7a3/go.mod h1:3r6x7q95whyfWQpmGZTu3gk3v2YkMi05HEzl7Tf7YEo=
-github.com/logos-messaging/logos-messaging-go-bindings v0.0.0-20260207154548-84c0d57ed4ac h1:VHc+mG2KDah6ps8zQa2xqCPCogdult0fZEwchdNCvOQ=
-github.com/logos-messaging/logos-messaging-go-bindings v0.0.0-20260207154548-84c0d57ed4ac/go.mod h1:i4rL328Q++wR+M+7x7Nqzgnzb4zDuSXLcX0AB5yRMR4=
+github.com/logos-messaging/logos-messaging-go-bindings v0.0.0-20260207160840-17fc5e00eef1 h1:8uwAlsIb8gDQpMEuWnjREKyG1fiqx8awZIlWnPk7HRg=
+github.com/logos-messaging/logos-messaging-go-bindings v0.0.0-20260207160840-17fc5e00eef1/go.mod h1:oQMc28BgujyjB2C+P7D8PsguXScjFXBf3LIyqmbXL0c=
 github.com/lucas-clemente/quic-go v0.7.1-0.20190401152353-907071221cf9/go.mod h1:PpMmPfPKO9nKJ/psF49ESTAGQSdfXxlg1otPbEB2nOw=
 github.com/lucas-clemente/quic-go v0.18.0/go.mod h1:yXttHsSNxQi8AWijC/vLP+OJczXqzHSOcJrM5ITUlCg=
 github.com/lucas-clemente/quic-go v0.19.3/go.mod h1:ADXpNbTQjq1hIzCpB+y/k5iz4n4z4IwqoLb94Kh5Hu8=

--- a/go.sum
+++ b/go.sum
@@ -1547,8 +1547,8 @@ github.com/libp2p/go-yamux/v4 v4.0.2/go.mod h1:C808cCRgOs1iBwY4S71T5oxgMxgLmqUw5
 github.com/lightstep/lightstep-tracer-common/golang/gogo v0.0.0-20190605223551-bc2310a04743/go.mod h1:qklhhLq1aX+mtWk9cPHPzaBjWImj5ULL6C7HFJtXQMM=
 github.com/lightstep/lightstep-tracer-go v0.18.1/go.mod h1:jlF1pusYV4pidLvZ+XD0UBX0ZE6WURAspgAczcDHrL4=
 github.com/linuxkit/virtsock v0.0.0-20201010232012-f8cee7dfc7a3/go.mod h1:3r6x7q95whyfWQpmGZTu3gk3v2YkMi05HEzl7Tf7YEo=
-github.com/logos-messaging/logos-messaging-go-bindings v0.0.0-20260125193545-66722e0a356b h1:ZCB+oDME4YVwExdXyB+O5woHU77ZzTCp8bGXOJgIsfk=
-github.com/logos-messaging/logos-messaging-go-bindings v0.0.0-20260125193545-66722e0a356b/go.mod h1:i4rL328Q++wR+M+7x7Nqzgnzb4zDuSXLcX0AB5yRMR4=
+github.com/logos-messaging/logos-messaging-go-bindings v0.0.0-20260125222137-088cc0f11b25 h1:z8+DTyFEGJlPf1dtRiORw4wx+Oqw4CwT7bdaTMM9Kag=
+github.com/logos-messaging/logos-messaging-go-bindings v0.0.0-20260125222137-088cc0f11b25/go.mod h1:i4rL328Q++wR+M+7x7Nqzgnzb4zDuSXLcX0AB5yRMR4=
 github.com/lucas-clemente/quic-go v0.7.1-0.20190401152353-907071221cf9/go.mod h1:PpMmPfPKO9nKJ/psF49ESTAGQSdfXxlg1otPbEB2nOw=
 github.com/lucas-clemente/quic-go v0.18.0/go.mod h1:yXttHsSNxQi8AWijC/vLP+OJczXqzHSOcJrM5ITUlCg=
 github.com/lucas-clemente/quic-go v0.19.3/go.mod h1:ADXpNbTQjq1hIzCpB+y/k5iz4n4z4IwqoLb94Kh5Hu8=

--- a/go.sum
+++ b/go.sum
@@ -2425,8 +2425,6 @@ github.com/waku-org/go-zerokit-rln-x86_64 v0.0.0-20230916171518-2a77c3734dd1 h1:
 github.com/waku-org/go-zerokit-rln-x86_64 v0.0.0-20230916171518-2a77c3734dd1/go.mod h1:+LeEYoW5/uBUTVjtBGLEVCUe9mOYAlu5ZPkIxLOSr5Y=
 github.com/waku-org/sds-go-bindings v0.0.0-20251222164514-d5b47a911904 h1:V6nJsnNpSl822Z013bYzh9lXnTfwBdQHptIOd3AVwXc=
 github.com/waku-org/sds-go-bindings v0.0.0-20251222164514-d5b47a911904/go.mod h1:GW6bN8Ski1GCOb2f5JbKKstH70wlPen1h8f1nzSDfSI=
-github.com/waku-org/waku-go-bindings v0.0.0-20251202095947-63b01b7d0ca9 h1:x4SKQ8zceFNhSBG02yULii7m/bFtGDuqX5XuahpSTCo=
-github.com/waku-org/waku-go-bindings v0.0.0-20251202095947-63b01b7d0ca9/go.mod h1:v6ogkMCyQRUTazRyQR5LIouukY4/2bkjjHpnBKBxcAY=
 github.com/wealdtech/go-ens/v3 v3.6.0 h1:EAByZlHRQ3vxqzzwNi0GvEq1AjVozfWO4DMldHcoVg8=
 github.com/wealdtech/go-ens/v3 v3.6.0/go.mod h1:hcmMr9qPoEgVSEXU2Bwzrn/9NczTWZ1rE53jIlqUpzw=
 github.com/wealdtech/go-multicodec v1.4.0 h1:iq5PgxwssxnXGGPTIK1srvt6U5bJwIp7k6kBrudIWxg=

--- a/nix/pkgs/status-go/library/default.nix
+++ b/nix/pkgs/status-go/library/default.nix
@@ -11,7 +11,7 @@ let
 in pkgs.buildGoModule {
   pname = "status-go";
   src = builtins.path { path = ./../../../..; name = "status-go-library"; };
-  vendorHash = "sha256-bJdsgpkTifRI6B1qk4pEaH0+I7iNnuRQ3O1aGojetJE=";
+  vendorHash = "sha256-/7BVpA++muClbLl74y3T/WcYU5B5up9qBk2xoBhhrBg=";
 
   inherit meta version;
 

--- a/nix/pkgs/status-go/library/default.nix
+++ b/nix/pkgs/status-go/library/default.nix
@@ -11,7 +11,7 @@ let
 in pkgs.buildGoModule {
   pname = "status-go";
   src = builtins.path { path = ./../../../..; name = "status-go-library"; };
-  vendorHash = "sha256-is6SmKVHD5SX+5WKPxOjXS7i53xzAr994Pb2m1PWAZs=";
+  vendorHash = "sha256-XZvabVLPPEfFaDyn7JEoX9YbmMqsxWK+Zz8q8pXAp6c=";
 
   inherit meta version;
 
@@ -48,6 +48,10 @@ in pkgs.buildGoModule {
         NIM_SDS_INC_DIR="${pkgs.lib-sds-pkg}/include" \
         NIM_SDS_LIB_DIR="${pkgs.lib-sds-pkg}/lib" \
         GO_GENERATE_CMD='go generate'
+  '';
+
+  postPatch = ''
+    patchShebangs scripts/cleanup_generated_files.sh
   '';
 
   # Build the Go library

--- a/nix/pkgs/status-go/library/default.nix
+++ b/nix/pkgs/status-go/library/default.nix
@@ -11,7 +11,7 @@ let
 in pkgs.buildGoModule {
   pname = "status-go";
   src = builtins.path { path = ./../../../..; name = "status-go-library"; };
-  vendorHash = "sha256-XZvabVLPPEfFaDyn7JEoX9YbmMqsxWK+Zz8q8pXAp6c=";
+  vendorHash = "sha256-bJdsgpkTifRI6B1qk4pEaH0+I7iNnuRQ3O1aGojetJE=";
 
   inherit meta version;
 

--- a/pkg/messaging/waku/config.go
+++ b/pkg/messaging/waku/config.go
@@ -25,7 +25,7 @@ import (
 
 	ethdisc "github.com/ethereum/go-ethereum/p2p/dnsdisc"
 
-	bindingscommon "github.com/waku-org/waku-go-bindings/waku/common"
+	bindingscommon "github.com/logos-messaging/logos-messaging-go-bindings/waku/common"
 
 	"github.com/status-im/status-go/pkg/messaging/waku/common"
 )

--- a/pkg/messaging/waku/nwaku.go
+++ b/pkg/messaging/waku/nwaku.go
@@ -54,9 +54,9 @@ import (
 	"github.com/waku-org/go-waku/waku/v2/protocol/relay"
 	"github.com/waku-org/go-waku/waku/v2/protocol/store"
 
-	"github.com/waku-org/waku-go-bindings/waku"
-	bindingscommon "github.com/waku-org/waku-go-bindings/waku/common"
-	wakutimesource "github.com/waku-org/waku-go-bindings/waku/timesource"
+	"github.com/logos-messaging/logos-messaging-go-bindings/waku"
+	bindingscommon "github.com/logos-messaging/logos-messaging-go-bindings/waku/common"
+	wakutimesource "github.com/logos-messaging/logos-messaging-go-bindings/waku/timesource"
 
 	gocommon "github.com/status-im/status-go/common"
 	"github.com/status-im/status-go/internal/connection"

--- a/pkg/messaging/waku/nwaku_test.go
+++ b/pkg/messaging/waku/nwaku_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/libp2p/go-libp2p/core/peer"
 	"go.uber.org/zap"
 
-	"github.com/waku-org/waku-go-bindings/waku"
+	"github.com/logos-messaging/logos-messaging-go-bindings/waku"
 
 	"github.com/waku-org/go-waku/waku/v2/api/history"
 	"github.com/waku-org/go-waku/waku/v2/protocol/store"

--- a/pkg/messaging/waku/nwaku_utils.go
+++ b/pkg/messaging/waku/nwaku_utils.go
@@ -14,17 +14,12 @@ import (
 )
 
 func HexToPbHash(hexHash bindings.MessageHash) (pb.MessageHash, error) {
-	bytesHash, err := hexHash.Bytes()
-	if err != nil {
-		return pb.MessageHash{}, err
-	}
-
-	pbHash := pb.ToMessageHash(bytesHash)
+	pbHash := pb.ToMessageHash(hexHash.Bytes())
 	return pbHash, nil
 }
 
 func PbToHexHash(pbHash pb.MessageHash) (bindings.MessageHash, error) {
-	return bindings.ToMessageHash(pbHash.String())
+	return bindings.ToMessageHashFromStringFormat(pbHash.String())
 }
 
 func PbToBindingsStoreRequest(pbStoreRequest *storepb.StoreQueryRequest) (*bindings.StoreQueryRequest, error) {
@@ -68,10 +63,7 @@ func PbToBindingsStoreRequest(pbStoreRequest *storepb.StoreQueryRequest) (*bindi
 
 func BindingsToPbStoreResponse(bindingsStoreResponse *bindings.StoreQueryResponse) (*storepb.StoreQueryResponse, error) {
 
-	paginationCursor, err := bindingsStoreResponse.PaginationCursor.Bytes()
-	if err != nil {
-		return nil, err
-	}
+	paginationCursor := bindingsStoreResponse.PaginationCursor.Bytes()
 
 	pbQueryResponse := storepb.StoreQueryResponse{
 		RequestId:        bindingsStoreResponse.RequestId,
@@ -88,11 +80,7 @@ func BindingsToPbStoreResponse(bindingsStoreResponse *bindings.StoreQueryRespons
 
 	for _, message := range *bindingsStoreResponse.Messages {
 
-		msgHash, err := message.MessageHash.Bytes()
-
-		if err != nil {
-			return nil, err
-		}
+		msgHash := message.MessageHash.Bytes()
 
 		var pbMessage storepb.WakuMessageKeyValue
 		if message.WakuMessage == nil {
@@ -137,7 +125,18 @@ func BindingsToCommonEnvelope(bindingsEnv bindings.Envelope) (common.Envelope, e
 		return nil, err
 	}
 
-	env := common.NewWakuEnvelope(bindingsEnv.Message(), bindingsEnv.PubsubTopic(), hash)
+	// Temporary conversion between bindings WakuMessage and go-waku WakuMessage
+	goWakuMessage := &pb.WakuMessage{
+		Payload:        bindingsEnv.Message().Payload,
+		ContentTopic:   bindingsEnv.Message().ContentTopic,
+		Version:        bindingsEnv.Message().Version,
+		Timestamp:      bindingsEnv.Message().Timestamp,
+		Meta:           bindingsEnv.Message().Meta,
+		Ephemeral:      bindingsEnv.Message().Ephemeral,
+		RateLimitProof: bindingsEnv.Message().RateLimitProof,
+	}
+
+	env := common.NewWakuEnvelope(goWakuMessage, bindingsEnv.PubsubTopic(), hash)
 
 	return env, nil
 }

--- a/pkg/messaging/waku/nwaku_utils.go
+++ b/pkg/messaging/waku/nwaku_utils.go
@@ -14,12 +14,15 @@ import (
 )
 
 func HexToPbHash(hexHash bindings.MessageHash) (pb.MessageHash, error) {
-	pbHash := pb.ToMessageHash(hexHash.Bytes())
-	return pbHash, nil
+	hexHashBytes, err := hexHash.Bytes()
+	if err != nil {
+		return pb.MessageHash{}, err
+	}
+	return pb.ToMessageHash(hexHashBytes), nil
 }
 
 func PbToHexHash(pbHash pb.MessageHash) (bindings.MessageHash, error) {
-	return bindings.ToMessageHashFromStringFormat(pbHash.String())
+	return bindings.ToMessageHash(pbHash.String())
 }
 
 func PbToBindingsStoreRequest(pbStoreRequest *storepb.StoreQueryRequest) (*bindings.StoreQueryRequest, error) {
@@ -63,7 +66,10 @@ func PbToBindingsStoreRequest(pbStoreRequest *storepb.StoreQueryRequest) (*bindi
 
 func BindingsToPbStoreResponse(bindingsStoreResponse *bindings.StoreQueryResponse) (*storepb.StoreQueryResponse, error) {
 
-	paginationCursor := bindingsStoreResponse.PaginationCursor.Bytes()
+	paginationCursor, err := bindingsStoreResponse.PaginationCursor.Bytes()
+	if err != nil {
+		return nil, err
+	}
 
 	pbQueryResponse := storepb.StoreQueryResponse{
 		RequestId:        bindingsStoreResponse.RequestId,
@@ -80,7 +86,10 @@ func BindingsToPbStoreResponse(bindingsStoreResponse *bindings.StoreQueryRespons
 
 	for _, message := range *bindingsStoreResponse.Messages {
 
-		msgHash := message.MessageHash.Bytes()
+		msgHash, err := message.MessageHash.Bytes()
+		if err != nil {
+			return nil, err
+		}
 
 		var pbMessage storepb.WakuMessageKeyValue
 		if message.WakuMessage == nil {

--- a/pkg/messaging/waku/nwaku_utils.go
+++ b/pkg/messaging/waku/nwaku_utils.go
@@ -5,7 +5,7 @@ package wakuv2
 
 // TODO-nwaku remove this entire file once go-waku is removed from status-go
 import (
-	bindings "github.com/waku-org/waku-go-bindings/waku/common"
+	bindings "github.com/logos-messaging/logos-messaging-go-bindings/waku/common"
 
 	"github.com/waku-org/go-waku/waku/v2/protocol/pb"
 	storepb "github.com/waku-org/go-waku/waku/v2/protocol/store/pb"

--- a/pkg/messaging/waku/pinger.go
+++ b/pkg/messaging/waku/pinger.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/libp2p/go-libp2p/core/peer"
 
-	"github.com/waku-org/waku-go-bindings/waku"
+	"github.com/logos-messaging/logos-messaging-go-bindings/waku"
 
 	commonapi "github.com/waku-org/go-waku/waku/v2/api/common"
 )

--- a/pkg/messaging/waku/publisher.go
+++ b/pkg/messaging/waku/publisher.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/libp2p/go-libp2p/core/peer"
 
-	"github.com/waku-org/waku-go-bindings/waku"
+	"github.com/logos-messaging/logos-messaging-go-bindings/waku"
 
 	"github.com/waku-org/go-waku/waku/v2/api/publish"
 	"github.com/waku-org/go-waku/waku/v2/protocol/pb"

--- a/pkg/messaging/waku/publisher.go
+++ b/pkg/messaging/waku/publisher.go
@@ -9,7 +9,7 @@ import (
 	"github.com/libp2p/go-libp2p/core/peer"
 
 	"github.com/logos-messaging/logos-messaging-go-bindings/waku"
-	"github.com/logos-messaging/logos-messaging-go-bindings/waku/common"
+	nimpb "github.com/logos-messaging/logos-messaging-go-bindings/waku/pb"
 
 	"github.com/waku-org/go-waku/waku/v2/api/publish"
 	"github.com/waku-org/go-waku/waku/v2/protocol/pb"
@@ -34,7 +34,7 @@ func (p *nwakuPublisher) RelayPublish(ctx context.Context, message *pb.WakuMessa
 	// TODO-nwaku improve this workaround to use the pb definition of the hash
 
 	// Temporary conversion to "nwaku" WakuMessage
-	nwakuWakuMessage := &common.WakuMessage{
+	nwakuWakuMessage := &nimpb.WakuMessage{
 		Payload:    message.Payload,
 		ContentTopic:   message.ContentTopic,
 		Version:        message.Version,
@@ -50,7 +50,11 @@ func (p *nwakuPublisher) RelayPublish(ctx context.Context, message *pb.WakuMessa
 	}
 
 	// Notice the simple conversion. Same definition but different packages.
-	return pb.ToMessageHash(hexHash.Bytes()), nil
+	hexHashBytes, err := hexHash.Bytes()
+	if err != nil {
+		return pb.MessageHash{}, err
+	}
+	return pb.ToMessageHash(hexHashBytes), nil
 }
 
 // LightpushPublish publishes a message via WakuLightPush

--- a/pkg/messaging/waku/publisher.go
+++ b/pkg/messaging/waku/publisher.go
@@ -9,7 +9,7 @@ import (
 	"github.com/libp2p/go-libp2p/core/peer"
 
 	"github.com/logos-messaging/logos-messaging-go-bindings/waku"
-	nimpb "github.com/logos-messaging/logos-messaging-go-bindings/waku/pb"
+	"github.com/waku-org/go-waku/waku/v2/protocol/pb"
 
 	"github.com/waku-org/go-waku/waku/v2/api/publish"
 	"github.com/waku-org/go-waku/waku/v2/protocol/pb"

--- a/pkg/messaging/waku/publisher.go
+++ b/pkg/messaging/waku/publisher.go
@@ -9,6 +9,7 @@ import (
 	"github.com/libp2p/go-libp2p/core/peer"
 
 	"github.com/logos-messaging/logos-messaging-go-bindings/waku"
+	"github.com/logos-messaging/logos-messaging-go-bindings/waku/common"
 
 	"github.com/waku-org/go-waku/waku/v2/api/publish"
 	"github.com/waku-org/go-waku/waku/v2/protocol/pb"
@@ -31,12 +32,25 @@ func (p *nwakuPublisher) RelayListPeers(pubsubTopic string) ([]peer.ID, error) {
 
 func (p *nwakuPublisher) RelayPublish(ctx context.Context, message *pb.WakuMessage, pubsubTopic string) (pb.MessageHash, error) {
 	// TODO-nwaku improve this workaround to use the pb definition of the hash
-	hexHash, err := p.node.RelayPublish(ctx, message, pubsubTopic)
+
+	// Temporary conversion to "nwaku" WakuMessage
+	nwakuWakuMessage := &common.WakuMessage{
+		Payload:    message.Payload,
+		ContentTopic:   message.ContentTopic,
+		Version:        message.Version,
+		Timestamp:      message.Timestamp,
+		Meta:           message.Meta,
+		Ephemeral:      message.Ephemeral,
+		RateLimitProof: message.RateLimitProof,
+	}
+
+	hexHash, err := p.node.RelayPublish(ctx, nwakuWakuMessage, pubsubTopic)
 	if err != nil {
 		return pb.MessageHash{}, err
 	}
 
-	return HexToPbHash(hexHash)
+	// Notice the simple conversion. Same definition but different packages.
+	return pb.ToMessageHash(hexHash.Bytes()), nil
 }
 
 // LightpushPublish publishes a message via WakuLightPush

--- a/pkg/messaging/waku/publisher.go
+++ b/pkg/messaging/waku/publisher.go
@@ -12,7 +12,6 @@ import (
 	"github.com/waku-org/go-waku/waku/v2/protocol/pb"
 
 	"github.com/waku-org/go-waku/waku/v2/api/publish"
-	"github.com/waku-org/go-waku/waku/v2/protocol/pb"
 )
 
 type nwakuPublisher struct {
@@ -34,7 +33,7 @@ func (p *nwakuPublisher) RelayPublish(ctx context.Context, message *pb.WakuMessa
 	// TODO-nwaku improve this workaround to use the pb definition of the hash
 
 	// Temporary conversion to "nwaku" WakuMessage
-	nwakuWakuMessage := &nimpb.WakuMessage{
+	nwakuWakuMessage := &pb.WakuMessage{
 		Payload:    message.Payload,
 		ContentTopic:   message.ContentTopic,
 		Version:        message.Version,

--- a/pkg/messaging/waku/result.go
+++ b/pkg/messaging/waku/result.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/libp2p/go-libp2p/core/peer"
 
-	"github.com/waku-org/waku-go-bindings/waku"
+	"github.com/logos-messaging/logos-messaging-go-bindings/waku"
 
 	"github.com/waku-org/go-waku/waku/v2/protocol"
 	"github.com/waku-org/go-waku/waku/v2/protocol/store"

--- a/pkg/messaging/waku/store_message_verifier.go
+++ b/pkg/messaging/waku/store_message_verifier.go
@@ -44,7 +44,7 @@ func (d *storenodeMessageVerifier) MessageHashesExist(ctx context.Context, reque
 	}
 
 	for i, mhash := range messageHashes {
-		hexHash, err := common.ToMessageHashFromStringFormat(mhash.String())
+		hexHash, err := common.ToMessageHash(mhash.String())
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/messaging/waku/store_message_verifier.go
+++ b/pkg/messaging/waku/store_message_verifier.go
@@ -44,7 +44,11 @@ func (d *storenodeMessageVerifier) MessageHashesExist(ctx context.Context, reque
 	}
 
 	for i, mhash := range messageHashes {
-		(*storeRequest.MessageHashes)[i] = common.MessageHash(mhash.String())
+		hexHash, err := common.ToMessageHashFromStringFormat(mhash.String())
+		if err != nil {
+			return nil, err
+		}
+		(*storeRequest.MessageHashes)[i] = hexHash
 	}
 
 	bindingsResponse, err := d.node.StoreQuery(ctx, storeRequest, peerInfo)

--- a/pkg/messaging/waku/store_message_verifier.go
+++ b/pkg/messaging/waku/store_message_verifier.go
@@ -12,8 +12,8 @@ import (
 	"github.com/golang/protobuf/proto"
 	"github.com/libp2p/go-libp2p/core/peer"
 
-	"github.com/waku-org/waku-go-bindings/waku"
-	"github.com/waku-org/waku-go-bindings/waku/common"
+	"github.com/logos-messaging/logos-messaging-go-bindings/waku"
+	"github.com/logos-messaging/logos-messaging-go-bindings/waku/common"
 
 	"github.com/waku-org/go-waku/waku/v2/api/publish"
 	"github.com/waku-org/go-waku/waku/v2/protocol/pb"

--- a/pkg/messaging/waku/storenode_requestor.go
+++ b/pkg/messaging/waku/storenode_requestor.go
@@ -13,7 +13,7 @@ import (
 	"github.com/libp2p/go-libp2p/core/peer"
 	"go.uber.org/zap"
 
-	"github.com/waku-org/waku-go-bindings/waku"
+	"github.com/logos-messaging/logos-messaging-go-bindings/waku"
 
 	commonapi "github.com/waku-org/go-waku/waku/v2/api/common"
 	"github.com/waku-org/go-waku/waku/v2/protocol"


### PR DESCRIPTION
Update to use `logos-messaging-nim` `v0.37-with-ffi`, and the `logos-messaging-go-bindings` module that accommodates to that.