### PR TITLE
fix: make go tags space separated

### DIFF
--- a/scripts/check_flakiness.py
+++ b/scripts/check_flakiness.py
@@ -6,7 +6,7 @@ import concurrent.futures
 import time
 
 def run_single_test(package_name, test_name, suite_test_name, log_dir, timeout, iteration):
-    cmd = ["go", "test", package_name, "-tags=gowaku_skip_migrations,gowaku_no_rln", "-count=1", f"-timeout={timeout}s"]
+    cmd = ["go", "test", package_name, "-tags='gowaku_skip_migrations gowaku_no_rln'", "-count=1", f"-timeout={timeout}s"]
     if test_name:
         cmd.extend(["-run", f"^{test_name}$"])
     if suite_test_name:

--- a/scripts/run_unit_tests.sh
+++ b/scripts/run_unit_tests.sh
@@ -15,7 +15,7 @@ if [[ $UNIT_TEST_USE_DEVELOPMENT_LOGGER == 'false' ]]; then
   if [[ -z $BUILD_TAGS ]]; then
     BUILD_TAGS="test_silent"
   else
-    BUILD_TAGS="${BUILD_TAGS},test_silent"
+    BUILD_TAGS="${BUILD_TAGS} test_silent"
   fi
 fi
 


### PR DESCRIPTION
Fixing `go: -tags space-separated list contains comma` issue, see `USE_NWAKU=true make test-unit `

https://github.com/golang/go/blob/master/src/cmd/go/testdata/script/build_tags_no_comma.txt