### PR TITLE
fix(nix): backport Android SDK error fixes

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,21 +2,23 @@
   "nodes": {
     "lmn": {
       "inputs": {
-        "nixpkgs": "nixpkgs",
+        "nixpkgs": [
+          "nixpkgs"
+        ],
         "zerokit": "zerokit"
       },
       "locked": {
-        "lastModified": 1767020554,
-        "narHash": "sha256-LvnMp8dcmznNk6rb8cVfqWmZCga9UG/NCMQxrj3riMQ=",
+        "lastModified": 1769507691,
+        "narHash": "sha256-NDWEPV5t9KKVrfn7X924Bf+cNXFj0Cqp6rx2h+TQt5M=",
         "ref": "refs/heads/master",
-        "rev": "33383fee2d1e5444947acbe7316d5d31221d2852",
+        "rev": "cccc8ab6fda0e54752936db0d5c80b02a2c34a3a",
         "revCount": 2196,
         "submodules": true,
         "type": "git",
         "url": "https://github.com/logos-messaging/logos-messaging-nim"
       },
       "original": {
-        "rev": "33383fee2d1e5444947acbe7316d5d31221d2852",
+        "rev": "cccc8ab6fda0e54752936db0d5c80b02a2c34a3a",
         "submodules": true,
         "type": "git",
         "url": "https://github.com/logos-messaging/logos-messaging-nim"
@@ -24,7 +26,7 @@
     },
     "nim-sds": {
       "inputs": {
-        "nixpkgs": "nixpkgs_2"
+        "nixpkgs": "nixpkgs"
       },
       "locked": {
         "lastModified": 1766504822,
@@ -45,17 +47,17 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1740603184,
-        "narHash": "sha256-t+VaahjQAWyA+Ctn2idyo1yxRIYpaDxMgHkgCNiMJa4=",
+        "lastModified": 1757590060,
+        "narHash": "sha256-EWwwdKLMZALkgHFyKW7rmyhxECO74+N+ZO5xTDnY/5c=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "f44bd8ca21e026135061a0a57dcf3d0775b67a49",
+        "rev": "0ef228213045d2cdb5a169a95d63ded38670b293",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "f44bd8ca21e026135061a0a57dcf3d0775b67a49",
+        "rev": "0ef228213045d2cdb5a169a95d63ded38670b293",
         "type": "github"
       }
     },
@@ -75,27 +77,11 @@
         "type": "github"
       }
     },
-    "nixpkgs_3": {
-      "locked": {
-        "lastModified": 1757590060,
-        "narHash": "sha256-EWwwdKLMZALkgHFyKW7rmyhxECO74+N+ZO5xTDnY/5c=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "0ef228213045d2cdb5a169a95d63ded38670b293",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "0ef228213045d2cdb5a169a95d63ded38670b293",
-        "type": "github"
-      }
-    },
     "root": {
       "inputs": {
         "lmn": "lmn",
         "nim-sds": "nim-sds",
-        "nixpkgs": "nixpkgs_3"
+        "nixpkgs": "nixpkgs_2"
       }
     },
     "rust-overlay": {
@@ -129,18 +115,18 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1749115386,
-        "narHash": "sha256-UexIE2D7zr6aRajwnKongXwCZCeRZDXOL0kfjhqUFSU=",
-        "owner": "vacp2p",
-        "repo": "zerokit",
-        "rev": "dc0b31752c91e7b4fefc441cfa6a8210ad7dba7b",
-        "type": "github"
+        "lastModified": 1762211504,
+        "narHash": "sha256-SbDoBElFYJ4cYebltxlO2lYnz6qOaDAVY6aNJ5bqHDE=",
+        "ref": "refs/heads/master",
+        "rev": "3160d9504d07791f2fc9b610948a6cf9a58ed488",
+        "revCount": 342,
+        "type": "git",
+        "url": "https://github.com/vacp2p/zerokit"
       },
       "original": {
-        "owner": "vacp2p",
-        "repo": "zerokit",
-        "rev": "dc0b31752c91e7b4fefc441cfa6a8210ad7dba7b",
-        "type": "github"
+        "rev": "3160d9504d07791f2fc9b610948a6cf9a58ed488",
+        "type": "git",
+        "url": "https://github.com/vacp2p/zerokit"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -16,8 +16,11 @@
     # We are pinning the commit because ultimately we want to use same commit across different projects.
     # A commit from nixpkgs 24.11 release : https://github.com/NixOS/nixpkgs/tree/release-24.11
     nixpkgs.url = "github:NixOS/nixpkgs/0ef228213045d2cdb5a169a95d63ded38670b293";
+    lmn = {
+      url = "git+https://github.com/logos-messaging/logos-messaging-nim?submodules=1&rev=cccc8ab6fda0e54752936db0d5c80b02a2c34a3a";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
     # We cannot do follows since the nim-unwrapped-2_0 doesn't exist in this nixpkgs version above
-    lmn.url = "git+https://github.com/logos-messaging/logos-messaging-nim?submodules=1&rev=fb4a112407460534a9154f3aaee8888045dc6852";
     nim-sds.url = "git+https://github.com/logos-messaging/nim-sds?submodules=1&rev=fb8039c5a56086ec7fb3e5e1a5a593bb3756ccb6";
   };
 

--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -18,7 +18,7 @@ in mkShell {
   buildInputs = with pkgs;
     lib.optionals (stdenv.isDarwin) [ xcodeWrapper ] ++ [
     git jq which
-    go golangci-lint go-junit-report gopls codecov-cli
+    gcc go golangci-lint go-junit-report gopls codecov-cli
     protobuf3_24 protoc-gen-go gotestsum openjdk openssl
     rustc cargo
     nim
@@ -28,15 +28,15 @@ in mkShell {
 
   shellHook = ''
     export USE_SYSTEM_NIM=1
-    
+
     export LIBWAKU_PATH="${pkgs.libwaku}"
     export LIBSDS_PATH="${pkgs.lib-sds-pkg}"
-    
+
     export LD_LIBRARY_PATH="${pkgs.libwaku}/bin:${pkgs.lib-sds-pkg}/lib:''${LD_LIBRARY_PATH:-}"
-    
+
     export CGO_CFLAGS="-I${pkgs.libwaku}/include -I${pkgs.lib-sds-pkg}/include"
     export CGO_LDFLAGS="-L${pkgs.libwaku}/bin -L${pkgs.lib-sds-pkg}/lib"
-    
+
     echo "CGO_CFLAGS: $CGO_CFLAGS"
     echo "CGO_LDFLAGS: $CGO_LDFLAGS"
   ''
@@ -53,4 +53,3 @@ in mkShell {
   # https://github.com/status-im/status-mobile/pull/13912
   __noChroot = stdenv.isDarwin;
 }
-


### PR DESCRIPTION
Resolves this error caused by Zerokit:
```
error: aarch64-darwin not supported for Android SDK. Use: NIXPKGS_SYSTEM_OVERRIDE=x86_64-darwin
```

Backports changes from this PR:
- https://github.com/logos-messaging/logos-messaging-nim/pull/3694