### PR TITLE
feat(collectibles): integrate nft-proxy with proof of work auth

### DIFF
--- a/params/config.go
+++ b/params/config.go
@@ -226,6 +226,7 @@ type WalletConfig struct {
 	StatusProxyMarketUser     security.SensitiveString `json:"StatusProxyMarketUser"`
 	StatusProxyMarketPassword security.SensitiveString `json:"StatusProxyMarketPassword"`
 	MarketDataProxyConfig     MarketDataProxyConfig    `json:"MarketDataProxyConfig"`
+	NftProxyConfig            NftProxyConfig           `json:"NftProxyConfig"`
 
 	StatusProxyUser     security.SensitiveString `json:"StatusProxyBlockchainUser"`
 	StatusProxyPassword security.SensitiveString `json:"StatusProxyBlockchainPassword"`
@@ -251,6 +252,14 @@ type MarketDataProxyConfig struct {
 	Password                security.SensitiveString `json:"Password"`
 	FullDataRefreshInterval int                      `json:"FullDataRefreshInterval"`
 	PriceRefreshInterval    int                      `json:"PriceRefreshInterval"`
+}
+
+type NftProxyConfig struct {
+	UrlOverride   security.SensitiveString `json:"UrlOverride"`
+	StageName     string                   `json:"StageName"`
+	User          security.SensitiveString `json:"User"`
+	Password      security.SensitiveString `json:"Password"`
+	UsePuzzleAuth bool                     `json:"UsePuzzleAuth"`
 }
 
 // MarshalJSON custom marshalling to avoid exposing sensitive data in log,

--- a/params/networkhelper/chain_mapping.go
+++ b/params/networkhelper/chain_mapping.go
@@ -1,0 +1,43 @@
+package networkhelper
+
+import (
+	"fmt"
+
+	"github.com/status-im/status-go/services/wallet/common"
+)
+
+// ChainIDToChainAndNetwork converts a chain ID to its corresponding chain and network string identifiers.
+// These strings are used in proxy URLs and other network-related configurations.
+// Returns an error if the chain ID is not supported.
+func ChainIDToChainAndNetwork(chainID uint64) (chain string, network string, err error) {
+	switch chainID {
+	case common.EthereumMainnet:
+		return "ethereum", "mainnet", nil
+	case common.EthereumSepolia:
+		return "ethereum", "sepolia", nil
+	case common.OptimismMainnet:
+		return "optimism", "mainnet", nil
+	case common.OptimismSepolia:
+		return "optimism", "sepolia", nil
+	case common.ArbitrumMainnet:
+		return "arbitrum", "mainnet", nil
+	case common.ArbitrumSepolia:
+		return "arbitrum", "sepolia", nil
+	case common.BaseMainnet:
+		return "base", "mainnet", nil
+	case common.BaseSepolia:
+		return "base", "sepolia", nil
+	case common.LineaMainnet:
+		return "linea", "mainnet", nil
+	case common.LineaSepolia:
+		return "linea", "sepolia", nil
+	case common.StatusNetworkSepolia:
+		return "status", "sepolia", nil
+	case common.BSCMainnet:
+		return "bsc", "mainnet", nil
+	case common.BSCTestnet:
+		return "bsc", "testnet", nil
+	default:
+		return "", "", fmt.Errorf("unsupported chain ID: %d", chainID)
+	}
+}

--- a/params/networkhelper/chain_mapping_test.go
+++ b/params/networkhelper/chain_mapping_test.go
@@ -1,0 +1,134 @@
+package networkhelper
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/status-im/status-go/services/wallet/common"
+)
+
+func TestChainIDToChainAndNetwork(t *testing.T) {
+	tests := []struct {
+		name            string
+		chainID         uint64
+		expectedChain   string
+		expectedNetwork string
+		expectError     bool
+	}{
+		{
+			name:            "Ethereum Mainnet",
+			chainID:         common.EthereumMainnet,
+			expectedChain:   "ethereum",
+			expectedNetwork: "mainnet",
+			expectError:     false,
+		},
+		{
+			name:            "Ethereum Sepolia",
+			chainID:         common.EthereumSepolia,
+			expectedChain:   "ethereum",
+			expectedNetwork: "sepolia",
+			expectError:     false,
+		},
+		{
+			name:            "Optimism Mainnet",
+			chainID:         common.OptimismMainnet,
+			expectedChain:   "optimism",
+			expectedNetwork: "mainnet",
+			expectError:     false,
+		},
+		{
+			name:            "Optimism Sepolia",
+			chainID:         common.OptimismSepolia,
+			expectedChain:   "optimism",
+			expectedNetwork: "sepolia",
+			expectError:     false,
+		},
+		{
+			name:            "Arbitrum Mainnet",
+			chainID:         common.ArbitrumMainnet,
+			expectedChain:   "arbitrum",
+			expectedNetwork: "mainnet",
+			expectError:     false,
+		},
+		{
+			name:            "Arbitrum Sepolia",
+			chainID:         common.ArbitrumSepolia,
+			expectedChain:   "arbitrum",
+			expectedNetwork: "sepolia",
+			expectError:     false,
+		},
+		{
+			name:            "Base Mainnet",
+			chainID:         common.BaseMainnet,
+			expectedChain:   "base",
+			expectedNetwork: "mainnet",
+			expectError:     false,
+		},
+		{
+			name:            "Base Sepolia",
+			chainID:         common.BaseSepolia,
+			expectedChain:   "base",
+			expectedNetwork: "sepolia",
+			expectError:     false,
+		},
+		{
+			name:            "Linea Mainnet",
+			chainID:         common.LineaMainnet,
+			expectedChain:   "linea",
+			expectedNetwork: "mainnet",
+			expectError:     false,
+		},
+		{
+			name:            "Linea Sepolia",
+			chainID:         common.LineaSepolia,
+			expectedChain:   "linea",
+			expectedNetwork: "sepolia",
+			expectError:     false,
+		},
+		{
+			name:            "Status Network Sepolia",
+			chainID:         common.StatusNetworkSepolia,
+			expectedChain:   "status",
+			expectedNetwork: "sepolia",
+			expectError:     false,
+		},
+		{
+			name:            "BSC Mainnet",
+			chainID:         common.BSCMainnet,
+			expectedChain:   "bsc",
+			expectedNetwork: "mainnet",
+			expectError:     false,
+		},
+		{
+			name:            "BSC Testnet",
+			chainID:         common.BSCTestnet,
+			expectedChain:   "bsc",
+			expectedNetwork: "testnet",
+			expectError:     false,
+		},
+		{
+			name:            "Unsupported chain ID",
+			chainID:         999999,
+			expectedChain:   "",
+			expectedNetwork: "",
+			expectError:     true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			chain, network, err := ChainIDToChainAndNetwork(tt.chainID)
+
+			if tt.expectError {
+				require.Error(t, err)
+				require.Empty(t, chain)
+				require.Empty(t, network)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tt.expectedChain, chain)
+				require.Equal(t, tt.expectedNetwork, network)
+			}
+		})
+	}
+}

--- a/pkg/backend/default_networks.go
+++ b/pkg/backend/default_networks.go
@@ -42,8 +42,7 @@ func smartProxyUrlWithProvider(proxyHost, chainName, networkName, provider strin
 
 func mainnet(proxyHost, stageName string, enableRpcProviders bool) params.Network {
 	const chainID = common.EthereumMainnet
-	const chainName = "ethereum"
-	const networkName = "mainnet"
+	chainName, networkName, _ := networkhelper.ChainIDToChainAndNetwork(chainID)
 
 	var rpcProviders []params.RpcProvider = []params.RpcProvider{}
 	if enableRpcProviders {
@@ -82,8 +81,7 @@ func mainnet(proxyHost, stageName string, enableRpcProviders bool) params.Networ
 
 func sepolia(proxyHost, stageName string, enableRpcProviders bool) params.Network {
 	const chainID = common.EthereumSepolia
-	const chainName = "ethereum"
-	const networkName = "sepolia"
+	chainName, networkName, _ := networkhelper.ChainIDToChainAndNetwork(chainID)
 
 	var rpcProviders []params.RpcProvider = []params.RpcProvider{}
 	if enableRpcProviders {
@@ -122,8 +120,7 @@ func sepolia(proxyHost, stageName string, enableRpcProviders bool) params.Networ
 
 func optimism(proxyHost, stageName string, enableRpcProviders bool) params.Network {
 	const chainID = common.OptimismMainnet
-	const chainName = "optimism"
-	const networkName = "mainnet"
+	chainName, networkName, _ := networkhelper.ChainIDToChainAndNetwork(chainID)
 
 	var rpcProviders []params.RpcProvider = []params.RpcProvider{}
 	if enableRpcProviders {
@@ -162,8 +159,7 @@ func optimism(proxyHost, stageName string, enableRpcProviders bool) params.Netwo
 
 func optimismSepolia(proxyHost, stageName string, enableRpcProviders bool) params.Network {
 	const chainID = common.OptimismSepolia
-	const chainName = "optimism"
-	const networkName = "sepolia"
+	chainName, networkName, _ := networkhelper.ChainIDToChainAndNetwork(chainID)
 
 	var rpcProviders []params.RpcProvider = []params.RpcProvider{}
 	if enableRpcProviders {
@@ -202,8 +198,7 @@ func optimismSepolia(proxyHost, stageName string, enableRpcProviders bool) param
 
 func arbitrum(proxyHost, stageName string, enableRpcProviders bool) params.Network {
 	const chainID = common.ArbitrumMainnet
-	const chainName = "arbitrum"
-	const networkName = "mainnet"
+	chainName, networkName, _ := networkhelper.ChainIDToChainAndNetwork(chainID)
 
 	var rpcProviders []params.RpcProvider = []params.RpcProvider{}
 	if enableRpcProviders {
@@ -242,8 +237,7 @@ func arbitrum(proxyHost, stageName string, enableRpcProviders bool) params.Netwo
 
 func arbitrumSepolia(proxyHost, stageName string, enableRpcProviders bool) params.Network {
 	const chainID = common.ArbitrumSepolia
-	const chainName = "arbitrum"
-	const networkName = "sepolia"
+	chainName, networkName, _ := networkhelper.ChainIDToChainAndNetwork(chainID)
 
 	var rpcProviders []params.RpcProvider = []params.RpcProvider{}
 	if enableRpcProviders {
@@ -282,8 +276,7 @@ func arbitrumSepolia(proxyHost, stageName string, enableRpcProviders bool) param
 
 func base(proxyHost, stageName string, enableRpcProviders bool) params.Network {
 	const chainID = common.BaseMainnet
-	const chainName = "base"
-	const networkName = "mainnet"
+	chainName, networkName, _ := networkhelper.ChainIDToChainAndNetwork(chainID)
 
 	var rpcProviders []params.RpcProvider = []params.RpcProvider{}
 	if enableRpcProviders {
@@ -322,8 +315,7 @@ func base(proxyHost, stageName string, enableRpcProviders bool) params.Network {
 
 func baseSepolia(proxyHost, stageName string, enableRpcProviders bool) params.Network {
 	const chainID = common.BaseSepolia
-	const chainName = "base"
-	const networkName = "sepolia"
+	chainName, networkName, _ := networkhelper.ChainIDToChainAndNetwork(chainID)
 
 	var rpcProviders []params.RpcProvider = []params.RpcProvider{}
 	if enableRpcProviders {
@@ -362,8 +354,7 @@ func baseSepolia(proxyHost, stageName string, enableRpcProviders bool) params.Ne
 
 func statusNetworkSepolia(proxyHost string, enableRpcProviders bool) params.Network {
 	const chainID = common.StatusNetworkSepolia
-	const chainName = "status"
-	const networkName = "sepolia"
+	chainName, networkName, _ := networkhelper.ChainIDToChainAndNetwork(chainID)
 
 	var rpcProviders []params.RpcProvider = []params.RpcProvider{}
 	if enableRpcProviders {
@@ -398,8 +389,7 @@ func statusNetworkSepolia(proxyHost string, enableRpcProviders bool) params.Netw
 
 func bnbSmartChain(proxyHost string, enableRpcProviders bool) params.Network {
 	const chainID = common.BSCMainnet
-	const chainName = "bsc"
-	const networkName = "mainnet"
+	chainName, networkName, _ := networkhelper.ChainIDToChainAndNetwork(chainID)
 
 	var rpcProviders []params.RpcProvider = []params.RpcProvider{}
 	if enableRpcProviders {
@@ -436,8 +426,7 @@ func bnbSmartChain(proxyHost string, enableRpcProviders bool) params.Network {
 
 func linea(proxyHost, stageName string, enableRpcProviders bool) params.Network {
 	const chainID = common.LineaMainnet
-	const chainName = "linea"
-	const networkName = "mainnet"
+	chainName, networkName, _ := networkhelper.ChainIDToChainAndNetwork(chainID)
 
 	var rpcProviders []params.RpcProvider = []params.RpcProvider{}
 	if enableRpcProviders {
@@ -476,8 +465,7 @@ func linea(proxyHost, stageName string, enableRpcProviders bool) params.Network 
 
 func lineaSepolia(proxyHost, stageName string, enableRpcProviders bool) params.Network {
 	const chainID = common.LineaSepolia
-	const chainName = "linea"
-	const networkName = "sepolia"
+	chainName, networkName, _ := networkhelper.ChainIDToChainAndNetwork(chainID)
 
 	var rpcProviders []params.RpcProvider = []params.RpcProvider{}
 	if enableRpcProviders {
@@ -516,8 +504,7 @@ func lineaSepolia(proxyHost, stageName string, enableRpcProviders bool) params.N
 
 func bnbSmartChainTestnet(proxyHost string, enableRpcProviders bool) params.Network {
 	const chainID = common.BSCTestnet
-	const chainName = "bsc"
-	const networkName = "testnet"
+	chainName, networkName, _ := networkhelper.ChainIDToChainAndNetwork(chainID)
 
 	var rpcProviders []params.RpcProvider = []params.RpcProvider{}
 	if enableRpcProviders {

--- a/pkg/backend/defaults.go
+++ b/pkg/backend/defaults.go
@@ -224,6 +224,21 @@ func buildWalletConfig(walletRequest *requests.WalletConfig, request *requests.W
 		walletConfig.EthRpcProxyPassword = request.EthRpcProxyPassword
 	}
 
+	// NftProxyConfig
+	if !request.NftProxyUrl.Empty() {
+		walletConfig.NftProxyConfig.UrlOverride = request.NftProxyUrl
+	}
+	if request.NftProxyStageName != "" {
+		walletConfig.NftProxyConfig.StageName = request.NftProxyStageName
+	}
+	if !request.NftProxyUser.Empty() {
+		walletConfig.NftProxyConfig.User = request.NftProxyUser
+	}
+	if !request.NftProxyPassword.Empty() {
+		walletConfig.NftProxyConfig.Password = request.NftProxyPassword
+	}
+	walletConfig.NftProxyConfig.UsePuzzleAuth = request.NftProxyUsePuzzleAuth
+
 	return walletConfig
 }
 

--- a/protocol/requests/create_account.go
+++ b/protocol/requests/create_account.go
@@ -124,6 +124,12 @@ type WalletSecretsConfig struct {
 	EthRpcProxyUrl      security.SensitiveString `json:"ethRpcProxyUrl"`
 	EthRpcProxyUser     security.SensitiveString `json:"ethRpcProxyUser"`
 	EthRpcProxyPassword security.SensitiveString `json:"ethRpcProxyPassword"`
+
+	NftProxyUrl           security.SensitiveString `json:"nftProxyUrl"`
+	NftProxyStageName     string                   `json:"nftProxyStageName"`
+	NftProxyUser          security.SensitiveString `json:"nftProxyUser"`
+	NftProxyPassword      security.SensitiveString `json:"nftProxyPassword"`
+	NftProxyUsePuzzleAuth bool                     `json:"nftProxyUsePuzzleAuth"`
 }
 
 func (c *CreateAccount) Validate(validation *CreateAccountValidation) error {

--- a/services/wallet/puzzleauth/client.go
+++ b/services/wallet/puzzleauth/client.go
@@ -46,21 +46,27 @@ func NewClient(origin string, httpClient *http.Client) *Client {
 func (c *Client) DoRequest(req *http.Request) (*http.Response, error) {
 	ctx := req.Context()
 
-	var bodyBytes []byte
-	if req.Body != nil {
-		var err error
-		bodyBytes, err = io.ReadAll(req.Body)
-		req.Body.Close()
+	// Ensure request body can be replayed for retries by setting up GetBody if needed
+	if req.Body != nil && req.GetBody == nil {
+		bodyBytes, err := io.ReadAll(req.Body)
 		if err != nil {
 			return nil, fmt.Errorf("failed to read request body: %w", err)
+		}
+		req.Body.Close()
+		req.Body = io.NopCloser(bytes.NewReader(bodyBytes))
+		req.GetBody = func() (io.ReadCloser, error) {
+			return io.NopCloser(bytes.NewReader(bodyBytes)), nil
 		}
 	}
 
 	for attempt := 0; attempt <= c.maxRetries; attempt++ {
 		clonedReq := req.Clone(ctx)
-		if bodyBytes != nil {
-			clonedReq.Body = io.NopCloser(bytes.NewReader(bodyBytes))
-			clonedReq.ContentLength = int64(len(bodyBytes))
+		if req.GetBody != nil && clonedReq.Body == nil {
+			body, err := req.GetBody()
+			if err != nil {
+				return nil, fmt.Errorf("failed to recreate request body: %w", err)
+			}
+			clonedReq.Body = body
 		}
 
 		token := c.authService.GetToken()

--- a/services/wallet/service.go
+++ b/services/wallet/service.go
@@ -91,7 +91,6 @@ func createAlchemyProxyClient(config params.NftProxyConfig) *alchemy.Client {
 	var puzzleClient *puzzleauth.Client
 	if config.UsePuzzleAuth {
 		origin := alchemy.GetNftProxyHost(config.UrlOverride.Reveal(), config.StageName)
-		// Share the http.Client with the alchemy client
 		httpClient := &http.Client{Timeout: time.Minute}
 		puzzleClient = puzzleauth.NewClient(origin, httpClient)
 	}

--- a/services/wallet/service.go
+++ b/services/wallet/service.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net/http"
 	"time"
 
 	"github.com/golang/protobuf/proto"
@@ -28,6 +29,7 @@ import (
 
 	"github.com/status-im/status-go/params"
 	"github.com/status-im/status-go/pkg/pubsub"
+	"github.com/status-im/status-go/pkg/security"
 	"github.com/status-im/status-go/protocol/backupsync"
 	protocolCommon "github.com/status-im/status-go/protocol/common"
 	"github.com/status-im/status-go/protocol/protobuf"
@@ -47,6 +49,7 @@ import (
 	"github.com/status-im/status-go/services/wallet/leaderboard"
 	"github.com/status-im/status-go/services/wallet/market"
 	"github.com/status-im/status-go/services/wallet/onramp"
+	"github.com/status-im/status-go/services/wallet/puzzleauth"
 	"github.com/status-im/status-go/services/wallet/routeexecution"
 	"github.com/status-im/status-go/services/wallet/router"
 	"github.com/status-im/status-go/services/wallet/router/pathprocessor"
@@ -72,6 +75,34 @@ func createCoingeckoProxyClient(config params.MarketDataProxyConfig) *coingecko.
 		URL:      baseURL,
 		User:     config.User,
 		Password: config.Password,
+	})
+}
+
+func createAlchemyProxyClient(config params.NftProxyConfig) *alchemy.Client {
+	var creds *thirdparty.BasicCreds
+	if !config.User.Empty() {
+		creds = &thirdparty.BasicCreds{
+			User:     config.User,
+			Password: config.Password,
+		}
+	}
+
+	// Create puzzle auth client if enabled
+	var puzzleClient *puzzleauth.Client
+	if config.UsePuzzleAuth {
+		origin := alchemy.GetNftProxyHost(config.UrlOverride.Reveal(), config.StageName)
+		// Share the http.Client with the alchemy client
+		httpClient := &http.Client{Timeout: time.Minute}
+		puzzleClient = puzzleauth.NewClient(origin, httpClient)
+	}
+
+	return alchemy.NewClientWithParams(alchemy.Params{
+		IsProxy:          true,
+		ProxyCustomURL:   config.UrlOverride.Reveal(),
+		ProxyStageName:   config.StageName,
+		APIKey:           security.SensitiveString{},
+		Creds:            creds,
+		PuzzleAuthClient: puzzleClient,
 	})
 }
 
@@ -141,24 +172,29 @@ func NewService(
 
 		raribleClient := rarible.NewClient(config.WalletConfig.RaribleMainnetAPIKey, config.WalletConfig.RaribleTestnetAPIKey)
 		alchemyClient := alchemy.NewClient(config.WalletConfig.AlchemyAPIKey)
+		alchemyProxy := createAlchemyProxyClient(config.WalletConfig.NftProxyConfig)
 
 		// Collectible providers in priority order (i.e. provider N+1 will be tried only if provider N fails)
 		contractOwnershipProviders := []thirdparty.CollectibleContractOwnershipProvider{
+			alchemyProxy,
 			raribleClient,
 			alchemyClient,
 		}
 
 		accountOwnershipProviders := []thirdparty.CollectibleAccountOwnershipProvider{
+			alchemyProxy,
 			raribleClient,
 			alchemyClient,
 		}
 
 		collectibleDataProviders := []thirdparty.CollectibleDataProvider{
+			alchemyProxy,
 			raribleClient,
 			alchemyClient,
 		}
 
 		collectionDataProviders := []thirdparty.CollectionDataProvider{
+			alchemyProxy,
 			raribleClient,
 			alchemyClient,
 		}

--- a/services/wallet/thirdparty/auth_transport.go
+++ b/services/wallet/thirdparty/auth_transport.go
@@ -1,0 +1,99 @@
+package thirdparty
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/status-im/status-go/pkg/security"
+	"github.com/status-im/status-go/services/wallet/puzzleauth"
+)
+
+var ErrPuzzleAuthClientRequired = errors.New("PuzzleAuthClient is required for AuthTypePOW")
+
+// AuthType specifies how requests are authenticated.
+type AuthType int
+
+const (
+	// AuthTypeAPIKey means API key is embedded in URL (direct Alchemy), no auth headers.
+	AuthTypeAPIKey AuthType = iota
+	// AuthTypeBasic means Basic auth (user/password) in headers.
+	AuthTypeBasic
+	// AuthTypePOW means proof-of-work auth via puzzleauth.Client.
+	AuthTypePOW
+	// AuthTypeNone means no authentication (e.g. proxy without creds or puzzle).
+	AuthTypeNone
+)
+
+// AuthParams holds authentication configuration for AuthTransport.
+type AuthParams struct {
+	Type             AuthType
+	APIKey           security.SensitiveString
+	Creds            *BasicCreds
+	PuzzleAuthClient *puzzleauth.Client
+}
+
+// AuthTransport executes HTTP requests with auth headers and retry logic.
+type AuthTransport struct {
+	httpClient *http.Client
+	auth       AuthParams
+	providerID string
+}
+
+// NewAuthTransport creates a new AuthTransport.
+func NewAuthTransport(httpClient *http.Client, auth AuthParams, providerID string) *AuthTransport {
+	if httpClient == nil {
+		httpClient = &http.Client{Timeout: time.Minute}
+	}
+	return &AuthTransport{
+		httpClient: httpClient,
+		auth:       auth,
+		providerID: providerID,
+	}
+}
+
+// Do executes the request with auth applied and retries as appropriate.
+func (t *AuthTransport) Do(req *http.Request) (*http.Response, error) {
+	t.applyAuth(req)
+	return t.doWithRetries(req)
+}
+
+func (t *AuthTransport) authTypeName() string {
+	switch t.auth.Type {
+	case AuthTypeAPIKey:
+		return "APIKey"
+	case AuthTypeBasic:
+		return "Basic"
+	case AuthTypePOW:
+		return "POW"
+	case AuthTypeNone:
+		return "None"
+	default:
+		return fmt.Sprintf("Unknown(%d)", t.auth.Type)
+	}
+}
+
+// Auth returns the auth params (e.g. for reading APIKey).
+func (t *AuthTransport) Auth() AuthParams {
+	return t.auth
+}
+
+func (t *AuthTransport) applyAuth(req *http.Request) {
+	if t.auth.Type == AuthTypeBasic && t.auth.Creds != nil {
+		req.SetBasicAuth(t.auth.Creds.User.Reveal(), t.auth.Creds.Password.Reveal())
+	}
+	// AuthTypeAPIKey: key is in URL, no header needed
+	// AuthTypePOW: puzzleauth.Client handles auth internally in DoRequest
+	// AuthTypeNone: no auth headers
+}
+
+func (t *AuthTransport) doWithRetries(req *http.Request) (*http.Response, error) {
+	if t.auth.Type == AuthTypePOW {
+		if t.auth.PuzzleAuthClient == nil {
+			return nil, ErrPuzzleAuthClientRequired
+		}
+		return t.auth.PuzzleAuthClient.DoRequest(req)
+	}
+	return DoWithExponentialBackoff(t.httpClient, req, t.providerID)
+}

--- a/services/wallet/thirdparty/auth_transport_test.go
+++ b/services/wallet/thirdparty/auth_transport_test.go
@@ -1,0 +1,232 @@
+package thirdparty
+
+import (
+	"context"
+	"encoding/hex"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/status-im/status-go/pkg/security"
+	"github.com/status-im/status-go/services/wallet/puzzleauth"
+)
+
+func TestAuthTransport_APIKey_Success(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Verify no auth headers (API key is in URL)
+		require.Empty(t, r.Header.Get("Authorization"))
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("success"))
+	}))
+	defer server.Close()
+
+	authParams := AuthParams{
+		Type:   AuthTypeAPIKey,
+		APIKey: security.NewSensitiveString("test-api-key"),
+	}
+	transport := NewAuthTransport(&http.Client{Timeout: time.Minute}, authParams, "test-provider")
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, server.URL, nil)
+	require.NoError(t, err)
+
+	resp, err := transport.Do(req)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	resp.Body.Close()
+}
+
+func TestAuthTransport_None_Success(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Empty(t, r.Header.Get("Authorization"))
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("success"))
+	}))
+	defer server.Close()
+
+	authParams := AuthParams{
+		Type: AuthTypeNone,
+	}
+	transport := NewAuthTransport(&http.Client{Timeout: time.Minute}, authParams, "test-provider")
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, server.URL, nil)
+	require.NoError(t, err)
+
+	resp, err := transport.Do(req)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	resp.Body.Close()
+}
+
+func TestAuthTransport_Basic_SetsAuthHeader(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		username, password, ok := r.BasicAuth()
+		require.True(t, ok)
+		require.Equal(t, "testuser", username)
+		require.Equal(t, "testpass", password)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("success"))
+	}))
+	defer server.Close()
+
+	authParams := AuthParams{
+		Type: AuthTypeBasic,
+		Creds: &BasicCreds{
+			User:     security.NewSensitiveString("testuser"),
+			Password: security.NewSensitiveString("testpass"),
+		},
+	}
+	transport := NewAuthTransport(&http.Client{Timeout: time.Minute}, authParams, "test-provider")
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, server.URL, nil)
+	require.NoError(t, err)
+
+	resp, err := transport.Do(req)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	resp.Body.Close()
+}
+
+func TestAuthTransport_Basic_RetryOn429(t *testing.T) {
+	var attempts int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		attempts++
+		if attempts < 3 {
+			w.WriteHeader(http.StatusTooManyRequests)
+		} else {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("success after retry"))
+		}
+	}))
+	defer server.Close()
+
+	authParams := AuthParams{
+		Type: AuthTypeBasic,
+		Creds: &BasicCreds{
+			User:     security.NewSensitiveString("user"),
+			Password: security.NewSensitiveString("pass"),
+		},
+	}
+	transport := NewAuthTransport(&http.Client{Timeout: time.Minute}, authParams, "test-provider")
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, server.URL, nil)
+	require.NoError(t, err)
+
+	resp, err := transport.Do(req)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.GreaterOrEqual(t, attempts, 3, "Should have retried at least twice before succeeding")
+	resp.Body.Close()
+}
+
+func newPuzzleAuthServerForTest(t *testing.T) *httptest.Server {
+	t.Helper()
+	puzzle := puzzleauth.Puzzle{
+		Challenge:  "testchallenge",
+		Salt:       hex.EncodeToString([]byte("testsalt12345678")),
+		Difficulty: 1,
+		HMAC:       "testhmac",
+		ExpiresAt:  time.Now().Add(1 * time.Hour).Format(time.RFC3339),
+		Argon2Params: puzzleauth.Argon2Params{
+			MemoryKB: 64,
+			Time:     1,
+			Threads:  1,
+			KeyLen:   32,
+		},
+	}
+	tokenResp := puzzleauth.TokenResponse{
+		Token:     "test-jwt-token",
+		ExpiresAt: time.Now().Add(1 * time.Hour).Format(time.RFC3339),
+	}
+
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/auth/puzzle":
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(puzzle)
+		case "/auth/solve":
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(tokenResp)
+		case "/resource":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("success"))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+}
+
+func TestAuthTransport_POW_DelegatesToPuzzleAuth(t *testing.T) {
+	server := newPuzzleAuthServerForTest(t)
+	defer server.Close()
+
+	puzzleClient := puzzleauth.NewClient(server.URL, nil)
+	authParams := AuthParams{
+		Type:             AuthTypePOW,
+		PuzzleAuthClient: puzzleClient,
+	}
+	transport := NewAuthTransport(&http.Client{Timeout: time.Minute}, authParams, "test-provider")
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, server.URL+"/resource", nil)
+	require.NoError(t, err)
+
+	resp, err := transport.Do(req)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	resp.Body.Close()
+}
+
+func TestAuthTransport_POW_NilPuzzleClient(t *testing.T) {
+	authParams := AuthParams{
+		Type:             AuthTypePOW,
+		PuzzleAuthClient: nil,
+	}
+	transport := NewAuthTransport(&http.Client{Timeout: time.Minute}, authParams, "test-provider")
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "http://localhost:1", nil)
+	require.NoError(t, err)
+
+	resp, err := transport.Do(req)
+	require.Error(t, err)
+	require.Nil(t, resp)
+	require.ErrorIs(t, err, ErrPuzzleAuthClientRequired)
+}
+
+func TestAuthTransport_Auth_Getter(t *testing.T) {
+	apiKey := security.NewSensitiveString("my-key")
+	creds := &BasicCreds{
+		User:     security.NewSensitiveString("u"),
+		Password: security.NewSensitiveString("p"),
+	}
+
+	tests := []struct {
+		name       string
+		authParams AuthParams
+	}{
+		{"APIKey", AuthParams{Type: AuthTypeAPIKey, APIKey: apiKey}},
+		{"Basic", AuthParams{Type: AuthTypeBasic, Creds: creds}},
+		{"None", AuthParams{Type: AuthTypeNone}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			transport := NewAuthTransport(nil, tt.authParams, "provider")
+			got := transport.Auth()
+			require.Equal(t, tt.authParams.Type, got.Type)
+			require.Equal(t, tt.authParams.APIKey.Reveal(), got.APIKey.Reveal())
+			if tt.authParams.Creds != nil {
+				require.NotNil(t, got.Creds)
+				require.Equal(t, tt.authParams.Creds.User.Reveal(), got.Creds.User.Reveal())
+				require.Equal(t, tt.authParams.Creds.Password.Reveal(), got.Creds.Password.Reveal())
+			}
+		})
+	}
+}

--- a/services/wallet/thirdparty/collectibles/alchemy/client.go
+++ b/services/wallet/thirdparty/collectibles/alchemy/client.go
@@ -32,89 +32,23 @@ type Params struct {
 	PuzzleAuthClient *puzzleauth.Client
 }
 
-func getBaseURL(chainID walletCommon.ChainID) (string, error) {
-	switch uint64(chainID) {
-	case walletCommon.EthereumMainnet:
-		return "https://eth-mainnet.g.alchemy.com", nil
-	case walletCommon.EthereumSepolia:
-		return "https://eth-sepolia.g.alchemy.com", nil
-	case walletCommon.OptimismMainnet:
-		return "https://opt-mainnet.g.alchemy.com", nil
-	case walletCommon.OptimismSepolia:
-		return "https://opt-sepolia.g.alchemy.com", nil
-	case walletCommon.ArbitrumMainnet:
-		return "https://arb-mainnet.g.alchemy.com", nil
-	case walletCommon.ArbitrumSepolia:
-		return "https://arb-sepolia.g.alchemy.com", nil
-	case walletCommon.BaseMainnet:
-		return "https://base-mainnet.g.alchemy.com", nil
-	case walletCommon.BaseSepolia:
-		return "https://base-sepolia.g.alchemy.com", nil
-	case walletCommon.LineaMainnet:
-		return "https://linea-mainnet.g.alchemy.com", nil
-	case walletCommon.LineaSepolia:
-		return "https://linea-sepolia.g.alchemy.com", nil
-	}
-
-	return "", thirdparty.ErrChainIDNotSupported
-}
-
 func (o *Client) ID() string {
 	return o.id
 }
 
 func (o *Client) IsChainSupported(chainID walletCommon.ChainID) bool {
-	// Check if using proxy with puzzle auth or basic auth
-	if o.isProxy {
-		_, err := GetNftProxyBaseURL(o.proxyCustomURL, o.proxyStageName, chainID)
-		return err == nil
-	}
-	// Check if using direct Alchemy API
-	_, err := getBaseURL(chainID)
-	return err == nil
+	return o.urlResolver.IsChainSupported(chainID)
 }
 
 func (o *Client) IsConnected() bool {
 	return o.connectionStatus.IsConnected()
 }
 
-func getAPIKeySubpath(apiKey security.SensitiveString) security.SensitiveString {
-	if apiKey.Empty() {
-		return security.NewSensitiveString("demo")
-	}
-	return apiKey
-}
-
-func getNFTBaseURL(chainID walletCommon.ChainID, apiKey security.SensitiveString) (string, error) {
-	baseURL, err := getBaseURL(chainID)
-
-	if err != nil {
-		return "", err
-	}
-
-	return fmt.Sprintf("%s/nft/v3/%s", baseURL, getAPIKeySubpath(apiKey).Reveal()), nil
-}
-
-func (o *Client) getNFTBaseURL(chainID walletCommon.ChainID) (string, error) {
-	// When using proxy (with puzzle auth or basic auth), use proxy URL
-	if o.isProxy {
-		return GetNftProxyBaseURL(o.proxyCustomURL, o.proxyStageName, chainID)
-	}
-
-	// When using direct Alchemy API, construct URL with API key
-	return getNFTBaseURL(chainID, o.apiKey)
-}
-
 type Client struct {
 	thirdparty.CollectibleContractOwnershipProvider
 	id               string
-	isProxy          bool
-	client           *http.Client
-	apiKey           security.SensitiveString
-	proxyCustomURL   string
-	proxyStageName   string
-	creds            *thirdparty.BasicCreds
-	puzzleAuthClient *puzzleauth.Client
+	urlResolver      URLResolver
+	authTransport    *thirdparty.AuthTransport
 	connectionStatus *connection.Status
 }
 
@@ -123,14 +57,15 @@ func NewClient(apiKey security.SensitiveString) *Client {
 		logutils.ZapLogger().Warn("Alchemy API key not available")
 	}
 
+	authParams := thirdparty.AuthParams{
+		Type:   thirdparty.AuthTypeAPIKey,
+		APIKey: apiKey,
+	}
+
 	return &Client{
 		id:               AlchemyID,
-		isProxy:          false,
-		client:           &http.Client{Timeout: time.Minute},
-		apiKey:           apiKey,
-		proxyCustomURL:   "",
-		proxyStageName:   "",
-		creds:            nil,
+		urlResolver:      &directURLResolver{apiKey: apiKey},
+		authTransport:    thirdparty.NewAuthTransport(&http.Client{Timeout: time.Minute}, authParams, AlchemyID),
 		connectionStatus: connection.NewStatus(),
 	}
 }
@@ -140,20 +75,38 @@ func NewClientWithParams(params Params) *Client {
 		logutils.ZapLogger().Warn("Alchemy API key, credentials, and puzzle auth not available")
 	}
 
+	authParams := thirdparty.AuthParams{
+		APIKey:           params.APIKey,
+		Creds:            params.Creds,
+		PuzzleAuthClient: params.PuzzleAuthClient,
+	}
+	switch {
+	case params.PuzzleAuthClient != nil:
+		authParams.Type = thirdparty.AuthTypePOW
+	case params.Creds != nil:
+		authParams.Type = thirdparty.AuthTypeBasic
+	case params.IsProxy:
+		authParams.Type = thirdparty.AuthTypeNone
+	default:
+		authParams.Type = thirdparty.AuthTypeAPIKey
+	}
+
 	clientID := AlchemyID
 	if params.IsProxy {
 		clientID = AlchemyProxyID
 	}
 
+	var resolver URLResolver
+	if params.IsProxy {
+		resolver = &proxyURLResolver{customURL: params.ProxyCustomURL, stageName: params.ProxyStageName}
+	} else {
+		resolver = &directURLResolver{apiKey: params.APIKey}
+	}
+
 	return &Client{
 		id:               clientID,
-		isProxy:          params.IsProxy,
-		client:           &http.Client{Timeout: time.Minute},
-		apiKey:           params.APIKey,
-		proxyCustomURL:   params.ProxyCustomURL,
-		proxyStageName:   params.ProxyStageName,
-		creds:            params.Creds,
-		puzzleAuthClient: params.PuzzleAuthClient,
+		urlResolver:      resolver,
+		authTransport:    thirdparty.NewAuthTransport(&http.Client{Timeout: time.Minute}, authParams, clientID),
 		connectionStatus: connection.NewStatus(),
 	}
 }
@@ -163,12 +116,7 @@ func (o *Client) doQuery(ctx context.Context, url string) (*http.Response, error
 	if err != nil {
 		return nil, err
 	}
-
-	if o.creds != nil {
-		req.SetBasicAuth(o.creds.User.Reveal(), o.creds.Password.Reveal())
-	}
-
-	return o.doWithRetries(req)
+	return o.authTransport.Do(req)
 }
 
 func (o *Client) doPostWithJSON(ctx context.Context, url string, payload any) (*http.Response, error) {
@@ -177,10 +125,7 @@ func (o *Client) doPostWithJSON(ctx context.Context, url string, payload any) (*
 		return nil, err
 	}
 
-	payloadString := string(payloadJSON)
-	payloadReader := strings.NewReader(payloadString)
-
-	req, err := http.NewRequestWithContext(ctx, "POST", url, payloadReader)
+	req, err := http.NewRequestWithContext(ctx, "POST", url, strings.NewReader(string(payloadJSON)))
 	if err != nil {
 		return nil, err
 	}
@@ -188,21 +133,7 @@ func (o *Client) doPostWithJSON(ctx context.Context, url string, payload any) (*
 	req.Header.Add("accept", "application/json")
 	req.Header.Add("content-type", "application/json")
 
-	if o.creds != nil {
-		req.SetBasicAuth(o.creds.User.Reveal(), o.creds.Password.Reveal())
-	}
-
-	return o.doWithRetries(req)
-}
-
-func (o *Client) doWithRetries(req *http.Request) (*http.Response, error) {
-	// If puzzle auth client is available, use it
-	if o.puzzleAuthClient != nil {
-		return o.puzzleAuthClient.DoRequest(req)
-	}
-
-	// Otherwise use the shared backoff retry logic
-	return thirdparty.DoWithExponentialBackoff(o.client, req, o.ID())
+	return o.authTransport.Do(req)
 }
 
 func (o *Client) FetchCollectibleOwnersByContractAddress(ctx context.Context, chainID walletCommon.ChainID, contractAddress common.Address) (*thirdparty.CollectibleContractOwnership, error) {
@@ -216,8 +147,7 @@ func (o *Client) FetchCollectibleOwnersByContractAddress(ctx context.Context, ch
 		"withTokenBalances": {"true"},
 	}
 
-	baseURL, err := o.getNFTBaseURL(chainID)
-
+	baseURL, err := o.urlResolver.GetNFTBaseURL(chainID)
 	if err != nil {
 		return nil, err
 	}
@@ -288,8 +218,7 @@ func (o *Client) fetchOwnedAssets(ctx context.Context, chainID walletCommon.Chai
 	}
 	assets.Provider = o.ID()
 
-	baseURL, err := o.getNFTBaseURL(chainID)
-
+	baseURL, err := o.urlResolver.GetNFTBaseURL(chainID)
 	if err != nil {
 		return nil, err
 	}
@@ -370,7 +299,7 @@ func getCollectibleUniqueIDBatches(ids []thirdparty.CollectibleUniqueID) []Batch
 }
 
 func (o *Client) fetchAssetsByBatchTokenIDs(ctx context.Context, chainID walletCommon.ChainID, batchIDs BatchTokenIDs) ([]thirdparty.FullCollectibleData, error) {
-	baseURL, err := o.getNFTBaseURL(chainID)
+	baseURL, err := o.urlResolver.GetNFTBaseURL(chainID)
 	if err != nil {
 		return nil, err
 	}
@@ -461,7 +390,7 @@ func getContractAddressBatches(ids []thirdparty.ContractID) []BatchContractAddre
 }
 
 func (o *Client) fetchCollectionsDataByBatchContractAddresses(ctx context.Context, chainID walletCommon.ChainID, batchAddresses BatchContractAddresses) ([]thirdparty.CollectionData, error) {
-	baseURL, err := o.getNFTBaseURL(chainID)
+	baseURL, err := o.urlResolver.GetNFTBaseURL(chainID)
 	if err != nil {
 		return nil, err
 	}

--- a/services/wallet/thirdparty/collectibles/alchemy/client.go
+++ b/services/wallet/thirdparty/collectibles/alchemy/client.go
@@ -10,20 +10,27 @@ import (
 	"strings"
 	"time"
 
-	"github.com/cenkalti/backoff/v4"
-	"go.uber.org/zap"
-
 	"github.com/ethereum/go-ethereum/common"
 
 	"github.com/status-im/status-go/internal/logutils"
 	"github.com/status-im/status-go/pkg/security"
 	walletCommon "github.com/status-im/status-go/services/wallet/common"
 	"github.com/status-im/status-go/services/wallet/connection"
+	"github.com/status-im/status-go/services/wallet/puzzleauth"
 	"github.com/status-im/status-go/services/wallet/thirdparty"
 )
 
 const nftMetadataBatchLimit = 100
 const contractMetadataBatchLimit = 100
+
+type Params struct {
+	IsProxy          bool
+	ProxyCustomURL   string
+	ProxyStageName   string
+	APIKey           security.SensitiveString
+	Creds            *thirdparty.BasicCreds
+	PuzzleAuthClient *puzzleauth.Client
+}
 
 func getBaseURL(chainID walletCommon.ChainID) (string, error) {
 	switch uint64(chainID) {
@@ -53,10 +60,16 @@ func getBaseURL(chainID walletCommon.ChainID) (string, error) {
 }
 
 func (o *Client) ID() string {
-	return AlchemyID
+	return o.id
 }
 
 func (o *Client) IsChainSupported(chainID walletCommon.ChainID) bool {
+	// Check if using proxy with puzzle auth or basic auth
+	if o.isProxy {
+		_, err := GetNftProxyBaseURL(o.proxyCustomURL, o.proxyStageName, chainID)
+		return err == nil
+	}
+	// Check if using direct Alchemy API
 	_, err := getBaseURL(chainID)
 	return err == nil
 }
@@ -82,10 +95,26 @@ func getNFTBaseURL(chainID walletCommon.ChainID, apiKey security.SensitiveString
 	return fmt.Sprintf("%s/nft/v3/%s", baseURL, getAPIKeySubpath(apiKey).Reveal()), nil
 }
 
+func (o *Client) getNFTBaseURL(chainID walletCommon.ChainID) (string, error) {
+	// When using proxy (with puzzle auth or basic auth), use proxy URL
+	if o.isProxy {
+		return GetNftProxyBaseURL(o.proxyCustomURL, o.proxyStageName, chainID)
+	}
+
+	// When using direct Alchemy API, construct URL with API key
+	return getNFTBaseURL(chainID, o.apiKey)
+}
+
 type Client struct {
 	thirdparty.CollectibleContractOwnershipProvider
+	id               string
+	isProxy          bool
 	client           *http.Client
 	apiKey           security.SensitiveString
+	proxyCustomURL   string
+	proxyStageName   string
+	creds            *thirdparty.BasicCreds
+	puzzleAuthClient *puzzleauth.Client
 	connectionStatus *connection.Status
 }
 
@@ -95,8 +124,36 @@ func NewClient(apiKey security.SensitiveString) *Client {
 	}
 
 	return &Client{
+		id:               AlchemyID,
+		isProxy:          false,
 		client:           &http.Client{Timeout: time.Minute},
 		apiKey:           apiKey,
+		proxyCustomURL:   "",
+		proxyStageName:   "",
+		creds:            nil,
+		connectionStatus: connection.NewStatus(),
+	}
+}
+
+func NewClientWithParams(params Params) *Client {
+	if params.APIKey.Empty() && params.Creds == nil && params.PuzzleAuthClient == nil {
+		logutils.ZapLogger().Warn("Alchemy API key, credentials, and puzzle auth not available")
+	}
+
+	clientID := AlchemyID
+	if params.IsProxy {
+		clientID = AlchemyProxyID
+	}
+
+	return &Client{
+		id:               clientID,
+		isProxy:          params.IsProxy,
+		client:           &http.Client{Timeout: time.Minute},
+		apiKey:           params.APIKey,
+		proxyCustomURL:   params.ProxyCustomURL,
+		proxyStageName:   params.ProxyStageName,
+		creds:            params.Creds,
+		puzzleAuthClient: params.PuzzleAuthClient,
 		connectionStatus: connection.NewStatus(),
 	}
 }
@@ -105,6 +162,10 @@ func (o *Client) doQuery(ctx context.Context, url string) (*http.Response, error
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
 		return nil, err
+	}
+
+	if o.creds != nil {
+		req.SetBasicAuth(o.creds.User.Reveal(), o.creds.Password.Reveal())
 	}
 
 	return o.doWithRetries(req)
@@ -127,42 +188,21 @@ func (o *Client) doPostWithJSON(ctx context.Context, url string, payload any) (*
 	req.Header.Add("accept", "application/json")
 	req.Header.Add("content-type", "application/json")
 
+	if o.creds != nil {
+		req.SetBasicAuth(o.creds.User.Reveal(), o.creds.Password.Reveal())
+	}
+
 	return o.doWithRetries(req)
 }
 
 func (o *Client) doWithRetries(req *http.Request) (*http.Response, error) {
-	b := backoff.NewExponentialBackOff()
-	b.InitialInterval = time.Millisecond * 1000
-	b.RandomizationFactor = 0.1
-	b.Multiplier = 1.5
-	b.MaxInterval = time.Second * 32
-	b.MaxElapsedTime = time.Second * 70
-
-	b.Reset()
-
-	op := func() (*http.Response, error) {
-		resp, err := o.client.Do(req)
-		if err != nil {
-			return nil, backoff.Permanent(err)
-		}
-
-		if resp.StatusCode == http.StatusOK {
-			return resp, nil
-		}
-
-		err = fmt.Errorf("unsuccessful request: %d %s", resp.StatusCode, http.StatusText(resp.StatusCode))
-		if resp.StatusCode == http.StatusTooManyRequests {
-			logutils.ZapLogger().Error("doWithRetries failed with http.StatusTooManyRequests",
-				zap.String("provider", o.ID()),
-				zap.Duration("elapsed time", b.GetElapsedTime()),
-				zap.Duration("next backoff", b.NextBackOff()),
-			)
-			return nil, err
-		}
-		return nil, backoff.Permanent(err)
+	// If puzzle auth client is available, use it
+	if o.puzzleAuthClient != nil {
+		return o.puzzleAuthClient.DoRequest(req)
 	}
 
-	return backoff.RetryWithData(op, b)
+	// Otherwise use the shared backoff retry logic
+	return thirdparty.DoWithExponentialBackoff(o.client, req, o.ID())
 }
 
 func (o *Client) FetchCollectibleOwnersByContractAddress(ctx context.Context, chainID walletCommon.ChainID, contractAddress common.Address) (*thirdparty.CollectibleContractOwnership, error) {
@@ -176,7 +216,7 @@ func (o *Client) FetchCollectibleOwnersByContractAddress(ctx context.Context, ch
 		"withTokenBalances": {"true"},
 	}
 
-	baseURL, err := getNFTBaseURL(chainID, o.apiKey)
+	baseURL, err := o.getNFTBaseURL(chainID)
 
 	if err != nil {
 		return nil, err
@@ -248,7 +288,7 @@ func (o *Client) fetchOwnedAssets(ctx context.Context, chainID walletCommon.Chai
 	}
 	assets.Provider = o.ID()
 
-	baseURL, err := getNFTBaseURL(chainID, o.apiKey)
+	baseURL, err := o.getNFTBaseURL(chainID)
 
 	if err != nil {
 		return nil, err
@@ -330,7 +370,7 @@ func getCollectibleUniqueIDBatches(ids []thirdparty.CollectibleUniqueID) []Batch
 }
 
 func (o *Client) fetchAssetsByBatchTokenIDs(ctx context.Context, chainID walletCommon.ChainID, batchIDs BatchTokenIDs) ([]thirdparty.FullCollectibleData, error) {
-	baseURL, err := getNFTBaseURL(chainID, o.apiKey)
+	baseURL, err := o.getNFTBaseURL(chainID)
 	if err != nil {
 		return nil, err
 	}
@@ -421,7 +461,7 @@ func getContractAddressBatches(ids []thirdparty.ContractID) []BatchContractAddre
 }
 
 func (o *Client) fetchCollectionsDataByBatchContractAddresses(ctx context.Context, chainID walletCommon.ChainID, batchAddresses BatchContractAddresses) ([]thirdparty.CollectionData, error) {
-	baseURL, err := getNFTBaseURL(chainID, o.apiKey)
+	baseURL, err := o.getNFTBaseURL(chainID)
 	if err != nil {
 		return nil, err
 	}

--- a/services/wallet/thirdparty/collectibles/alchemy/nft_proxy_utils.go
+++ b/services/wallet/thirdparty/collectibles/alchemy/nft_proxy_utils.go
@@ -33,5 +33,5 @@ func GetNftProxyBaseURL(customURL, stageName string, chainID walletCommon.ChainI
 		return "", thirdparty.ErrChainIDNotSupported
 	}
 
-	return fmt.Sprintf("%s/%s/%s", host, chainPath, networkPath), nil
+	return fmt.Sprintf("%s/%s/%s/nft/v3", host, chainPath, networkPath), nil
 }

--- a/services/wallet/thirdparty/collectibles/alchemy/nft_proxy_utils.go
+++ b/services/wallet/thirdparty/collectibles/alchemy/nft_proxy_utils.go
@@ -1,0 +1,37 @@
+package alchemy
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/status-im/status-go/params/networkhelper"
+	walletCommon "github.com/status-im/status-go/services/wallet/common"
+	"github.com/status-im/status-go/services/wallet/thirdparty"
+)
+
+const (
+	NftProxyHostSuffix = "nft.status.im"
+)
+
+// GetNftProxyHost creates NFT proxy base URL based on stage name
+func GetNftProxyHost(customUrl, stageName string) string {
+	if customUrl != "" {
+		return strings.TrimRight(customUrl, "/")
+	}
+	if stageName == "" {
+		stageName = "test"
+	}
+	return fmt.Sprintf("https://%s.%s", stageName, NftProxyHostSuffix)
+}
+
+// GetNftProxyBaseURL creates NFT proxy URL for a specific chain
+func GetNftProxyBaseURL(customUrl, stageName string, chainID walletCommon.ChainID) (string, error) {
+	host := GetNftProxyHost(customUrl, stageName)
+
+	chainPath, networkPath, err := networkhelper.ChainIDToChainAndNetwork(uint64(chainID))
+	if err != nil {
+		return "", thirdparty.ErrChainIDNotSupported
+	}
+
+	return fmt.Sprintf("%s/%s/%s", host, chainPath, networkPath), nil
+}

--- a/services/wallet/thirdparty/collectibles/alchemy/nft_proxy_utils.go
+++ b/services/wallet/thirdparty/collectibles/alchemy/nft_proxy_utils.go
@@ -14,9 +14,9 @@ const (
 )
 
 // GetNftProxyHost creates NFT proxy base URL based on stage name
-func GetNftProxyHost(customUrl, stageName string) string {
-	if customUrl != "" {
-		return strings.TrimRight(customUrl, "/")
+func GetNftProxyHost(customURL, stageName string) string {
+	if customURL != "" {
+		return strings.TrimRight(customURL, "/")
 	}
 	if stageName == "" {
 		stageName = "test"
@@ -25,8 +25,8 @@ func GetNftProxyHost(customUrl, stageName string) string {
 }
 
 // GetNftProxyBaseURL creates NFT proxy URL for a specific chain
-func GetNftProxyBaseURL(customUrl, stageName string, chainID walletCommon.ChainID) (string, error) {
-	host := GetNftProxyHost(customUrl, stageName)
+func GetNftProxyBaseURL(customURL, stageName string, chainID walletCommon.ChainID) (string, error) {
+	host := GetNftProxyHost(customURL, stageName)
 
 	chainPath, networkPath, err := networkhelper.ChainIDToChainAndNetwork(uint64(chainID))
 	if err != nil {

--- a/services/wallet/thirdparty/collectibles/alchemy/nft_proxy_utils_test.go
+++ b/services/wallet/thirdparty/collectibles/alchemy/nft_proxy_utils_test.go
@@ -1,0 +1,96 @@
+package alchemy
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	walletCommon "github.com/status-im/status-go/services/wallet/common"
+	"github.com/status-im/status-go/services/wallet/thirdparty"
+)
+
+func TestGetNftProxyHost(t *testing.T) {
+	tests := []struct {
+		name      string
+		customURL string
+		stageName string
+		expected  string
+	}{
+		{
+			name:      "custom URL with trailing slash",
+			customURL: "https://custom.example.com/",
+			stageName: "",
+			expected:  "https://custom.example.com",
+		},
+		{
+			name:      "custom URL without trailing slash",
+			customURL: "https://custom.example.com",
+			stageName: "",
+			expected:  "https://custom.example.com",
+		},
+		{
+			name:      "stage name provided",
+			customURL: "",
+			stageName: "production",
+			expected:  "https://production.nft.status.im",
+		},
+		{
+			name:      "empty stage name defaults to test",
+			customURL: "",
+			stageName: "",
+			expected:  "https://test.nft.status.im",
+		},
+		{
+			name:      "custom URL takes precedence over stage name",
+			customURL: "https://override.example.com",
+			stageName: "production",
+			expected:  "https://override.example.com",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := GetNftProxyHost(tt.customURL, tt.stageName)
+			require.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestGetNftProxyBaseURL(t *testing.T) {
+	tests := []struct {
+		name     string
+		chainID  walletCommon.ChainID
+		expected string
+		wantErr  bool
+	}{
+		{
+			name:     "Supported chain - Ethereum mainnet",
+			chainID:  walletCommon.ChainID(walletCommon.EthereumMainnet),
+			expected: "https://test.nft.status.im/ethereum/mainnet",
+		},
+		{
+			name:     "Supported chain - Arbitrum Sepolia",
+			chainID:  walletCommon.ChainID(walletCommon.ArbitrumSepolia),
+			expected: "https://test.nft.status.im/arbitrum/sepolia",
+		},
+		{
+			name:    "Unsupported chain ID",
+			chainID: walletCommon.ChainID(999999),
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := GetNftProxyBaseURL("", "test", tt.chainID)
+			if tt.wantErr {
+				require.Error(t, err)
+				require.Equal(t, thirdparty.ErrChainIDNotSupported, err)
+				require.Empty(t, result)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tt.expected, result)
+			}
+		})
+	}
+}

--- a/services/wallet/thirdparty/collectibles/alchemy/nft_proxy_utils_test.go
+++ b/services/wallet/thirdparty/collectibles/alchemy/nft_proxy_utils_test.go
@@ -66,12 +66,12 @@ func TestGetNftProxyBaseURL(t *testing.T) {
 		{
 			name:     "Supported chain - Ethereum mainnet",
 			chainID:  walletCommon.ChainID(walletCommon.EthereumMainnet),
-			expected: "https://test.nft.status.im/ethereum/mainnet",
+			expected: "https://test.nft.status.im/ethereum/mainnet/nft/v3",
 		},
 		{
 			name:     "Supported chain - Arbitrum Sepolia",
 			chainID:  walletCommon.ChainID(walletCommon.ArbitrumSepolia),
-			expected: "https://test.nft.status.im/arbitrum/sepolia",
+			expected: "https://test.nft.status.im/arbitrum/sepolia/nft/v3",
 		},
 		{
 			name:    "Unsupported chain ID",

--- a/services/wallet/thirdparty/collectibles/alchemy/types.go
+++ b/services/wallet/thirdparty/collectibles/alchemy/types.go
@@ -18,6 +18,7 @@ import (
 )
 
 const AlchemyID = "alchemy"
+const AlchemyProxyID = "alchemy-proxy"
 
 type TokenBalance struct {
 	TokenID *bigint.BigInt `json:"tokenId"`

--- a/services/wallet/thirdparty/collectibles/alchemy/url_resolver.go
+++ b/services/wallet/thirdparty/collectibles/alchemy/url_resolver.go
@@ -1,0 +1,84 @@
+package alchemy
+
+import (
+	"fmt"
+
+	"github.com/status-im/status-go/pkg/security"
+	walletCommon "github.com/status-im/status-go/services/wallet/common"
+	"github.com/status-im/status-go/services/wallet/thirdparty"
+)
+
+// URLResolver constructs base URLs for Alchemy Client
+type URLResolver interface {
+	// For direct Alchemy: "https://eth-mainnet.g.alchemy.com/nft/v3/{apiKey}"
+	// For proxy: "https://test.nft.status.im/ethereum/mainnet/nft/v3"
+	GetNFTBaseURL(chainID walletCommon.ChainID) (string, error)
+
+	// IsChainSupported returns true if the resolver can construct a URL for this chain.
+	IsChainSupported(chainID walletCommon.ChainID) bool
+}
+
+type directURLResolver struct {
+	apiKey security.SensitiveString
+}
+
+func (r *directURLResolver) GetNFTBaseURL(chainID walletCommon.ChainID) (string, error) {
+	baseURL, err := getBaseURL(chainID)
+	if err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("%s/nft/v3/%s", baseURL, getAPIKeySubpath(r.apiKey).Reveal()), nil
+}
+
+func (r *directURLResolver) IsChainSupported(chainID walletCommon.ChainID) bool {
+	_, err := getBaseURL(chainID)
+	return err == nil
+}
+
+type proxyURLResolver struct {
+	customURL string
+	stageName string
+}
+
+func (r *proxyURLResolver) GetNFTBaseURL(chainID walletCommon.ChainID) (string, error) {
+	return GetNftProxyBaseURL(r.customURL, r.stageName, chainID)
+}
+
+func (r *proxyURLResolver) IsChainSupported(chainID walletCommon.ChainID) bool {
+	_, err := GetNftProxyBaseURL(r.customURL, r.stageName, chainID)
+	return err == nil
+}
+
+func getBaseURL(chainID walletCommon.ChainID) (string, error) {
+	switch uint64(chainID) {
+	case walletCommon.EthereumMainnet:
+		return "https://eth-mainnet.g.alchemy.com", nil
+	case walletCommon.EthereumSepolia:
+		return "https://eth-sepolia.g.alchemy.com", nil
+	case walletCommon.OptimismMainnet:
+		return "https://opt-mainnet.g.alchemy.com", nil
+	case walletCommon.OptimismSepolia:
+		return "https://opt-sepolia.g.alchemy.com", nil
+	case walletCommon.ArbitrumMainnet:
+		return "https://arb-mainnet.g.alchemy.com", nil
+	case walletCommon.ArbitrumSepolia:
+		return "https://arb-sepolia.g.alchemy.com", nil
+	case walletCommon.BaseMainnet:
+		return "https://base-mainnet.g.alchemy.com", nil
+	case walletCommon.BaseSepolia:
+		return "https://base-sepolia.g.alchemy.com", nil
+	case walletCommon.LineaMainnet:
+		return "https://linea-mainnet.g.alchemy.com", nil
+	case walletCommon.LineaSepolia:
+		return "https://linea-sepolia.g.alchemy.com", nil
+	}
+
+	return "", thirdparty.ErrChainIDNotSupported
+}
+
+func getAPIKeySubpath(apiKey security.SensitiveString) security.SensitiveString {
+	if apiKey.Empty() {
+		return security.NewSensitiveString("demo")
+	}
+	return apiKey
+}

--- a/services/wallet/thirdparty/collectibles/alchemy/url_resolver_test.go
+++ b/services/wallet/thirdparty/collectibles/alchemy/url_resolver_test.go
@@ -1,0 +1,100 @@
+package alchemy
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/status-im/status-go/pkg/security"
+	walletCommon "github.com/status-im/status-go/services/wallet/common"
+)
+
+func TestDirectURLResolver_GetNFTBaseURL(t *testing.T) {
+	tests := []struct {
+		name     string
+		chainID  walletCommon.ChainID
+		apiKey   string
+		expected string
+	}{
+		{
+			name:     "Ethereum mainnet",
+			chainID:  walletCommon.ChainID(walletCommon.EthereumMainnet),
+			apiKey:   "my-api-key",
+			expected: "https://eth-mainnet.g.alchemy.com/nft/v3/my-api-key",
+		},
+		{
+			name:     "Ethereum Sepolia",
+			chainID:  walletCommon.ChainID(walletCommon.EthereumSepolia),
+			apiKey:   "key",
+			expected: "https://eth-sepolia.g.alchemy.com/nft/v3/key",
+		},
+		{
+			name:     "Base mainnet",
+			chainID:  walletCommon.ChainID(walletCommon.BaseMainnet),
+			apiKey:   "abc",
+			expected: "https://base-mainnet.g.alchemy.com/nft/v3/abc",
+		},
+		{
+			name:     "Arbitrum Sepolia",
+			chainID:  walletCommon.ChainID(walletCommon.ArbitrumSepolia),
+			apiKey:   "xyz",
+			expected: "https://arb-sepolia.g.alchemy.com/nft/v3/xyz",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resolver := &directURLResolver{apiKey: security.NewSensitiveString(tt.apiKey)}
+			result, err := resolver.GetNFTBaseURL(tt.chainID)
+			require.NoError(t, err)
+			require.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestDirectURLResolver_EmptyAPIKey(t *testing.T) {
+	resolver := &directURLResolver{apiKey: security.SensitiveString{}}
+	result, err := resolver.GetNFTBaseURL(walletCommon.ChainID(walletCommon.EthereumMainnet))
+	require.NoError(t, err)
+	require.Equal(t, "https://eth-mainnet.g.alchemy.com/nft/v3/demo", result)
+}
+
+func TestDirectURLResolver_UnsupportedChain(t *testing.T) {
+	resolver := &directURLResolver{apiKey: security.NewSensitiveString("key")}
+	_, err := resolver.GetNFTBaseURL(walletCommon.ChainID(999999))
+	require.Error(t, err)
+}
+
+func TestProxyURLResolver_GetNFTBaseURL(t *testing.T) {
+	resolver := &proxyURLResolver{customURL: "", stageName: "test"}
+	result, err := resolver.GetNFTBaseURL(walletCommon.ChainID(walletCommon.EthereumMainnet))
+	require.NoError(t, err)
+	require.Equal(t, "https://test.nft.status.im/ethereum/mainnet/nft/v3", result)
+}
+
+func TestProxyURLResolver_CustomURL(t *testing.T) {
+	resolver := &proxyURLResolver{customURL: "https://custom.example.com", stageName: "test"}
+	result, err := resolver.GetNFTBaseURL(walletCommon.ChainID(walletCommon.EthereumMainnet))
+	require.NoError(t, err)
+	require.Equal(t, "https://custom.example.com/ethereum/mainnet/nft/v3", result)
+}
+
+func TestProxyURLResolver_UnsupportedChain(t *testing.T) {
+	resolver := &proxyURLResolver{customURL: "", stageName: "test"}
+	_, err := resolver.GetNFTBaseURL(walletCommon.ChainID(999999))
+	require.Error(t, err)
+}
+
+func TestDirectURLResolver_IsChainSupported(t *testing.T) {
+	resolver := &directURLResolver{apiKey: security.NewSensitiveString("key")}
+	require.True(t, resolver.IsChainSupported(walletCommon.ChainID(walletCommon.EthereumMainnet)))
+	require.True(t, resolver.IsChainSupported(walletCommon.ChainID(walletCommon.BaseSepolia)))
+	require.False(t, resolver.IsChainSupported(walletCommon.ChainID(999999)))
+}
+
+func TestProxyURLResolver_IsChainSupported(t *testing.T) {
+	resolver := &proxyURLResolver{customURL: "", stageName: "test"}
+	require.True(t, resolver.IsChainSupported(walletCommon.ChainID(walletCommon.EthereumMainnet)))
+	require.True(t, resolver.IsChainSupported(walletCommon.ChainID(walletCommon.ArbitrumSepolia)))
+	require.False(t, resolver.IsChainSupported(walletCommon.ChainID(999999)))
+}

--- a/services/wallet/thirdparty/collectibles/rarible/client.go
+++ b/services/wallet/thirdparty/collectibles/rarible/client.go
@@ -11,9 +11,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/cenkalti/backoff/v4"
-	"go.uber.org/zap"
-
 	"github.com/ethereum/go-ethereum/common"
 
 	"github.com/status-im/status-go/internal/logutils"
@@ -147,40 +144,11 @@ func (o *Client) doPostWithJSON(ctx context.Context, url string, payload any, ap
 }
 
 func (o *Client) doWithRetries(req *http.Request, apiKey security.SensitiveString) (*http.Response, error) {
-	b := backoff.NewExponentialBackOff()
-	b.InitialInterval = time.Millisecond * 1000
-	b.RandomizationFactor = 0.1
-	b.Multiplier = 1.5
-	b.MaxInterval = time.Second * 32
-	b.MaxElapsedTime = time.Second * 70
-
-	b.Reset()
-
+	// Set API key header before making the request
 	req.Header.Set("X-API-KEY", apiKey.Reveal())
 
-	op := func() (*http.Response, error) {
-		resp, err := o.client.Do(req)
-		if err != nil {
-			return nil, backoff.Permanent(err)
-		}
-
-		if resp.StatusCode == http.StatusOK {
-			return resp, nil
-		}
-
-		err = fmt.Errorf("unsuccessful request: %d %s", resp.StatusCode, http.StatusText(resp.StatusCode))
-		if resp.StatusCode == http.StatusTooManyRequests {
-			logutils.ZapLogger().Error("doWithRetries failed with http.StatusTooManyRequests",
-				zap.String("provider", o.ID()),
-				zap.Duration("elapsed time", b.GetElapsedTime()),
-				zap.Duration("next backoff", b.NextBackOff()),
-			)
-			return nil, err
-		}
-		return nil, backoff.Permanent(err)
-	}
-
-	return backoff.RetryWithData(op, b)
+	// Use the shared backoff retry logic
+	return thirdparty.DoWithExponentialBackoff(o.client, req, o.ID())
 }
 
 func (o *Client) FetchCollectibleOwnersByContractAddress(ctx context.Context, chainID walletCommon.ChainID, contractAddress common.Address) (*thirdparty.CollectibleContractOwnership, error) {

--- a/services/wallet/thirdparty/http_client.go
+++ b/services/wallet/thirdparty/http_client.go
@@ -298,8 +298,21 @@ func (c *HTTPClient) BuildURL(proxyURL, endpoint string) string {
 }
 
 // DoWithExponentialBackoff executes an HTTP request with exponential backoff retry logic
-// for handling rate limiting and transient errors
+// for handling rate limiting responses (HTTP 429)
 func DoWithExponentialBackoff(client *http.Client, req *http.Request, providerID string) (*http.Response, error) {
+	// Ensure request body can be replayed for retries by setting up GetBody if needed
+	if req.Body != nil && req.GetBody == nil {
+		bodyBytes, err := io.ReadAll(req.Body)
+		if err != nil {
+			return nil, err
+		}
+		req.Body.Close()
+		req.Body = io.NopCloser(bytes.NewReader(bodyBytes))
+		req.GetBody = func() (io.ReadCloser, error) {
+			return io.NopCloser(bytes.NewReader(bodyBytes)), nil
+		}
+	}
+
 	b := backoff.NewExponentialBackOff()
 	b.InitialInterval = time.Millisecond * 1000
 	b.RandomizationFactor = 0.1
@@ -310,7 +323,16 @@ func DoWithExponentialBackoff(client *http.Client, req *http.Request, providerID
 	b.Reset()
 
 	op := func() (*http.Response, error) {
-		resp, err := client.Do(req)
+		attemptReq := req.Clone(req.Context())
+		if req.GetBody != nil && attemptReq.Body == nil {
+			body, err := req.GetBody()
+			if err != nil {
+				return nil, backoff.Permanent(err)
+			}
+			attemptReq.Body = body
+		}
+
+		resp, err := client.Do(attemptReq)
 		if err != nil {
 			return nil, backoff.Permanent(err)
 		}
@@ -319,12 +341,14 @@ func DoWithExponentialBackoff(client *http.Client, req *http.Request, providerID
 			return resp, nil
 		}
 
+		_, _ = io.Copy(io.Discard, resp.Body)
+		resp.Body.Close()
+
 		err = fmt.Errorf("unsuccessful request: %d %s", resp.StatusCode, http.StatusText(resp.StatusCode))
 		if resp.StatusCode == http.StatusTooManyRequests {
-			logutils.ZapLogger().Error("doWithRetries failed with http.StatusTooManyRequests",
+			logutils.ZapLogger().Warn("request throttled with http.StatusTooManyRequests; will retry",
 				zap.String("provider", providerID),
 				zap.Duration("elapsed time", b.GetElapsedTime()),
-				zap.Duration("next backoff", b.NextBackOff()),
 			)
 			return nil, err
 		}

--- a/services/wallet/thirdparty/http_client.go
+++ b/services/wallet/thirdparty/http_client.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/cenkalti/backoff/v4"
 	"go.uber.org/zap"
 
 	"github.com/status-im/status-go/internal/logutils"
@@ -294,4 +295,41 @@ func (c *HTTPClient) BuildURL(proxyURL, endpoint string) string {
 	baseURL := strings.TrimRight(proxyURL, "/")
 	cleanEndpoint := strings.TrimLeft(endpoint, "/")
 	return baseURL + "/" + cleanEndpoint
+}
+
+// DoWithExponentialBackoff executes an HTTP request with exponential backoff retry logic
+// for handling rate limiting and transient errors
+func DoWithExponentialBackoff(client *http.Client, req *http.Request, providerID string) (*http.Response, error) {
+	b := backoff.NewExponentialBackOff()
+	b.InitialInterval = time.Millisecond * 1000
+	b.RandomizationFactor = 0.1
+	b.Multiplier = 1.5
+	b.MaxInterval = time.Second * 32
+	b.MaxElapsedTime = time.Second * 70
+
+	b.Reset()
+
+	op := func() (*http.Response, error) {
+		resp, err := client.Do(req)
+		if err != nil {
+			return nil, backoff.Permanent(err)
+		}
+
+		if resp.StatusCode == http.StatusOK {
+			return resp, nil
+		}
+
+		err = fmt.Errorf("unsuccessful request: %d %s", resp.StatusCode, http.StatusText(resp.StatusCode))
+		if resp.StatusCode == http.StatusTooManyRequests {
+			logutils.ZapLogger().Error("doWithRetries failed with http.StatusTooManyRequests",
+				zap.String("provider", providerID),
+				zap.Duration("elapsed time", b.GetElapsedTime()),
+				zap.Duration("next backoff", b.NextBackOff()),
+			)
+			return nil, err
+		}
+		return nil, backoff.Permanent(err)
+	}
+
+	return backoff.RetryWithData(op, b)
 }

--- a/services/wallet/thirdparty/http_client_test.go
+++ b/services/wallet/thirdparty/http_client_test.go
@@ -315,7 +315,7 @@ func gzipEncode(data []byte) ([]byte, error) {
 func TestDoWithExponentialBackoff_Success(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte("success"))
+		_, _ = w.Write([]byte("success"))
 	}))
 	defer server.Close()
 
@@ -338,7 +338,7 @@ func TestDoWithExponentialBackoff_RateLimit(t *testing.T) {
 			w.WriteHeader(http.StatusTooManyRequests)
 		} else {
 			w.WriteHeader(http.StatusOK)
-			w.Write([]byte("success after retry"))
+			_, _ = w.Write([]byte("success after retry"))
 		}
 	}))
 	defer server.Close()

--- a/services/wallet/thirdparty/http_client_test.go
+++ b/services/wallet/thirdparty/http_client_test.go
@@ -311,3 +311,107 @@ func gzipEncode(data []byte) ([]byte, error) {
 	}
 	return buf.Bytes(), nil
 }
+
+func TestDoWithExponentialBackoff_Success(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("success"))
+	}))
+	defer server.Close()
+
+	client := &http.Client{}
+	req, err := http.NewRequest(http.MethodGet, server.URL, nil)
+	require.NoError(t, err)
+
+	resp, err := DoWithExponentialBackoff(client, req, "test-provider")
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	resp.Body.Close()
+}
+
+func TestDoWithExponentialBackoff_RateLimit(t *testing.T) {
+	var attempts int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		attempts++
+		if attempts < 3 {
+			w.WriteHeader(http.StatusTooManyRequests)
+		} else {
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte("success after retry"))
+		}
+	}))
+	defer server.Close()
+
+	client := &http.Client{}
+	req, err := http.NewRequest(http.MethodGet, server.URL, nil)
+	require.NoError(t, err)
+
+	resp, err := DoWithExponentialBackoff(client, req, "test-provider")
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.GreaterOrEqual(t, attempts, 3, "Should have retried at least twice before succeeding")
+	resp.Body.Close()
+}
+
+func TestDoWithExponentialBackoff_PermanentErrors(t *testing.T) {
+	tests := []struct {
+		name       string
+		statusCode int
+	}{
+		{"400 error", http.StatusBadRequest},
+		{"404 error", http.StatusNotFound},
+		{"500 error", http.StatusInternalServerError},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var attempts int
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				attempts++
+				w.WriteHeader(tt.statusCode)
+			}))
+			defer server.Close()
+
+			client := &http.Client{}
+			req, err := http.NewRequest(http.MethodGet, server.URL, nil)
+			require.NoError(t, err)
+
+			resp, err := DoWithExponentialBackoff(client, req, "test-provider")
+			require.Error(t, err)
+			require.Nil(t, resp)
+			require.Contains(t, err.Error(), "unsuccessful request")
+			require.Equal(t, 1, attempts)
+		})
+	}
+}
+
+func TestDoWithExponentialBackoff_NetworkError(t *testing.T) {
+	client := &http.Client{}
+	req, err := http.NewRequest(http.MethodGet, "http://localhost:1", nil)
+	require.NoError(t, err)
+
+	resp, err := DoWithExponentialBackoff(client, req, "test-provider")
+	require.Error(t, err)
+	require.Nil(t, resp)
+}
+
+func TestDoWithExponentialBackoff_RetryExhaustion(t *testing.T) {
+	var attempts int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		attempts++
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	client := &http.Client{}
+	req, err := http.NewRequest(http.MethodGet, server.URL, nil)
+	require.NoError(t, err)
+
+	resp, err := DoWithExponentialBackoff(client, req, "test-provider")
+	require.Error(t, err)
+	require.Nil(t, resp)
+	require.Contains(t, err.Error(), "unsuccessful request")
+	require.Greater(t, attempts, 1)
+}


### PR DESCRIPTION
Integrates the `puzzleauth` package into the Alchemy collectibles client so NFT requests can go through the status nft-proxy with proof-of-work authentication.

**Key changes:**

- Alchemy client now supports 3 auth modes: direct API key, basic auth, puzzle auth — selected via new `Params` struct and `NewClientWithParams` constructor


- New `NftProxyConfig` in `WalletConfig` — configures proxy URL/stage, credentials, and `UsePuzzleAuth` flag
- `nft_proxy_utils` — builds proxy URLs per chain (`{stage}.nft.status.im/{chain}/{network}`)
- `networkhelper.ChainIDToChainAndNetwork` — chainID→(chain, network) mapping
- `thirdparty.DoWithExponentialBackoff` — backoff retry logic extracted from Alchemy client

**How it works:**  
When `UsePuzzleAuth` is enabled, the Alchemy client delegates HTTP requests to `puzzleauth.Client`, which handles token acquisition and auto-retry on 401/403/429. Otherwise falls back to basic auth or direct API key mode.

depends on https://github.com/status-im/status-go/pull/7321

refs #7320
