### PR TITLE
chore: change in Makefile test sds with Nimble

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -109,7 +109,7 @@ endif
 # `nim-sds` variables
 
 # Pin nim-sds revision here. Can be a tag (default) or commit hash.
-NIM_SDS_VERSION ?= 415c037f556008886ac85a25b6479511f1fb76e0
+NIM_SDS_VERSION ?= 1c904d7d8840bd03233db6e02dceb86b263d7bdb
 
 # Option 1: Provide NIM_SDS_SOURCE_DIR. Make clones it if missing.
 NIM_SDS_SOURCE_DIR ?= $(GIT_ROOT)/../nim-sds
@@ -275,7 +275,6 @@ endif
 $(LIBSDS): clone-nim-sds
 ifeq ($(NIM_SDS_BUILD_FROM_SOURCE),true)
 	@echo "Building nim-sds: $(LIBSDS)"
-	$(MAKE) -C $(NIM_SDS_SOURCE_DIR) update
 	$(MAKE) -C $(NIM_SDS_SOURCE_DIR) libsds USE_SYSTEM_NIM=$(USE_SYSTEM_NIM) NIMFLAGS=-d:noSignalHandler SHELL=/bin/bash
 else
 	@test -f $(LIBSDS) || (echo "Error: libsds not found at $(LIBSDS)" && exit 1)

--- a/Makefile
+++ b/Makefile
@@ -109,7 +109,7 @@ endif
 # `nim-sds` variables
 
 # Pin nim-sds revision here. Can be a tag (default) or commit hash.
-NIM_SDS_VERSION ?= v0.2.4
+NIM_SDS_VERSION ?= 415c037f556008886ac85a25b6479511f1fb76e0
 
 # Option 1: Provide NIM_SDS_SOURCE_DIR. Make clones it if missing.
 NIM_SDS_SOURCE_DIR ?= $(GIT_ROOT)/../nim-sds

--- a/flake.lock
+++ b/flake.lock
@@ -34,14 +34,12 @@
         "ref": "refs/heads/start-using-nimble",
         "rev": "1c904d7d8840bd03233db6e02dceb86b263d7bdb",
         "revCount": 85,
-        "submodules": true,
         "type": "git",
         "url": "https://github.com/logos-messaging/nim-sds"
       },
       "original": {
         "ref": "refs/heads/start-using-nimble",
         "rev": "1c904d7d8840bd03233db6e02dceb86b263d7bdb",
-        "submodules": true,
         "type": "git",
         "url": "https://github.com/logos-messaging/nim-sds"
       }

--- a/flake.lock
+++ b/flake.lock
@@ -28,18 +28,18 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1769964616,
-        "narHash": "sha256-m10ES2aJGWxFaByF757HaJa+WDvEdjKMXgAnnQ8g0vw=",
+        "lastModified": 1769965422,
+        "narHash": "sha256-W1m8Y17+gQ26Hgha5UBECNjTlFzX3Of6ldAOcSzYyXs=",
         "ref": "refs/heads/start-using-nimble",
-        "rev": "2d6e1fcd5b70c0a9cf5befab14a359a13a69c8cc",
-        "revCount": 88,
+        "rev": "0454556582583031218e393398185c0012583148",
+        "revCount": 89,
         "submodules": true,
         "type": "git",
         "url": "https://github.com/logos-messaging/nim-sds"
       },
       "original": {
         "ref": "refs/heads/start-using-nimble",
-        "rev": "2d6e1fcd5b70c0a9cf5befab14a359a13a69c8cc",
+        "rev": "0454556582583031218e393398185c0012583148",
         "submodules": true,
         "type": "git",
         "url": "https://github.com/logos-messaging/nim-sds"

--- a/flake.lock
+++ b/flake.lock
@@ -28,18 +28,18 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1769963040,
-        "narHash": "sha256-SCed9j6fKnk4fx/dZzZjjEdwTB0arLIXeHrSepCrdKI=",
+        "lastModified": 1769964332,
+        "narHash": "sha256-t73Hph72AHQVSRW1VfGyp9nl5Rhita6X7yAo0YN2/UY=",
         "ref": "refs/heads/start-using-nimble",
-        "rev": "a48beb922031698a3970a9210852c5759f3ee551",
-        "revCount": 86,
+        "rev": "f1cfb160c4000561d8a968b58e079b2d726ca65a",
+        "revCount": 87,
         "submodules": true,
         "type": "git",
         "url": "https://github.com/logos-messaging/nim-sds"
       },
       "original": {
         "ref": "refs/heads/start-using-nimble",
-        "rev": "a48beb922031698a3970a9210852c5759f3ee551",
+        "rev": "f1cfb160c4000561d8a968b58e079b2d726ca65a",
         "submodules": true,
         "type": "git",
         "url": "https://github.com/logos-messaging/nim-sds"

--- a/flake.lock
+++ b/flake.lock
@@ -9,8 +9,7 @@
       },
       "locked": {
         "lastModified": 1769507691,
-        "narHash": "sha256-NDWEPV5t9KKVrfn7X924Bf+cNXFj0Cqp6rx2h+TQt5M=",
-        "ref": "refs/heads/master",
+        "narHash": "sha256-+OWq0G/Q5UvYAMG908cu1qpHGNuLvrezMbI1vOymWL0=",
         "rev": "cccc8ab6fda0e54752936db0d5c80b02a2c34a3a",
         "revCount": 2196,
         "submodules": true,

--- a/flake.lock
+++ b/flake.lock
@@ -28,18 +28,18 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1769964332,
-        "narHash": "sha256-t73Hph72AHQVSRW1VfGyp9nl5Rhita6X7yAo0YN2/UY=",
+        "lastModified": 1769964616,
+        "narHash": "sha256-m10ES2aJGWxFaByF757HaJa+WDvEdjKMXgAnnQ8g0vw=",
         "ref": "refs/heads/start-using-nimble",
-        "rev": "f1cfb160c4000561d8a968b58e079b2d726ca65a",
-        "revCount": 87,
+        "rev": "2d6e1fcd5b70c0a9cf5befab14a359a13a69c8cc",
+        "revCount": 88,
         "submodules": true,
         "type": "git",
         "url": "https://github.com/logos-messaging/nim-sds"
       },
       "original": {
         "ref": "refs/heads/start-using-nimble",
-        "rev": "f1cfb160c4000561d8a968b58e079b2d726ca65a",
+        "rev": "2d6e1fcd5b70c0a9cf5befab14a359a13a69c8cc",
         "submodules": true,
         "type": "git",
         "url": "https://github.com/logos-messaging/nim-sds"

--- a/flake.lock
+++ b/flake.lock
@@ -34,12 +34,14 @@
         "ref": "refs/heads/start-using-nimble",
         "rev": "1c904d7d8840bd03233db6e02dceb86b263d7bdb",
         "revCount": 85,
+        "submodules": true,
         "type": "git",
         "url": "https://github.com/logos-messaging/nim-sds"
       },
       "original": {
         "ref": "refs/heads/start-using-nimble",
         "rev": "1c904d7d8840bd03233db6e02dceb86b263d7bdb",
+        "submodules": true,
         "type": "git",
         "url": "https://github.com/logos-messaging/nim-sds"
       }

--- a/flake.lock
+++ b/flake.lock
@@ -28,18 +28,18 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1769872025,
-        "narHash": "sha256-4HTTAPIz7zxvhAUNx8EDEZBAUCBoW0DCsJt5zeNBrIQ=",
+        "lastModified": 1769963040,
+        "narHash": "sha256-SCed9j6fKnk4fx/dZzZjjEdwTB0arLIXeHrSepCrdKI=",
         "ref": "refs/heads/start-using-nimble",
-        "rev": "1c904d7d8840bd03233db6e02dceb86b263d7bdb",
-        "revCount": 85,
+        "rev": "a48beb922031698a3970a9210852c5759f3ee551",
+        "revCount": 86,
         "submodules": true,
         "type": "git",
         "url": "https://github.com/logos-messaging/nim-sds"
       },
       "original": {
         "ref": "refs/heads/start-using-nimble",
-        "rev": "1c904d7d8840bd03233db6e02dceb86b263d7bdb",
+        "rev": "a48beb922031698a3970a9210852c5759f3ee551",
         "submodules": true,
         "type": "git",
         "url": "https://github.com/logos-messaging/nim-sds"

--- a/flake.lock
+++ b/flake.lock
@@ -9,7 +9,7 @@
       },
       "locked": {
         "lastModified": 1769507691,
-        "narHash": "sha256-+OWq0G/Q5UvYAMG908cu1qpHGNuLvrezMbI1vOymWL0=",
+        "narHash": "sha256-NDWEPV5t9KKVrfn7X924Bf+cNXFj0Cqp6rx2h+TQt5M=",
         "rev": "cccc8ab6fda0e54752936db0d5c80b02a2c34a3a",
         "revCount": 2196,
         "submodules": true,

--- a/flake.lock
+++ b/flake.lock
@@ -29,17 +29,18 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1766504822,
-        "narHash": "sha256-tWVLbYoi8/xNzsbJmzMBnuc4GsB7/4oH05yCwuokKT8=",
-        "ref": "refs/heads/master",
-        "rev": "fb8039c5a56086ec7fb3e5e1a5a593bb3756ccb6",
-        "revCount": 76,
+        "lastModified": 1769872025,
+        "narHash": "sha256-4HTTAPIz7zxvhAUNx8EDEZBAUCBoW0DCsJt5zeNBrIQ=",
+        "ref": "refs/heads/start-using-nimble",
+        "rev": "1c904d7d8840bd03233db6e02dceb86b263d7bdb",
+        "revCount": 85,
         "submodules": true,
         "type": "git",
         "url": "https://github.com/logos-messaging/nim-sds"
       },
       "original": {
-        "rev": "fb8039c5a56086ec7fb3e5e1a5a593bb3756ccb6",
+        "ref": "refs/heads/start-using-nimble",
+        "rev": "1c904d7d8840bd03233db6e02dceb86b263d7bdb",
         "submodules": true,
         "type": "git",
         "url": "https://github.com/logos-messaging/nim-sds"

--- a/flake.nix
+++ b/flake.nix
@@ -21,7 +21,7 @@
       inputs.nixpkgs.follows = "nixpkgs";
     };
     # We cannot do follows since the nim-unwrapped-2_0 doesn't exist in this nixpkgs version above
-    nim-sds.url = "git+https://github.com/logos-messaging/nim-sds?submodules=1&rev=fb8039c5a56086ec7fb3e5e1a5a593bb3756ccb6";
+    nim-sds.url = "git+https://github.com/logos-messaging/nim-sds?ref=refs/heads/start-using-nimble&submodules=1&rev=1c904d7d8840bd03233db6e02dceb86b263d7bdb";
   };
 
   outputs = { self, nixpkgs, lmn, nim-sds }:

--- a/flake.nix
+++ b/flake.nix
@@ -21,7 +21,7 @@
       inputs.nixpkgs.follows = "nixpkgs";
     };
     # We cannot do follows since the nim-unwrapped-2_0 doesn't exist in this nixpkgs version above
-    nim-sds.url = "git+https://github.com/logos-messaging/nim-sds?ref=refs/heads/start-using-nimble&submodules=1&rev=1c904d7d8840bd03233db6e02dceb86b263d7bdb";
+    nim-sds.url = "git+https://github.com/logos-messaging/nim-sds?ref=refs/heads/start-using-nimble&rev=1c904d7d8840bd03233db6e02dceb86b263d7bdb";
   };
 
   outputs = { self, nixpkgs, lmn, nim-sds }:

--- a/flake.nix
+++ b/flake.nix
@@ -21,7 +21,7 @@
       inputs.nixpkgs.follows = "nixpkgs";
     };
     # We cannot do follows since the nim-unwrapped-2_0 doesn't exist in this nixpkgs version above
-    nim-sds.url = "git+https://github.com/logos-messaging/nim-sds?ref=refs/heads/start-using-nimble&submodules=1&rev=1c904d7d8840bd03233db6e02dceb86b263d7bdb";
+    nim-sds.url = "git+https://github.com/logos-messaging/nim-sds?ref=refs/heads/start-using-nimble&submodules=1&rev=a48beb922031698a3970a9210852c5759f3ee551";
   };
 
   outputs = { self, nixpkgs, lmn, nim-sds }:

--- a/flake.nix
+++ b/flake.nix
@@ -21,7 +21,7 @@
       inputs.nixpkgs.follows = "nixpkgs";
     };
     # We cannot do follows since the nim-unwrapped-2_0 doesn't exist in this nixpkgs version above
-    nim-sds.url = "git+https://github.com/logos-messaging/nim-sds?ref=refs/heads/start-using-nimble&submodules=1&rev=f1cfb160c4000561d8a968b58e079b2d726ca65a";
+    nim-sds.url = "git+https://github.com/logos-messaging/nim-sds?ref=refs/heads/start-using-nimble&submodules=1&rev=2d6e1fcd5b70c0a9cf5befab14a359a13a69c8cc";
   };
 
   outputs = { self, nixpkgs, lmn, nim-sds }:

--- a/flake.nix
+++ b/flake.nix
@@ -21,7 +21,7 @@
       inputs.nixpkgs.follows = "nixpkgs";
     };
     # We cannot do follows since the nim-unwrapped-2_0 doesn't exist in this nixpkgs version above
-    nim-sds.url = "git+https://github.com/logos-messaging/nim-sds?ref=refs/heads/start-using-nimble&submodules=1&rev=2d6e1fcd5b70c0a9cf5befab14a359a13a69c8cc";
+    nim-sds.url = "git+https://github.com/logos-messaging/nim-sds?ref=refs/heads/start-using-nimble&submodules=1&rev=0454556582583031218e393398185c0012583148";
   };
 
   outputs = { self, nixpkgs, lmn, nim-sds }:

--- a/flake.nix
+++ b/flake.nix
@@ -21,7 +21,7 @@
       inputs.nixpkgs.follows = "nixpkgs";
     };
     # We cannot do follows since the nim-unwrapped-2_0 doesn't exist in this nixpkgs version above
-    nim-sds.url = "git+https://github.com/logos-messaging/nim-sds?ref=refs/heads/start-using-nimble&submodules=1&rev=a48beb922031698a3970a9210852c5759f3ee551";
+    nim-sds.url = "git+https://github.com/logos-messaging/nim-sds?ref=refs/heads/start-using-nimble&submodules=1&rev=f1cfb160c4000561d8a968b58e079b2d726ca65a";
   };
 
   outputs = { self, nixpkgs, lmn, nim-sds }:

--- a/flake.nix
+++ b/flake.nix
@@ -21,7 +21,7 @@
       inputs.nixpkgs.follows = "nixpkgs";
     };
     # We cannot do follows since the nim-unwrapped-2_0 doesn't exist in this nixpkgs version above
-    nim-sds.url = "git+https://github.com/logos-messaging/nim-sds?ref=refs/heads/start-using-nimble&rev=1c904d7d8840bd03233db6e02dceb86b263d7bdb";
+    nim-sds.url = "git+https://github.com/logos-messaging/nim-sds?ref=refs/heads/start-using-nimble&submodules=1&rev=1c904d7d8840bd03233db6e02dceb86b263d7bdb";
   };
 
   outputs = { self, nixpkgs, lmn, nim-sds }:

--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -22,6 +22,7 @@ in mkShell {
     protobuf3_24 protoc-gen-go gotestsum openjdk openssl
     rustc cargo
     nim
+    nimble
     lib-sds-pkg
     libwaku
   ];


### PR DESCRIPTION
Use of `nim-sds` dependency when it uses _Nimble_ instead of _nimbus-build-system_.

No logic change.