### PR TITLE
fix(urls): fixes to shared urls for non existing contacts

### DIFF
--- a/services/sharedurls/service.go
+++ b/services/sharedurls/service.go
@@ -505,7 +505,15 @@ func (s *Service) ShareUserURLWithData(contactID string) (string, error) {
 		return "", errors.Wrap(err, "failed to get contact")
 	}
 	if contact == nil {
-		return "", ErrContactNotFound
+		// For unknown contacts, we can still generate a URL with the chat key, but without additional data
+		publicKey, err := crypto.HexToPubkey(contactID)
+		if err != nil {
+			return "", errors.Wrap(err, "failed to convert contact ID to public key")
+		}
+		contact, err = contacts.BuildContact(contactID, publicKey)
+		if err != nil {
+			return "", errors.Wrap(err, "failed to build contact")
+		}
 	}
 	return ShareUserURLWithData(contact)
 }

--- a/services/sharedurls/service.go
+++ b/services/sharedurls/service.go
@@ -468,8 +468,10 @@ func prepareEncodedUserData(contact *contacts.Contact) (string, string, error) {
 		return "", "", err
 	}
 
-	if contact.DisplayName == "" && contact.Bio == "" {
-		return "", shortKey, nil
+	if contact.DisplayName == "" {
+		// We always want to have some display name in the URL
+		// So if the contact doesn't have a display name, we use the alias
+		contact.DisplayName = contact.Alias
 	}
 
 	userProto := &protobuf.User{

--- a/services/sharedurls/service_test.go
+++ b/services/sharedurls/service_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/suite"
 	"go.uber.org/mock/gomock"
 
+	"github.com/status-im/status-go/internal/crypto"
 	"github.com/status-im/status-go/pkg/multiformat"
 	"github.com/status-im/status-go/protocol/communities"
 	"github.com/status-im/status-go/protocol/contacts"
@@ -488,8 +489,8 @@ func (s *ShareUrlsSuite) TestPrepareEncodedUserDataWithEmptyAccount() {
 
 	userData, chatKey, err := prepareEncodedUserData(contact)
 	s.Require().NoError(err)
-	// The data should be empty if no display name or bio is set
-	s.Require().Empty(userData)
+	// The data should still have a basic alias as display name, so it should not be empty
+	s.Require().NotEmpty(userData)
 	s.Require().NotEmpty(chatKey)
 }
 
@@ -510,5 +511,31 @@ func (s *ShareUrlsSuite) TestShareAndParseUserURLWithData() {
 
 	s.Require().NotNil(urlData.Contact)
 	s.Require().Equal(contact.DisplayName, urlData.Contact.DisplayName)
+	s.Require().Equal(shortKey, urlData.Contact.PublicKey)
+}
+
+func (s *ShareUrlsSuite) TestParseUserURLWithNonExistingContact() {
+	contact := s.fakeContact()
+
+	// Fake not known contact by returning nil
+	s.provider.EXPECT().GetContactByID(contact.ID).Return(nil, nil).Times(1)
+
+	url, err := s.service.ShareUserURLWithData(contact.ID)
+	s.Require().NoError(err)
+	s.Require().NotEmpty(url)
+
+	urlData, err := ParseSharedURL(url)
+	s.Require().NoError(err)
+
+	shortKey, err := multiformat.SerializeLegacyKey(contact.ID)
+	s.Require().NoError(err)
+
+	publicKey, err := crypto.HexToPubkey(contact.ID)
+	s.Require().NoError(err)
+	contact, err = contacts.BuildContact(contact.ID, publicKey)
+	s.Require().NoError(err)
+
+	s.Require().NotNil(urlData.Contact)
+	s.Require().Equal(contact.Alias, urlData.Contact.DisplayName)
 	s.Require().Equal(shortKey, urlData.Contact.PublicKey)
 }


### PR DESCRIPTION
We had two issues:
- Generating a URL for unknown contacts (in a community for example) would fail. Fixed in the first commit
- Contacts with no Display Names would return a URL with just the ID, but then in the website, it would often fail to retrieve it and it would show an error page. Putting the Alias as display name fixes it