### PR TITLE
chore(ci): remove artifacts older than 30d, keep 1 per PR

### DIFF
--- a/_assets/ci/Jenkinsfile
+++ b/_assets/ci/Jenkinsfile
@@ -30,6 +30,7 @@ pipeline {
       numToKeepStr: '5',
       daysToKeepStr: '30',
       artifactNumToKeepStr: '1',
+      artifactDaysToKeepStr: '30',
     ))
   }
 

--- a/_assets/ci/Jenkinsfile.android
+++ b/_assets/ci/Jenkinsfile.android
@@ -37,6 +37,7 @@ pipeline {
       numToKeepStr: '5',
       daysToKeepStr: '30',
       artifactNumToKeepStr: '1',
+      artifactDaysToKeepStr: '30',
     ))
   }
 

--- a/_assets/ci/Jenkinsfile.desktop
+++ b/_assets/ci/Jenkinsfile.desktop
@@ -38,10 +38,11 @@ pipeline {
       disableRestartFromStage()
       /* manage how many builds we keep */
       buildDiscarder(logRotator(
-            numToKeepStr: '5',
-            daysToKeepStr: '30',
-            artifactNumToKeepStr: '1',
-            ))
+        numToKeepStr: '5',
+        daysToKeepStr: '30',
+        artifactNumToKeepStr: '1',
+        artifactDaysToKeepStr: '30',
+      ))
   }
 
   environment {

--- a/_assets/ci/Jenkinsfile.docker
+++ b/_assets/ci/Jenkinsfile.docker
@@ -35,6 +35,7 @@ pipeline {
       numToKeepStr: '5',
       daysToKeepStr: '30',
       artifactNumToKeepStr: '1',
+      artifactDaysToKeepStr: '30',
     ))
   }
 

--- a/_assets/ci/Jenkinsfile.linux
+++ b/_assets/ci/Jenkinsfile.linux
@@ -42,6 +42,7 @@ pipeline {
       numToKeepStr: '5',
       daysToKeepStr: '30',
       artifactNumToKeepStr: '1',
+      artifactDaysToKeepStr: '30',
     ))
   }
 

--- a/_assets/ci/Jenkinsfile.linux-nix
+++ b/_assets/ci/Jenkinsfile.linux-nix
@@ -17,8 +17,10 @@ pipeline {
     disableRestartFromStage()
     /* manage how many builds we keep */
     buildDiscarder(logRotator(
-      numToKeepStr: '20',
+      numToKeepStr: '5',
       daysToKeepStr: '30',
+      artifactNumToKeepStr: '1',
+      artifactDaysToKeepStr: '30',
     ))
   }
 

--- a/_assets/ci/Jenkinsfile.mobile
+++ b/_assets/ci/Jenkinsfile.mobile
@@ -39,6 +39,7 @@ pipeline {
       numToKeepStr: '5',
       daysToKeepStr: '30',
       artifactNumToKeepStr: '1',
+      artifactDaysToKeepStr: '30',
     ))
   }
 

--- a/_assets/ci/Jenkinsfile.nix
+++ b/_assets/ci/Jenkinsfile.nix
@@ -23,8 +23,10 @@ pipeline {
     disableRestartFromStage()
     /* manage how many builds we keep */
     buildDiscarder(logRotator(
-      numToKeepStr: '20',
+      numToKeepStr: '5',
       daysToKeepStr: '30',
+      artifactNumToKeepStr: '1',
+      artifactDaysToKeepStr: '30',
     ))
   }
 

--- a/_assets/ci/Jenkinsfile.nwaku
+++ b/_assets/ci/Jenkinsfile.nwaku
@@ -42,6 +42,7 @@ pipeline {
       numToKeepStr: '5',
       daysToKeepStr: '30',
       artifactNumToKeepStr: '1',
+      artifactDaysToKeepStr: '30',
     ))
   }
 

--- a/_assets/ci/Jenkinsfile.tests
+++ b/_assets/ci/Jenkinsfile.tests
@@ -67,8 +67,9 @@ pipeline {
     /* manage how many builds we keep */
     buildDiscarder(logRotator(
       numToKeepStr: getAmountToKeep(),
-      daysToKeepStr: '-1',
+      daysToKeepStr: '30',
       artifactNumToKeepStr: getAmountToKeep(),
+      artifactDaysToKeepStr: '30',
     ))
   }
 

--- a/_assets/ci/Jenkinsfile.tests-benchmark
+++ b/_assets/ci/Jenkinsfile.tests-benchmark
@@ -38,6 +38,7 @@ pipeline {
       numToKeepStr: '10',
       daysToKeepStr: '30',
       artifactNumToKeepStr: '1',
+      artifactDaysToKeepStr: '30',
     ))
   }
 

--- a/_assets/ci/Jenkinsfile.tests-rpc
+++ b/_assets/ci/Jenkinsfile.tests-rpc
@@ -46,8 +46,9 @@ pipeline {
     /* manage how many builds we keep */
     buildDiscarder(logRotator(
       numToKeepStr: getAmountToKeep(),
-      daysToKeepStr: '-1',
+      daysToKeepStr: '30',
       artifactNumToKeepStr: getAmountToKeep(),
+      artifactDaysToKeepStr: '30',
     ))
   }
 


### PR DESCRIPTION
Set Jenkins job build discarder to remove with following rules:
```groovy
artifactNumToKeepStr: '1',
artifactDaysToKeepStr: '30'
```

Keep 1 per PR, but not older than 30 days.

For nightly/develop jobs keep `Num` setting, but set `Days` to 30 still.