### PR TITLE
test: Update `_calculate_port_range` logic to support xdist worker pa…

### DIFF
--- a/tests-functional/clients/statusgo_container.py
+++ b/tests-functional/clients/statusgo_container.py
@@ -319,8 +319,11 @@ class StatusGoContainer:
     @classmethod
     def acquire_port(cls):
         with cls._port_lock:
+            if not Config.status_backend_port_range:
+                raise RuntimeError("Port pool exhausted: no more ports available. " "Consider increasing range_size in _calculate_port_range().")
             host_port = random.choice(Config.status_backend_port_range)
             Config.status_backend_port_range.remove(host_port)
+            logging.debug(f"Acquired port {host_port} ({len(Config.status_backend_port_range)} remaining)")
             return host_port
 
     def connect_to_bridge_network(self):

--- a/tests-functional/conftest.py
+++ b/tests-functional/conftest.py
@@ -89,18 +89,38 @@ def _status_backend_url_generator(urls) -> Iterator[str]:
 
 
 def _calculate_port_range():
-    executor_number = int(os.getenv("EXECUTOR_NUMBER", 5))
+    executor_number = int(os.getenv("EXECUTOR_NUMBER", "5"))
+    Config.executor_number = executor_number
     base_port = 7000
-    range_size = 100
+    range_size = 2000
     max_port = 65535
     min_port = 1024
 
     start_port = base_port + (executor_number * range_size)
-    end_port = start_port + 20000
+    end_port = start_port + range_size
 
-    # Ensure generated ports are within the valid range
+    # Validate executor-level range BEFORE xdist partitioning.
+    # xdist only narrows the range, so if the full range is valid, all sub-ranges are too.
     if start_port < min_port or end_port > max_port:
-        raise ValueError(f"Generated port range ({start_port}-{end_port}) is outside the allowed range ({min_port}-{max_port}).")
+        raise ValueError(
+            f"Generated port range ({start_port}-{end_port}) is outside the allowed range "
+            f"({min_port}-{max_port}). executor_number={executor_number}, range_size={range_size}"
+        )
+
+    # Sub-partition for pytest-xdist workers to avoid intra-executor collisions.
+    # Each xdist worker is a separate process (spawned via execnet, not fork),
+    # so each gets its own copy of the port pool — threading.Lock does not help across processes.
+    worker_id = os.getenv("PYTEST_XDIST_WORKER")  # "gw0", "gw1", etc.
+    if worker_id:
+        worker_num = int(worker_id.replace("gw", ""))
+        num_workers = int(os.getenv("PYTEST_XDIST_WORKER_COUNT", 12))
+        if num_workers <= 0:
+            raise ValueError(f"PYTEST_XDIST_WORKER_COUNT must be positive, got {num_workers}")
+        worker_range = range_size // num_workers
+        if worker_range == 0:
+            raise ValueError(f"range_size={range_size} is too small for {num_workers} xdist workers " f"(worker_range would be 0)")
+        start_port = start_port + (worker_num * worker_range)
+        end_port = start_port + worker_range
 
     return list(range(start_port, end_port))
 
@@ -125,12 +145,16 @@ def pytest_configure(config):
 
 
 def pytest_report_header(config):
+    port_range = Config.status_backend_port_range
+    port_range_info = f"port range: {port_range[0]}-{port_range[-1]} ({len(port_range)} ports)" if port_range else "port range: empty"
     return [
         f"docker image: {Config.docker_image}",
         f"waku fleets config file: {config.option.waku_fleets_config}",
         f"waku fleet: {config.option.waku_fleet}",
         f"push fleets config file: {config.option.push_fleets_config}",
         f"disable override networks: {config.option.disable_override_networks}",
+        f"executor number: {Config.executor_number}",
+        f"{port_range_info}",
     ]
 
 

--- a/tests-functional/utils/config.py
+++ b/tests-functional/utils/config.py
@@ -3,7 +3,7 @@ from typing import List, Iterator
 
 
 class Config:
-    executor_number: int = 5
+    executor_number: int = 0  # Always overwritten by _calculate_port_range() in conftest.py
     status_backend_port_range: List[int] = field(default_factory=list)
     base_dir: str = ""
 

--- a/tests-functional/utils/config.py
+++ b/tests-functional/utils/config.py
@@ -3,6 +3,7 @@ from typing import List, Iterator
 
 
 class Config:
+    executor_number: int = 5
     status_backend_port_range: List[int] = field(default_factory=list)
     base_dir: str = ""
 


### PR DESCRIPTION
Fixes functional-test port allocation to avoid collisions across executors and xdist workers.

Important changes:

-  Consistent non-overlapping port range calculation.
-  Deterministic executor boundary validation.
-  xdist worker-count validation guards.
-  Clear port-pool exhaustion error.
-  Executor/port-range info in pytest header.