### PR TITLE
feat(wallet): add module for proof-of-work auth

### DIFF
--- a/nix/pkgs/status-go/library/default.nix
+++ b/nix/pkgs/status-go/library/default.nix
@@ -11,7 +11,7 @@ let
 in pkgs.buildGoModule {
   pname = "status-go";
   src = builtins.path { path = ./../../../..; name = "status-go-library"; };
-  vendorHash = "sha256-is6SmKVHD5SX+5WKPxOjXS7i53xzAr994Pb2m1PWAZs=";
+  vendorHash = "sha256-BuyGx8FPi2vK5m+F3MAgllOix/KNhQaE+9DB48cdxX8=";
 
   inherit meta version;
 

--- a/params/config.go
+++ b/params/config.go
@@ -226,6 +226,7 @@ type WalletConfig struct {
 	StatusProxyMarketUser     security.SensitiveString `json:"StatusProxyMarketUser"`
 	StatusProxyMarketPassword security.SensitiveString `json:"StatusProxyMarketPassword"`
 	MarketDataProxyConfig     MarketDataProxyConfig    `json:"MarketDataProxyConfig"`
+	NftProxyConfig            NftProxyConfig           `json:"NftProxyConfig"`
 
 	StatusProxyUser     security.SensitiveString `json:"StatusProxyBlockchainUser"`
 	StatusProxyPassword security.SensitiveString `json:"StatusProxyBlockchainPassword"`
@@ -251,6 +252,14 @@ type MarketDataProxyConfig struct {
 	Password                security.SensitiveString `json:"Password"`
 	FullDataRefreshInterval int                      `json:"FullDataRefreshInterval"`
 	PriceRefreshInterval    int                      `json:"PriceRefreshInterval"`
+}
+
+type NftProxyConfig struct {
+	UrlOverride   security.SensitiveString `json:"UrlOverride"`
+	StageName     string                   `json:"StageName"`
+	User          security.SensitiveString `json:"User"`
+	Password      security.SensitiveString `json:"Password"`
+	UsePuzzleAuth bool                     `json:"UsePuzzleAuth"`
 }
 
 // MarshalJSON custom marshalling to avoid exposing sensitive data in log,

--- a/params/networkhelper/chain_mapping.go
+++ b/params/networkhelper/chain_mapping.go
@@ -1,0 +1,43 @@
+package networkhelper
+
+import (
+	"fmt"
+
+	"github.com/status-im/status-go/services/wallet/common"
+)
+
+// ChainIDToChainAndNetwork converts a chain ID to its corresponding chain and network string identifiers.
+// These strings are used in proxy URLs and other network-related configurations.
+// Returns an error if the chain ID is not supported.
+func ChainIDToChainAndNetwork(chainID uint64) (chain string, network string, err error) {
+	switch chainID {
+	case common.EthereumMainnet:
+		return "ethereum", "mainnet", nil
+	case common.EthereumSepolia:
+		return "ethereum", "sepolia", nil
+	case common.OptimismMainnet:
+		return "optimism", "mainnet", nil
+	case common.OptimismSepolia:
+		return "optimism", "sepolia", nil
+	case common.ArbitrumMainnet:
+		return "arbitrum", "mainnet", nil
+	case common.ArbitrumSepolia:
+		return "arbitrum", "sepolia", nil
+	case common.BaseMainnet:
+		return "base", "mainnet", nil
+	case common.BaseSepolia:
+		return "base", "sepolia", nil
+	case common.LineaMainnet:
+		return "linea", "mainnet", nil
+	case common.LineaSepolia:
+		return "linea", "sepolia", nil
+	case common.StatusNetworkSepolia:
+		return "status", "sepolia", nil
+	case common.BSCMainnet:
+		return "bsc", "mainnet", nil
+	case common.BSCTestnet:
+		return "bsc", "testnet", nil
+	default:
+		return "", "", fmt.Errorf("unsupported chain ID: %d", chainID)
+	}
+}

--- a/params/networkhelper/chain_mapping_test.go
+++ b/params/networkhelper/chain_mapping_test.go
@@ -1,0 +1,134 @@
+package networkhelper
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/status-im/status-go/services/wallet/common"
+)
+
+func TestChainIDToChainAndNetwork(t *testing.T) {
+	tests := []struct {
+		name            string
+		chainID         uint64
+		expectedChain   string
+		expectedNetwork string
+		expectError     bool
+	}{
+		{
+			name:            "Ethereum Mainnet",
+			chainID:         common.EthereumMainnet,
+			expectedChain:   "ethereum",
+			expectedNetwork: "mainnet",
+			expectError:     false,
+		},
+		{
+			name:            "Ethereum Sepolia",
+			chainID:         common.EthereumSepolia,
+			expectedChain:   "ethereum",
+			expectedNetwork: "sepolia",
+			expectError:     false,
+		},
+		{
+			name:            "Optimism Mainnet",
+			chainID:         common.OptimismMainnet,
+			expectedChain:   "optimism",
+			expectedNetwork: "mainnet",
+			expectError:     false,
+		},
+		{
+			name:            "Optimism Sepolia",
+			chainID:         common.OptimismSepolia,
+			expectedChain:   "optimism",
+			expectedNetwork: "sepolia",
+			expectError:     false,
+		},
+		{
+			name:            "Arbitrum Mainnet",
+			chainID:         common.ArbitrumMainnet,
+			expectedChain:   "arbitrum",
+			expectedNetwork: "mainnet",
+			expectError:     false,
+		},
+		{
+			name:            "Arbitrum Sepolia",
+			chainID:         common.ArbitrumSepolia,
+			expectedChain:   "arbitrum",
+			expectedNetwork: "sepolia",
+			expectError:     false,
+		},
+		{
+			name:            "Base Mainnet",
+			chainID:         common.BaseMainnet,
+			expectedChain:   "base",
+			expectedNetwork: "mainnet",
+			expectError:     false,
+		},
+		{
+			name:            "Base Sepolia",
+			chainID:         common.BaseSepolia,
+			expectedChain:   "base",
+			expectedNetwork: "sepolia",
+			expectError:     false,
+		},
+		{
+			name:            "Linea Mainnet",
+			chainID:         common.LineaMainnet,
+			expectedChain:   "linea",
+			expectedNetwork: "mainnet",
+			expectError:     false,
+		},
+		{
+			name:            "Linea Sepolia",
+			chainID:         common.LineaSepolia,
+			expectedChain:   "linea",
+			expectedNetwork: "sepolia",
+			expectError:     false,
+		},
+		{
+			name:            "Status Network Sepolia",
+			chainID:         common.StatusNetworkSepolia,
+			expectedChain:   "status",
+			expectedNetwork: "sepolia",
+			expectError:     false,
+		},
+		{
+			name:            "BSC Mainnet",
+			chainID:         common.BSCMainnet,
+			expectedChain:   "bsc",
+			expectedNetwork: "mainnet",
+			expectError:     false,
+		},
+		{
+			name:            "BSC Testnet",
+			chainID:         common.BSCTestnet,
+			expectedChain:   "bsc",
+			expectedNetwork: "testnet",
+			expectError:     false,
+		},
+		{
+			name:            "Unsupported chain ID",
+			chainID:         999999,
+			expectedChain:   "",
+			expectedNetwork: "",
+			expectError:     true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			chain, network, err := ChainIDToChainAndNetwork(tt.chainID)
+
+			if tt.expectError {
+				require.Error(t, err)
+				require.Empty(t, chain)
+				require.Empty(t, network)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tt.expectedChain, chain)
+				require.Equal(t, tt.expectedNetwork, network)
+			}
+		})
+	}
+}

--- a/pkg/backend/default_networks.go
+++ b/pkg/backend/default_networks.go
@@ -42,8 +42,7 @@ func smartProxyUrlWithProvider(proxyHost, chainName, networkName, provider strin
 
 func mainnet(proxyHost, stageName string, enableRpcProviders bool) params.Network {
 	const chainID = common.EthereumMainnet
-	const chainName = "ethereum"
-	const networkName = "mainnet"
+	chainName, networkName, _ := networkhelper.ChainIDToChainAndNetwork(chainID)
 
 	var rpcProviders []params.RpcProvider = []params.RpcProvider{}
 	if enableRpcProviders {
@@ -82,8 +81,7 @@ func mainnet(proxyHost, stageName string, enableRpcProviders bool) params.Networ
 
 func sepolia(proxyHost, stageName string, enableRpcProviders bool) params.Network {
 	const chainID = common.EthereumSepolia
-	const chainName = "ethereum"
-	const networkName = "sepolia"
+	chainName, networkName, _ := networkhelper.ChainIDToChainAndNetwork(chainID)
 
 	var rpcProviders []params.RpcProvider = []params.RpcProvider{}
 	if enableRpcProviders {
@@ -122,8 +120,7 @@ func sepolia(proxyHost, stageName string, enableRpcProviders bool) params.Networ
 
 func optimism(proxyHost, stageName string, enableRpcProviders bool) params.Network {
 	const chainID = common.OptimismMainnet
-	const chainName = "optimism"
-	const networkName = "mainnet"
+	chainName, networkName, _ := networkhelper.ChainIDToChainAndNetwork(chainID)
 
 	var rpcProviders []params.RpcProvider = []params.RpcProvider{}
 	if enableRpcProviders {
@@ -162,8 +159,7 @@ func optimism(proxyHost, stageName string, enableRpcProviders bool) params.Netwo
 
 func optimismSepolia(proxyHost, stageName string, enableRpcProviders bool) params.Network {
 	const chainID = common.OptimismSepolia
-	const chainName = "optimism"
-	const networkName = "sepolia"
+	chainName, networkName, _ := networkhelper.ChainIDToChainAndNetwork(chainID)
 
 	var rpcProviders []params.RpcProvider = []params.RpcProvider{}
 	if enableRpcProviders {
@@ -202,8 +198,7 @@ func optimismSepolia(proxyHost, stageName string, enableRpcProviders bool) param
 
 func arbitrum(proxyHost, stageName string, enableRpcProviders bool) params.Network {
 	const chainID = common.ArbitrumMainnet
-	const chainName = "arbitrum"
-	const networkName = "mainnet"
+	chainName, networkName, _ := networkhelper.ChainIDToChainAndNetwork(chainID)
 
 	var rpcProviders []params.RpcProvider = []params.RpcProvider{}
 	if enableRpcProviders {
@@ -242,8 +237,7 @@ func arbitrum(proxyHost, stageName string, enableRpcProviders bool) params.Netwo
 
 func arbitrumSepolia(proxyHost, stageName string, enableRpcProviders bool) params.Network {
 	const chainID = common.ArbitrumSepolia
-	const chainName = "arbitrum"
-	const networkName = "sepolia"
+	chainName, networkName, _ := networkhelper.ChainIDToChainAndNetwork(chainID)
 
 	var rpcProviders []params.RpcProvider = []params.RpcProvider{}
 	if enableRpcProviders {
@@ -282,8 +276,7 @@ func arbitrumSepolia(proxyHost, stageName string, enableRpcProviders bool) param
 
 func base(proxyHost, stageName string, enableRpcProviders bool) params.Network {
 	const chainID = common.BaseMainnet
-	const chainName = "base"
-	const networkName = "mainnet"
+	chainName, networkName, _ := networkhelper.ChainIDToChainAndNetwork(chainID)
 
 	var rpcProviders []params.RpcProvider = []params.RpcProvider{}
 	if enableRpcProviders {
@@ -322,8 +315,7 @@ func base(proxyHost, stageName string, enableRpcProviders bool) params.Network {
 
 func baseSepolia(proxyHost, stageName string, enableRpcProviders bool) params.Network {
 	const chainID = common.BaseSepolia
-	const chainName = "base"
-	const networkName = "sepolia"
+	chainName, networkName, _ := networkhelper.ChainIDToChainAndNetwork(chainID)
 
 	var rpcProviders []params.RpcProvider = []params.RpcProvider{}
 	if enableRpcProviders {
@@ -362,8 +354,7 @@ func baseSepolia(proxyHost, stageName string, enableRpcProviders bool) params.Ne
 
 func statusNetworkSepolia(proxyHost string, enableRpcProviders bool) params.Network {
 	const chainID = common.StatusNetworkSepolia
-	const chainName = "status"
-	const networkName = "sepolia"
+	chainName, networkName, _ := networkhelper.ChainIDToChainAndNetwork(chainID)
 
 	var rpcProviders []params.RpcProvider = []params.RpcProvider{}
 	if enableRpcProviders {
@@ -398,8 +389,7 @@ func statusNetworkSepolia(proxyHost string, enableRpcProviders bool) params.Netw
 
 func bnbSmartChain(proxyHost string, enableRpcProviders bool) params.Network {
 	const chainID = common.BSCMainnet
-	const chainName = "bsc"
-	const networkName = "mainnet"
+	chainName, networkName, _ := networkhelper.ChainIDToChainAndNetwork(chainID)
 
 	var rpcProviders []params.RpcProvider = []params.RpcProvider{}
 	if enableRpcProviders {
@@ -436,8 +426,7 @@ func bnbSmartChain(proxyHost string, enableRpcProviders bool) params.Network {
 
 func linea(proxyHost, stageName string, enableRpcProviders bool) params.Network {
 	const chainID = common.LineaMainnet
-	const chainName = "linea"
-	const networkName = "mainnet"
+	chainName, networkName, _ := networkhelper.ChainIDToChainAndNetwork(chainID)
 
 	var rpcProviders []params.RpcProvider = []params.RpcProvider{}
 	if enableRpcProviders {
@@ -476,8 +465,7 @@ func linea(proxyHost, stageName string, enableRpcProviders bool) params.Network 
 
 func lineaSepolia(proxyHost, stageName string, enableRpcProviders bool) params.Network {
 	const chainID = common.LineaSepolia
-	const chainName = "linea"
-	const networkName = "sepolia"
+	chainName, networkName, _ := networkhelper.ChainIDToChainAndNetwork(chainID)
 
 	var rpcProviders []params.RpcProvider = []params.RpcProvider{}
 	if enableRpcProviders {
@@ -516,8 +504,7 @@ func lineaSepolia(proxyHost, stageName string, enableRpcProviders bool) params.N
 
 func bnbSmartChainTestnet(proxyHost string, enableRpcProviders bool) params.Network {
 	const chainID = common.BSCTestnet
-	const chainName = "bsc"
-	const networkName = "testnet"
+	chainName, networkName, _ := networkhelper.ChainIDToChainAndNetwork(chainID)
 
 	var rpcProviders []params.RpcProvider = []params.RpcProvider{}
 	if enableRpcProviders {

--- a/pkg/backend/defaults.go
+++ b/pkg/backend/defaults.go
@@ -224,6 +224,21 @@ func buildWalletConfig(walletRequest *requests.WalletConfig, request *requests.W
 		walletConfig.EthRpcProxyPassword = request.EthRpcProxyPassword
 	}
 
+	// NftProxyConfig
+	if !request.NftProxyUrl.Empty() {
+		walletConfig.NftProxyConfig.UrlOverride = request.NftProxyUrl
+	}
+	if request.NftProxyStageName != "" {
+		walletConfig.NftProxyConfig.StageName = request.NftProxyStageName
+	}
+	if !request.NftProxyUser.Empty() {
+		walletConfig.NftProxyConfig.User = request.NftProxyUser
+	}
+	if !request.NftProxyPassword.Empty() {
+		walletConfig.NftProxyConfig.Password = request.NftProxyPassword
+	}
+	walletConfig.NftProxyConfig.UsePuzzleAuth = request.NftProxyUsePuzzleAuth
+
 	return walletConfig
 }
 

--- a/protocol/requests/create_account.go
+++ b/protocol/requests/create_account.go
@@ -124,6 +124,12 @@ type WalletSecretsConfig struct {
 	EthRpcProxyUrl      security.SensitiveString `json:"ethRpcProxyUrl"`
 	EthRpcProxyUser     security.SensitiveString `json:"ethRpcProxyUser"`
 	EthRpcProxyPassword security.SensitiveString `json:"ethRpcProxyPassword"`
+
+	NftProxyUrl           security.SensitiveString `json:"nftProxyUrl"`
+	NftProxyStageName     string                   `json:"nftProxyStageName"`
+	NftProxyUser          security.SensitiveString `json:"nftProxyUser"`
+	NftProxyPassword      security.SensitiveString `json:"nftProxyPassword"`
+	NftProxyUsePuzzleAuth bool                     `json:"nftProxyUsePuzzleAuth"`
 }
 
 func (c *CreateAccount) Validate(validation *CreateAccountValidation) error {

--- a/services/wallet/puzzleauth/client.go
+++ b/services/wallet/puzzleauth/client.go
@@ -46,21 +46,27 @@ func NewClient(origin string, httpClient *http.Client) *Client {
 func (c *Client) DoRequest(req *http.Request) (*http.Response, error) {
 	ctx := req.Context()
 
-	var bodyBytes []byte
-	if req.Body != nil {
-		var err error
-		bodyBytes, err = io.ReadAll(req.Body)
-		req.Body.Close()
+	// Ensure request body can be replayed for retries by setting up GetBody if needed
+	if req.Body != nil && req.GetBody == nil {
+		bodyBytes, err := io.ReadAll(req.Body)
 		if err != nil {
 			return nil, fmt.Errorf("failed to read request body: %w", err)
+		}
+		req.Body.Close()
+		req.Body = io.NopCloser(bytes.NewReader(bodyBytes))
+		req.GetBody = func() (io.ReadCloser, error) {
+			return io.NopCloser(bytes.NewReader(bodyBytes)), nil
 		}
 	}
 
 	for attempt := 0; attempt <= c.maxRetries; attempt++ {
 		clonedReq := req.Clone(ctx)
-		if bodyBytes != nil {
-			clonedReq.Body = io.NopCloser(bytes.NewReader(bodyBytes))
-			clonedReq.ContentLength = int64(len(bodyBytes))
+		if req.GetBody != nil && clonedReq.Body == nil {
+			body, err := req.GetBody()
+			if err != nil {
+				return nil, fmt.Errorf("failed to recreate request body: %w", err)
+			}
+			clonedReq.Body = body
 		}
 
 		token := c.authService.GetToken()

--- a/services/wallet/puzzleauth/client.go
+++ b/services/wallet/puzzleauth/client.go
@@ -1,0 +1,138 @@
+package puzzleauth
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	netUrl "net/url"
+	"time"
+
+	"go.uber.org/zap"
+
+	"github.com/status-im/status-go/internal/logutils"
+)
+
+var retryStatusCodes = map[int]bool{
+	http.StatusUnauthorized:    true, // 401
+	http.StatusForbidden:       true, // 403
+	http.StatusTooManyRequests: true, // 429
+}
+
+// Client is an HTTP client with automatic puzzle authentication
+type Client struct {
+	httpClient  *http.Client
+	authService *Service
+	maxRetries  int
+}
+
+// NewClient creates a new puzzle auth HTTP client
+// If httpClient is nil, a default client with 60 second timeout will be created
+func NewClient(origin string, httpClient *http.Client) *Client {
+	if httpClient == nil {
+		httpClient = &http.Client{
+			Timeout: 60 * time.Second,
+		}
+	}
+	return &Client{
+		httpClient:  httpClient,
+		authService: NewService(origin, httpClient),
+		maxRetries:  2, // Original attempt + 2 retries after auth
+	}
+}
+
+// DoRequest executes an HTTP request with automatic puzzle authentication
+func (c *Client) DoRequest(req *http.Request) (*http.Response, error) {
+	ctx := req.Context()
+
+	var bodyBytes []byte
+	if req.Body != nil {
+		var err error
+		bodyBytes, err = io.ReadAll(req.Body)
+		req.Body.Close()
+		if err != nil {
+			return nil, fmt.Errorf("failed to read request body: %w", err)
+		}
+	}
+
+	for attempt := 0; attempt <= c.maxRetries; attempt++ {
+		clonedReq := req.Clone(ctx)
+		if bodyBytes != nil {
+			clonedReq.Body = io.NopCloser(bytes.NewReader(bodyBytes))
+			clonedReq.ContentLength = int64(len(bodyBytes))
+		}
+
+		token := c.authService.GetToken()
+		if token != "" {
+			clonedReq.Header.Set("Authorization", fmt.Sprintf("Bearer %s", token))
+		}
+
+		resp, err := c.httpClient.Do(clonedReq)
+		if err != nil {
+			return nil, err
+		}
+
+		// Check if we need to retry with authentication
+		if retryStatusCodes[resp.StatusCode] && attempt < c.maxRetries {
+			// Read and close body before retrying
+			_, _ = io.Copy(io.Discard, resp.Body)
+			resp.Body.Close()
+
+			logutils.ZapLogger().Debug("Puzzle auth retry needed",
+				zap.Int("statusCode", resp.StatusCode),
+				zap.Int("attempt", attempt+1))
+
+			c.authService.InvalidateToken()
+
+			token, err := c.authService.EnsureToken(ctx)
+			if err != nil {
+				return nil, fmt.Errorf("failed to get auth token: %w", err)
+			}
+
+			req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", token))
+
+			continue
+		}
+
+		return resp, nil
+	}
+
+	// This should never be reached
+	return nil, fmt.Errorf("puzzle auth: unexpected state after %d attempts", c.maxRetries+1)
+}
+
+// DoGetRequest performs a GET request with puzzle authentication
+func (c *Client) DoGetRequest(ctx context.Context, url string, params netUrl.Values) ([]byte, error) {
+	if len(params) > 0 {
+		url = url + "?" + params.Encode()
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := c.DoRequest(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("request failed with status %d: %s", resp.StatusCode, string(body))
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response body: %w", err)
+	}
+
+	return body, nil
+}
+
+// GetAuthService returns the underlying auth service (useful for testing)
+func (c *Client) GetAuthService() *Service {
+	return c.authService
+}

--- a/services/wallet/puzzleauth/client_test.go
+++ b/services/wallet/puzzleauth/client_test.go
@@ -293,3 +293,12 @@ func TestClient_GetAuthService(t *testing.T) {
 	require.NotNil(t, service)
 	require.Equal(t, "https://test.nft.status.im", service.origin)
 }
+
+func TestClient_DoRequest_ContextCancelled(t *testing.T) {
+	client := NewClient("https://test.nft.status.im", nil)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	req, _ := http.NewRequestWithContext(ctx, http.MethodGet, "http://localhost:1", nil)
+	_, err := client.DoRequest(req)
+	require.Error(t, err)
+}

--- a/services/wallet/puzzleauth/client_test.go
+++ b/services/wallet/puzzleauth/client_test.go
@@ -1,0 +1,295 @@
+package puzzleauth
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	netUrl "net/url"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewClient(t *testing.T) {
+	tests := []struct {
+		name            string
+		httpClient      *http.Client
+		expectedTimeout time.Duration
+	}{
+		{
+			name:            "default HTTP client",
+			httpClient:      nil,
+			expectedTimeout: 60 * time.Second,
+		},
+		{
+			name:            "custom HTTP client",
+			httpClient:      &http.Client{Timeout: 10 * time.Second},
+			expectedTimeout: 10 * time.Second,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := NewClient("https://test.nft.status.im", tt.httpClient)
+			require.NotNil(t, client)
+			require.NotNil(t, client.httpClient)
+			require.NotNil(t, client.authService)
+			require.Equal(t, 2, client.maxRetries)
+			require.Equal(t, tt.expectedTimeout, client.httpClient.Timeout)
+		})
+	}
+}
+
+func TestClient_DoRequest_Success(t *testing.T) {
+	var resourceReq int32
+	server := newPuzzleAuthServer(t)
+	defer server.Close()
+
+	client := NewClient(server.URL, nil)
+	ctx := context.Background()
+
+	resourceHandler := func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&resourceReq, 1)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("success"))
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, server.URL+"/resource", nil)
+	require.NoError(t, err)
+
+	server2 := newPuzzleAuthServer(t, withResourceHandler(resourceHandler))
+	defer server2.Close()
+	parsedURL, err := netUrl.Parse(server2.URL)
+	require.NoError(t, err)
+	req.URL.Host = parsedURL.Host
+	req.URL.Scheme = parsedURL.Scheme
+
+	resp, err := client.DoRequest(req)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.Equal(t, int32(1), atomic.LoadInt32(&resourceReq))
+	resp.Body.Close()
+}
+
+func TestClient_DoRequest_AuthRetry(t *testing.T) {
+	var resourceReq, puzzleReq, solveReq int32
+	var tokenProvided bool
+
+	resourceHandler := func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&resourceReq, 1)
+		authHeader := r.Header.Get("Authorization")
+		if authHeader == "" {
+			w.WriteHeader(http.StatusUnauthorized)
+			_, _ = w.Write([]byte("unauthorized"))
+		} else {
+			tokenProvided = true
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("success"))
+		}
+	}
+
+	server := newPuzzleAuthServer(t,
+		withResourceHandler(resourceHandler),
+		withCounters(&puzzleReq, &solveReq))
+	defer server.Close()
+
+	client := NewClient(server.URL, nil)
+	ctx := context.Background()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, server.URL+"/resource", nil)
+	require.NoError(t, err)
+
+	resp, err := client.DoRequest(req)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.Equal(t, int32(2), atomic.LoadInt32(&resourceReq))
+	require.Equal(t, int32(1), atomic.LoadInt32(&puzzleReq))
+	require.Equal(t, int32(1), atomic.LoadInt32(&solveReq))
+	require.True(t, tokenProvided)
+	resp.Body.Close()
+}
+
+func TestClient_DoRequest_RetryStatusCodes(t *testing.T) {
+	tests := []struct {
+		name       string
+		statusCode int
+	}{
+		{"403 retry", http.StatusForbidden},
+		{"429 retry", http.StatusTooManyRequests},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var resourceReq, requestsWithToken int32
+
+			resourceHandler := func(w http.ResponseWriter, r *http.Request) {
+				atomic.AddInt32(&resourceReq, 1)
+				authHeader := r.Header.Get("Authorization")
+				if authHeader != "" {
+					atomic.AddInt32(&requestsWithToken, 1)
+					w.WriteHeader(http.StatusOK)
+				} else {
+					w.WriteHeader(tt.statusCode)
+				}
+			}
+
+			server := newPuzzleAuthServer(t, withResourceHandler(resourceHandler))
+			defer server.Close()
+
+			client := NewClient(server.URL, nil)
+			ctx := context.Background()
+
+			req, err := http.NewRequestWithContext(ctx, http.MethodGet, server.URL+"/resource", nil)
+			require.NoError(t, err)
+
+			resp, err := client.DoRequest(req)
+			require.NoError(t, err)
+			require.Equal(t, http.StatusOK, resp.StatusCode)
+			require.GreaterOrEqual(t, atomic.LoadInt32(&resourceReq), int32(2))
+			require.Equal(t, int32(1), atomic.LoadInt32(&requestsWithToken))
+			resp.Body.Close()
+		})
+	}
+}
+
+func TestClient_DoRequest_MaxRetriesExceeded(t *testing.T) {
+	var attempts int32
+
+	resourceHandler := func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&attempts, 1)
+		w.WriteHeader(http.StatusUnauthorized)
+	}
+
+	server := newPuzzleAuthServer(t, withResourceHandler(resourceHandler))
+	defer server.Close()
+
+	client := NewClient(server.URL, nil)
+	ctx := context.Background()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, server.URL+"/resource", nil)
+	require.NoError(t, err)
+
+	resp, err := client.DoRequest(req)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	require.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+	resp.Body.Close()
+
+	numAttempts := atomic.LoadInt32(&attempts)
+	require.Equal(t, int32(3), numAttempts, fmt.Sprintf("Expected 3 attempts, got %d", numAttempts))
+}
+
+func TestClient_DoRequest_AuthFailure(t *testing.T) {
+	var resourceReq int32
+
+	resourceHandler := func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&resourceReq, 1)
+		w.WriteHeader(http.StatusUnauthorized)
+	}
+
+	server := newPuzzleAuthServer(t,
+		withResourceHandler(resourceHandler),
+		withPuzzleError(500))
+	defer server.Close()
+
+	client := NewClient(server.URL, nil)
+	ctx := context.Background()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, server.URL+"/resource", nil)
+	require.NoError(t, err)
+
+	resp, err := client.DoRequest(req)
+	require.Error(t, err)
+	require.Nil(t, resp)
+	require.Contains(t, err.Error(), "failed to get auth token")
+	require.GreaterOrEqual(t, atomic.LoadInt32(&resourceReq), int32(1))
+}
+
+func TestClient_DoRequest_NetworkError(t *testing.T) {
+	client := NewClient("http://localhost:1", nil)
+	ctx := context.Background()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "http://localhost:1/resource", nil)
+	require.NoError(t, err)
+
+	resp, err := client.DoRequest(req)
+	require.Error(t, err)
+	require.Nil(t, resp)
+}
+
+func TestClient_DoGetRequest(t *testing.T) {
+	tests := []struct {
+		name     string
+		params   netUrl.Values
+		expected string
+	}{
+		{
+			name: "with params",
+			params: netUrl.Values{
+				"param1": []string{"value1"},
+				"param2": []string{"value2"},
+			},
+			expected: `{"result": "success"}`,
+		},
+		{
+			name:     "no params",
+			params:   nil,
+			expected: "success",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resourceHandler := func(w http.ResponseWriter, r *http.Request) {
+				if tt.params != nil {
+					require.Equal(t, "value1", r.URL.Query().Get("param1"))
+					require.Equal(t, "value2", r.URL.Query().Get("param2"))
+					_, _ = w.Write([]byte(`{"result": "success"}`))
+				} else {
+					require.Empty(t, r.URL.RawQuery)
+					_, _ = w.Write([]byte("success"))
+				}
+			}
+
+			server := newPuzzleAuthServer(t, withResourceHandler(resourceHandler))
+			defer server.Close()
+
+			client := NewClient(server.URL, nil)
+			ctx := context.Background()
+
+			body, err := client.DoGetRequest(ctx, server.URL+"/resource", tt.params)
+			require.NoError(t, err)
+			require.Equal(t, tt.expected, string(body))
+		})
+	}
+}
+
+func TestClient_DoGetRequest_NonOK(t *testing.T) {
+	resourceHandler := func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte("not found"))
+	}
+
+	server := newPuzzleAuthServer(t, withResourceHandler(resourceHandler))
+	defer server.Close()
+
+	client := NewClient(server.URL, nil)
+	ctx := context.Background()
+
+	body, err := client.DoGetRequest(ctx, server.URL+"/resource", nil)
+	require.Error(t, err)
+	require.Nil(t, body)
+	require.Contains(t, err.Error(), "request failed with status 404")
+}
+
+func TestClient_GetAuthService(t *testing.T) {
+	client := NewClient("https://test.nft.status.im", nil)
+
+	service := client.GetAuthService()
+	require.NotNil(t, service)
+	require.Equal(t, "https://test.nft.status.im", service.origin)
+}

--- a/services/wallet/puzzleauth/helpers_test.go
+++ b/services/wallet/puzzleauth/helpers_test.go
@@ -1,0 +1,153 @@
+package puzzleauth
+
+import (
+	"encoding/hex"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func testPuzzle() Puzzle {
+	return Puzzle{
+		Challenge:  "testchallenge",
+		Salt:       hex.EncodeToString([]byte("testsalt12345678")),
+		Difficulty: 1,
+		HMAC:       "testhmac",
+		ExpiresAt:  time.Now().Add(1 * time.Hour).Format(time.RFC3339),
+		Argon2Params: Argon2Params{
+			MemoryKB: 64,
+			Time:     1,
+			Threads:  1,
+			KeyLen:   32,
+		},
+	}
+}
+
+func testTokenResponse(expiresAt string) TokenResponse {
+	if expiresAt == "" {
+		expiresAt = time.Now().Add(1 * time.Hour).Format(time.RFC3339)
+	}
+	return TokenResponse{
+		Token:     "test-jwt-token",
+		ExpiresAt: expiresAt,
+	}
+}
+
+type authServerConfig struct {
+	puzzleStatus  int
+	puzzleBody    string
+	solveStatus   int
+	solveBody     string
+	resourceFunc  func(w http.ResponseWriter, r *http.Request)
+	puzzleCounter *int32
+	solveCounter  *int32
+}
+
+type authServerOption func(*authServerConfig)
+
+func withPuzzleError(status int) authServerOption {
+	return func(c *authServerConfig) {
+		c.puzzleStatus = status
+		c.puzzleBody = "error"
+	}
+}
+
+func withSolveError(status int) authServerOption {
+	return func(c *authServerConfig) {
+		c.solveStatus = status
+		c.solveBody = "error"
+	}
+}
+
+func withPuzzleBody(body string) authServerOption {
+	return func(c *authServerConfig) {
+		c.puzzleBody = body
+	}
+}
+
+func withSolveBody(body string) authServerOption {
+	return func(c *authServerConfig) {
+		c.solveBody = body
+	}
+}
+
+func withInvalidExpiry() authServerOption {
+	return func(c *authServerConfig) {
+		c.solveBody = `{"token":"test-jwt-token","expires_at":"invalid-date"}`
+	}
+}
+
+func withResourceHandler(fn func(w http.ResponseWriter, r *http.Request)) authServerOption {
+	return func(c *authServerConfig) {
+		c.resourceFunc = fn
+	}
+}
+
+func withCounters(puzzleCounter, solveCounter *int32) authServerOption {
+	return func(c *authServerConfig) {
+		c.puzzleCounter = puzzleCounter
+		c.solveCounter = solveCounter
+	}
+}
+
+func newPuzzleAuthServer(t *testing.T, opts ...authServerOption) *httptest.Server {
+	cfg := &authServerConfig{
+		puzzleStatus: http.StatusOK,
+		solveStatus:  http.StatusOK,
+	}
+	for _, opt := range opts {
+		opt(cfg)
+	}
+
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/auth/puzzle":
+			if cfg.puzzleCounter != nil {
+				atomic.AddInt32(cfg.puzzleCounter, 1)
+			}
+			if cfg.puzzleStatus != http.StatusOK {
+				w.WriteHeader(cfg.puzzleStatus)
+				_, _ = w.Write([]byte(cfg.puzzleBody))
+				return
+			}
+			if cfg.puzzleBody != "" {
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(cfg.puzzleBody))
+				return
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(testPuzzle())
+
+		case "/auth/solve":
+			if cfg.solveCounter != nil {
+				atomic.AddInt32(cfg.solveCounter, 1)
+			}
+			if cfg.solveStatus != http.StatusOK {
+				w.WriteHeader(cfg.solveStatus)
+				_, _ = w.Write([]byte(cfg.solveBody))
+				return
+			}
+			if cfg.solveBody != "" {
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(cfg.solveBody))
+				return
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(testTokenResponse(""))
+
+		case "/resource":
+			if cfg.resourceFunc != nil {
+				cfg.resourceFunc(w, r)
+			} else {
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write([]byte("success"))
+			}
+
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+}

--- a/services/wallet/puzzleauth/service.go
+++ b/services/wallet/puzzleauth/service.go
@@ -1,0 +1,202 @@
+package puzzleauth
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	netUrl "net/url"
+	"sync"
+	"time"
+
+	"go.uber.org/zap"
+
+	"github.com/status-im/status-go/internal/logutils"
+)
+
+// Service manages puzzle authentication tokens
+type Service struct {
+	origin      string
+	httpClient  *http.Client
+	tokenCache  *TokenData
+	mu          sync.RWMutex
+	refreshLock sync.Mutex
+}
+
+// NewService creates a new puzzle auth service for the given origin
+// If httpClient is nil, a default client with 30 second timeout will be created
+func NewService(origin string, httpClient *http.Client) *Service {
+	if httpClient == nil {
+		httpClient = &http.Client{
+			Timeout: 30 * time.Second,
+		}
+	}
+	return &Service{
+		origin:     origin,
+		httpClient: httpClient,
+	}
+}
+
+// GetToken returns the current valid token (synchronously)
+// Returns empty string if token is expired or doesn't exist
+func (s *Service) GetToken() string {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	if s.tokenCache != nil && s.tokenCache.IsValid() {
+		return s.tokenCache.Token
+	}
+
+	return ""
+}
+
+// InvalidateToken clears the cached token
+func (s *Service) InvalidateToken() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.tokenCache = nil
+	logutils.ZapLogger().Debug("Puzzle auth token invalidated",
+		zap.String("origin", s.origin))
+}
+
+// EnsureToken returns a valid token, refreshing if necessary
+func (s *Service) EnsureToken(ctx context.Context) (string, error) {
+	if token := s.GetToken(); token != "" {
+		return token, nil
+	}
+
+	// Need to refresh - use lock to prevent concurrent refreshes
+	s.refreshLock.Lock()
+	defer s.refreshLock.Unlock()
+
+	// Double-check after acquiring lock (another goroutine might have refreshed)
+	if token := s.GetToken(); token != "" {
+		return token, nil
+	}
+
+	return s.refreshToken(ctx)
+}
+
+// refreshToken fetches a new token by solving a puzzle
+func (s *Service) refreshToken(ctx context.Context) (string, error) {
+	logutils.ZapLogger().Debug("Refreshing puzzle auth token",
+		zap.String("origin", s.origin))
+
+	startTime := time.Now()
+
+	// Step 1: Get puzzle
+	puzzle, err := s.getPuzzle(ctx)
+	if err != nil {
+		return "", fmt.Errorf("failed to get puzzle: %w", err)
+	}
+
+	// Step 2: Solve puzzle
+	solution, err := Solve(ctx, puzzle)
+	if err != nil {
+		return "", fmt.Errorf("failed to solve puzzle: %w", err)
+	}
+
+	solveTime := time.Since(startTime)
+	logutils.ZapLogger().Debug("Puzzle solved",
+		zap.String("origin", s.origin),
+		zap.Uint64("nonce", solution.Nonce),
+		zap.Duration("solveTime", solveTime))
+
+	// Step 3: Submit solution
+	tokenResp, err := s.submitSolution(ctx, solution)
+	if err != nil {
+		return "", fmt.Errorf("failed to submit solution: %w", err)
+	}
+
+	expiresAt, err := time.Parse(time.RFC3339, tokenResp.ExpiresAt)
+	if err != nil {
+		logutils.ZapLogger().Warn("Failed to parse token expiry, using 1 hour default",
+			zap.Error(err))
+		expiresAt = time.Now().Add(1 * time.Hour)
+	}
+
+	s.mu.Lock()
+	s.tokenCache = &TokenData{
+		Token:     tokenResp.Token,
+		ExpiresAt: expiresAt,
+	}
+	s.mu.Unlock()
+
+	logutils.ZapLogger().Debug("Puzzle auth token refreshed",
+		zap.String("origin", s.origin),
+		zap.Time("expiresAt", expiresAt),
+		zap.Duration("totalTime", time.Since(startTime)))
+
+	return tokenResp.Token, nil
+}
+
+// getPuzzle fetches a puzzle from the auth server
+func (s *Service) getPuzzle(ctx context.Context) (*Puzzle, error) {
+	url, err := netUrl.JoinPath(s.origin, "auth", "puzzle")
+	if err != nil {
+		return nil, fmt.Errorf("failed to construct puzzle URL: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := s.httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("puzzle request failed with status %d: %s", resp.StatusCode, string(body))
+	}
+
+	var puzzle Puzzle
+	if err := json.NewDecoder(resp.Body).Decode(&puzzle); err != nil {
+		return nil, err
+	}
+
+	return &puzzle, nil
+}
+
+// submitSolution submits a solved puzzle to get a JWT token
+func (s *Service) submitSolution(ctx context.Context, solution *Solution) (*TokenResponse, error) {
+	url, err := netUrl.JoinPath(s.origin, "auth", "solve")
+	if err != nil {
+		return nil, fmt.Errorf("failed to construct solve URL: %w", err)
+	}
+
+	jsonData, err := json.Marshal(solution)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewBuffer(jsonData))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := s.httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("solution submission failed with status %d: %s", resp.StatusCode, string(body))
+	}
+
+	var tokenResp TokenResponse
+	if err := json.NewDecoder(resp.Body).Decode(&tokenResp); err != nil {
+		return nil, err
+	}
+
+	return &tokenResp, nil
+}

--- a/services/wallet/puzzleauth/service_test.go
+++ b/services/wallet/puzzleauth/service_test.go
@@ -1,0 +1,201 @@
+package puzzleauth
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestService_GetToken(t *testing.T) {
+	service := NewService("https://test.nft.status.im", nil)
+
+	token := service.GetToken()
+	require.Empty(t, token)
+
+	service.mu.Lock()
+	service.tokenCache = &TokenData{
+		Token:     "test-token",
+		ExpiresAt: time.Now().Add(1 * time.Hour),
+	}
+	service.mu.Unlock()
+
+	token = service.GetToken()
+	require.Equal(t, "test-token", token)
+
+	service.mu.Lock()
+	service.tokenCache = &TokenData{
+		Token:     "expired-token",
+		ExpiresAt: time.Now().Add(-1 * time.Hour),
+	}
+	service.mu.Unlock()
+
+	token = service.GetToken()
+	require.Empty(t, token)
+}
+
+func TestService_InvalidateToken(t *testing.T) {
+	service := NewService("https://test.nft.status.im", nil)
+
+	service.mu.Lock()
+	service.tokenCache = &TokenData{
+		Token:     "test-token",
+		ExpiresAt: time.Now().Add(1 * time.Hour),
+	}
+	service.mu.Unlock()
+
+	require.NotEmpty(t, service.GetToken())
+
+	service.InvalidateToken()
+
+	require.Empty(t, service.GetToken())
+	require.Nil(t, service.tokenCache)
+}
+
+func TestNewService(t *testing.T) {
+	origin := "https://test.nft.status.im"
+	service := NewService(origin, nil)
+
+	require.NotNil(t, service)
+	require.Equal(t, origin, service.origin)
+	require.NotNil(t, service.httpClient)
+	require.Nil(t, service.tokenCache)
+}
+
+func TestService_EnsureToken_FreshToken(t *testing.T) {
+	var puzzleReq, solveReq int32
+	server := newPuzzleAuthServer(t, withCounters(&puzzleReq, &solveReq))
+	defer server.Close()
+
+	service := NewService(server.URL, nil)
+	ctx := context.Background()
+
+	token, err := service.EnsureToken(ctx)
+	require.NoError(t, err)
+	require.Equal(t, "test-jwt-token", token)
+	require.Equal(t, int32(1), atomic.LoadInt32(&puzzleReq))
+	require.Equal(t, int32(1), atomic.LoadInt32(&solveReq))
+	require.NotNil(t, service.tokenCache)
+	require.Equal(t, "test-jwt-token", service.tokenCache.Token)
+}
+
+func TestService_EnsureToken_CachedToken(t *testing.T) {
+	var puzzleReq int32
+	server := newPuzzleAuthServer(t, withCounters(&puzzleReq, nil))
+	defer server.Close()
+
+	service := NewService(server.URL, nil)
+	ctx := context.Background()
+
+	service.mu.Lock()
+	service.tokenCache = &TokenData{
+		Token:     "cached-token",
+		ExpiresAt: time.Now().Add(1 * time.Hour),
+	}
+	service.mu.Unlock()
+
+	token, err := service.EnsureToken(ctx)
+	require.NoError(t, err)
+	require.Equal(t, "cached-token", token)
+	require.Equal(t, int32(0), atomic.LoadInt32(&puzzleReq))
+}
+
+func TestService_EnsureToken_ConcurrentRequests(t *testing.T) {
+	var puzzleReq, solveReq int32
+	server := newPuzzleAuthServer(t, withCounters(&puzzleReq, &solveReq))
+	defer server.Close()
+
+	service := NewService(server.URL, nil)
+	ctx := context.Background()
+
+	const numRequests = 10
+	var wg sync.WaitGroup
+	wg.Add(numRequests)
+	errors := make([]error, numRequests)
+	tokens := make([]string, numRequests)
+
+	for i := 0; i < numRequests; i++ {
+		go func(idx int) {
+			defer wg.Done()
+			token, err := service.EnsureToken(ctx)
+			tokens[idx] = token
+			errors[idx] = err
+		}(i)
+	}
+
+	wg.Wait()
+
+	for i := 0; i < numRequests; i++ {
+		require.NoError(t, errors[i])
+		require.Equal(t, "test-jwt-token", tokens[i])
+	}
+
+	require.Equal(t, int32(1), atomic.LoadInt32(&puzzleReq))
+	require.Equal(t, int32(1), atomic.LoadInt32(&solveReq))
+}
+
+func TestService_RefreshToken_Errors(t *testing.T) {
+	tests := []struct {
+		name    string
+		opts    []authServerOption
+		wantErr string
+	}{
+		{
+			name:    "puzzle error",
+			opts:    []authServerOption{withPuzzleError(500)},
+			wantErr: "failed to get puzzle",
+		},
+		{
+			name:    "solve error",
+			opts:    []authServerOption{withSolveError(400)},
+			wantErr: "failed to submit solution",
+		},
+		{
+			name:    "puzzle JSON error",
+			opts:    []authServerOption{withPuzzleBody("invalid json")},
+			wantErr: "failed to get puzzle",
+		},
+		{
+			name:    "solve JSON error",
+			opts:    []authServerOption{withSolveBody("invalid json")},
+			wantErr: "failed to submit solution",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := newPuzzleAuthServer(t, tt.opts...)
+			defer server.Close()
+
+			service := NewService(server.URL, nil)
+			ctx := context.Background()
+
+			token, err := service.EnsureToken(ctx)
+			require.Error(t, err)
+			require.Empty(t, token)
+			require.Contains(t, err.Error(), tt.wantErr)
+		})
+	}
+}
+
+func TestService_RefreshToken_InvalidExpiry(t *testing.T) {
+	server := newPuzzleAuthServer(t, withInvalidExpiry())
+	defer server.Close()
+
+	service := NewService(server.URL, nil)
+	ctx := context.Background()
+
+	token, err := service.EnsureToken(ctx)
+	require.NoError(t, err)
+	require.Equal(t, "test-jwt-token", token)
+
+	require.NotNil(t, service.tokenCache)
+	require.Equal(t, "test-jwt-token", service.tokenCache.Token)
+	timeDiff := service.tokenCache.ExpiresAt.Sub(time.Now())
+	require.True(t, timeDiff > 55*time.Minute && timeDiff < 65*time.Minute,
+		fmt.Sprintf("Expected expiry around 1 hour, got %v", timeDiff))
+}

--- a/services/wallet/puzzleauth/service_test.go
+++ b/services/wallet/puzzleauth/service_test.go
@@ -199,3 +199,11 @@ func TestService_RefreshToken_InvalidExpiry(t *testing.T) {
 	require.True(t, timeDiff > 55*time.Minute && timeDiff < 65*time.Minute,
 		fmt.Sprintf("Expected expiry around 1 hour, got %v", timeDiff))
 }
+
+func TestService_EnsureToken_ContextCancelled(t *testing.T) {
+	service := NewService("https://test.nft.status.im", nil)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	_, err := service.EnsureToken(ctx)
+	require.Error(t, err)
+}

--- a/services/wallet/puzzleauth/solver.go
+++ b/services/wallet/puzzleauth/solver.go
@@ -1,0 +1,92 @@
+package puzzleauth
+
+import (
+	"context"
+	"encoding/hex"
+	"fmt"
+
+	"golang.org/x/crypto/argon2"
+)
+
+const maxAttempts = 1000000
+
+// Solve attempts to solve the puzzle by finding a nonce that produces
+// a hash with the required number of leading zeros
+func Solve(ctx context.Context, puzzle *Puzzle) (*Solution, error) {
+	if puzzle == nil {
+		return nil, fmt.Errorf("puzzle cannot be nil")
+	}
+
+	if puzzle.Difficulty < 0 {
+		return nil, fmt.Errorf("invalid difficulty: %d", puzzle.Difficulty)
+	}
+	if puzzle.Argon2Params.MemoryKB <= 0 || puzzle.Argon2Params.MemoryKB > 4*1024*1024 { // max 4GB
+		return nil, fmt.Errorf("invalid memory_kb: %d", puzzle.Argon2Params.MemoryKB)
+	}
+	if puzzle.Argon2Params.Time <= 0 || puzzle.Argon2Params.Time > 100 {
+		return nil, fmt.Errorf("invalid time: %d", puzzle.Argon2Params.Time)
+	}
+	if puzzle.Argon2Params.Threads <= 0 || puzzle.Argon2Params.Threads > 255 {
+		return nil, fmt.Errorf("invalid threads: %d", puzzle.Argon2Params.Threads)
+	}
+	if puzzle.Argon2Params.KeyLen <= 0 || puzzle.Argon2Params.KeyLen > 1024 {
+		return nil, fmt.Errorf("invalid key_len: %d", puzzle.Argon2Params.KeyLen)
+	}
+
+	saltBytes, err := hex.DecodeString(puzzle.Salt)
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode salt: %w", err)
+	}
+
+	memory := uint32(puzzle.Argon2Params.MemoryKB)
+	time := uint32(puzzle.Argon2Params.Time)
+	threads := uint8(puzzle.Argon2Params.Threads)
+	keyLen := uint32(puzzle.Argon2Params.KeyLen)
+
+	// Try different nonces until we find one that meets the difficulty requirement
+	for nonce := uint64(0); nonce < maxAttempts; nonce++ {
+		if nonce%1000 == 0 {
+			select {
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			default:
+			}
+		}
+
+		// Create input: challenge + salt + nonce
+		input := fmt.Sprintf("%s%s%d", puzzle.Challenge, puzzle.Salt, nonce)
+
+		// Compute Argon2id hash
+		hash := argon2.IDKey([]byte(input), saltBytes, time, memory, threads, keyLen)
+		argonHash := hex.EncodeToString(hash)
+
+		// Check if hash meets difficulty requirement
+		if checkDifficulty(argonHash, puzzle.Difficulty) {
+			return &Solution{
+				Challenge: puzzle.Challenge,
+				Salt:      puzzle.Salt,
+				Nonce:     nonce,
+				ArgonHash: argonHash,
+				HMAC:      puzzle.HMAC,
+				ExpiresAt: puzzle.ExpiresAt,
+			}, nil
+		}
+	}
+
+	return nil, fmt.Errorf("failed to solve puzzle within %d attempts", maxAttempts)
+}
+
+// checkDifficulty checks if the hash has the required number of leading zeros
+func checkDifficulty(hash string, difficulty int) bool {
+	if len(hash) < difficulty {
+		return false
+	}
+
+	for i := 0; i < difficulty; i++ {
+		if hash[i] != '0' {
+			return false
+		}
+	}
+
+	return true
+}

--- a/services/wallet/puzzleauth/solver_test.go
+++ b/services/wallet/puzzleauth/solver_test.go
@@ -1,0 +1,157 @@
+package puzzleauth
+
+import (
+	"context"
+	"encoding/hex"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCheckDifficulty(t *testing.T) {
+	tests := []struct {
+		name       string
+		hash       string
+		difficulty int
+		expected   bool
+	}{
+		{
+			name:       "zero difficulty always passes",
+			hash:       "abcdef123456",
+			difficulty: 0,
+			expected:   true,
+		},
+		{
+			name:       "one leading zero passes",
+			hash:       "0abcdef123456",
+			difficulty: 1,
+			expected:   true,
+		},
+		{
+			name:       "two leading zeros passes",
+			hash:       "00abcdef123456",
+			difficulty: 2,
+			expected:   true,
+		},
+		{
+			name:       "no leading zeros fails",
+			hash:       "abcdef123456",
+			difficulty: 1,
+			expected:   false,
+		},
+		{
+			name:       "one leading zero fails for difficulty 2",
+			hash:       "0abcdef123456",
+			difficulty: 2,
+			expected:   false,
+		},
+		{
+			name:       "hash too short",
+			hash:       "00",
+			difficulty: 3,
+			expected:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := checkDifficulty(tt.hash, tt.difficulty)
+			require.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestSolve(t *testing.T) {
+	tests := []struct {
+		name        string
+		puzzle      *Puzzle
+		expectError bool
+	}{
+		{
+			name:        "nil puzzle returns error",
+			puzzle:      nil,
+			expectError: true,
+		},
+		{
+			name: "invalid salt hex returns error",
+			puzzle: &Puzzle{
+				Challenge:  "test",
+				Salt:       "invalid-hex",
+				Difficulty: 1,
+				Argon2Params: Argon2Params{
+					MemoryKB: 64,
+					Time:     1,
+					Threads:  1,
+					KeyLen:   32,
+				},
+			},
+			expectError: true,
+		},
+		{
+			name: "valid puzzle with low difficulty should solve",
+			puzzle: &Puzzle{
+				Challenge:  "testchallenge123",
+				Salt:       hex.EncodeToString([]byte("testsalt12345678")),
+				Difficulty: 1,
+				HMAC:       "testhmac",
+				ExpiresAt:  "2025-12-31T23:59:59Z",
+				Argon2Params: Argon2Params{
+					MemoryKB: 64,
+					Time:     1,
+					Threads:  1,
+					KeyLen:   32,
+				},
+			},
+			expectError: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			solution, err := Solve(context.Background(), tt.puzzle)
+
+			if tt.expectError {
+				require.Error(t, err)
+				require.Nil(t, solution)
+			} else {
+				require.NoError(t, err)
+				require.NotNil(t, solution)
+				require.Equal(t, tt.puzzle.Challenge, solution.Challenge)
+				require.Equal(t, tt.puzzle.Salt, solution.Salt)
+				require.Equal(t, tt.puzzle.HMAC, solution.HMAC)
+				require.Equal(t, tt.puzzle.ExpiresAt, solution.ExpiresAt)
+				require.NotEmpty(t, solution.ArgonHash)
+
+				// Verify the solution has the required difficulty
+				require.True(t, checkDifficulty(solution.ArgonHash, tt.puzzle.Difficulty),
+					"solution hash %s does not meet difficulty %d", solution.ArgonHash, tt.puzzle.Difficulty)
+			}
+		})
+	}
+}
+
+func TestSolve_HighDifficulty(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping high difficulty test in short mode")
+	}
+
+	// This test verifies that solve can handle moderate difficulty
+	puzzle := &Puzzle{
+		Challenge:  "challenge",
+		Salt:       hex.EncodeToString([]byte("salt12345678")),
+		Difficulty: 2,
+		HMAC:       "hmac",
+		ExpiresAt:  "2025-12-31T23:59:59Z",
+		Argon2Params: Argon2Params{
+			MemoryKB: 64,
+			Time:     1,
+			Threads:  1,
+			KeyLen:   32,
+		},
+	}
+
+	solution, err := Solve(context.Background(), puzzle)
+	require.NoError(t, err)
+	require.NotNil(t, solution)
+	require.True(t, checkDifficulty(solution.ArgonHash, puzzle.Difficulty))
+}

--- a/services/wallet/puzzleauth/solver_test.go
+++ b/services/wallet/puzzleauth/solver_test.go
@@ -155,3 +155,40 @@ func TestSolve_HighDifficulty(t *testing.T) {
 	require.NotNil(t, solution)
 	require.True(t, checkDifficulty(solution.ArgonHash, puzzle.Difficulty))
 }
+
+func TestSolve_ParamValidation(t *testing.T) {
+	salt := hex.EncodeToString([]byte("testsalt"))
+	tests := []struct {
+		name   string
+		puzzle *Puzzle
+	}{
+		{"negative difficulty", &Puzzle{Difficulty: -1, Salt: salt, Argon2Params: Argon2Params{MemoryKB: 64, Time: 1, Threads: 1, KeyLen: 32}}},
+		{"zero memory", &Puzzle{Difficulty: 1, Salt: salt, Argon2Params: Argon2Params{MemoryKB: 0, Time: 1, Threads: 1, KeyLen: 32}}},
+		{"excessive memory", &Puzzle{Difficulty: 1, Salt: salt, Argon2Params: Argon2Params{MemoryKB: 5000000, Time: 1, Threads: 1, KeyLen: 32}}},
+		{"zero time", &Puzzle{Difficulty: 1, Salt: salt, Argon2Params: Argon2Params{MemoryKB: 64, Time: 0, Threads: 1, KeyLen: 32}}},
+		{"excessive time", &Puzzle{Difficulty: 1, Salt: salt, Argon2Params: Argon2Params{MemoryKB: 64, Time: 101, Threads: 1, KeyLen: 32}}},
+		{"zero threads", &Puzzle{Difficulty: 1, Salt: salt, Argon2Params: Argon2Params{MemoryKB: 64, Time: 1, Threads: 0, KeyLen: 32}}},
+		{"excessive threads", &Puzzle{Difficulty: 1, Salt: salt, Argon2Params: Argon2Params{MemoryKB: 64, Time: 1, Threads: 256, KeyLen: 32}}},
+		{"zero keylen", &Puzzle{Difficulty: 1, Salt: salt, Argon2Params: Argon2Params{MemoryKB: 64, Time: 1, Threads: 1, KeyLen: 0}}},
+		{"excessive keylen", &Puzzle{Difficulty: 1, Salt: salt, Argon2Params: Argon2Params{MemoryKB: 64, Time: 1, Threads: 1, KeyLen: 1025}}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := Solve(context.Background(), tt.puzzle)
+			require.Error(t, err)
+		})
+	}
+}
+
+func TestSolve_ContextCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	puzzle := &Puzzle{
+		Challenge:    "test",
+		Salt:         hex.EncodeToString([]byte("testsalt")),
+		Difficulty:   5,
+		Argon2Params: Argon2Params{MemoryKB: 64, Time: 1, Threads: 1, KeyLen: 32},
+	}
+	_, err := Solve(ctx, puzzle)
+	require.ErrorIs(t, err, context.Canceled)
+}

--- a/services/wallet/puzzleauth/types.go
+++ b/services/wallet/puzzleauth/types.go
@@ -1,0 +1,56 @@
+package puzzleauth
+
+import (
+	"time"
+)
+
+// Argon2Params represents Argon2id algorithm parameters
+type Argon2Params struct {
+	MemoryKB int `json:"memory_kb"`
+	Time     int `json:"time"`
+	Threads  int `json:"threads"`
+	KeyLen   int `json:"key_len"`
+}
+
+// Puzzle represents a proof-of-work puzzle from the server
+type Puzzle struct {
+	Challenge    string       `json:"challenge"`
+	Salt         string       `json:"salt"`
+	Difficulty   int          `json:"difficulty"`
+	ExpiresAt    string       `json:"expires_at"`
+	HMAC         string       `json:"hmac"`
+	Argon2Params Argon2Params `json:"argon2_params"`
+}
+
+// Solution represents a solved puzzle
+type Solution struct {
+	Challenge string `json:"challenge"`
+	Salt      string `json:"salt"`
+	Nonce     uint64 `json:"nonce"`
+	ArgonHash string `json:"argon_hash"`
+	HMAC      string `json:"hmac"`
+	ExpiresAt string `json:"expires_at"`
+}
+
+// TokenResponse represents the response from the auth server
+type TokenResponse struct {
+	Token        string `json:"token"`
+	ExpiresAt    string `json:"expires_at"`
+	RequestLimit int    `json:"request_limit"`
+}
+
+// TokenData represents cached token data
+type TokenData struct {
+	Token     string
+	ExpiresAt time.Time
+}
+
+// IsValid checks if the token is still valid
+func (t *TokenData) IsValid() bool {
+	if t == nil || t.Token == "" {
+		return false
+	}
+	// Consider token expired 5 minutes before actual expiry
+	expiryBuffer := 5 * time.Minute
+	return time.Now().Before(t.ExpiresAt.Add(-expiryBuffer))
+}

--- a/services/wallet/puzzleauth/types_test.go
+++ b/services/wallet/puzzleauth/types_test.go
@@ -1,0 +1,69 @@
+package puzzleauth
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestTokenData_IsValid(t *testing.T) {
+	tests := []struct {
+		name      string
+		tokenData *TokenData
+		expected  bool
+	}{
+		{
+			name:      "nil token is invalid",
+			tokenData: nil,
+			expected:  false,
+		},
+		{
+			name: "empty token is invalid",
+			tokenData: &TokenData{
+				Token:     "",
+				ExpiresAt: time.Now().Add(1 * time.Hour),
+			},
+			expected: false,
+		},
+		{
+			name: "expired token is invalid",
+			tokenData: &TokenData{
+				Token:     "valid-token",
+				ExpiresAt: time.Now().Add(-1 * time.Hour),
+			},
+			expected: false,
+		},
+		{
+			name: "token expiring soon (within 5 min) is invalid",
+			tokenData: &TokenData{
+				Token:     "valid-token",
+				ExpiresAt: time.Now().Add(3 * time.Minute),
+			},
+			expected: false,
+		},
+		{
+			name: "valid token with sufficient time is valid",
+			tokenData: &TokenData{
+				Token:     "valid-token",
+				ExpiresAt: time.Now().Add(10 * time.Minute),
+			},
+			expected: true,
+		},
+		{
+			name: "valid token with 1 hour expiry is valid",
+			tokenData: &TokenData{
+				Token:     "valid-token",
+				ExpiresAt: time.Now().Add(1 * time.Hour),
+			},
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := tt.tokenData.IsValid()
+			require.Equal(t, tt.expected, result)
+		})
+	}
+}

--- a/services/wallet/service.go
+++ b/services/wallet/service.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net/http"
 	"time"
 
 	"github.com/golang/protobuf/proto"
@@ -28,6 +29,7 @@ import (
 
 	"github.com/status-im/status-go/params"
 	"github.com/status-im/status-go/pkg/pubsub"
+	"github.com/status-im/status-go/pkg/security"
 	"github.com/status-im/status-go/protocol/backupsync"
 	protocolCommon "github.com/status-im/status-go/protocol/common"
 	"github.com/status-im/status-go/protocol/protobuf"
@@ -47,6 +49,7 @@ import (
 	"github.com/status-im/status-go/services/wallet/leaderboard"
 	"github.com/status-im/status-go/services/wallet/market"
 	"github.com/status-im/status-go/services/wallet/onramp"
+	"github.com/status-im/status-go/services/wallet/puzzleauth"
 	"github.com/status-im/status-go/services/wallet/routeexecution"
 	"github.com/status-im/status-go/services/wallet/router"
 	"github.com/status-im/status-go/services/wallet/router/pathprocessor"
@@ -72,6 +75,33 @@ func createCoingeckoProxyClient(config params.MarketDataProxyConfig) *coingecko.
 		URL:      baseURL,
 		User:     config.User,
 		Password: config.Password,
+	})
+}
+
+func createAlchemyProxyClient(config params.NftProxyConfig) *alchemy.Client {
+	var creds *thirdparty.BasicCreds
+	if !config.User.Empty() {
+		creds = &thirdparty.BasicCreds{
+			User:     config.User,
+			Password: config.Password,
+		}
+	}
+
+	// Create puzzle auth client if enabled
+	var puzzleClient *puzzleauth.Client
+	if config.UsePuzzleAuth {
+		origin := alchemy.GetNftProxyHost(config.UrlOverride.Reveal(), config.StageName)
+		httpClient := &http.Client{Timeout: time.Minute}
+		puzzleClient = puzzleauth.NewClient(origin, httpClient)
+	}
+
+	return alchemy.NewClientWithParams(alchemy.Params{
+		IsProxy:          true,
+		ProxyCustomURL:   config.UrlOverride.Reveal(),
+		ProxyStageName:   config.StageName,
+		APIKey:           security.SensitiveString{},
+		Creds:            creds,
+		PuzzleAuthClient: puzzleClient,
 	})
 }
 
@@ -141,24 +171,29 @@ func NewService(
 
 		raribleClient := rarible.NewClient(config.WalletConfig.RaribleMainnetAPIKey, config.WalletConfig.RaribleTestnetAPIKey)
 		alchemyClient := alchemy.NewClient(config.WalletConfig.AlchemyAPIKey)
+		alchemyProxy := createAlchemyProxyClient(config.WalletConfig.NftProxyConfig)
 
 		// Collectible providers in priority order (i.e. provider N+1 will be tried only if provider N fails)
 		contractOwnershipProviders := []thirdparty.CollectibleContractOwnershipProvider{
+			alchemyProxy,
 			raribleClient,
 			alchemyClient,
 		}
 
 		accountOwnershipProviders := []thirdparty.CollectibleAccountOwnershipProvider{
+			alchemyProxy,
 			raribleClient,
 			alchemyClient,
 		}
 
 		collectibleDataProviders := []thirdparty.CollectibleDataProvider{
+			alchemyProxy,
 			raribleClient,
 			alchemyClient,
 		}
 
 		collectionDataProviders := []thirdparty.CollectionDataProvider{
+			alchemyProxy,
 			raribleClient,
 			alchemyClient,
 		}

--- a/services/wallet/thirdparty/auth_transport.go
+++ b/services/wallet/thirdparty/auth_transport.go
@@ -1,0 +1,99 @@
+package thirdparty
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/status-im/status-go/pkg/security"
+	"github.com/status-im/status-go/services/wallet/puzzleauth"
+)
+
+var ErrPuzzleAuthClientRequired = errors.New("PuzzleAuthClient is required for AuthTypePOW")
+
+// AuthType specifies how requests are authenticated.
+type AuthType int
+
+const (
+	// AuthTypeAPIKey means API key is embedded in URL (direct Alchemy), no auth headers.
+	AuthTypeAPIKey AuthType = iota
+	// AuthTypeBasic means Basic auth (user/password) in headers.
+	AuthTypeBasic
+	// AuthTypePOW means proof-of-work auth via puzzleauth.Client.
+	AuthTypePOW
+	// AuthTypeNone means no authentication (e.g. proxy without creds or puzzle).
+	AuthTypeNone
+)
+
+// AuthParams holds authentication configuration for AuthTransport.
+type AuthParams struct {
+	Type             AuthType
+	APIKey           security.SensitiveString
+	Creds            *BasicCreds
+	PuzzleAuthClient *puzzleauth.Client
+}
+
+// AuthTransport executes HTTP requests with auth headers and retry logic.
+type AuthTransport struct {
+	httpClient *http.Client
+	auth       AuthParams
+	providerID string
+}
+
+// NewAuthTransport creates a new AuthTransport.
+func NewAuthTransport(httpClient *http.Client, auth AuthParams, providerID string) *AuthTransport {
+	if httpClient == nil {
+		httpClient = &http.Client{Timeout: time.Minute}
+	}
+	return &AuthTransport{
+		httpClient: httpClient,
+		auth:       auth,
+		providerID: providerID,
+	}
+}
+
+// Do executes the request with auth applied and retries as appropriate.
+func (t *AuthTransport) Do(req *http.Request) (*http.Response, error) {
+	t.applyAuth(req)
+	return t.doWithRetries(req)
+}
+
+func (t *AuthTransport) authTypeName() string {
+	switch t.auth.Type {
+	case AuthTypeAPIKey:
+		return "APIKey"
+	case AuthTypeBasic:
+		return "Basic"
+	case AuthTypePOW:
+		return "POW"
+	case AuthTypeNone:
+		return "None"
+	default:
+		return fmt.Sprintf("Unknown(%d)", t.auth.Type)
+	}
+}
+
+// Auth returns the auth params (e.g. for reading APIKey).
+func (t *AuthTransport) Auth() AuthParams {
+	return t.auth
+}
+
+func (t *AuthTransport) applyAuth(req *http.Request) {
+	if t.auth.Type == AuthTypeBasic && t.auth.Creds != nil {
+		req.SetBasicAuth(t.auth.Creds.User.Reveal(), t.auth.Creds.Password.Reveal())
+	}
+	// AuthTypeAPIKey: key is in URL, no header needed
+	// AuthTypePOW: puzzleauth.Client handles auth internally in DoRequest
+	// AuthTypeNone: no auth headers
+}
+
+func (t *AuthTransport) doWithRetries(req *http.Request) (*http.Response, error) {
+	if t.auth.Type == AuthTypePOW {
+		if t.auth.PuzzleAuthClient == nil {
+			return nil, ErrPuzzleAuthClientRequired
+		}
+		return t.auth.PuzzleAuthClient.DoRequest(req)
+	}
+	return DoWithExponentialBackoff(t.httpClient, req, t.providerID)
+}

--- a/services/wallet/thirdparty/auth_transport_test.go
+++ b/services/wallet/thirdparty/auth_transport_test.go
@@ -1,0 +1,260 @@
+package thirdparty
+
+import (
+	"context"
+	"encoding/hex"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/status-im/status-go/pkg/security"
+	"github.com/status-im/status-go/services/wallet/puzzleauth"
+)
+
+func TestAuthTransport_APIKey_Success(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Verify no auth headers (API key is in URL)
+		require.Empty(t, r.Header.Get("Authorization"))
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("success"))
+	}))
+	defer server.Close()
+
+	authParams := AuthParams{
+		Type:   AuthTypeAPIKey,
+		APIKey: security.NewSensitiveString("test-api-key"),
+	}
+	transport := NewAuthTransport(&http.Client{Timeout: time.Minute}, authParams, "test-provider")
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, server.URL, nil)
+	require.NoError(t, err)
+
+	resp, err := transport.Do(req)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	resp.Body.Close()
+}
+
+func TestAuthTransport_None_Success(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Empty(t, r.Header.Get("Authorization"))
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("success"))
+	}))
+	defer server.Close()
+
+	authParams := AuthParams{
+		Type: AuthTypeNone,
+	}
+	transport := NewAuthTransport(&http.Client{Timeout: time.Minute}, authParams, "test-provider")
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, server.URL, nil)
+	require.NoError(t, err)
+
+	resp, err := transport.Do(req)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	resp.Body.Close()
+}
+
+func TestAuthTransport_Basic_SetsAuthHeader(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		username, password, ok := r.BasicAuth()
+		require.True(t, ok)
+		require.Equal(t, "testuser", username)
+		require.Equal(t, "testpass", password)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("success"))
+	}))
+	defer server.Close()
+
+	authParams := AuthParams{
+		Type: AuthTypeBasic,
+		Creds: &BasicCreds{
+			User:     security.NewSensitiveString("testuser"),
+			Password: security.NewSensitiveString("testpass"),
+		},
+	}
+	transport := NewAuthTransport(&http.Client{Timeout: time.Minute}, authParams, "test-provider")
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, server.URL, nil)
+	require.NoError(t, err)
+
+	resp, err := transport.Do(req)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	resp.Body.Close()
+}
+
+func TestAuthTransport_Basic_RetryOn429(t *testing.T) {
+	var attempts int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		attempts++
+		if attempts < 3 {
+			w.WriteHeader(http.StatusTooManyRequests)
+		} else {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("success after retry"))
+		}
+	}))
+	defer server.Close()
+
+	authParams := AuthParams{
+		Type: AuthTypeBasic,
+		Creds: &BasicCreds{
+			User:     security.NewSensitiveString("user"),
+			Password: security.NewSensitiveString("pass"),
+		},
+	}
+	transport := NewAuthTransport(&http.Client{Timeout: time.Minute}, authParams, "test-provider")
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, server.URL, nil)
+	require.NoError(t, err)
+
+	resp, err := transport.Do(req)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.GreaterOrEqual(t, attempts, 3, "Should have retried at least twice before succeeding")
+	resp.Body.Close()
+}
+
+func newPuzzleAuthServerForTest(t *testing.T) *httptest.Server {
+	t.Helper()
+	puzzle := puzzleauth.Puzzle{
+		Challenge:  "testchallenge",
+		Salt:       hex.EncodeToString([]byte("testsalt12345678")),
+		Difficulty: 1,
+		HMAC:       "testhmac",
+		ExpiresAt:  time.Now().Add(1 * time.Hour).Format(time.RFC3339),
+		Argon2Params: puzzleauth.Argon2Params{
+			MemoryKB: 64,
+			Time:     1,
+			Threads:  1,
+			KeyLen:   32,
+		},
+	}
+	tokenResp := puzzleauth.TokenResponse{
+		Token:     "test-jwt-token",
+		ExpiresAt: time.Now().Add(1 * time.Hour).Format(time.RFC3339),
+	}
+
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/auth/puzzle":
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(puzzle)
+		case "/auth/solve":
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(tokenResp)
+		case "/resource":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("success"))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+}
+
+func TestAuthTransport_POW_DelegatesToPuzzleAuth(t *testing.T) {
+	server := newPuzzleAuthServerForTest(t)
+	defer server.Close()
+
+	puzzleClient := puzzleauth.NewClient(server.URL, nil)
+	authParams := AuthParams{
+		Type:             AuthTypePOW,
+		PuzzleAuthClient: puzzleClient,
+	}
+	transport := NewAuthTransport(&http.Client{Timeout: time.Minute}, authParams, "test-provider")
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, server.URL+"/resource", nil)
+	require.NoError(t, err)
+
+	resp, err := transport.Do(req)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	resp.Body.Close()
+}
+
+func TestAuthTransport_POW_NilPuzzleClient(t *testing.T) {
+	authParams := AuthParams{
+		Type:             AuthTypePOW,
+		PuzzleAuthClient: nil,
+	}
+	transport := NewAuthTransport(&http.Client{Timeout: time.Minute}, authParams, "test-provider")
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "http://localhost:1", nil)
+	require.NoError(t, err)
+
+	resp, err := transport.Do(req)
+	require.Error(t, err)
+	require.Nil(t, resp)
+	require.ErrorIs(t, err, ErrPuzzleAuthClientRequired)
+}
+
+func TestAuthTransport_Auth_Getter(t *testing.T) {
+	apiKey := security.NewSensitiveString("my-key")
+	creds := &BasicCreds{
+		User:     security.NewSensitiveString("u"),
+		Password: security.NewSensitiveString("p"),
+	}
+
+	tests := []struct {
+		name       string
+		authParams AuthParams
+	}{
+		{"APIKey", AuthParams{Type: AuthTypeAPIKey, APIKey: apiKey}},
+		{"Basic", AuthParams{Type: AuthTypeBasic, Creds: creds}},
+		{"None", AuthParams{Type: AuthTypeNone}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			transport := NewAuthTransport(nil, tt.authParams, "provider")
+			got := transport.Auth()
+			require.Equal(t, tt.authParams.Type, got.Type)
+			require.Equal(t, tt.authParams.APIKey.Reveal(), got.APIKey.Reveal())
+			if tt.authParams.Creds != nil {
+				require.NotNil(t, got.Creds)
+				require.Equal(t, tt.authParams.Creds.User.Reveal(), got.Creds.User.Reveal())
+				require.Equal(t, tt.authParams.Creds.Password.Reveal(), got.Creds.Password.Reveal())
+			}
+		})
+	}
+}
+
+func TestAuthTransport_AuthTypeName(t *testing.T) {
+	tests := []struct {
+		name     string
+		authType AuthType
+		expected string
+	}{
+		{"APIKey", AuthTypeAPIKey, "APIKey"},
+		{"Basic", AuthTypeBasic, "Basic"},
+		{"POW", AuthTypePOW, "POW"},
+		{"None", AuthTypeNone, "None"},
+		{"Unknown", AuthType(99), "Unknown(99)"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			transport := NewAuthTransport(nil, AuthParams{Type: tt.authType}, "test")
+			require.Equal(t, tt.expected, transport.authTypeName())
+		})
+	}
+}
+
+func TestNewAuthTransport_NilClient(t *testing.T) {
+	transport := NewAuthTransport(nil, AuthParams{Type: AuthTypeNone}, "test")
+	require.NotNil(t, transport)
+	require.NotNil(t, transport.httpClient)
+	require.Equal(t, time.Minute, transport.httpClient.Timeout)
+}

--- a/services/wallet/thirdparty/collectibles/alchemy/client.go
+++ b/services/wallet/thirdparty/collectibles/alchemy/client.go
@@ -10,82 +10,45 @@ import (
 	"strings"
 	"time"
 
-	"github.com/cenkalti/backoff/v4"
-	"go.uber.org/zap"
-
 	"github.com/ethereum/go-ethereum/common"
 
 	"github.com/status-im/status-go/internal/logutils"
 	"github.com/status-im/status-go/pkg/security"
 	walletCommon "github.com/status-im/status-go/services/wallet/common"
 	"github.com/status-im/status-go/services/wallet/connection"
+	"github.com/status-im/status-go/services/wallet/puzzleauth"
 	"github.com/status-im/status-go/services/wallet/thirdparty"
 )
 
 const nftMetadataBatchLimit = 100
 const contractMetadataBatchLimit = 100
 
-func getBaseURL(chainID walletCommon.ChainID) (string, error) {
-	switch uint64(chainID) {
-	case walletCommon.EthereumMainnet:
-		return "https://eth-mainnet.g.alchemy.com", nil
-	case walletCommon.EthereumSepolia:
-		return "https://eth-sepolia.g.alchemy.com", nil
-	case walletCommon.OptimismMainnet:
-		return "https://opt-mainnet.g.alchemy.com", nil
-	case walletCommon.OptimismSepolia:
-		return "https://opt-sepolia.g.alchemy.com", nil
-	case walletCommon.ArbitrumMainnet:
-		return "https://arb-mainnet.g.alchemy.com", nil
-	case walletCommon.ArbitrumSepolia:
-		return "https://arb-sepolia.g.alchemy.com", nil
-	case walletCommon.BaseMainnet:
-		return "https://base-mainnet.g.alchemy.com", nil
-	case walletCommon.BaseSepolia:
-		return "https://base-sepolia.g.alchemy.com", nil
-	case walletCommon.LineaMainnet:
-		return "https://linea-mainnet.g.alchemy.com", nil
-	case walletCommon.LineaSepolia:
-		return "https://linea-sepolia.g.alchemy.com", nil
-	}
-
-	return "", thirdparty.ErrChainIDNotSupported
+type Params struct {
+	IsProxy          bool
+	ProxyCustomURL   string
+	ProxyStageName   string
+	APIKey           security.SensitiveString
+	Creds            *thirdparty.BasicCreds
+	PuzzleAuthClient *puzzleauth.Client
 }
 
 func (o *Client) ID() string {
-	return AlchemyID
+	return o.id
 }
 
 func (o *Client) IsChainSupported(chainID walletCommon.ChainID) bool {
-	_, err := getBaseURL(chainID)
-	return err == nil
+	return o.urlResolver.IsChainSupported(chainID)
 }
 
 func (o *Client) IsConnected() bool {
 	return o.connectionStatus.IsConnected()
 }
 
-func getAPIKeySubpath(apiKey security.SensitiveString) security.SensitiveString {
-	if apiKey.Empty() {
-		return security.NewSensitiveString("demo")
-	}
-	return apiKey
-}
-
-func getNFTBaseURL(chainID walletCommon.ChainID, apiKey security.SensitiveString) (string, error) {
-	baseURL, err := getBaseURL(chainID)
-
-	if err != nil {
-		return "", err
-	}
-
-	return fmt.Sprintf("%s/nft/v3/%s", baseURL, getAPIKeySubpath(apiKey).Reveal()), nil
-}
-
 type Client struct {
 	thirdparty.CollectibleContractOwnershipProvider
-	client           *http.Client
-	apiKey           security.SensitiveString
+	id               string
+	urlResolver      URLResolver
+	authTransport    *thirdparty.AuthTransport
 	connectionStatus *connection.Status
 }
 
@@ -94,9 +57,56 @@ func NewClient(apiKey security.SensitiveString) *Client {
 		logutils.ZapLogger().Warn("Alchemy API key not available")
 	}
 
+	authParams := thirdparty.AuthParams{
+		Type:   thirdparty.AuthTypeAPIKey,
+		APIKey: apiKey,
+	}
+
 	return &Client{
-		client:           &http.Client{Timeout: time.Minute},
-		apiKey:           apiKey,
+		id:               AlchemyID,
+		urlResolver:      &directURLResolver{apiKey: apiKey},
+		authTransport:    thirdparty.NewAuthTransport(&http.Client{Timeout: time.Minute}, authParams, AlchemyID),
+		connectionStatus: connection.NewStatus(),
+	}
+}
+
+func NewClientWithParams(params Params) *Client {
+	if params.APIKey.Empty() && params.Creds == nil && params.PuzzleAuthClient == nil {
+		logutils.ZapLogger().Warn("Alchemy API key, credentials, and puzzle auth not available")
+	}
+
+	authParams := thirdparty.AuthParams{
+		APIKey:           params.APIKey,
+		Creds:            params.Creds,
+		PuzzleAuthClient: params.PuzzleAuthClient,
+	}
+	switch {
+	case params.PuzzleAuthClient != nil:
+		authParams.Type = thirdparty.AuthTypePOW
+	case params.Creds != nil:
+		authParams.Type = thirdparty.AuthTypeBasic
+	case params.IsProxy:
+		authParams.Type = thirdparty.AuthTypeNone
+	default:
+		authParams.Type = thirdparty.AuthTypeAPIKey
+	}
+
+	clientID := AlchemyID
+	if params.IsProxy {
+		clientID = AlchemyProxyID
+	}
+
+	var resolver URLResolver
+	if params.IsProxy {
+		resolver = &proxyURLResolver{customURL: params.ProxyCustomURL, stageName: params.ProxyStageName}
+	} else {
+		resolver = &directURLResolver{apiKey: params.APIKey}
+	}
+
+	return &Client{
+		id:               clientID,
+		urlResolver:      resolver,
+		authTransport:    thirdparty.NewAuthTransport(&http.Client{Timeout: time.Minute}, authParams, clientID),
 		connectionStatus: connection.NewStatus(),
 	}
 }
@@ -106,8 +116,7 @@ func (o *Client) doQuery(ctx context.Context, url string) (*http.Response, error
 	if err != nil {
 		return nil, err
 	}
-
-	return o.doWithRetries(req)
+	return o.authTransport.Do(req)
 }
 
 func (o *Client) doPostWithJSON(ctx context.Context, url string, payload any) (*http.Response, error) {
@@ -116,10 +125,7 @@ func (o *Client) doPostWithJSON(ctx context.Context, url string, payload any) (*
 		return nil, err
 	}
 
-	payloadString := string(payloadJSON)
-	payloadReader := strings.NewReader(payloadString)
-
-	req, err := http.NewRequestWithContext(ctx, "POST", url, payloadReader)
+	req, err := http.NewRequestWithContext(ctx, "POST", url, strings.NewReader(string(payloadJSON)))
 	if err != nil {
 		return nil, err
 	}
@@ -127,42 +133,7 @@ func (o *Client) doPostWithJSON(ctx context.Context, url string, payload any) (*
 	req.Header.Add("accept", "application/json")
 	req.Header.Add("content-type", "application/json")
 
-	return o.doWithRetries(req)
-}
-
-func (o *Client) doWithRetries(req *http.Request) (*http.Response, error) {
-	b := backoff.NewExponentialBackOff()
-	b.InitialInterval = time.Millisecond * 1000
-	b.RandomizationFactor = 0.1
-	b.Multiplier = 1.5
-	b.MaxInterval = time.Second * 32
-	b.MaxElapsedTime = time.Second * 70
-
-	b.Reset()
-
-	op := func() (*http.Response, error) {
-		resp, err := o.client.Do(req)
-		if err != nil {
-			return nil, backoff.Permanent(err)
-		}
-
-		if resp.StatusCode == http.StatusOK {
-			return resp, nil
-		}
-
-		err = fmt.Errorf("unsuccessful request: %d %s", resp.StatusCode, http.StatusText(resp.StatusCode))
-		if resp.StatusCode == http.StatusTooManyRequests {
-			logutils.ZapLogger().Error("doWithRetries failed with http.StatusTooManyRequests",
-				zap.String("provider", o.ID()),
-				zap.Duration("elapsed time", b.GetElapsedTime()),
-				zap.Duration("next backoff", b.NextBackOff()),
-			)
-			return nil, err
-		}
-		return nil, backoff.Permanent(err)
-	}
-
-	return backoff.RetryWithData(op, b)
+	return o.authTransport.Do(req)
 }
 
 func (o *Client) FetchCollectibleOwnersByContractAddress(ctx context.Context, chainID walletCommon.ChainID, contractAddress common.Address) (*thirdparty.CollectibleContractOwnership, error) {
@@ -176,8 +147,7 @@ func (o *Client) FetchCollectibleOwnersByContractAddress(ctx context.Context, ch
 		"withTokenBalances": {"true"},
 	}
 
-	baseURL, err := getNFTBaseURL(chainID, o.apiKey)
-
+	baseURL, err := o.urlResolver.GetNFTBaseURL(chainID)
 	if err != nil {
 		return nil, err
 	}
@@ -248,8 +218,7 @@ func (o *Client) fetchOwnedAssets(ctx context.Context, chainID walletCommon.Chai
 	}
 	assets.Provider = o.ID()
 
-	baseURL, err := getNFTBaseURL(chainID, o.apiKey)
-
+	baseURL, err := o.urlResolver.GetNFTBaseURL(chainID)
 	if err != nil {
 		return nil, err
 	}
@@ -330,7 +299,7 @@ func getCollectibleUniqueIDBatches(ids []thirdparty.CollectibleUniqueID) []Batch
 }
 
 func (o *Client) fetchAssetsByBatchTokenIDs(ctx context.Context, chainID walletCommon.ChainID, batchIDs BatchTokenIDs) ([]thirdparty.FullCollectibleData, error) {
-	baseURL, err := getNFTBaseURL(chainID, o.apiKey)
+	baseURL, err := o.urlResolver.GetNFTBaseURL(chainID)
 	if err != nil {
 		return nil, err
 	}
@@ -421,7 +390,7 @@ func getContractAddressBatches(ids []thirdparty.ContractID) []BatchContractAddre
 }
 
 func (o *Client) fetchCollectionsDataByBatchContractAddresses(ctx context.Context, chainID walletCommon.ChainID, batchAddresses BatchContractAddresses) ([]thirdparty.CollectionData, error) {
-	baseURL, err := getNFTBaseURL(chainID, o.apiKey)
+	baseURL, err := o.urlResolver.GetNFTBaseURL(chainID)
 	if err != nil {
 		return nil, err
 	}

--- a/services/wallet/thirdparty/collectibles/alchemy/nft_proxy_utils.go
+++ b/services/wallet/thirdparty/collectibles/alchemy/nft_proxy_utils.go
@@ -1,0 +1,37 @@
+package alchemy
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/status-im/status-go/params/networkhelper"
+	walletCommon "github.com/status-im/status-go/services/wallet/common"
+	"github.com/status-im/status-go/services/wallet/thirdparty"
+)
+
+const (
+	NftProxyHostSuffix = "nft.status.im"
+)
+
+// GetNftProxyHost creates NFT proxy base URL based on stage name
+func GetNftProxyHost(customURL, stageName string) string {
+	if customURL != "" {
+		return strings.TrimRight(customURL, "/")
+	}
+	if stageName == "" {
+		stageName = "test"
+	}
+	return fmt.Sprintf("https://%s.%s", stageName, NftProxyHostSuffix)
+}
+
+// GetNftProxyBaseURL creates NFT proxy URL for a specific chain
+func GetNftProxyBaseURL(customURL, stageName string, chainID walletCommon.ChainID) (string, error) {
+	host := GetNftProxyHost(customURL, stageName)
+
+	chainPath, networkPath, err := networkhelper.ChainIDToChainAndNetwork(uint64(chainID))
+	if err != nil {
+		return "", thirdparty.ErrChainIDNotSupported
+	}
+
+	return fmt.Sprintf("%s/%s/%s/nft/v3", host, chainPath, networkPath), nil
+}

--- a/services/wallet/thirdparty/collectibles/alchemy/nft_proxy_utils_test.go
+++ b/services/wallet/thirdparty/collectibles/alchemy/nft_proxy_utils_test.go
@@ -1,0 +1,96 @@
+package alchemy
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	walletCommon "github.com/status-im/status-go/services/wallet/common"
+	"github.com/status-im/status-go/services/wallet/thirdparty"
+)
+
+func TestGetNftProxyHost(t *testing.T) {
+	tests := []struct {
+		name      string
+		customURL string
+		stageName string
+		expected  string
+	}{
+		{
+			name:      "custom URL with trailing slash",
+			customURL: "https://custom.example.com/",
+			stageName: "",
+			expected:  "https://custom.example.com",
+		},
+		{
+			name:      "custom URL without trailing slash",
+			customURL: "https://custom.example.com",
+			stageName: "",
+			expected:  "https://custom.example.com",
+		},
+		{
+			name:      "stage name provided",
+			customURL: "",
+			stageName: "production",
+			expected:  "https://production.nft.status.im",
+		},
+		{
+			name:      "empty stage name defaults to test",
+			customURL: "",
+			stageName: "",
+			expected:  "https://test.nft.status.im",
+		},
+		{
+			name:      "custom URL takes precedence over stage name",
+			customURL: "https://override.example.com",
+			stageName: "production",
+			expected:  "https://override.example.com",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := GetNftProxyHost(tt.customURL, tt.stageName)
+			require.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestGetNftProxyBaseURL(t *testing.T) {
+	tests := []struct {
+		name     string
+		chainID  walletCommon.ChainID
+		expected string
+		wantErr  bool
+	}{
+		{
+			name:     "Supported chain - Ethereum mainnet",
+			chainID:  walletCommon.ChainID(walletCommon.EthereumMainnet),
+			expected: "https://test.nft.status.im/ethereum/mainnet/nft/v3",
+		},
+		{
+			name:     "Supported chain - Arbitrum Sepolia",
+			chainID:  walletCommon.ChainID(walletCommon.ArbitrumSepolia),
+			expected: "https://test.nft.status.im/arbitrum/sepolia/nft/v3",
+		},
+		{
+			name:    "Unsupported chain ID",
+			chainID: walletCommon.ChainID(999999),
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := GetNftProxyBaseURL("", "test", tt.chainID)
+			if tt.wantErr {
+				require.Error(t, err)
+				require.Equal(t, thirdparty.ErrChainIDNotSupported, err)
+				require.Empty(t, result)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tt.expected, result)
+			}
+		})
+	}
+}

--- a/services/wallet/thirdparty/collectibles/alchemy/types.go
+++ b/services/wallet/thirdparty/collectibles/alchemy/types.go
@@ -18,6 +18,7 @@ import (
 )
 
 const AlchemyID = "alchemy"
+const AlchemyProxyID = "alchemy-proxy"
 
 type TokenBalance struct {
 	TokenID *bigint.BigInt `json:"tokenId"`

--- a/services/wallet/thirdparty/collectibles/alchemy/url_resolver.go
+++ b/services/wallet/thirdparty/collectibles/alchemy/url_resolver.go
@@ -1,0 +1,84 @@
+package alchemy
+
+import (
+	"fmt"
+
+	"github.com/status-im/status-go/pkg/security"
+	walletCommon "github.com/status-im/status-go/services/wallet/common"
+	"github.com/status-im/status-go/services/wallet/thirdparty"
+)
+
+// URLResolver constructs base URLs for Alchemy Client
+type URLResolver interface {
+	// For direct Alchemy: "https://eth-mainnet.g.alchemy.com/nft/v3/{apiKey}"
+	// For proxy: "https://test.nft.status.im/ethereum/mainnet/nft/v3"
+	GetNFTBaseURL(chainID walletCommon.ChainID) (string, error)
+
+	// IsChainSupported returns true if the resolver can construct a URL for this chain.
+	IsChainSupported(chainID walletCommon.ChainID) bool
+}
+
+type directURLResolver struct {
+	apiKey security.SensitiveString
+}
+
+func (r *directURLResolver) GetNFTBaseURL(chainID walletCommon.ChainID) (string, error) {
+	baseURL, err := getBaseURL(chainID)
+	if err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("%s/nft/v3/%s", baseURL, getAPIKeySubpath(r.apiKey).Reveal()), nil
+}
+
+func (r *directURLResolver) IsChainSupported(chainID walletCommon.ChainID) bool {
+	_, err := getBaseURL(chainID)
+	return err == nil
+}
+
+type proxyURLResolver struct {
+	customURL string
+	stageName string
+}
+
+func (r *proxyURLResolver) GetNFTBaseURL(chainID walletCommon.ChainID) (string, error) {
+	return GetNftProxyBaseURL(r.customURL, r.stageName, chainID)
+}
+
+func (r *proxyURLResolver) IsChainSupported(chainID walletCommon.ChainID) bool {
+	_, err := GetNftProxyBaseURL(r.customURL, r.stageName, chainID)
+	return err == nil
+}
+
+func getBaseURL(chainID walletCommon.ChainID) (string, error) {
+	switch uint64(chainID) {
+	case walletCommon.EthereumMainnet:
+		return "https://eth-mainnet.g.alchemy.com", nil
+	case walletCommon.EthereumSepolia:
+		return "https://eth-sepolia.g.alchemy.com", nil
+	case walletCommon.OptimismMainnet:
+		return "https://opt-mainnet.g.alchemy.com", nil
+	case walletCommon.OptimismSepolia:
+		return "https://opt-sepolia.g.alchemy.com", nil
+	case walletCommon.ArbitrumMainnet:
+		return "https://arb-mainnet.g.alchemy.com", nil
+	case walletCommon.ArbitrumSepolia:
+		return "https://arb-sepolia.g.alchemy.com", nil
+	case walletCommon.BaseMainnet:
+		return "https://base-mainnet.g.alchemy.com", nil
+	case walletCommon.BaseSepolia:
+		return "https://base-sepolia.g.alchemy.com", nil
+	case walletCommon.LineaMainnet:
+		return "https://linea-mainnet.g.alchemy.com", nil
+	case walletCommon.LineaSepolia:
+		return "https://linea-sepolia.g.alchemy.com", nil
+	}
+
+	return "", thirdparty.ErrChainIDNotSupported
+}
+
+func getAPIKeySubpath(apiKey security.SensitiveString) security.SensitiveString {
+	if apiKey.Empty() {
+		return security.NewSensitiveString("demo")
+	}
+	return apiKey
+}

--- a/services/wallet/thirdparty/collectibles/alchemy/url_resolver_test.go
+++ b/services/wallet/thirdparty/collectibles/alchemy/url_resolver_test.go
@@ -1,0 +1,100 @@
+package alchemy
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/status-im/status-go/pkg/security"
+	walletCommon "github.com/status-im/status-go/services/wallet/common"
+)
+
+func TestDirectURLResolver_GetNFTBaseURL(t *testing.T) {
+	tests := []struct {
+		name     string
+		chainID  walletCommon.ChainID
+		apiKey   string
+		expected string
+	}{
+		{
+			name:     "Ethereum mainnet",
+			chainID:  walletCommon.ChainID(walletCommon.EthereumMainnet),
+			apiKey:   "my-api-key",
+			expected: "https://eth-mainnet.g.alchemy.com/nft/v3/my-api-key",
+		},
+		{
+			name:     "Ethereum Sepolia",
+			chainID:  walletCommon.ChainID(walletCommon.EthereumSepolia),
+			apiKey:   "key",
+			expected: "https://eth-sepolia.g.alchemy.com/nft/v3/key",
+		},
+		{
+			name:     "Base mainnet",
+			chainID:  walletCommon.ChainID(walletCommon.BaseMainnet),
+			apiKey:   "abc",
+			expected: "https://base-mainnet.g.alchemy.com/nft/v3/abc",
+		},
+		{
+			name:     "Arbitrum Sepolia",
+			chainID:  walletCommon.ChainID(walletCommon.ArbitrumSepolia),
+			apiKey:   "xyz",
+			expected: "https://arb-sepolia.g.alchemy.com/nft/v3/xyz",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resolver := &directURLResolver{apiKey: security.NewSensitiveString(tt.apiKey)}
+			result, err := resolver.GetNFTBaseURL(tt.chainID)
+			require.NoError(t, err)
+			require.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestDirectURLResolver_EmptyAPIKey(t *testing.T) {
+	resolver := &directURLResolver{apiKey: security.SensitiveString{}}
+	result, err := resolver.GetNFTBaseURL(walletCommon.ChainID(walletCommon.EthereumMainnet))
+	require.NoError(t, err)
+	require.Equal(t, "https://eth-mainnet.g.alchemy.com/nft/v3/demo", result)
+}
+
+func TestDirectURLResolver_UnsupportedChain(t *testing.T) {
+	resolver := &directURLResolver{apiKey: security.NewSensitiveString("key")}
+	_, err := resolver.GetNFTBaseURL(walletCommon.ChainID(999999))
+	require.Error(t, err)
+}
+
+func TestProxyURLResolver_GetNFTBaseURL(t *testing.T) {
+	resolver := &proxyURLResolver{customURL: "", stageName: "test"}
+	result, err := resolver.GetNFTBaseURL(walletCommon.ChainID(walletCommon.EthereumMainnet))
+	require.NoError(t, err)
+	require.Equal(t, "https://test.nft.status.im/ethereum/mainnet/nft/v3", result)
+}
+
+func TestProxyURLResolver_CustomURL(t *testing.T) {
+	resolver := &proxyURLResolver{customURL: "https://custom.example.com", stageName: "test"}
+	result, err := resolver.GetNFTBaseURL(walletCommon.ChainID(walletCommon.EthereumMainnet))
+	require.NoError(t, err)
+	require.Equal(t, "https://custom.example.com/ethereum/mainnet/nft/v3", result)
+}
+
+func TestProxyURLResolver_UnsupportedChain(t *testing.T) {
+	resolver := &proxyURLResolver{customURL: "", stageName: "test"}
+	_, err := resolver.GetNFTBaseURL(walletCommon.ChainID(999999))
+	require.Error(t, err)
+}
+
+func TestDirectURLResolver_IsChainSupported(t *testing.T) {
+	resolver := &directURLResolver{apiKey: security.NewSensitiveString("key")}
+	require.True(t, resolver.IsChainSupported(walletCommon.ChainID(walletCommon.EthereumMainnet)))
+	require.True(t, resolver.IsChainSupported(walletCommon.ChainID(walletCommon.BaseSepolia)))
+	require.False(t, resolver.IsChainSupported(walletCommon.ChainID(999999)))
+}
+
+func TestProxyURLResolver_IsChainSupported(t *testing.T) {
+	resolver := &proxyURLResolver{customURL: "", stageName: "test"}
+	require.True(t, resolver.IsChainSupported(walletCommon.ChainID(walletCommon.EthereumMainnet)))
+	require.True(t, resolver.IsChainSupported(walletCommon.ChainID(walletCommon.ArbitrumSepolia)))
+	require.False(t, resolver.IsChainSupported(walletCommon.ChainID(999999)))
+}

--- a/services/wallet/thirdparty/collectibles/rarible/client.go
+++ b/services/wallet/thirdparty/collectibles/rarible/client.go
@@ -11,9 +11,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/cenkalti/backoff/v4"
-	"go.uber.org/zap"
-
 	"github.com/ethereum/go-ethereum/common"
 
 	"github.com/status-im/status-go/internal/logutils"
@@ -147,40 +144,11 @@ func (o *Client) doPostWithJSON(ctx context.Context, url string, payload any, ap
 }
 
 func (o *Client) doWithRetries(req *http.Request, apiKey security.SensitiveString) (*http.Response, error) {
-	b := backoff.NewExponentialBackOff()
-	b.InitialInterval = time.Millisecond * 1000
-	b.RandomizationFactor = 0.1
-	b.Multiplier = 1.5
-	b.MaxInterval = time.Second * 32
-	b.MaxElapsedTime = time.Second * 70
-
-	b.Reset()
-
+	// Set API key header before making the request
 	req.Header.Set("X-API-KEY", apiKey.Reveal())
 
-	op := func() (*http.Response, error) {
-		resp, err := o.client.Do(req)
-		if err != nil {
-			return nil, backoff.Permanent(err)
-		}
-
-		if resp.StatusCode == http.StatusOK {
-			return resp, nil
-		}
-
-		err = fmt.Errorf("unsuccessful request: %d %s", resp.StatusCode, http.StatusText(resp.StatusCode))
-		if resp.StatusCode == http.StatusTooManyRequests {
-			logutils.ZapLogger().Error("doWithRetries failed with http.StatusTooManyRequests",
-				zap.String("provider", o.ID()),
-				zap.Duration("elapsed time", b.GetElapsedTime()),
-				zap.Duration("next backoff", b.NextBackOff()),
-			)
-			return nil, err
-		}
-		return nil, backoff.Permanent(err)
-	}
-
-	return backoff.RetryWithData(op, b)
+	// Use the shared backoff retry logic
+	return thirdparty.DoWithExponentialBackoff(o.client, req, o.ID())
 }
 
 func (o *Client) FetchCollectibleOwnersByContractAddress(ctx context.Context, chainID walletCommon.ChainID, contractAddress common.Address) (*thirdparty.CollectibleContractOwnership, error) {

--- a/services/wallet/thirdparty/http_client.go
+++ b/services/wallet/thirdparty/http_client.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/cenkalti/backoff/v4"
 	"go.uber.org/zap"
 
 	"github.com/status-im/status-go/internal/logutils"
@@ -294,4 +295,65 @@ func (c *HTTPClient) BuildURL(proxyURL, endpoint string) string {
 	baseURL := strings.TrimRight(proxyURL, "/")
 	cleanEndpoint := strings.TrimLeft(endpoint, "/")
 	return baseURL + "/" + cleanEndpoint
+}
+
+// DoWithExponentialBackoff executes an HTTP request with exponential backoff retry logic
+// for handling rate limiting responses (HTTP 429)
+func DoWithExponentialBackoff(client *http.Client, req *http.Request, providerID string) (*http.Response, error) {
+	// Ensure request body can be replayed for retries by setting up GetBody if needed
+	if req.Body != nil && req.GetBody == nil {
+		bodyBytes, err := io.ReadAll(req.Body)
+		if err != nil {
+			return nil, err
+		}
+		req.Body.Close()
+		req.Body = io.NopCloser(bytes.NewReader(bodyBytes))
+		req.GetBody = func() (io.ReadCloser, error) {
+			return io.NopCloser(bytes.NewReader(bodyBytes)), nil
+		}
+	}
+
+	b := backoff.NewExponentialBackOff()
+	b.InitialInterval = time.Millisecond * 1000
+	b.RandomizationFactor = 0.1
+	b.Multiplier = 1.5
+	b.MaxInterval = time.Second * 32
+	b.MaxElapsedTime = time.Second * 70
+
+	b.Reset()
+
+	op := func() (*http.Response, error) {
+		attemptReq := req.Clone(req.Context())
+		if req.GetBody != nil && attemptReq.Body == nil {
+			body, err := req.GetBody()
+			if err != nil {
+				return nil, backoff.Permanent(err)
+			}
+			attemptReq.Body = body
+		}
+
+		resp, err := client.Do(attemptReq)
+		if err != nil {
+			return nil, backoff.Permanent(err)
+		}
+
+		if resp.StatusCode == http.StatusOK {
+			return resp, nil
+		}
+
+		_, _ = io.Copy(io.Discard, resp.Body)
+		resp.Body.Close()
+
+		err = fmt.Errorf("unsuccessful request: %d %s", resp.StatusCode, http.StatusText(resp.StatusCode))
+		if resp.StatusCode == http.StatusTooManyRequests {
+			logutils.ZapLogger().Warn("request throttled with http.StatusTooManyRequests; will retry",
+				zap.String("provider", providerID),
+				zap.Duration("elapsed time", b.GetElapsedTime()),
+			)
+			return nil, err
+		}
+		return nil, backoff.Permanent(err)
+	}
+
+	return backoff.RetryWithData(op, b)
 }

--- a/services/wallet/thirdparty/http_client_test.go
+++ b/services/wallet/thirdparty/http_client_test.go
@@ -6,9 +6,11 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -310,4 +312,136 @@ func gzipEncode(data []byte) ([]byte, error) {
 		return nil, err
 	}
 	return buf.Bytes(), nil
+}
+
+func TestDoWithExponentialBackoff_Success(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("success"))
+	}))
+	defer server.Close()
+
+	client := &http.Client{}
+	req, err := http.NewRequest(http.MethodGet, server.URL, nil)
+	require.NoError(t, err)
+
+	resp, err := DoWithExponentialBackoff(client, req, "test-provider")
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	resp.Body.Close()
+}
+
+func TestDoWithExponentialBackoff_RateLimit(t *testing.T) {
+	var attempts int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		attempts++
+		if attempts < 3 {
+			w.WriteHeader(http.StatusTooManyRequests)
+		} else {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("success after retry"))
+		}
+	}))
+	defer server.Close()
+
+	client := &http.Client{}
+	req, err := http.NewRequest(http.MethodGet, server.URL, nil)
+	require.NoError(t, err)
+
+	resp, err := DoWithExponentialBackoff(client, req, "test-provider")
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.GreaterOrEqual(t, attempts, 3, "Should have retried at least twice before succeeding")
+	resp.Body.Close()
+}
+
+func TestDoWithExponentialBackoff_PermanentErrors(t *testing.T) {
+	tests := []struct {
+		name       string
+		statusCode int
+	}{
+		{"400 error", http.StatusBadRequest},
+		{"404 error", http.StatusNotFound},
+		{"500 error", http.StatusInternalServerError},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var attempts int
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				attempts++
+				w.WriteHeader(tt.statusCode)
+			}))
+			defer server.Close()
+
+			client := &http.Client{}
+			req, err := http.NewRequest(http.MethodGet, server.URL, nil)
+			require.NoError(t, err)
+
+			resp, err := DoWithExponentialBackoff(client, req, "test-provider")
+			require.Error(t, err)
+			require.Nil(t, resp)
+			require.Contains(t, err.Error(), "unsuccessful request")
+			require.Equal(t, 1, attempts)
+		})
+	}
+}
+
+func TestDoWithExponentialBackoff_NetworkError(t *testing.T) {
+	client := &http.Client{}
+	req, err := http.NewRequest(http.MethodGet, "http://localhost:1", nil)
+	require.NoError(t, err)
+
+	resp, err := DoWithExponentialBackoff(client, req, "test-provider")
+	require.Error(t, err)
+	require.Nil(t, resp)
+}
+
+func TestDoWithExponentialBackoff_RetryExhaustion(t *testing.T) {
+	var attempts int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		attempts++
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	client := &http.Client{}
+	req, err := http.NewRequest(http.MethodGet, server.URL, nil)
+	require.NoError(t, err)
+
+	resp, err := DoWithExponentialBackoff(client, req, "test-provider")
+	require.Error(t, err)
+	require.Nil(t, resp)
+	require.Contains(t, err.Error(), "unsuccessful request")
+	require.Greater(t, attempts, 1)
+}
+
+func TestDoWithExponentialBackoff_WithBody(t *testing.T) {
+	var attempts int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		attempts++
+		body, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+		require.Equal(t, "test-body", string(body))
+		if attempts < 2 {
+			w.WriteHeader(http.StatusTooManyRequests)
+		} else {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("success"))
+		}
+	}))
+	defer server.Close()
+
+	client := &http.Client{}
+	req, err := http.NewRequest(http.MethodPost, server.URL, strings.NewReader("test-body"))
+	require.NoError(t, err)
+
+	resp, err := DoWithExponentialBackoff(client, req, "test-provider")
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.GreaterOrEqual(t, attempts, 2)
+	resp.Body.Close()
 }

--- a/tests-functional/clients/async_status_backend.py
+++ b/tests-functional/clients/async_status_backend.py
@@ -69,6 +69,10 @@ class AsyncStatusBackend:
         return self._backend.data_dir
 
     @property
+    def waku_light_client(self) -> bool:
+        return getattr(self._backend, "waku_light_client", False)
+
+    @property
     def router(self) -> SignalRouter:
         """Access signal router."""
         return self._router

--- a/tests-functional/clients/status_backend.py
+++ b/tests-functional/clients/status_backend.py
@@ -326,6 +326,7 @@ class StatusBackend(RpcClient, SignalClient, ApiClient):
 
     def _create_account_request(self, password: str, **kwargs):
         self.password = password
+        self.waku_light_client = kwargs.get("waku_light_client", False)
         data = {
             "rootDataDir": self.data_dir,
             "kdfIterations": 256000,

--- a/tests-functional/steps/async_messenger.py
+++ b/tests-functional/steps/async_messenger.py
@@ -221,8 +221,13 @@ class AsyncMessengerSteps:
         if not community:
             raise Exception(f"Community {self.community_id} not visible to member after retries")
 
-        # Ensure admin has community data
+        # Ensure admin has community data (triggers filter subscriptions for community topics)
         self.fetch_community(admin, self.community_id)
+        # In light client mode, filter subscriptions are async and take several seconds.
+        # If the member sends the join request before the admin subscribes,
+        # the message is lost (filter protocol doesn't deliver historical messages).
+        if getattr(admin, "waku_light_client", False):
+            await asyncio.sleep(10)
 
         # Request to join
         response_to_join = member.wakuext_service.request_to_join_community(self.community_id)
@@ -264,16 +269,16 @@ class AsyncMessengerSteps:
                 last_latest = admin.wakuext_service.latest_request_to_join_for_community(self.community_id)
                 if last_latest and last_latest.get("id"):
                     admin_observed_ids.add(last_latest["id"])
-            except Exception:
-                pass
+            except Exception as e:
+                logging.debug(f"Attempt {attempt + 1}/120 latest_request check failed: {e}")
 
             try:
                 all_non_approved = admin.wakuext_service.all_non_approved_communities_requests_to_join() or []
                 for r in all_non_approved:
                     if r.get("communityId") == self.community_id and r.get("id"):
                         admin_observed_ids.add(r["id"])
-            except Exception:
-                pass
+            except Exception as e:
+                logging.debug(f"Attempt {attempt + 1}/120 all_non_approved check failed: {e}")
 
             if join_id in admin_observed_ids:
                 accept_id = join_id
@@ -281,6 +286,18 @@ class AsyncMessengerSteps:
             elif len(admin_observed_ids) == 1:
                 accept_id = next(iter(admin_observed_ids))
                 break
+
+            # Re-send the join request periodically in case the original was lost
+            # (e.g. published before admin's filter subscription was active)
+            if attempt > 0 and attempt % 30 == 0:
+                logging.debug(f"Re-sending join request (attempt {attempt}/120)")
+                try:
+                    retry_resp = member.wakuext_service.request_to_join_community(self.community_id)
+                    retry_req = (retry_resp.get("requestsToJoinCommunity") or [{}])[0]
+                    if retry_req.get("id"):
+                        join_id = retry_req["id"]
+                except Exception as e:
+                    logging.debug(f"Re-send join request failed: {e}")
 
             await asyncio.sleep(1)
 
@@ -301,7 +318,7 @@ class AsyncMessengerSteps:
 
         # Validate accept was successful (state=3 means accepted)
         accept_state = (response.get("requestsToJoinCommunity") or [{}])[0].get("state")
-        if accept_state != 3 and str(accept_state) != "3":
+        if not _is_accepted(accept_state):
             raise Exception(f"Accept request failed. State: {accept_state}, Response: {response}")
 
         # Extract chat_id from response (sorted by position, pick first valid)

--- a/tests-functional/steps/async_messenger.py
+++ b/tests-functional/steps/async_messenger.py
@@ -199,8 +199,12 @@ class AsyncMessengerSteps:
     async def join_community(self, member, admin) -> str:
         """Join member to community created by admin.
 
-        Simplified implementation based on develop branch - uses simple RPC retry
-        instead of complex polling with spectate/reevaluation signals.
+        Uses a two-phase approach:
+        1. Wait for the admin to see the pending join request (propagation via Waku)
+        2. Accept the request once visible
+
+        This is critical for light client mode where Waku message propagation
+        can take significantly longer than in relay mode.
 
         Returns:
             str: The community chat ID (community_id + chat_id)
@@ -222,15 +226,77 @@ class AsyncMessengerSteps:
 
         # Request to join
         response_to_join = member.wakuext_service.request_to_join_community(self.community_id)
-        join_id = (response_to_join.get("requestsToJoinCommunity") or [{}])[0].get("id")
+        join_req = (response_to_join.get("requestsToJoinCommunity") or [{}])[0]
+        join_id = join_req.get("id")
+        join_state = join_req.get("state")
         assert join_id, f"Failed to request to join community: {response_to_join}"
 
-        # Simple async retry for accept (like retry_call in develop: 40 attempts × 0.5s = 20s max)
+        def _is_accepted(state) -> bool:
+            return state == 3 or str(state) == "3"
+
+        # Auto-accept: if state is already accepted, skip admin accept phase
+        if _is_accepted(join_state):
+            community = self.fetch_community(member, self.community_id)
+            chats = community.get("chats", {}) if community else {}
+            chat_id = self._pick_chat_id(chats)
+            if chat_id:
+                return self.community_id + chat_id
+
+        # Phase 1: Wait for admin to see the pending request.
+        # In light client mode, the join request propagates via Waku filter protocol
+        # and can take much longer than in relay mode.
+        # Check multiple endpoints (like sync version) since the request may appear
+        # in one before the others due to eventual consistency.
+        accept_id = None
+        last_pending = None
+        last_latest = None
+        for attempt in range(120):
+            admin_observed_ids: set[str] = set()
+            try:
+                last_pending = admin.wakuext_service.pending_requests_to_join_for_community(self.community_id) or []
+                for req in last_pending:
+                    if req.get("id"):
+                        admin_observed_ids.add(req["id"])
+            except Exception as e:
+                logging.debug(f"Attempt {attempt + 1}/120 pending_requests check failed: {e}")
+
+            try:
+                last_latest = admin.wakuext_service.latest_request_to_join_for_community(self.community_id)
+                if last_latest and last_latest.get("id"):
+                    admin_observed_ids.add(last_latest["id"])
+            except Exception:
+                pass
+
+            try:
+                all_non_approved = admin.wakuext_service.all_non_approved_communities_requests_to_join() or []
+                for r in all_non_approved:
+                    if r.get("communityId") == self.community_id and r.get("id"):
+                        admin_observed_ids.add(r["id"])
+            except Exception:
+                pass
+
+            if join_id in admin_observed_ids:
+                accept_id = join_id
+                break
+            elif len(admin_observed_ids) == 1:
+                accept_id = next(iter(admin_observed_ids))
+                break
+
+            await asyncio.sleep(1)
+
+        if not accept_id:
+            raise Exception(
+                f"Admin never saw pending request for community {self.community_id} "
+                f"(join_id={join_id}) after 120s. "
+                f"last_pending={last_pending}, last_latest={last_latest}"
+            )
+
+        # Phase 2: Accept the request (should succeed quickly now that it's visible)
         response = await self._async_retry_call(
             admin.wakuext_service.accept_request_to_join_community,
-            join_id,
-            max_attempts=40,
-            retry_interval=0.5,
+            accept_id,
+            max_attempts=20,
+            retry_interval=1.0,
         )
 
         # Validate accept was successful (state=3 means accepted)


### PR DESCRIPTION
ℹ️ it's a client from the proxy repo https://github.com/status-im/proxy-common/tree/master/auth/puzzle

Adds `puzzleauth` package — client-side implementation of proof-of-work authentication based on Argon2id, compatible with our proxies

**What it does:**
- `Solver` — brute-forces nonce so that Argon2id hash has required leading zeros
- `Service` — manages token lifecycle: fetches puzzle from server, solves it, caches JWT, handles expiry (with 5-min buffer) and concurrent refresh
- `Client` — HTTP client wrapper that transparently adds Bearer token and auto-retries on 401/403/429

**Flow:**  
`GET /auth/puzzle` → solve locally → `POST /auth/solve` → receive JWT → attach to requests

Fixes #7320