### PR TITLE
fix(walletconnect): session  improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -281,7 +281,7 @@ endif
 $(LIBSDS): clone-nim-sds
 ifeq ($(NIM_SDS_BUILD_FROM_SOURCE),true)
 	@echo "Building nim-sds: $(LIBSDS)"
-	$(MAKE) -C $(NIM_SDS_SOURCE_DIR) update
+	$(MAKE) -C $(NIM_SDS_SOURCE_DIR) update USE_SYSTEM_NIM=$(USE_SYSTEM_NIM)
 	$(MAKE) -C $(NIM_SDS_SOURCE_DIR) libsds USE_SYSTEM_NIM=$(USE_SYSTEM_NIM) NIMFLAGS=-d:noSignalHandler SHELL=$(MAKE_SHELL)
 else
 	@test -f $(LIBSDS) || (echo "Error: libsds not found at $(LIBSDS)" && exit 1)

--- a/internal/db/walletdatabase/migrations/sql/1771341674_add_sym_key_to_wc_sessions.up.sql
+++ b/internal/db/walletdatabase/migrations/sql/1771341674_add_sym_key_to_wc_sessions.up.sql
@@ -1,0 +1,2 @@
+-- Add sym_key column to connector_wc_sessions for session restoration after reconnect
+ALTER TABLE connector_wc_sessions ADD COLUMN sym_key TEXT NOT NULL DEFAULT '';

--- a/services/connector/api.go
+++ b/services/connector/api.go
@@ -2,8 +2,10 @@ package connector
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
+	"time"
 
 	"go.uber.org/zap"
 
@@ -11,6 +13,7 @@ import (
 	"github.com/status-im/status-go/services/connector/commands"
 	persistence "github.com/status-im/status-go/services/connector/database"
 	"github.com/status-im/status-go/services/connector/walletconnect"
+	"github.com/status-im/status-go/signal"
 )
 
 var (
@@ -24,9 +27,10 @@ type API struct {
 	s                          *Service
 	r                          *CommandRegistry
 	c                          *commands.ClientSideHandler
+	wcClient                   *walletconnect.Client
 	changeAccountCommand       *commands.ChangeAccountCommand
 	pairWCCommand              *commands.PairWCCommand
-	disconnectWCSessionCommand *commands.DisconnectWCSessionCommand
+	wcSessionDisconnector      commands.WCSessionDisconnector
 	getWCActiveSessionsCommand *commands.GetWCActiveSessionsCommand
 	approveWCSessionCommand    *commands.ApproveWCSessionCommand
 	rejectWCSessionCommand     *commands.RejectWCSessionCommand
@@ -36,7 +40,51 @@ type API struct {
 
 func NewAPI(s *Service) *API {
 	r := NewCommandRegistry()
-	c := commands.NewClientSideHandler(s.db)
+
+	wcClient, err := walletconnect.NewClient(s.config.ProjectID)
+	if err != nil {
+		s.logger.Error("failed to create WalletConnect client", zap.Error(err))
+	}
+
+	if wcClient != nil {
+		activeSessions, err := persistence.SelectActiveWCSessions(s.db, time.Now().Unix())
+		if err != nil {
+			s.logger.Error("failed to load active WC sessions", zap.Error(err))
+		} else if len(activeSessions) > 0 {
+			restoredSessions := make([]walletconnect.RestoredSession, 0, len(activeSessions))
+			for _, session := range activeSessions {
+				restoredSessions = append(restoredSessions, walletconnect.RestoredSession{
+					Topic:  session.Topic,
+					SymKey: session.SymKey,
+				})
+			}
+			wcClient.RestoreSessions(restoredSessions)
+			s.logger.Info("restored WalletConnect sessions", zap.Int("count", len(restoredSessions)))
+			if err := wcClient.ConnectAndResubscribe(); err != nil {
+				s.logger.Warn("failed to connect relay for restored WC sessions", zap.Error(err))
+			}
+		}
+	}
+
+	wcSessionDisconnector := commands.NewWCSessionDisconnector(s.db, wcClient)
+
+	if wcClient != nil {
+		wcClient.SetSessionDeleteHandler(func(topic string) {
+			s.logger.Info("received wc_sessionDelete", zap.String("topic", topic))
+			session, err := persistence.SelectWCSession(s.db, topic)
+			dappURL := ""
+			if err == nil && session != nil {
+				dappURL = session.DAppURL
+			}
+			if err := wcSessionDisconnector.DisconnectSession(context.Background(), topic); err != nil {
+				s.logger.Error("failed to disconnect WC session", zap.String("topic", topic), zap.Error(err))
+			} else {
+				s.logger.Info("WC session disconnected", zap.String("topic", topic), zap.String("dappURL", dappURL))
+			}
+			signal.SendWCSessionDelete(topic, dappURL)
+		})
+	}
+	c := commands.NewClientSideHandler(s.db, wcClient)
 
 	// Transactions and signing
 	r.Register("eth_sendTransaction", commands.NewSendTransactionCommand(s.db, s.ethClientGetter, s.feeManager, c))
@@ -60,22 +108,18 @@ func NewAPI(s *Service) *API {
 	// Permissions
 	r.Register("wallet_requestPermissions", commands.NewRequestPermissionsCommand(s.db))
 	r.Register("wallet_getPermissions", commands.NewGetPermissionsCommand(s.db))
-	r.Register("wallet_revokePermissions", commands.NewRevokePermissionsCommand(s.db))
+	r.Register("wallet_revokePermissions", commands.NewRevokePermissionsCommand(s.db, wcSessionDisconnector))
 
 	changeAccountCommand := commands.NewChangeAccountCommand(s.db)
-
-	wcClient, err := walletconnect.NewClient(s.config.ProjectID)
-	if err != nil {
-		s.logger.Error("failed to create WalletConnect client", zap.Error(err))
-	}
 
 	return &API{
 		s:                          s,
 		r:                          r,
 		c:                          c,
+		wcClient:                   wcClient,
 		changeAccountCommand:       changeAccountCommand,
 		pairWCCommand:              commands.NewPairWCCommand(wcClient),
-		disconnectWCSessionCommand: commands.NewDisconnectWCSessionCommand(s.db, wcClient),
+		wcSessionDisconnector:      wcSessionDisconnector,
 		getWCActiveSessionsCommand: commands.NewGetWCActiveSessionsCommand(s.db),
 		approveWCSessionCommand:    commands.NewApproveWCSessionCommand(s.db, wcClient),
 		rejectWCSessionCommand:     commands.NewRejectWCSessionCommand(wcClient),
@@ -183,15 +227,15 @@ func (api *API) PairWalletConnect(ctx context.Context, uri string) error {
 }
 
 func (api *API) DisconnectWCSession(ctx context.Context, topic string) error {
-	return api.disconnectWCSessionCommand.Execute(ctx, topic)
+	return api.wcSessionDisconnector.DisconnectSession(ctx, topic)
 }
 
 func (api *API) GetWCActiveSessions(ctx context.Context, validAtTimestamp int64) ([]persistence.WCSession, error) {
 	return api.getWCActiveSessionsCommand.Execute(ctx, validAtTimestamp)
 }
 
-func (api *API) ApproveWCSession(ctx context.Context, proposalID, account string, chainID uint64, dappURL, dappName, dappIcon string) (string, error) {
-	return api.approveWCSessionCommand.Execute(ctx, proposalID, account, chainID, dappURL, dappName, dappIcon)
+func (api *API) ApproveWCSession(ctx context.Context, proposalID, account string, dappURL, dappName, dappIcon string, supportedChains []uint64) (string, error) {
+	return api.approveWCSessionCommand.Execute(ctx, proposalID, account, dappURL, dappName, dappIcon, supportedChains)
 }
 
 func (api *API) RejectWCSession(ctx context.Context, proposalID string) error {
@@ -204,4 +248,96 @@ func (api *API) ApproveWCSessionRequest(ctx context.Context, topic, requestIDStr
 
 func (api *API) RejectWCSessionRequest(ctx context.Context, topic, requestIDStr string, code int, message string) error {
 	return api.rejectWCSessionRequestCmd.Execute(ctx, topic, requestIDStr, code, message)
+}
+
+func (api *API) UpdateWCSessionChains(ctx context.Context, topic string, account string, chains []uint64) error {
+	if api.wcClient == nil {
+		return fmt.Errorf("WalletConnect client not initialized")
+	}
+
+	if len(chains) == 0 {
+		return fmt.Errorf("chains must not be empty")
+	}
+	primaryChainID := chains[0]
+
+	// Get existing session from DB to extract metadata
+	session, err := persistence.SelectWCSession(api.s.db, topic)
+	if err != nil || session == nil {
+		return fmt.Errorf("session not found: %w", err)
+	}
+
+	// Parse existing session JSON to get proposal params
+	var existingSession walletconnect.Session
+	if err := json.Unmarshal([]byte(session.SessionJSON), &existingSession); err != nil {
+		return fmt.Errorf("failed to parse session: %w", err)
+	}
+
+	// Convert chains to int64
+	chainIDs := make([]int64, len(chains))
+	for i, c := range chains {
+		chainIDs[i] = int64(c)
+	}
+
+	// Carry forward the dApp icon from the persisted session peer metadata.
+	dappIcon := ""
+	if len(existingSession.Peer.Metadata.Icons) > 0 {
+		dappIcon = existingSession.Peer.Metadata.Icons[0]
+	}
+
+	// Build updated namespaces using existing proposal structure
+	meta := walletconnect.SessionMetadata{
+		Account:   account,
+		ChainID:   primaryChainID,
+		Chains:    chainIDs,
+		DAppURL:   session.DAppURL,
+		DAppName:  existingSession.Peer.Metadata.Name,
+		DAppIcon:  dappIcon,
+		ExpirySec: 0,
+	}
+
+	// Create a minimal proposal params from existing session
+	proposal := &walletconnect.ProposalParams{
+		RequiredNamespaces: existingSession.RequiredNamespaces,
+	}
+
+	namespaces, _, _ := walletconnect.BuildNamespaces(meta, proposal)
+
+	// Send session update to dApp
+	if err := api.wcClient.SendSessionUpdate(topic, namespaces); err != nil {
+		return fmt.Errorf("failed to send session update: %w", err)
+	}
+
+	// Update session in database
+	existingSession.Namespaces = namespaces
+	updatedSessionJSON, err := json.Marshal(existingSession)
+	if err != nil {
+		return fmt.Errorf("failed to marshal updated session: %w", err)
+	}
+
+	if err := persistence.UpsertWCSession(api.s.db, topic, string(updatedSessionJSON), session.Expiry, session.PairingTopic, session.DAppURL, session.SymKey, time.Now().Unix()); err != nil {
+		return fmt.Errorf("failed to update session in database: %w", err)
+	}
+
+	return nil
+}
+
+// EmitWCSessionEvent sends a wc_sessionEvent to the dapp (e.g., chainChanged, accountsChanged, connect, disconnect).
+func (api *API) EmitWCSessionEvent(ctx context.Context, topic, name, dataJSON, chainID string) error {
+	if api.wcClient == nil {
+		return fmt.Errorf("WalletConnect client not initialized")
+	}
+
+	var data interface{}
+	if dataJSON != "" {
+		if err := json.Unmarshal([]byte(dataJSON), &data); err != nil {
+			return fmt.Errorf("invalid dataJSON: %w", err)
+		}
+	}
+
+	event := walletconnect.SessionEvent{
+		Name: name,
+		Data: data,
+	}
+
+	return api.wcClient.SendSessionEvent(topic, event, chainID)
 }

--- a/services/connector/api_test.go
+++ b/services/connector/api_test.go
@@ -5,8 +5,13 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
 
+	types2 "github.com/status-im/status-go/internal/crypto/types"
+	"github.com/status-im/status-go/internal/rpc/network"
 	"github.com/status-im/status-go/services/connector/commands"
+	persistence "github.com/status-im/status-go/services/connector/database"
+	"github.com/status-im/status-go/services/connector/walletconnect"
 )
 
 func TestCallRPC_UntrustedConnection(t *testing.T) {
@@ -159,4 +164,228 @@ func TestGetPermittedDAppsList(t *testing.T) {
 	dapps, err := state.api.GetPermittedDAppsList()
 	require.NoError(t, err)
 	require.Empty(t, dapps)
+}
+
+func TestGetWCActiveSessions(t *testing.T) {
+	state := setupTests(t)
+
+	// Empty initially
+	sessions, err := state.api.GetWCActiveSessions(state.ctx, 0)
+	require.NoError(t, err)
+	require.Empty(t, sessions)
+
+	// Insert a WC session
+	dappURL := "https://wc-test-dapp.com"
+	require.NoError(t, persistence.UpsertDApp(state.walletDb, &persistence.DApp{
+		URL: dappURL, Name: "WC Test", IconURL: "", ClientID: persistence.WCClientID,
+		SharedAccount: types2.Address{}, ChainID: 0x1,
+	}))
+	require.NoError(t, persistence.UpsertWCSession(state.walletDb, "topic1", `{"session":"data"}`, 9999999999, "pairing1", dappURL, "symkey", 100))
+
+	// Now should return the session
+	sessions, err = state.api.GetWCActiveSessions(state.ctx, 0)
+	require.NoError(t, err)
+	require.Len(t, sessions, 1)
+	require.Equal(t, "topic1", sessions[0].Topic)
+}
+
+func TestDisconnectWCSession(t *testing.T) {
+	state := setupTests(t)
+
+	// Disconnect non-existent session is idempotent
+	err := state.api.DisconnectWCSession(state.ctx, "non-existent-topic")
+	require.NoError(t, err)
+
+	// Insert WC session and DApp
+	dappURL := "https://wc-disconnect-test.com"
+	require.NoError(t, persistence.UpsertDApp(state.walletDb, &persistence.DApp{
+		URL: dappURL, Name: "WC Disconnect Test", IconURL: "", ClientID: persistence.WCClientID,
+		SharedAccount: types2.Address{}, ChainID: 0x1,
+	}))
+	require.NoError(t, persistence.UpsertWCSession(state.walletDb, "topic-disconnect", `{"session":"data"}`, 9999999999, "pairing1", dappURL, "symkey", 100))
+
+	session, err := persistence.SelectWCSession(state.walletDb, "topic-disconnect")
+	require.NoError(t, err)
+	require.NotNil(t, session)
+
+	err = state.api.DisconnectWCSession(state.ctx, "topic-disconnect")
+	require.NoError(t, err)
+
+	session, err = persistence.SelectWCSession(state.walletDb, "topic-disconnect")
+	require.NoError(t, err)
+	require.Nil(t, session)
+}
+
+func TestUpdateWCSessionChains_EmptyChains(t *testing.T) {
+	state := setupTests(t)
+
+	err := state.api.UpdateWCSessionChains(state.ctx, "some-topic", "0x1234", []uint64{})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "chains must not be empty")
+}
+
+func TestUpdateWCSessionChains_SessionNotFound(t *testing.T) {
+	state := setupTests(t)
+
+	err := state.api.UpdateWCSessionChains(state.ctx, "non-existent-topic", "0x1234", []uint64{1})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "session not found")
+}
+
+func TestUpdateWCSessionChains_InvalidSessionJSON(t *testing.T) {
+	state := setupTests(t)
+
+	dappURL := "https://wc-update-test.com"
+	require.NoError(t, persistence.UpsertDApp(state.walletDb, &persistence.DApp{
+		URL: dappURL, Name: "WC Update Test", IconURL: "", ClientID: persistence.WCClientID,
+		SharedAccount: types2.Address{}, ChainID: 0x1,
+	}))
+	// Store invalid JSON as session data
+	require.NoError(t, persistence.UpsertWCSession(state.walletDb, "topic-update-invalid", `not-valid-json`, 9999999999, "pairing1", dappURL, "symkey", 100))
+
+	err := state.api.UpdateWCSessionChains(state.ctx, "topic-update-invalid", "0x1234", []uint64{1})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "failed to parse session")
+}
+
+func TestEmitWCSessionEvent_InvalidDataJSON(t *testing.T) {
+	state := setupTests(t)
+
+	err := state.api.EmitWCSessionEvent(state.ctx, "some-topic", "accountsChanged", "invalid-json", "eip155:1")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "invalid dataJSON")
+}
+
+func TestEmitWCSessionEvent_EmptyDataJSON(t *testing.T) {
+	state := setupTests(t)
+
+	// Empty dataJSON should not fail on JSON parsing, but session won't be found
+	err := state.api.EmitWCSessionEvent(state.ctx, "non-existent-topic", "accountsChanged", "", "eip155:1")
+	require.Error(t, err)
+	require.ErrorIs(t, err, walletconnect.ErrSessionNotFound)
+}
+
+func TestEmitWCSessionEvent_SessionNotFound(t *testing.T) {
+	state := setupTests(t)
+
+	err := state.api.EmitWCSessionEvent(state.ctx, "non-existent-topic", "chainChanged", `{"chainId":"0x1"}`, "eip155:1")
+	require.Error(t, err)
+	require.ErrorIs(t, err, walletconnect.ErrSessionNotFound)
+}
+
+func TestApproveWCSession_InvalidAccount(t *testing.T) {
+	state := setupTests(t)
+
+	_, err := state.api.ApproveWCSession(state.ctx, "proposal1", "not-an-address", "https://dapp.com", "DApp", "", []uint64{1})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "invalid account address")
+}
+
+func TestApproveWCSession_EmptyChains(t *testing.T) {
+	state := setupTests(t)
+
+	_, err := state.api.ApproveWCSession(state.ctx, "proposal1", "0x1234567890abcdef1234567890abcdef12345678", "https://dapp.com", "DApp", "", []uint64{})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "supportedChains must not be empty")
+}
+
+func TestApproveWCSession_ProposalNotFound(t *testing.T) {
+	state := setupTests(t)
+
+	_, err := state.api.ApproveWCSession(state.ctx, "non-existent-proposal", "0x1234567890abcdef1234567890abcdef12345678", "https://dapp.com", "DApp", "", []uint64{1})
+	require.Error(t, err)
+	require.ErrorIs(t, err, walletconnect.ErrProposalNotFound)
+}
+
+func TestRejectWCSession_ProposalNotFound(t *testing.T) {
+	state := setupTests(t)
+
+	err := state.api.RejectWCSession(state.ctx, "non-existent-proposal")
+	require.Error(t, err)
+	require.ErrorIs(t, err, walletconnect.ErrProposalNotFound)
+}
+
+func TestApproveWCSessionRequest_InvalidRequestID(t *testing.T) {
+	state := setupTests(t)
+
+	err := state.api.ApproveWCSessionRequest(state.ctx, "some-topic", "not-a-number", "0xsignature")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "invalid request ID")
+}
+
+func TestApproveWCSessionRequest_SessionNotFound(t *testing.T) {
+	state := setupTests(t)
+
+	err := state.api.ApproveWCSessionRequest(state.ctx, "non-existent-topic", "12345", "0xsignature")
+	require.Error(t, err)
+	require.ErrorIs(t, err, walletconnect.ErrSessionNotFound)
+}
+
+func TestRejectWCSessionRequest_InvalidRequestID(t *testing.T) {
+	state := setupTests(t)
+
+	err := state.api.RejectWCSessionRequest(state.ctx, "some-topic", "not-a-number", 4001, "User rejected")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "invalid request ID")
+}
+
+func TestRejectWCSessionRequest_SessionNotFound(t *testing.T) {
+	state := setupTests(t)
+
+	err := state.api.RejectWCSessionRequest(state.ctx, "non-existent-topic", "12345", 4001, "User rejected")
+	require.Error(t, err)
+	require.ErrorIs(t, err, walletconnect.ErrSessionNotFound)
+}
+
+func TestPairWalletConnect_InvalidURI(t *testing.T) {
+	state := setupTests(t)
+
+	err := state.api.PairWalletConnect(state.ctx, "not-a-valid-wc-uri")
+	require.Error(t, err)
+}
+
+func TestUpdateWCSessionChains_NilClient(t *testing.T) {
+	state := setupTests(t)
+	state.api.wcClient = nil
+
+	err := state.api.UpdateWCSessionChains(state.ctx, "some-topic", "0x1234", []uint64{1})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "WalletConnect client not initialized")
+}
+
+func TestEmitWCSessionEvent_NilClient(t *testing.T) {
+	state := setupTests(t)
+	state.api.wcClient = nil
+
+	err := state.api.EmitWCSessionEvent(state.ctx, "some-topic", "accountsChanged", "", "eip155:1")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "WalletConnect client not initialized")
+}
+
+func TestNewAPI_WithRestoredSessions(t *testing.T) {
+	// Pre-insert a WC session so NewAPI enters the session restoration path.
+	// ConnectAndResubscribe will fail to reach the relay (no server in tests)
+	// but the error is non-fatal (logged as a warning).
+	walletDb := createWalletDB(t)
+	db := createDB(t)
+
+	dappURL := "https://wc-restore-test.com"
+	require.NoError(t, persistence.UpsertDApp(walletDb, &persistence.DApp{
+		URL: dappURL, Name: "WC Restore Test", IconURL: "", ClientID: persistence.WCClientID,
+		SharedAccount: types2.Address{}, ChainID: 0x1,
+	}))
+	require.NoError(t, persistence.UpsertWCSession(walletDb, "restore-topic-1", `{"session":"data"}`, 9999999999, "pairing1", dappURL, "symkey1", 100))
+
+	networkManager := network.NewManager(db, nil)
+	service := NewService(
+		zap.NewNop(),
+		walletDb,
+		nil,
+		nil,
+		networkManager,
+		&Config{},
+	)
+
+	api := NewAPI(service)
+	require.NotNil(t, api)
 }

--- a/services/connector/commands/client_handler.go
+++ b/services/connector/commands/client_handler.go
@@ -1,6 +1,7 @@
 package commands
 
 import (
+	"context"
 	"crypto/sha256"
 	"database/sql"
 	"encoding/hex"
@@ -11,6 +12,7 @@ import (
 
 	types2 "github.com/status-im/status-go/internal/crypto/types"
 	persistence "github.com/status-im/status-go/services/connector/database"
+	"github.com/status-im/status-go/services/connector/walletconnect"
 	"github.com/status-im/status-go/services/wallet/wallettypes"
 	"github.com/status-im/status-go/signal"
 )
@@ -44,16 +46,18 @@ type Message struct {
 }
 
 type ClientSideHandler struct {
-	Db               *sql.DB
-	responseChannel  chan Message
-	isRequestRunning int32
+	Db                    *sql.DB
+	wcSessionDisconnector WCSessionDisconnector
+	responseChannel       chan Message
+	isRequestRunning      int32
 }
 
-func NewClientSideHandler(db *sql.DB) *ClientSideHandler {
+func NewClientSideHandler(db *sql.DB, wcClient *walletconnect.Client) *ClientSideHandler {
 	return &ClientSideHandler{
-		Db:               db,
-		responseChannel:  make(chan Message, 1), // Buffer of 1 to avoid blocking
-		isRequestRunning: 0,
+		Db:                    db,
+		wcSessionDisconnector: NewWCSessionDisconnector(db, wcClient),
+		responseChannel:       make(chan Message, 1),
+		isRequestRunning:      0,
 	}
 }
 
@@ -133,6 +137,16 @@ func (c *ClientSideHandler) RecallDAppPermissions(args RecallDAppPermissionsArgs
 
 	if dApp == nil {
 		return ErrDAppDoesNotHavePermissions
+	}
+
+	// If this is a WalletConnect DApp, disconnect all WC sessions first
+	if c.wcSessionDisconnector != nil && dApp.ClientID == persistence.WCClientID {
+		sessions, err := persistence.SelectWCSessionsByDAppURL(c.Db, dApp.URL)
+		if err == nil && len(sessions) > 0 {
+			for _, session := range sessions {
+				_ = c.wcSessionDisconnector.DisconnectSession(context.Background(), session.Topic)
+			}
+		}
 	}
 
 	err = persistence.DeleteDApp(c.Db, dApp.URL, dApp.ClientID)

--- a/services/connector/commands/client_handler_test.go
+++ b/services/connector/commands/client_handler_test.go
@@ -14,7 +14,7 @@ func TestClientHandlerTimeout(t *testing.T) {
 	db, cleanup := createWalletDB(t)
 	t.Cleanup(cleanup)
 
-	clientHandler := NewClientSideHandler(db)
+	clientHandler := NewClientSideHandler(db, nil)
 
 	backupWalletResponseMaxInterval := WalletResponseMaxInterval
 	WalletResponseMaxInterval = 1 * time.Millisecond
@@ -28,7 +28,7 @@ func TestRequestRejectedWhileWaiting(t *testing.T) {
 	db, cleanup := createWalletDB(t)
 	t.Cleanup(cleanup)
 
-	clientHandler := NewClientSideHandler(db)
+	clientHandler := NewClientSideHandler(db, nil)
 
 	clientHandler.setRequestRunning()
 
@@ -56,7 +56,7 @@ func TestRecallDAppPermission(t *testing.T) {
 	assert.Equal(t, persistedDapp, &dapp)
 	assert.NoError(t, err)
 
-	clientHandler := NewClientSideHandler(db)
+	clientHandler := NewClientSideHandler(db, nil)
 	err = clientHandler.RecallDAppPermissions(RecallDAppPermissionsArgs{URL: dapp.URL, ClientID: dapp.ClientID})
 	assert.NoError(t, err)
 

--- a/services/connector/commands/disconnect_wc_session_test.go
+++ b/services/connector/commands/disconnect_wc_session_test.go
@@ -1,0 +1,156 @@
+package commands
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	types2 "github.com/status-im/status-go/internal/crypto/types"
+	persistence "github.com/status-im/status-go/services/connector/database"
+	"github.com/status-im/status-go/signal"
+)
+
+func TestDisconnectWCSessionDeletesDApp(t *testing.T) {
+	db, close := createWalletDB(t)
+	t.Cleanup(close)
+
+	sharedAccount := types2.BytesToAddress(types2.FromHex("0x6d0aa2a774b74bb1d36f97700315adf962c69fcg"))
+	wcDAppData := signal.ConnectorDApp{
+		URL:      "https://wc-test-dapp.com",
+		Name:     "WC Test DApp",
+		IconURL:  "https://wc-test-icon.com",
+		ClientID: persistence.WCClientID,
+	}
+
+	// Persist WalletConnect DApp
+	err := PersistDAppData(db, wcDAppData, sharedAccount, 0x1)
+	assert.NoError(t, err)
+
+	// Insert a WC session
+	topic := "test-topic-123"
+	err = persistence.UpsertWCSession(db, topic, `{"session":"data"}`, 9999999999, "pairing1", wcDAppData.URL, "", 100)
+	assert.NoError(t, err)
+
+	// Verify DApp and session exist
+	dApp, err := persistence.SelectDApp(db, wcDAppData.URL, wcDAppData.ClientID)
+	assert.NoError(t, err)
+	assert.NotNil(t, dApp)
+
+	session, err := persistence.SelectWCSession(db, topic)
+	assert.NoError(t, err)
+	assert.NotNil(t, session)
+
+	// Disconnect the WC session
+	disconnector := NewWCSessionDisconnector(db, nil)
+	err = disconnector.DisconnectSession(context.Background(), topic)
+	assert.NoError(t, err)
+
+	// Verify session is deleted
+	session, err = persistence.SelectWCSession(db, topic)
+	assert.NoError(t, err)
+	assert.Nil(t, session)
+
+	// Verify DApp is also deleted
+	dApp, err = persistence.SelectDApp(db, wcDAppData.URL, wcDAppData.ClientID)
+	assert.NoError(t, err)
+	assert.Nil(t, dApp)
+}
+
+func TestDisconnectWCSessionIdempotent(t *testing.T) {
+	db, close := createWalletDB(t)
+	t.Cleanup(close)
+
+	// Try to disconnect a non-existent session
+	disconnector := NewWCSessionDisconnector(db, nil)
+	err := disconnector.DisconnectSession(context.Background(), "non-existent-topic")
+
+	// Should not error - idempotent operation
+	assert.NoError(t, err)
+}
+
+func TestDisconnectWCSessionWithMultipleSessions(t *testing.T) {
+	db, close := createWalletDB(t)
+	t.Cleanup(close)
+
+	sharedAccount := types2.BytesToAddress(types2.FromHex("0x6d0aa2a774b74bb1d36f97700315adf962c69fcg"))
+	wcDAppData := signal.ConnectorDApp{
+		URL:      "https://wc-test-dapp.com",
+		Name:     "WC Test DApp",
+		IconURL:  "https://wc-test-icon.com",
+		ClientID: persistence.WCClientID,
+	}
+
+	// Persist WalletConnect DApp
+	err := PersistDAppData(db, wcDAppData, sharedAccount, 0x1)
+	assert.NoError(t, err)
+
+	// Insert 2 WC sessions for the same DApp
+	err = persistence.UpsertWCSession(db, "topic1", `{"session":"data1"}`, 9999999999, "pairing1", wcDAppData.URL, "", 100)
+	assert.NoError(t, err)
+	err = persistence.UpsertWCSession(db, "topic2", `{"session":"data2"}`, 9999999999, "pairing2", wcDAppData.URL, "", 200)
+	assert.NoError(t, err)
+
+	// Disconnect first session
+	disconnector := NewWCSessionDisconnector(db, nil)
+	err = disconnector.DisconnectSession(context.Background(), "topic1")
+	assert.NoError(t, err)
+
+	// Verify first session is deleted
+	session1, err := persistence.SelectWCSession(db, "topic1")
+	assert.NoError(t, err)
+	assert.Nil(t, session1)
+
+	// Verify second session still exists
+	session2, err := persistence.SelectWCSession(db, "topic2")
+	assert.NoError(t, err)
+	assert.NotNil(t, session2)
+
+	// DApp entry should still exist (other session remains)
+	dApp, err := persistence.SelectDApp(db, wcDAppData.URL, wcDAppData.ClientID)
+	assert.NoError(t, err)
+	assert.NotNil(t, dApp, "DApp entry should be preserved when other sessions exist")
+
+	// Now disconnect the second session
+	err = disconnector.DisconnectSession(context.Background(), "topic2")
+	assert.NoError(t, err)
+
+	// Verify second session is deleted
+	session2, err = persistence.SelectWCSession(db, "topic2")
+	assert.NoError(t, err)
+	assert.Nil(t, session2)
+
+	// DApp entry should now be deleted (no sessions remain)
+	dApp, err = persistence.SelectDApp(db, wcDAppData.URL, wcDAppData.ClientID)
+	assert.NoError(t, err)
+	assert.Nil(t, dApp, "DApp entry should be deleted when last session is removed")
+}
+
+func TestDisconnectWCSessionHandlesNonWCDApp(t *testing.T) {
+	db, close := createWalletDB(t)
+	t.Cleanup(close)
+
+	// Create a non-WC DApp (browser connector)
+	sharedAccount := types2.BytesToAddress(types2.FromHex("0x6d0aa2a774b74bb1d36f97700315adf962c69fcg"))
+	bcDAppData := signal.ConnectorDApp{
+		URL:      "https://bc-test-dapp.com",
+		Name:     "BC Test DApp",
+		IconURL:  "https://bc-test-icon.com",
+		ClientID: "", // Browser connector has empty client ID
+	}
+
+	err := PersistDAppData(db, bcDAppData, sharedAccount, 0x1)
+	assert.NoError(t, err)
+
+	// Try to disconnect with a bogus topic (no session exists)
+	disconnector := NewWCSessionDisconnector(db, nil)
+	err = disconnector.DisconnectSession(context.Background(), "non-existent-topic")
+
+	// Should not error
+	assert.NoError(t, err)
+
+	// Browser connector DApp should still exist (wasn't touched)
+	dApp, err := persistence.SelectDApp(db, bcDAppData.URL, bcDAppData.ClientID)
+	assert.NoError(t, err)
+	assert.NotNil(t, dApp)
+}

--- a/services/connector/commands/interfaces.go
+++ b/services/connector/commands/interfaces.go
@@ -1,0 +1,10 @@
+package commands
+
+import "context"
+
+//go:generate go tool mockgen -source=interfaces.go -destination=mock/interfaces.go -package=mock_commands
+
+// WCSessionDisconnector handles disconnecting WalletConnect sessions
+type WCSessionDisconnector interface {
+	DisconnectSession(ctx context.Context, topic string) error
+}

--- a/services/connector/commands/revoke_permissions.go
+++ b/services/connector/commands/revoke_permissions.go
@@ -9,12 +9,14 @@ import (
 )
 
 type RevokePermissionsCommand struct {
-	db *sql.DB
+	db                    *sql.DB
+	wcSessionDisconnector WCSessionDisconnector
 }
 
-func NewRevokePermissionsCommand(db *sql.DB) *RevokePermissionsCommand {
+func NewRevokePermissionsCommand(db *sql.DB, wcSessionDisconnector WCSessionDisconnector) *RevokePermissionsCommand {
 	return &RevokePermissionsCommand{
-		db: db,
+		db:                    db,
+		wcSessionDisconnector: wcSessionDisconnector,
 	}
 }
 
@@ -33,7 +35,16 @@ func (c *RevokePermissionsCommand) Execute(ctx context.Context, request RPCReque
 		return "", ErrDAppIsNotPermittedByUser
 	}
 
-	// Delete the dApp entry (CASCADE will automatically delete permissions)
+	// If this is a WalletConnect DApp, disconnect all WC sessions first
+	if c.wcSessionDisconnector != nil && dApp.ClientID == persistence.WCClientID {
+		sessions, err := persistence.SelectWCSessionsByDAppURL(c.db, dApp.URL)
+		if err == nil && len(sessions) > 0 {
+			for _, session := range sessions {
+				_ = c.wcSessionDisconnector.DisconnectSession(ctx, session.Topic)
+			}
+		}
+	}
+
 	err = persistence.DeleteDApp(c.db, dApp.URL, dApp.ClientID)
 	if err != nil {
 		return "", err

--- a/services/connector/commands/revoke_permissions_test.go
+++ b/services/connector/commands/revoke_permissions_test.go
@@ -71,3 +71,58 @@ func TestRevokePermissionsSucceeded(t *testing.T) {
 
 	assert.True(t, dAppPermissionRevoked)
 }
+
+func TestRevokePermissionsDeletesWCSessions(t *testing.T) {
+	state, close := setupCommand(t, Method_RevokePermissions)
+	t.Cleanup(close)
+
+	sharedAccount := types2.BytesToAddress(types2.FromHex("0x6d0aa2a774b74bb1d36f97700315adf962c69fcg"))
+	wcDAppData := signal.ConnectorDApp{
+		URL:      "https://wc-test-dapp.com",
+		Name:     "WC Test DApp",
+		IconURL:  "https://wc-test-icon.com",
+		ClientID: persistence.WCClientID,
+	}
+
+	// Persist WalletConnect DApp
+	err := PersistDAppData(state.walletDb, wcDAppData, sharedAccount, 0x1)
+	assert.NoError(t, err)
+
+	// Insert 2 WC sessions for this DApp
+	err = persistence.UpsertWCSession(state.walletDb, "topic1", `{"session":"data1"}`, 9999999999, "pairing1", wcDAppData.URL, "", 100)
+	assert.NoError(t, err)
+	err = persistence.UpsertWCSession(state.walletDb, "topic2", `{"session":"data2"}`, 9999999999, "pairing2", wcDAppData.URL, "", 200)
+	assert.NoError(t, err)
+
+	// Verify sessions exist
+	sessions, err := persistence.SelectWCSessionsByDAppURL(state.walletDb, wcDAppData.URL)
+	assert.NoError(t, err)
+	assert.Len(t, sessions, 2)
+
+	// Revoke permissions
+	request, err := ConstructRPCRequest("wallet_revokePermissions", []interface{}{}, &wcDAppData)
+	assert.NoError(t, err)
+
+	result, err := state.cmd.Execute(state.ctx, request)
+	assert.NoError(t, err)
+	assert.Empty(t, result)
+
+	// Verify DApp is deleted
+	dApp, err := persistence.SelectDApp(state.walletDb, wcDAppData.URL, wcDAppData.ClientID)
+	assert.NoError(t, err)
+	assert.Nil(t, dApp)
+
+	// Verify WC sessions are also deleted
+	sessions, err = persistence.SelectWCSessionsByDAppURL(state.walletDb, wcDAppData.URL)
+	assert.NoError(t, err)
+	assert.Len(t, sessions, 0, "WC sessions should be deleted when DApp permissions are revoked")
+
+	// Verify individual sessions are deleted
+	session1, err := persistence.SelectWCSession(state.walletDb, "topic1")
+	assert.NoError(t, err)
+	assert.Nil(t, session1)
+
+	session2, err := persistence.SelectWCSession(state.walletDb, "topic2")
+	assert.NoError(t, err)
+	assert.Nil(t, session2)
+}

--- a/services/connector/commands/test_helpers.go
+++ b/services/connector/commands/test_helpers.go
@@ -85,11 +85,13 @@ func setupCommand(t *testing.T, method string) (state testState, close func()) {
 	err := networkManager.InitEmbeddedNetworks(initNetworks)
 	require.NoError(t, err)
 
-	state.handler = NewClientSideHandler(state.db)
+	state.handler = NewClientSideHandler(state.db, nil)
 
 	state.mockCtrl = gomock.NewController(t)
 	state.ethClientGetter = mock_chainutils.NewMockEthClientGetter(state.mockCtrl)
 	state.feeManager = mock_chainutils.NewMockFeeManager(state.mockCtrl)
+
+	wcSessionDisconnector := NewWCSessionDisconnector(state.walletDb, nil)
 
 	switch method {
 	case Method_EthAccounts:
@@ -111,7 +113,7 @@ func setupCommand(t *testing.T, method string) (state testState, close func()) {
 	case Method_RequestPermissions:
 		state.cmd = NewRequestPermissionsCommand(state.walletDb)
 	case Method_RevokePermissions:
-		state.cmd = NewRevokePermissionsCommand(state.walletDb)
+		state.cmd = NewRevokePermissionsCommand(state.walletDb, wcSessionDisconnector)
 	case Method_SwitchEthereumChain:
 		state.cmd = NewSwitchEthereumChainCommand(state.walletDb, networkManager)
 	}

--- a/services/connector/commands/walletconnect.go
+++ b/services/connector/commands/walletconnect.go
@@ -11,6 +11,40 @@ import (
 	"github.com/status-im/status-go/services/connector/walletconnect"
 )
 
+type wcSessionDisconnector struct {
+	db       *sql.DB
+	wcClient *walletconnect.Client
+}
+
+// NewWCSessionDisconnector creates a new WCSessionDisconnector
+func NewWCSessionDisconnector(db *sql.DB, wcClient *walletconnect.Client) WCSessionDisconnector {
+	return &wcSessionDisconnector{
+		db:       db,
+		wcClient: wcClient,
+	}
+}
+
+// DisconnectSession disconnects a WalletConnect session by topic.
+// It sends a wc_sessionDelete message to the dApp and removes the session from the local DB.
+// Relay notification failures are non-fatal: the session is always cleaned up locally.
+func (d *wcSessionDisconnector) DisconnectSession(ctx context.Context, topic string) error {
+	if d.wcClient != nil {
+		// Notify the dApp via the relay before cleaning up locally.
+		// Non-fatal: the dApp will discover the session is gone on its next interaction.
+		_ = d.wcClient.SendSessionDelete(ctx, topic)
+	}
+	session, err := persistence.SelectWCSession(d.db, topic)
+	if err == nil && session != nil {
+		_ = persistence.DeleteWCSession(d.db, topic)
+		remaining, _ := persistence.SelectWCSessionsByDAppURL(d.db, session.DAppURL)
+		if len(remaining) == 0 {
+			_ = persistence.DeleteDApp(d.db, session.DAppURL, session.ClientID)
+		}
+		return nil
+	}
+	return persistence.DeleteWCSession(d.db, topic)
+}
+
 type PairWCCommand struct {
 	wcClient *walletconnect.Client
 }
@@ -23,29 +57,6 @@ func NewPairWCCommand(wcClient *walletconnect.Client) *PairWCCommand {
 
 func (c *PairWCCommand) Execute(ctx context.Context, uri string) error {
 	return c.wcClient.Pair(ctx, uri)
-}
-
-type DisconnectWCSessionCommand struct {
-	db       *sql.DB
-	wcClient *walletconnect.Client
-}
-
-func NewDisconnectWCSessionCommand(db *sql.DB, wcClient *walletconnect.Client) *DisconnectWCSessionCommand {
-	return &DisconnectWCSessionCommand{
-		db:       db,
-		wcClient: wcClient,
-	}
-}
-
-func (c *DisconnectWCSessionCommand) Execute(ctx context.Context, topic string) error {
-	if c.wcClient != nil {
-		c.wcClient.RemoveSession(topic)
-	}
-	session, err := persistence.SelectWCSession(c.db, topic)
-	if err == nil && session != nil {
-		_ = persistence.DeleteDApp(c.db, session.DAppURL, session.ClientID)
-	}
-	return persistence.DeleteWCSession(c.db, topic)
 }
 
 type GetWCActiveSessionsCommand struct {
@@ -74,7 +85,7 @@ func NewApproveWCSessionCommand(db *sql.DB, wcClient *walletconnect.Client) *App
 	}
 }
 
-func (c *ApproveWCSessionCommand) Execute(ctx context.Context, proposalID, account string, chainID uint64, dappURL, dappName, dappIcon string) (string, error) {
+func (c *ApproveWCSessionCommand) Execute(ctx context.Context, proposalID, account string, dappURL, dappName, dappIcon string, supportedChains []uint64) (string, error) {
 	if !types.IsHexAddress(account) {
 		return "", fmt.Errorf("invalid account address: %s", account)
 	}
@@ -83,10 +94,20 @@ func (c *ApproveWCSessionCommand) Execute(ctx context.Context, proposalID, accou
 		return "", fmt.Errorf("WalletConnect client not initialized")
 	}
 
+	if len(supportedChains) == 0 {
+		return "", fmt.Errorf("supportedChains must not be empty")
+	}
+	chainID := supportedChains[0]
+
+	chains := make([]int64, 0, len(supportedChains))
+	for _, ch := range supportedChains {
+		chains = append(chains, int64(ch))
+	}
+
 	meta := walletconnect.SessionMetadata{
 		Account:   account,
 		ChainID:   chainID,
-		Chains:    []int64{int64(chainID)},
+		Chains:    chains,
 		DAppURL:   dappURL,
 		DAppName:  dappName,
 		DAppIcon:  dappIcon,
@@ -112,10 +133,9 @@ func (c *ApproveWCSessionCommand) Execute(ctx context.Context, proposalID, accou
 	}
 
 	createdAt := time.Now().Unix()
-	if err := persistence.UpsertWCSession(c.db, result.Topic, result.SessionJSON, result.Expiry, result.PairingTopic, dappURL, createdAt); err != nil {
+	if err := persistence.UpsertWCSession(c.db, result.Topic, result.SessionJSON, result.Expiry, result.PairingTopic, dappURL, result.SymKey, createdAt); err != nil {
 		return "", fmt.Errorf("upsert session: %w", err)
 	}
-
 	return result.SessionJSON, nil
 }
 

--- a/services/connector/commands/walletconnect_test.go
+++ b/services/connector/commands/walletconnect_test.go
@@ -1,0 +1,190 @@
+package commands
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	persistence "github.com/status-im/status-go/services/connector/database"
+	"github.com/status-im/status-go/services/connector/walletconnect"
+)
+
+// --- GetWCActiveSessionsCommand tests ---
+
+func TestGetWCActiveSessionsCommand_Empty(t *testing.T) {
+	db, cleanup := createWalletDB(t)
+	t.Cleanup(cleanup)
+
+	cmd := NewGetWCActiveSessionsCommand(db)
+	sessions, err := cmd.Execute(context.Background(), 0)
+	require.NoError(t, err)
+	require.Empty(t, sessions)
+}
+
+func TestGetWCActiveSessionsCommand_WithActiveSessions(t *testing.T) {
+	db, cleanup := createWalletDB(t)
+	t.Cleanup(cleanup)
+
+	// WC sessions require an associated DApp (foreign key)
+	dappURL := "https://dapp.com"
+	require.NoError(t, persistence.UpsertDApp(db, &persistence.DApp{
+		URL: dappURL, Name: "Test DApp", IconURL: "", ClientID: persistence.WCClientID,
+	}))
+
+	err := persistence.UpsertWCSession(db, "active-topic", `{}`, 9999999999, "pairing1", dappURL, "symkey1", 100)
+	require.NoError(t, err)
+	err = persistence.UpsertWCSession(db, "expired-topic", `{}`, 1000, "pairing2", dappURL, "symkey2", 100)
+	require.NoError(t, err)
+
+	cmd := NewGetWCActiveSessionsCommand(db)
+
+	// With timestamp 0 — both sessions returned
+	sessions, err := cmd.Execute(context.Background(), 0)
+	require.NoError(t, err)
+	require.Len(t, sessions, 2)
+
+	// With a timestamp that makes the second session expired
+	sessions, err = cmd.Execute(context.Background(), 9999999998)
+	require.NoError(t, err)
+	require.Len(t, sessions, 1)
+	require.Equal(t, "active-topic", sessions[0].Topic)
+}
+
+// --- ApproveWCSessionCommand tests ---
+
+func TestApproveWCSessionCommand_InvalidAccount(t *testing.T) {
+	db, cleanup := createWalletDB(t)
+	t.Cleanup(cleanup)
+
+	cmd := NewApproveWCSessionCommand(db, nil)
+	_, err := cmd.Execute(context.Background(), "proposal1", "not-an-address", "https://dapp.com", "DApp", "", []uint64{1})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "invalid account address")
+}
+
+func TestApproveWCSessionCommand_EmptyChains(t *testing.T) {
+	db, cleanup := createWalletDB(t)
+	t.Cleanup(cleanup)
+
+	// Need a non-nil client to reach the chains validation (nil check comes before chains check)
+	client, err := walletconnect.NewClient("test")
+	require.NoError(t, err)
+
+	cmd := NewApproveWCSessionCommand(db, client)
+	_, err = cmd.Execute(context.Background(), "proposal1", "0x1234567890abcdef1234567890abcdef12345678", "https://dapp.com", "DApp", "", []uint64{})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "supportedChains must not be empty")
+}
+
+func TestApproveWCSessionCommand_NilClient(t *testing.T) {
+	db, cleanup := createWalletDB(t)
+	t.Cleanup(cleanup)
+
+	cmd := NewApproveWCSessionCommand(db, nil)
+	_, err := cmd.Execute(context.Background(), "proposal1", "0x1234567890abcdef1234567890abcdef12345678", "https://dapp.com", "DApp", "", []uint64{1})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "WalletConnect client not initialized")
+}
+
+func TestApproveWCSessionCommand_ProposalNotFound(t *testing.T) {
+	db, cleanup := createWalletDB(t)
+	t.Cleanup(cleanup)
+
+	client, err := walletconnect.NewClient("test")
+	require.NoError(t, err)
+
+	cmd := NewApproveWCSessionCommand(db, client)
+	_, err = cmd.Execute(context.Background(), "non-existent-proposal", "0x1234567890abcdef1234567890abcdef12345678", "https://dapp.com", "DApp", "", []uint64{1})
+	require.Error(t, err)
+	require.ErrorIs(t, err, walletconnect.ErrProposalNotFound)
+}
+
+// --- RejectWCSessionCommand tests ---
+
+func TestRejectWCSessionCommand_NilClient(t *testing.T) {
+	cmd := NewRejectWCSessionCommand(nil)
+	err := cmd.Execute(context.Background(), "proposal1")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "WalletConnect client not initialized")
+}
+
+func TestRejectWCSessionCommand_ProposalNotFound(t *testing.T) {
+	client, err := walletconnect.NewClient("test")
+	require.NoError(t, err)
+
+	cmd := NewRejectWCSessionCommand(client)
+	err = cmd.Execute(context.Background(), "non-existent-proposal")
+	require.Error(t, err)
+	require.ErrorIs(t, err, walletconnect.ErrProposalNotFound)
+}
+
+// --- ApproveWCSessionRequestCommand tests ---
+
+func TestApproveWCSessionRequestCommand_NilClient(t *testing.T) {
+	cmd := NewApproveWCSessionRequestCommand(nil)
+	err := cmd.Execute(context.Background(), "topic", "12345", "0xsignature")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "WalletConnect client not initialized")
+}
+
+func TestApproveWCSessionRequestCommand_InvalidRequestID(t *testing.T) {
+	client, err := walletconnect.NewClient("test")
+	require.NoError(t, err)
+
+	cmd := NewApproveWCSessionRequestCommand(client)
+	err = cmd.Execute(context.Background(), "topic", "not-a-number", "0xsignature")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "invalid request ID")
+}
+
+func TestApproveWCSessionRequestCommand_SessionNotFound(t *testing.T) {
+	client, err := walletconnect.NewClient("test")
+	require.NoError(t, err)
+
+	cmd := NewApproveWCSessionRequestCommand(client)
+	err = cmd.Execute(context.Background(), "non-existent-topic", "12345", "0xsignature")
+	require.Error(t, err)
+	require.ErrorIs(t, err, walletconnect.ErrSessionNotFound)
+}
+
+// --- RejectWCSessionRequestCommand tests ---
+
+func TestRejectWCSessionRequestCommand_NilClient(t *testing.T) {
+	cmd := NewRejectWCSessionRequestCommand(nil)
+	err := cmd.Execute(context.Background(), "topic", "12345", 4001, "User rejected")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "WalletConnect client not initialized")
+}
+
+func TestRejectWCSessionRequestCommand_InvalidRequestID(t *testing.T) {
+	client, err := walletconnect.NewClient("test")
+	require.NoError(t, err)
+
+	cmd := NewRejectWCSessionRequestCommand(client)
+	err = cmd.Execute(context.Background(), "topic", "not-a-number", 4001, "User rejected")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "invalid request ID")
+}
+
+func TestRejectWCSessionRequestCommand_SessionNotFound(t *testing.T) {
+	client, err := walletconnect.NewClient("test")
+	require.NoError(t, err)
+
+	cmd := NewRejectWCSessionRequestCommand(client)
+	err = cmd.Execute(context.Background(), "non-existent-topic", "12345", 4001, "User rejected")
+	require.Error(t, err)
+	require.ErrorIs(t, err, walletconnect.ErrSessionNotFound)
+}
+
+// --- PairWCCommand tests ---
+
+func TestPairWCCommand_InvalidURI(t *testing.T) {
+	client, err := walletconnect.NewClient("test")
+	require.NoError(t, err)
+
+	cmd := NewPairWCCommand(client)
+	// An invalid URI that fails ParseURI before any network access
+	err = cmd.Execute(context.Background(), "not-a-valid-wc-uri")
+	require.Error(t, err)
+}

--- a/services/connector/database/persistence.go
+++ b/services/connector/database/persistence.go
@@ -155,11 +155,34 @@ func DeletePermissions(db *sql.DB, url string, clientID string) error {
 }
 
 const (
-	wcClientID            = "walletconnect"
-	upsertWCSessionQuery  = "INSERT INTO connector_wc_sessions (topic, session_json, expiry, pairing_topic, dapp_url, client_id, created_timestamp) VALUES (?, ?, ?, ?, ?, ?, ?) ON CONFLICT(topic) DO UPDATE SET session_json = excluded.session_json, expiry = excluded.expiry, pairing_topic = excluded.pairing_topic, dapp_url = excluded.dapp_url"
-	selectWCSessionQuery  = "SELECT topic, session_json, expiry, pairing_topic, dapp_url, client_id FROM connector_wc_sessions WHERE topic = ?"
-	deleteWCSessionQuery  = "DELETE FROM connector_wc_sessions WHERE topic = ?"
-	selectWCSessionsQuery = "SELECT topic, session_json, expiry, pairing_topic, dapp_url, client_id FROM connector_wc_sessions WHERE expiry >= ? ORDER BY created_timestamp DESC"
+	// WCClientID is the client ID used for WalletConnect sessions
+	WCClientID = "walletconnect"
+
+	upsertWCSessionQuery = `INSERT INTO connector_wc_sessions 
+		(topic, session_json, expiry, pairing_topic, dapp_url, client_id, created_timestamp, sym_key) 
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?) 
+		ON CONFLICT(topic) DO UPDATE SET 
+			session_json = excluded.session_json, 
+			expiry = excluded.expiry, 
+			pairing_topic = excluded.pairing_topic, 
+			dapp_url = excluded.dapp_url, 
+			sym_key = excluded.sym_key`
+
+	selectWCSessionQuery = `SELECT topic, session_json, expiry, pairing_topic, dapp_url, client_id, sym_key 
+		FROM connector_wc_sessions 
+		WHERE topic = ?`
+
+	deleteWCSessionQuery = `DELETE FROM connector_wc_sessions 
+		WHERE topic = ?`
+
+	selectWCSessionsQuery = `SELECT topic, session_json, expiry, pairing_topic, dapp_url, client_id, sym_key 
+		FROM connector_wc_sessions 
+		WHERE expiry >= ? 
+		ORDER BY created_timestamp DESC`
+
+	selectWCSessionsByDAppURLQuery = `SELECT topic, session_json, expiry, pairing_topic, dapp_url, client_id, sym_key 
+		FROM connector_wc_sessions 
+		WHERE dapp_url = ?`
 )
 
 type WCSession struct {
@@ -169,17 +192,18 @@ type WCSession struct {
 	PairingTopic string `json:"pairingTopic"`
 	DAppURL      string `json:"dappUrl"`
 	ClientID     string `json:"clientId"`
+	SymKey       string `json:"symKey"`
 }
 
-func UpsertWCSession(db *sql.DB, topic, sessionJSON string, expiry int64, pairingTopic, dappURL string, createdAt int64) error {
+func UpsertWCSession(db *sql.DB, topic, sessionJSON string, expiry int64, pairingTopic, dappURL, symKey string, createdAt int64) error {
 	normalizedURL := NormalizeURL(dappURL)
-	_, err := db.Exec(upsertWCSessionQuery, topic, sessionJSON, expiry, pairingTopic, normalizedURL, wcClientID, createdAt)
+	_, err := db.Exec(upsertWCSessionQuery, topic, sessionJSON, expiry, pairingTopic, normalizedURL, WCClientID, createdAt, symKey)
 	return err
 }
 
 func SelectWCSession(db *sql.DB, topic string) (*WCSession, error) {
 	s := &WCSession{Topic: topic}
-	err := db.QueryRow(selectWCSessionQuery, topic).Scan(&s.Topic, &s.SessionJSON, &s.Expiry, &s.PairingTopic, &s.DAppURL, &s.ClientID)
+	err := db.QueryRow(selectWCSessionQuery, topic).Scan(&s.Topic, &s.SessionJSON, &s.Expiry, &s.PairingTopic, &s.DAppURL, &s.ClientID, &s.SymKey)
 	if err == sql.ErrNoRows {
 		return nil, nil
 	}
@@ -201,7 +225,27 @@ func SelectActiveWCSessions(db *sql.DB, validAtTimestamp int64) ([]WCSession, er
 	var sessions []WCSession
 	for rows.Next() {
 		var s WCSession
-		err = rows.Scan(&s.Topic, &s.SessionJSON, &s.Expiry, &s.PairingTopic, &s.DAppURL, &s.ClientID)
+		err = rows.Scan(&s.Topic, &s.SessionJSON, &s.Expiry, &s.PairingTopic, &s.DAppURL, &s.ClientID, &s.SymKey)
+		if err != nil {
+			return nil, err
+		}
+		sessions = append(sessions, s)
+	}
+	return sessions, nil
+}
+
+func SelectWCSessionsByDAppURL(db *sql.DB, dappURL string) ([]WCSession, error) {
+	normalizedURL := NormalizeURL(dappURL)
+	rows, err := db.Query(selectWCSessionsByDAppURLQuery, normalizedURL)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var sessions []WCSession
+	for rows.Next() {
+		var s WCSession
+		err = rows.Scan(&s.Topic, &s.SessionJSON, &s.Expiry, &s.PairingTopic, &s.DAppURL, &s.ClientID, &s.SymKey)
 		if err != nil {
 			return nil, err
 		}

--- a/services/connector/database/persistence_test.go
+++ b/services/connector/database/persistence_test.go
@@ -468,3 +468,179 @@ func TestSelectPermissionsReturnsNilForNonExistent(t *testing.T) {
 	require.Nil(t, permissions)
 	require.Len(t, permissions, 0)
 }
+
+func TestSelectWCSessionsByDAppURL(t *testing.T) {
+	db, close := setupTestDB(t)
+	defer close()
+
+	dappURL := "https://test-dapp.com"
+	wcDApp := DApp{URL: dappURL, Name: "Test", IconURL: "", ClientID: WCClientID, SharedAccount: types.HexToAddress("0x0"), ChainID: 0x1}
+	require.NoError(t, UpsertDApp(db, &wcDApp))
+
+	err := UpsertWCSession(db, "topic1", `{"session":"data1"}`, 9999999999, "pairing1", dappURL, "symkey1", 100)
+	require.NoError(t, err)
+
+	err = UpsertWCSession(db, "topic2", `{"session":"data2"}`, 9999999999, "pairing2", dappURL, "symkey2", 200)
+	require.NoError(t, err)
+
+	err = UpsertWCSession(db, "topic3", `{"session":"data3"}`, 9999999999, "pairing3", dappURL, "symkey3", 300)
+	require.NoError(t, err)
+
+	otherDApp := DApp{URL: "https://other-dapp.com", Name: "Other", IconURL: "", ClientID: WCClientID, SharedAccount: types.HexToAddress("0x0"), ChainID: 0x1}
+	require.NoError(t, UpsertDApp(db, &otherDApp))
+	err = UpsertWCSession(db, "topic4", `{"session":"data4"}`, 9999999999, "pairing4", "https://other-dapp.com", "symkey4", 400)
+	require.NoError(t, err)
+
+	// Test: Select sessions by DApp URL
+	sessions, err := SelectWCSessionsByDAppURL(db, dappURL)
+	require.NoError(t, err)
+	require.Len(t, sessions, 3, "Should return all 3 sessions for the DApp")
+
+	// Verify topics
+	topics := make(map[string]bool)
+	for _, s := range sessions {
+		topics[s.Topic] = true
+		require.Equal(t, dappURL, s.DAppURL)
+		require.Equal(t, WCClientID, s.ClientID)
+	}
+	require.True(t, topics["topic1"])
+	require.True(t, topics["topic2"])
+	require.True(t, topics["topic3"])
+	require.False(t, topics["topic4"])
+}
+
+func TestSelectWCSessionsByDAppURLNormalization(t *testing.T) {
+	db, close := setupTestDB(t)
+	defer close()
+
+	wcDApp := DApp{URL: "https://test-dapp.com", Name: "Test", IconURL: "", ClientID: WCClientID, SharedAccount: types.HexToAddress("0x0"), ChainID: 0x1}
+	require.NoError(t, UpsertDApp(db, &wcDApp))
+
+	err := UpsertWCSession(db, "topic1", `{"session":"data1"}`, 9999999999, "pairing1", "https://test-dapp.com/", "symkey", 100)
+	require.NoError(t, err)
+
+	// Query without trailing slash (should normalize and find it)
+	sessions, err := SelectWCSessionsByDAppURL(db, "https://test-dapp.com")
+	require.NoError(t, err)
+	require.Len(t, sessions, 1)
+	require.Equal(t, "topic1", sessions[0].Topic)
+}
+
+func TestSelectWCSessionsByDAppURLReturnsEmpty(t *testing.T) {
+	db, close := setupTestDB(t)
+	defer close()
+
+	sessions, err := SelectWCSessionsByDAppURL(db, "https://nonexistent-dapp.com")
+	require.NoError(t, err)
+	require.Len(t, sessions, 0)
+}
+
+func TestUpsertWCSessionWithSymKey(t *testing.T) {
+	db, close := setupTestDB(t)
+	defer close()
+
+	dappURL := "https://test-dapp.com"
+	wcDApp := DApp{URL: dappURL, Name: "Test", IconURL: "", ClientID: WCClientID, SharedAccount: types.HexToAddress("0x0"), ChainID: 0x1}
+	require.NoError(t, UpsertDApp(db, &wcDApp))
+
+	topic := "test-topic"
+	sessionJSON := `{"session":"data"}`
+	expiry := int64(9999999999)
+	pairingTopic := "pairing-topic"
+	symKey := "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+	createdAt := int64(100)
+
+	// Insert session with sym_key
+	err := UpsertWCSession(db, topic, sessionJSON, expiry, pairingTopic, dappURL, symKey, createdAt)
+	require.NoError(t, err)
+
+	// Select and verify sym_key is stored
+	session, err := SelectWCSession(db, topic)
+	require.NoError(t, err)
+	require.NotNil(t, session)
+	require.Equal(t, topic, session.Topic)
+	require.Equal(t, sessionJSON, session.SessionJSON)
+	require.Equal(t, expiry, session.Expiry)
+	require.Equal(t, pairingTopic, session.PairingTopic)
+	require.Equal(t, dappURL, session.DAppURL)
+	require.Equal(t, WCClientID, session.ClientID)
+	require.Equal(t, symKey, session.SymKey)
+}
+
+func TestDeleteWCSession(t *testing.T) {
+	db, close := setupTestDB(t)
+	defer close()
+
+	dappURL := "https://test-dapp.com"
+	wcDApp := DApp{URL: dappURL, Name: "Test", IconURL: "", ClientID: WCClientID, SharedAccount: types.HexToAddress("0x0"), ChainID: 0x1}
+	require.NoError(t, UpsertDApp(db, &wcDApp))
+
+	topic := "test-topic-delete"
+	require.NoError(t, UpsertWCSession(db, topic, `{"session":"data"}`, 9999999999, "pairing1", dappURL, "symkey", 100))
+
+	session, err := SelectWCSession(db, topic)
+	require.NoError(t, err)
+	require.NotNil(t, session)
+
+	err = DeleteWCSession(db, topic)
+	require.NoError(t, err)
+
+	session, err = SelectWCSession(db, topic)
+	require.NoError(t, err)
+	require.Nil(t, session)
+}
+
+func TestDeleteWCSessionIdempotent(t *testing.T) {
+	db, close := setupTestDB(t)
+	defer close()
+
+	// Deleting non-existent session should not error
+	err := DeleteWCSession(db, "non-existent-topic")
+	require.NoError(t, err)
+}
+
+func TestSelectWCSessionReturnsNilForNonExistent(t *testing.T) {
+	db, close := setupTestDB(t)
+	defer close()
+
+	session, err := SelectWCSession(db, "non-existent-topic")
+	require.NoError(t, err)
+	require.Nil(t, session)
+}
+
+func TestSelectActiveWCSessionsWithSymKey(t *testing.T) {
+	db, close := setupTestDB(t)
+	defer close()
+
+	dappURL := "https://test-dapp.com"
+	wcDApp := DApp{URL: dappURL, Name: "Test", IconURL: "", ClientID: WCClientID, SharedAccount: types.HexToAddress("0x0"), ChainID: 0x1}
+	require.NoError(t, UpsertDApp(db, &wcDApp))
+
+	symKey1 := "key1111111111111111111111111111111111111111111111111111111111111"
+	symKey2 := "key2222222222222222222222222222222222222222222222222222222222222"
+
+	// Insert active sessions
+	err := UpsertWCSession(db, "topic1", `{"session":"data1"}`, 9999999999, "pairing1", dappURL, symKey1, 100)
+	require.NoError(t, err)
+
+	err = UpsertWCSession(db, "topic2", `{"session":"data2"}`, 9999999999, "pairing2", dappURL, symKey2, 200)
+	require.NoError(t, err)
+
+	// Insert expired session (should not be returned)
+	err = UpsertWCSession(db, "topic3", `{"session":"data3"}`, 100, "pairing3", dappURL, "oldkey", 300)
+	require.NoError(t, err)
+
+	// Select active sessions
+	validAt := int64(1000)
+	sessions, err := SelectActiveWCSessions(db, validAt)
+	require.NoError(t, err)
+	require.Len(t, sessions, 2)
+
+	// Verify sym_keys are included
+	symKeys := make(map[string]string)
+	for _, s := range sessions {
+		symKeys[s.Topic] = s.SymKey
+	}
+	require.Equal(t, symKey1, symKeys["topic1"])
+	require.Equal(t, symKey2, symKeys["topic2"])
+}

--- a/services/connector/service.go
+++ b/services/connector/service.go
@@ -109,6 +109,12 @@ func (s *Service) Stop() error {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
 	defer cancel()
 
+	if s.api != nil && s.api.wcClient != nil {
+		if err := s.api.wcClient.Close(); err != nil {
+			s.logger.Error("failed to close WalletConnect client", zap.Error(err))
+		}
+	}
+
 	if s.wsServer == nil {
 		return nil
 	}

--- a/services/connector/walletconnect/client.go
+++ b/services/connector/walletconnect/client.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"sync"
+	"time"
 
 	"go.uber.org/zap"
 
@@ -14,12 +15,22 @@ import (
 
 // WalletConnect protocol message tags (from spec)
 const (
-	tagSessionPropose        = 1100
-	tagSessionProposeResult  = 1101
-	tagSessionSettle         = 1102
-	tagSessionRequest        = 1108
-	tagSessionProposeReject  = 1120
-	defaultSessionExpirySecs = 7 * 24 * 3600 // 7 days
+	tagSessionPropose         = 1100
+	tagSessionProposeResult   = 1101
+	tagSessionSettle          = 1102
+	tagSessionSettleResponse  = 1103
+	tagSessionUpdate          = 1104
+	tagSessionUpdateResponse  = 1105
+	tagSessionRequest         = 1108
+	tagSessionRequestResponse = 1109
+	tagSessionEvent           = 1110
+	tagSessionEventResponse   = 1111
+	tagSessionDelete          = 1112
+	tagSessionDeleteResponse  = 1113
+	tagSessionPing            = 1114
+	tagSessionPingResponse    = 1115
+	tagSessionProposeReject   = 1120
+	defaultSessionExpirySecs  = 7 * 24 * 3600 // 7 days
 )
 
 // pairingContext holds the context needed to respond to a session proposal.
@@ -34,18 +45,21 @@ type pairingContext struct {
 
 // Client handles WalletConnect protocol operations via the relay.
 type Client struct {
-	relay            *RelayClient
+	relay            Relay
 	logger           *zap.Logger
 	mu               sync.Mutex
 	handlers         *clientHandlers
 	pendingProposals map[string]*pairingContext // key = fmt.Sprintf("%d", jsonRpcId)
-	pairingTopics    map[string]string          // topic -> pairing symKey (hex), set on Pair()
-	activeSessions   map[string]string          // topic -> session symKey (hex), set on ApproveSession
+	pendingRequests  map[int64]chan *JSONRPCResponse
+	pairingTopics    map[string]string // topic -> pairing symKey (hex), set on Pair()
+	activeSessions   map[string]string // topic -> session symKey (hex), set on ApproveSession
 }
 
 type clientHandlers struct {
 	onSessionProposal func(proposalJSON string)
 	onSessionRequest  func(topic string, requestJSON string)
+	onSessionUpdate   func(topic string, namespacesJSON string)
+	onSessionDelete   func(topic string)
 }
 
 // NewClient creates a new WalletConnect client.
@@ -55,37 +69,45 @@ func NewClient(projectID string) (*Client, error) {
 		return nil, fmt.Errorf("create relay client: %w", err)
 	}
 
-	return &Client{
+	c := &Client{
 		relay:            relay,
 		logger:           logutils.ZapLogger(),
 		handlers:         &clientHandlers{},
 		pendingProposals: make(map[string]*pairingContext),
+		pendingRequests:  make(map[int64]chan *JSONRPCResponse),
 		pairingTopics:    make(map[string]string),
 		activeSessions:   make(map[string]string),
-	}, nil
+	}
+
+	// Set reconnection handler to re-subscribe to all active sessions
+	relay.SetReconnectedHandler(func() {
+		c.onReconnected()
+	})
+
+	return c, nil
 }
 
 // Pair initiates pairing with a WalletConnect URI.
 // It subscribes to the pairing topic and fetches any pending session proposals.
-// FIXED: Set message handler BEFORE subscribing to prevent race condition
+// SetMessageHandler is called before Connect() to avoid race: readLoop starts in Connect()
+// and would drop messages if handler were set only after Connect returns.
 func (c *Client) Pair(ctx context.Context, uri string) error {
 	parsed, err := ParseURI(uri)
 	if err != nil {
 		return fmt.Errorf("parse URI: %w", err)
 	}
 
-	if err := c.relay.Connect(); err != nil {
-		return fmt.Errorf("connect relay: %w", err)
-	}
-
 	c.mu.Lock()
 	c.pairingTopics[parsed.Topic] = parsed.SymKey
 	c.mu.Unlock()
 
-	// Set handler BEFORE subscribing to avoid race condition
 	c.relay.SetMessageHandler(func(topic, message string, tag int) {
 		c.handleRelayMessage(topic, message, tag)
 	})
+
+	if err := c.relay.Connect(); err != nil {
+		return fmt.Errorf("connect relay: %w", err)
+	}
 
 	_, err = c.relay.Subscribe(parsed.Topic)
 	if err != nil {
@@ -108,7 +130,6 @@ func (c *Client) Pair(ctx context.Context, uri string) error {
 	for _, m := range messages {
 		c.handleRelayMessage(m.Topic, m.Message, m.Tag)
 	}
-
 	return nil
 }
 
@@ -123,6 +144,54 @@ func (c *Client) getSymKeyForTopic(topic string) (string, bool) {
 		return symKey, true
 	}
 	return "", false
+}
+
+// registerPending registers a pending outgoing request ID and returns a channel to receive the response.
+func (c *Client) registerPending(id int64) <-chan *JSONRPCResponse {
+	ch := make(chan *JSONRPCResponse, 1)
+	c.mu.Lock()
+	c.pendingRequests[id] = ch
+	c.mu.Unlock()
+	return ch
+}
+
+// resolvePending delivers a response to a pending request and returns true if it was matched.
+func (c *Client) resolvePending(id int64, resp *JSONRPCResponse) bool {
+	c.mu.Lock()
+	ch, ok := c.pendingRequests[id]
+	if ok {
+		delete(c.pendingRequests, id)
+	}
+	c.mu.Unlock()
+	if ok {
+		select {
+		case ch <- resp:
+		default:
+		}
+	}
+	return ok
+}
+
+// cancelPending removes a pending request entry without delivering a response,
+// preventing the pendingRequests map from leaking entries on timeout.
+func (c *Client) cancelPending(id int64) {
+	c.mu.Lock()
+	delete(c.pendingRequests, id)
+	c.mu.Unlock()
+}
+
+// sendAckResponse sends a JSON-RPC success response with result: true.
+func (c *Client) sendAckResponse(topic, symKey string, id int64, tag int) error {
+	response := JSONRPCResponse{JSONRPC: "2.0", ID: id, Result: true}
+	responseJSON, err := json.Marshal(response)
+	if err != nil {
+		return err
+	}
+	encrypted, err := EncryptType0Envelope(symKey, responseJSON)
+	if err != nil {
+		return err
+	}
+	return c.relay.Publish(topic, encrypted, tag)
 }
 
 // handleRelayMessage processes a message from the relay.
@@ -141,7 +210,7 @@ func (c *Client) handleRelayMessage(topic, message string, tag int) {
 	}
 
 	var payload struct {
-		ID     int64           `json:"id"`
+		ID     json.RawMessage `json:"id"`
 		Method string          `json:"method"`
 		Params json.RawMessage `json:"params"`
 	}
@@ -150,9 +219,56 @@ func (c *Client) handleRelayMessage(topic, message string, tag int) {
 		return
 	}
 
+	// Helper to extract int64 ID from either string or number format
+	parseID := func(rawID json.RawMessage) (int64, error) {
+		// Try as int64 first
+		var numID int64
+		if err := json.Unmarshal(rawID, &numID); err == nil {
+			return numID, nil
+		}
+		// Try as string
+		var strID string
+		if err := json.Unmarshal(rawID, &strID); err == nil {
+			var id int64
+			if _, err := fmt.Sscanf(strID, "%d", &id); err == nil {
+				return id, nil
+			}
+		}
+		return 0, fmt.Errorf("invalid id format")
+	}
+
+	msgID, err := parseID(payload.ID)
+	if err != nil {
+		c.logger.Debug("ignoring message with invalid ID format", zap.Error(err))
+		return
+	}
+
+	// JSON-RPC responses have no method field; route to pending outgoing requests
+	if payload.Method == "" {
+		var resp struct {
+			Result any           `json:"result,omitempty"`
+			Error  *JSONRPCError `json:"error,omitempty"`
+		}
+		if err := json.Unmarshal(plaintext, &resp); err != nil {
+			c.logger.Debug("failed to parse response payload", zap.Error(err))
+			return
+		}
+		jsonRpcResp := &JSONRPCResponse{
+			JSONRPC: "2.0",
+			ID:      msgID,
+			Result:  resp.Result,
+			Error:   resp.Error,
+		}
+		if c.resolvePending(msgID, jsonRpcResp) {
+			return
+		}
+		c.logger.Debug("response for unknown request ID", zap.Int64("id", msgID))
+		return
+	}
+
 	switch payload.Method {
 	case "wc_sessionPropose":
-		requestID := fmt.Sprintf("%d", payload.ID)
+		requestID := fmt.Sprintf("%d", msgID)
 		paramsStr := string(payload.Params)
 
 		var proposalParams struct {
@@ -173,7 +289,7 @@ func (c *Client) handleRelayMessage(topic, message string, tag int) {
 			PairingTopic:   topic,
 			PairingSymKey:  symKey,
 			ProposerPubKey: proposalParams.Proposer.PublicKey,
-			JsonRpcID:      payload.ID,
+			JsonRpcID:      msgID,
 			ProposalParams: payload.Params,
 		}
 		c.mu.Lock()
@@ -193,8 +309,35 @@ func (c *Client) handleRelayMessage(topic, message string, tag int) {
 		if handler != nil {
 			handler(topic, string(payload.Params))
 		} else {
-			signal.SendWCSessionRequest(topic, payload.ID, string(payload.Params))
+			signal.SendWCSessionRequest(topic, msgID, string(payload.Params))
 		}
+	case "wc_sessionPing":
+		if err := c.sendAckResponse(topic, symKey, msgID, tagSessionPingResponse); err != nil {
+			c.logger.Debug("failed to send ping ack", zap.Error(err))
+		}
+	case "wc_sessionUpdate":
+		if err := c.sendAckResponse(topic, symKey, msgID, tagSessionUpdateResponse); err != nil {
+			c.logger.Debug("failed to send session update ack", zap.Error(err))
+		}
+		c.mu.Lock()
+		updateHandler := c.handlers.onSessionUpdate
+		c.mu.Unlock()
+		if updateHandler != nil {
+			updateHandler(topic, string(payload.Params))
+		}
+	case "wc_sessionDelete":
+		// Remove session immediately then attempt to ack
+		c.mu.Lock()
+		delete(c.activeSessions, topic)
+		deleteHandler := c.handlers.onSessionDelete
+		c.mu.Unlock()
+		if deleteHandler != nil {
+			deleteHandler(topic)
+		}
+		if err := c.sendAckResponse(topic, symKey, msgID, tagSessionDeleteResponse); err != nil {
+			c.logger.Debug("failed to send session delete ack", zap.Error(err))
+		}
+	default:
 	}
 }
 
@@ -210,6 +353,20 @@ func (c *Client) SetSessionRequestHandler(handler func(topic, requestJSON string
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	c.handlers.onSessionRequest = handler
+}
+
+// SetSessionUpdateHandler sets the callback for incoming session update requests.
+func (c *Client) SetSessionUpdateHandler(handler func(topic, namespacesJSON string)) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.handlers.onSessionUpdate = handler
+}
+
+// SetSessionDeleteHandler sets the callback for session delete events.
+func (c *Client) SetSessionDeleteHandler(handler func(topic string)) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.handlers.onSessionDelete = handler
 }
 
 // Publish publishes a message to a topic.
@@ -239,6 +396,7 @@ type SessionResult struct {
 	PairingTopic string
 	SessionJSON  string
 	Expiry       int64
+	SymKey       string
 }
 
 // ApproveSession completes the WalletConnect session approval flow using typed structures:
@@ -248,7 +406,6 @@ type SessionResult struct {
 // 4. Send wc_sessionSettle on session topic (tag 1102)
 // 5. Return session details for persistence
 func (c *Client) ApproveSession(ctx context.Context, proposalID string, meta SessionMetadata) (*SessionResult, error) {
-	// Step 1: Retrieve pending proposal
 	c.mu.Lock()
 	pc, ok := c.pendingProposals[proposalID]
 	c.mu.Unlock()
@@ -256,44 +413,39 @@ func (c *Client) ApproveSession(ctx context.Context, proposalID string, meta Ses
 		return nil, fmt.Errorf("%w: %s", ErrProposalNotFound, proposalID)
 	}
 
-	// Step 2: Parse proposal parameters
 	var proposal ProposalParams
 	if err := json.Unmarshal(pc.ProposalParams, &proposal); err != nil {
 		return nil, fmt.Errorf("%w: %v", ErrInvalidProposal, err)
 	}
 
-	// Step 3: Perform key exchange
 	keys, err := c.performKeyExchange(pc.ProposerPubKey)
 	if err != nil {
 		return nil, err
 	}
 
-	// Step 4: Send proposal response
 	if err := c.sendProposalResponse(pc, keys); err != nil {
 		return nil, fmt.Errorf("send proposal response: %w", err)
 	}
 
-	// Step 5: Subscribe to session topic
 	if _, err := c.relay.Subscribe(keys.SessionTopic); err != nil {
 		return nil, fmt.Errorf("subscribe to session topic: %w", err)
 	}
 
 	// Step 6: Build namespaces
 	expiry := computeExpiry(meta.ExpirySec)
-	namespaces, _, _ := buildNamespaces(meta, &proposal)
+	namespaces, _, _ := BuildNamespaces(meta, &proposal)
 
-	// Step 7: Send session settle
-	if err := c.sendSessionSettle(keys, &proposal, namespaces, expiry); err != nil {
-		return nil, fmt.Errorf("send settle: %w", err)
-	}
-
-	// Step 8: Update state
+	// Step 7: Update state BEFORE sending settle so we can decrypt incoming messages
+	// (dApp may respond immediately with ack or session request)
 	c.mu.Lock()
 	c.activeSessions[keys.SessionTopic] = keys.SessionSymKeyHex
 	delete(c.pendingProposals, proposalID)
 	c.mu.Unlock()
 
-	// Step 9: Build session object for persistence
+	if err := c.sendSessionSettle(keys, &proposal, namespaces, expiry); err != nil {
+		return nil, fmt.Errorf("send settle: %w", err)
+	}
+
 	session, err := buildSessionObject(pc, keys, &proposal, meta, namespaces, expiry)
 	if err != nil {
 		return nil, fmt.Errorf("build session object: %w", err)
@@ -309,6 +461,7 @@ func (c *Client) ApproveSession(ctx context.Context, proposalID string, meta Ses
 		PairingTopic: pc.PairingTopic,
 		SessionJSON:  string(sessionJSON),
 		Expiry:       expiry,
+		SymKey:       keys.SessionSymKeyHex,
 	}, nil
 }
 
@@ -317,6 +470,63 @@ func (c *Client) RemoveSession(topic string) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	delete(c.activeSessions, topic)
+}
+
+// SendSessionDelete sends a wc_sessionDelete request to the dApp and removes the session from activeSessions
+func (c *Client) SendSessionDelete(ctx context.Context, topic string) error {
+	c.mu.Lock()
+	symKey, ok := c.activeSessions[topic]
+	c.mu.Unlock()
+	if !ok {
+		// Session already gone locally — nothing to send.
+		return nil
+	}
+
+	deleteID := payloadID()
+	ch := c.registerPending(deleteID)
+
+	request := JSONRPCRequest{
+		JSONRPC: "2.0",
+		ID:      deleteID,
+		Method:  "wc_sessionDelete",
+		Params: map[string]interface{}{
+			"code":    6000,
+			"message": "User disconnected",
+		},
+	}
+
+	requestJSON, err := json.Marshal(request)
+	if err != nil {
+		return fmt.Errorf("marshal session delete request: %w", err)
+	}
+
+	encrypted, err := EncryptType0Envelope(symKey, requestJSON)
+	if err != nil {
+		return fmt.Errorf("encrypt session delete request: %w", err)
+	}
+
+	if err := c.relay.Publish(topic, encrypted, tagSessionDelete); err != nil {
+		// Still remove locally even if relay send failed.
+		c.RemoveSession(topic)
+		return err
+	}
+
+	// Wait briefly for the dApp's ack. Non-fatal if it times out — the dApp will
+	// discover the session is gone on its next interaction.
+	ackCtx := ctx
+	if ackCtx == nil {
+		ackCtx = context.Background()
+	}
+	select {
+	case <-ch:
+	case <-time.After(5 * time.Second):
+		c.cancelPending(deleteID)
+	case <-ackCtx.Done():
+		c.cancelPending(deleteID)
+	}
+
+	c.RemoveSession(topic)
+	return nil
 }
 
 // RespondToWCSessionRequest sends a JSON-RPC success response for a wc_sessionRequest.
@@ -343,8 +553,7 @@ func (c *Client) RespondToWCSessionRequest(topic string, requestID int64, result
 	if err != nil {
 		return fmt.Errorf("encrypt response: %w", err)
 	}
-
-	return c.relay.Publish(topic, encrypted, tagSessionRequest)
+	return c.relay.Publish(topic, encrypted, tagSessionRequestResponse)
 }
 
 // RejectWCSessionRequest sends a JSON-RPC error response for a wc_sessionRequest.
@@ -374,8 +583,7 @@ func (c *Client) RejectWCSessionRequest(topic string, requestID int64, code int,
 	if err != nil {
 		return fmt.Errorf("encrypt error response: %w", err)
 	}
-
-	return c.relay.Publish(topic, encrypted, tagSessionRequest)
+	return c.relay.Publish(topic, encrypted, tagSessionRequestResponse)
 }
 
 // RejectSession sends a JSON-RPC error response to the relay when the user rejects a session proposal.
@@ -409,9 +617,168 @@ func (c *Client) RejectSession(proposalID string) error {
 	if err := c.relay.Publish(pc.PairingTopic, encrypted, tagSessionProposeReject); err != nil {
 		return fmt.Errorf("publish reject: %w", err)
 	}
-
 	c.mu.Lock()
 	delete(c.pendingProposals, proposalID)
 	c.mu.Unlock()
 	return nil
+}
+
+// SendSessionUpdate sends a wc_sessionUpdate request to update session namespaces (e.g., add/remove chains).
+func (c *Client) SendSessionUpdate(topic string, namespaces map[string]Namespace) error {
+	c.mu.Lock()
+	symKey, ok := c.activeSessions[topic]
+	c.mu.Unlock()
+	if !ok {
+		return fmt.Errorf("%w: %s", ErrSessionNotFound, topic)
+	}
+
+	updateID := payloadID()
+	ch := c.registerPending(updateID)
+	updateParams := map[string]interface{}{
+		"namespaces": namespaces,
+	}
+
+	request := JSONRPCRequest{
+		JSONRPC: "2.0",
+		ID:      updateID,
+		Method:  "wc_sessionUpdate",
+		Params:  updateParams,
+	}
+
+	requestJSON, err := json.Marshal(request)
+	if err != nil {
+		return fmt.Errorf("marshal update request: %w", err)
+	}
+
+	encrypted, err := EncryptType0Envelope(symKey, requestJSON)
+	if err != nil {
+		return fmt.Errorf("encrypt update request: %w", err)
+	}
+
+	if err := c.relay.Publish(topic, encrypted, tagSessionUpdate); err != nil {
+		return err
+	}
+
+	select {
+	case resp := <-ch:
+		if resp.Error != nil {
+			return fmt.Errorf("update rejected: %s", resp.Error.Message)
+		}
+	case <-time.After(15 * time.Second):
+		c.cancelPending(updateID)
+		c.logger.Debug("session update response timeout (non-fatal)")
+	}
+	return nil
+}
+
+// SendSessionEvent sends a wc_sessionEvent to the dapp (e.g., accountsChanged, chainChanged).
+func (c *Client) SendSessionEvent(topic string, event SessionEvent, chainID string) error {
+	c.mu.Lock()
+	symKey, ok := c.activeSessions[topic]
+	c.mu.Unlock()
+	if !ok {
+		return fmt.Errorf("%w: %s", ErrSessionNotFound, topic)
+	}
+
+	eventID := payloadID()
+	ch := c.registerPending(eventID)
+	params := map[string]interface{}{
+		"event":   event,
+		"chainId": chainID,
+	}
+	request := JSONRPCRequest{
+		JSONRPC: "2.0",
+		ID:      eventID,
+		Method:  "wc_sessionEvent",
+		Params:  params,
+	}
+	requestJSON, err := json.Marshal(request)
+	if err != nil {
+		return fmt.Errorf("marshal session event: %w", err)
+	}
+	encrypted, err := EncryptType0Envelope(symKey, requestJSON)
+	if err != nil {
+		return fmt.Errorf("encrypt session event: %w", err)
+	}
+	if err := c.relay.Publish(topic, encrypted, tagSessionEvent); err != nil {
+		return err
+	}
+
+	select {
+	case resp := <-ch:
+		if resp.Error != nil {
+			c.logger.Debug("dapp rejected session event", zap.String("event", event.Name), zap.Any("error", resp.Error))
+		}
+	case <-time.After(15 * time.Second):
+		c.cancelPending(eventID)
+		c.logger.Debug("session event response timeout (non-fatal)")
+	}
+	return nil
+}
+
+// onReconnected re-subscribes to all active session and pairing topics.
+func (c *Client) onReconnected() {
+	c.mu.Lock()
+	sessionTopics := make([]string, 0, len(c.activeSessions))
+	for topic := range c.activeSessions {
+		sessionTopics = append(sessionTopics, topic)
+	}
+	pairingTopics := make([]string, 0, len(c.pairingTopics))
+	for topic := range c.pairingTopics {
+		pairingTopics = append(pairingTopics, topic)
+	}
+	c.mu.Unlock()
+	c.resubscribeTopics("session", sessionTopics)
+	c.resubscribeTopics("pairing", pairingTopics)
+}
+
+func (c *Client) resubscribeTopics(label string, topics []string) {
+	for _, topic := range topics {
+		if _, err := c.relay.Subscribe(topic); err != nil {
+			c.logger.Error("failed to re-subscribe", zap.String("type", label), zap.String("topic", topic), zap.Error(err))
+		} else {
+			c.logger.Info("re-subscribed", zap.String("type", label), zap.String("topic", topic))
+		}
+	}
+}
+
+// RestoredSession holds topic and symKey for session restoration from DB.
+type RestoredSession struct {
+	Topic  string
+	SymKey string
+}
+
+// ConnectAndResubscribe connects the relay WebSocket and subscribes to all
+// session topics. Must be called after RestoreSessions
+func (c *Client) ConnectAndResubscribe() error {
+	c.relay.SetMessageHandler(func(topic, message string, tag int) {
+		c.handleRelayMessage(topic, message, tag)
+	})
+
+	if err := c.relay.Connect(); err != nil {
+		return fmt.Errorf("connect relay: %w", err)
+	}
+
+	c.mu.Lock()
+	topics := make([]string, 0, len(c.activeSessions))
+	for topic := range c.activeSessions {
+		topics = append(topics, topic)
+	}
+	c.mu.Unlock()
+
+	c.resubscribeTopics("session", topics)
+	return nil
+}
+
+// RestoreSessions populates activeSessions from database. Call on startup after a restart.
+func (c *Client) RestoreSessions(sessions []RestoredSession) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	for _, s := range sessions {
+		if s.Topic != "" && s.SymKey != "" {
+			c.activeSessions[s.Topic] = s.SymKey
+			c.logger.Info("restored WalletConnect session", zap.String("topic", s.Topic))
+		}
+	}
 }

--- a/services/connector/walletconnect/client_test.go
+++ b/services/connector/walletconnect/client_test.go
@@ -2,13 +2,52 @@ package walletconnect
 
 import (
 	"context"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+
+	"github.com/status-im/status-go/internal/logutils"
 )
+
+// newTestClient creates a Client with the supplied relay, bypassing NewClient.
+// Use this to inject a MockRelay in tests.
+func newTestClient(relay Relay) *Client {
+	return &Client{
+		relay:            relay,
+		logger:           logutils.ZapLogger(),
+		handlers:         &clientHandlers{},
+		pendingProposals: make(map[string]*pairingContext),
+		pendingRequests:  make(map[int64]chan *JSONRPCResponse),
+		pairingTopics:    make(map[string]string),
+		activeSessions:   make(map[string]string),
+	}
+}
+
+// autoAckOnPublish returns a gomock Do-function that asynchronously resolves
+// every pending request on c with a success result. Attach it to a Publish
+// EXPECT to avoid 15-second timeouts in sendSessionSettle / SendSessionUpdate.
+func autoAckOnPublish(c *Client) func(string, string, int) {
+	return func(_, _ string, _ int) {
+		go func() {
+			time.Sleep(5 * time.Millisecond)
+			c.mu.Lock()
+			for id, ch := range c.pendingRequests {
+				resp := &JSONRPCResponse{JSONRPC: "2.0", ID: id, Result: true}
+				select {
+				case ch <- resp:
+				default:
+				}
+			}
+			c.mu.Unlock()
+		}()
+	}
+}
 
 func TestNewClient(t *testing.T) {
 	client, err := NewClient("test-project-id")
@@ -17,6 +56,7 @@ func TestNewClient(t *testing.T) {
 	require.NotNil(t, client.relay)
 	require.NotNil(t, client.handlers)
 	require.NotNil(t, client.pendingProposals)
+	require.NotNil(t, client.pendingRequests)
 	require.NotNil(t, client.pairingTopics)
 	require.NotNil(t, client.activeSessions)
 }
@@ -206,28 +246,6 @@ func TestClient_HandleRelayMessage_SessionRequest(t *testing.T) {
 	require.NotEmpty(t, receivedRequest)
 }
 
-// FIXME we need to mock client.relay as it doesn't have a real connection in this test
-// func TestClient_RejectSession(t *testing.T) {
-// 	client, _ := NewClient("test")
-
-// 	symKey := "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
-// 	client.mu.Lock()
-// 	client.pendingProposals["123"] = &pairingContext{
-// 		PairingTopic:  "pairing-topic",
-// 		PairingSymKey: symKey,
-// 		JsonRpcID:     123,
-// 	}
-// 	client.mu.Unlock()
-
-// 	err := client.RejectSession("123")
-// 	require.NoError(t, err)
-
-// 	client.mu.Lock()
-// 	_, exists := client.pendingProposals["123"]
-// 	client.mu.Unlock()
-// 	require.False(t, exists)
-// }
-
 func TestClient_RejectSession_NotFound(t *testing.T) {
 	client, _ := NewClient("test")
 
@@ -285,4 +303,985 @@ func TestSentinelErrors(t *testing.T) {
 			require.True(t, errors.Is(tt.err, tt.expectedError))
 		})
 	}
+}
+
+func TestClient_RegisterPending_ResolvePending(t *testing.T) {
+	client, _ := NewClient("test")
+
+	ch := client.registerPending(12345)
+	require.NotNil(t, ch)
+
+	resp := &JSONRPCResponse{JSONRPC: "2.0", ID: 12345, Result: true}
+	ok := client.resolvePending(12345, resp)
+	require.True(t, ok)
+
+	got := <-ch
+	require.Equal(t, true, got.Result)
+
+	// Second resolve for same ID should not match
+	ok = client.resolvePending(12345, resp)
+	require.False(t, ok)
+}
+
+func TestClient_HandleRelayMessage_JSONRPCResponse_ResolvesPending(t *testing.T) {
+	client, _ := NewClient("test")
+
+	symKey := "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+	client.mu.Lock()
+	client.activeSessions["topic"] = symKey
+	client.mu.Unlock()
+
+	ch := client.registerPending(999)
+
+	resp := map[string]any{
+		"jsonrpc": "2.0",
+		"id":      999,
+		"result":  true,
+	}
+	respJSON, _ := json.Marshal(resp)
+	encrypted, _ := EncryptType0Envelope(symKey, respJSON)
+
+	client.handleRelayMessage("topic", encrypted, tagSessionSettleResponse)
+
+	select {
+	case r := <-ch:
+		require.NotNil(t, r)
+		require.Equal(t, true, r.Result)
+		require.Nil(t, r.Error)
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("expected response to be delivered to pending channel")
+	}
+}
+
+func TestClient_HandleRelayMessage_SessionPing(t *testing.T) {
+	client, _ := NewClient("test")
+
+	symKey := "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+	client.mu.Lock()
+	client.activeSessions["topic"] = symKey
+	client.mu.Unlock()
+
+	// Use a mock relay to capture the publish call
+	// For now we just verify it doesn't panic - full test would need relay mock
+	ping := map[string]any{
+		"id":     int64(1),
+		"method": "wc_sessionPing",
+		"params": map[string]any{},
+	}
+	pingJSON, _ := json.Marshal(ping)
+	encrypted, _ := EncryptType0Envelope(symKey, pingJSON)
+
+	require.NotPanics(t, func() {
+		client.handleRelayMessage("topic", encrypted, tagSessionPing)
+	})
+}
+
+func TestClient_HandleRelayMessage_SessionUpdate(t *testing.T) {
+	client, _ := NewClient("test")
+
+	symKey := "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+	client.mu.Lock()
+	client.activeSessions["topic"] = symKey
+	client.mu.Unlock()
+
+	called := false
+	client.SetSessionUpdateHandler(func(topic, namespacesJSON string) {
+		called = true
+		require.Equal(t, "topic", topic)
+		require.Contains(t, namespacesJSON, "eip155")
+	})
+
+	update := map[string]any{
+		"id":     int64(2),
+		"method": "wc_sessionUpdate",
+		"params": map[string]any{
+			"namespaces": map[string]any{
+				"eip155": map[string]any{
+					"accounts": []string{"eip155:1:0x123"},
+					"chains":   []string{"eip155:1"},
+					"methods":  []string{"personal_sign"},
+					"events":   []string{"accountsChanged"},
+				},
+			},
+		},
+	}
+	updateJSON, _ := json.Marshal(update)
+	encrypted, _ := EncryptType0Envelope(symKey, updateJSON)
+
+	client.handleRelayMessage("topic", encrypted, tagSessionUpdate)
+
+	time.Sleep(10 * time.Millisecond)
+	require.True(t, called)
+}
+
+func TestClient_HandleRelayMessage_SessionDelete_RemovesFromActiveSessions(t *testing.T) {
+	client, _ := NewClient("test")
+
+	symKey := "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+	client.mu.Lock()
+	client.activeSessions["topic"] = symKey
+	client.mu.Unlock()
+
+	deleteReq := map[string]any{
+		"id":     int64(3),
+		"method": "wc_sessionDelete",
+		"params": map[string]any{"code": int64(1000), "message": "disconnect"},
+	}
+	deleteJSON, _ := json.Marshal(deleteReq)
+	encrypted, _ := EncryptType0Envelope(symKey, deleteJSON)
+
+	client.handleRelayMessage("topic", encrypted, tagSessionDelete)
+
+	client.mu.Lock()
+	_, exists := client.activeSessions["topic"]
+	client.mu.Unlock()
+	require.False(t, exists, "session should be removed from activeSessions on wc_sessionDelete")
+}
+
+func TestClient_HandleRelayMessage_SessionDelete_CallsHandler(t *testing.T) {
+	client, _ := NewClient("test")
+
+	symKey := "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+	client.mu.Lock()
+	client.activeSessions["topic"] = symKey
+	client.mu.Unlock()
+
+	called := false
+	var receivedTopic string
+	client.SetSessionDeleteHandler(func(topic string) {
+		called = true
+		receivedTopic = topic
+	})
+
+	deleteReq := map[string]any{
+		"id":     int64(4),
+		"method": "wc_sessionDelete",
+		"params": map[string]any{"code": int64(1000), "message": "disconnect"},
+	}
+	deleteJSON, _ := json.Marshal(deleteReq)
+	encrypted, _ := EncryptType0Envelope(symKey, deleteJSON)
+
+	client.handleRelayMessage("topic", encrypted, tagSessionDelete)
+
+	require.True(t, called)
+	require.Equal(t, "topic", receivedTopic)
+}
+
+func TestClient_SetSessionDeleteHandler(t *testing.T) {
+	client, _ := NewClient("test")
+
+	called := false
+	handler := func(topic string) {
+		called = true
+	}
+
+	client.SetSessionDeleteHandler(handler)
+
+	client.mu.Lock()
+	h := client.handlers.onSessionDelete
+	client.mu.Unlock()
+
+	require.NotNil(t, h)
+	h("topic")
+	require.True(t, called)
+}
+
+func TestClient_Close(t *testing.T) {
+	client, _ := NewClient("test")
+
+	err := client.Close()
+	require.NoError(t, err)
+}
+
+func TestClient_SendSessionEvent_NoSession(t *testing.T) {
+	client, _ := NewClient("test")
+
+	err := client.SendSessionEvent("unknown-topic", SessionEvent{Name: "accountsChanged", Data: []string{"0x123"}}, "eip155:1")
+	require.Error(t, err)
+	require.ErrorIs(t, err, ErrSessionNotFound)
+}
+
+func TestClient_SetSessionUpdateHandler(t *testing.T) {
+	client, _ := NewClient("test")
+
+	called := false
+	handler := func(topic, namespacesJSON string) {
+		called = true
+	}
+
+	client.SetSessionUpdateHandler(handler)
+
+	client.mu.Lock()
+	h := client.handlers.onSessionUpdate
+	client.mu.Unlock()
+
+	h("topic", `{"namespaces":{}}`)
+	require.True(t, called)
+}
+
+func TestClient_RestoreSessions(t *testing.T) {
+	client, _ := NewClient("test")
+
+	sessions := []RestoredSession{
+		{Topic: "topic1", SymKey: "key1"},
+		{Topic: "topic2", SymKey: "key2"},
+		{Topic: "", SymKey: "key3"},   // Should be ignored
+		{Topic: "topic4", SymKey: ""}, // Should be ignored
+	}
+
+	client.RestoreSessions(sessions)
+
+	client.mu.Lock()
+	require.Equal(t, 2, len(client.activeSessions))
+	require.Equal(t, "key1", client.activeSessions["topic1"])
+	require.Equal(t, "key2", client.activeSessions["topic2"])
+	_, exists := client.activeSessions[""]
+	require.False(t, exists)
+	_, exists = client.activeSessions["topic4"]
+	require.False(t, exists)
+	client.mu.Unlock()
+}
+
+// validWCURI returns a well-formed WalletConnect v2 URI for the given topic+symKey.
+// Topic must be 64 hex chars (32 bytes).
+const testPairingTopic = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+const testPairingSymKey = "aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899"
+
+func validWCURI(topic, symKey string) string {
+	return fmt.Sprintf("wc:%s@2?relay-protocol=irn&symKey=%s", topic, symKey)
+}
+
+func TestClient_Pair_InvalidURI(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	relay := NewMockRelay(ctrl)
+	client := newTestClient(relay)
+
+	err := client.Pair(context.Background(), "not-a-valid-wc-uri")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "parse URI")
+}
+
+func TestClient_Pair_ConnectError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	relay := NewMockRelay(ctrl)
+	client := newTestClient(relay)
+
+	relay.EXPECT().SetMessageHandler(gomock.Any())
+	relay.EXPECT().Connect().Return(fmt.Errorf("dial failed"))
+
+	err := client.Pair(context.Background(), validWCURI(testPairingTopic, testPairingSymKey))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "connect relay")
+}
+
+func TestClient_Pair_SubscribeError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	relay := NewMockRelay(ctrl)
+	client := newTestClient(relay)
+
+	relay.EXPECT().SetMessageHandler(gomock.Any())
+	relay.EXPECT().Connect().Return(nil)
+	relay.EXPECT().Subscribe(testPairingTopic).Return("", fmt.Errorf("subscribe failed"))
+
+	err := client.Pair(context.Background(), validWCURI(testPairingTopic, testPairingSymKey))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "subscribe")
+}
+
+func TestClient_Pair_Success_NoMessages(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	relay := NewMockRelay(ctrl)
+	client := newTestClient(relay)
+
+	relay.EXPECT().SetMessageHandler(gomock.Any())
+	relay.EXPECT().Connect().Return(nil)
+	relay.EXPECT().Subscribe(testPairingTopic).Return("sub-id", nil)
+	relay.EXPECT().FetchMessages(testPairingTopic).Return(nil, false, fmt.Errorf("no messages"))
+
+	err := client.Pair(context.Background(), validWCURI(testPairingTopic, testPairingSymKey))
+	require.NoError(t, err)
+}
+
+func TestClient_Pair_WithFetchedMessages(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	relay := NewMockRelay(ctrl)
+	client := newTestClient(relay)
+
+	payload := map[string]any{
+		"id":     int64(1),
+		"method": "wc_unknown",
+		"params": map[string]any{},
+	}
+	payloadJSON, _ := json.Marshal(payload)
+	encrypted, _ := EncryptType0Envelope(testPairingSymKey, payloadJSON)
+
+	relay.EXPECT().SetMessageHandler(gomock.Any())
+	relay.EXPECT().Connect().Return(nil)
+	relay.EXPECT().Subscribe(testPairingTopic).Return("sub-id", nil)
+	relay.EXPECT().FetchMessages(testPairingTopic).Return(
+		[]RelayMessage{{Topic: testPairingTopic, Message: encrypted, Tag: defaultMessageTag}},
+		false, nil,
+	)
+
+	err := client.Pair(context.Background(), validWCURI(testPairingTopic, testPairingSymKey))
+	require.NoError(t, err)
+}
+
+func TestClient_ConnectAndResubscribe_ConnectError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	relay := NewMockRelay(ctrl)
+	client := newTestClient(relay)
+
+	client.mu.Lock()
+	client.activeSessions["topic1"] = "key1"
+	client.mu.Unlock()
+
+	relay.EXPECT().SetMessageHandler(gomock.Any())
+	relay.EXPECT().Connect().Return(fmt.Errorf("connect failed"))
+
+	err := client.ConnectAndResubscribe()
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "connect relay")
+}
+
+func TestClient_ConnectAndResubscribe_Success(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	relay := NewMockRelay(ctrl)
+	client := newTestClient(relay)
+
+	client.mu.Lock()
+	client.activeSessions["topic1"] = "key1"
+	client.activeSessions["topic2"] = "key2"
+	client.mu.Unlock()
+
+	relay.EXPECT().SetMessageHandler(gomock.Any())
+	relay.EXPECT().Connect().Return(nil)
+	relay.EXPECT().Subscribe(gomock.Any()).Return("sub-id", nil).Times(2)
+
+	err := client.ConnectAndResubscribe()
+	require.NoError(t, err)
+}
+
+func TestClient_onReconnected_ResubscribesAll(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	relay := NewMockRelay(ctrl)
+	client := newTestClient(relay)
+
+	client.mu.Lock()
+	client.activeSessions["session-topic"] = "skey"
+	client.pairingTopics["pairing-topic"] = "pkey"
+	client.mu.Unlock()
+
+	relay.EXPECT().Subscribe(gomock.Any()).Return("sub-id", nil).Times(2)
+
+	client.onReconnected()
+}
+
+func TestClient_resubscribeTopics_SubscribeError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	relay := NewMockRelay(ctrl)
+	client := newTestClient(relay)
+
+	relay.EXPECT().Subscribe(gomock.Any()).Return("", fmt.Errorf("subscribe failed")).Times(2)
+
+	require.NotPanics(t, func() {
+		client.resubscribeTopics("session", []string{"topic1", "topic2"})
+	})
+}
+
+func TestClient_RejectSession_Success(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	relay := NewMockRelay(ctrl)
+	client := newTestClient(relay)
+
+	symKey := "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+	client.mu.Lock()
+	client.pendingProposals["proposal1"] = &pairingContext{
+		PairingTopic:  "pairing-topic",
+		PairingSymKey: symKey,
+		JsonRpcID:     42,
+	}
+	client.mu.Unlock()
+
+	relay.EXPECT().Publish("pairing-topic", gomock.Any(), tagSessionProposeReject).Return(nil)
+
+	err := client.RejectSession("proposal1")
+	require.NoError(t, err)
+
+	client.mu.Lock()
+	_, exists := client.pendingProposals["proposal1"]
+	client.mu.Unlock()
+	require.False(t, exists)
+}
+
+func TestClient_RejectSession_PublishError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	relay := NewMockRelay(ctrl)
+	client := newTestClient(relay)
+
+	symKey := "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+	client.mu.Lock()
+	client.pendingProposals["proposal1"] = &pairingContext{
+		PairingTopic:  "pairing-topic",
+		PairingSymKey: symKey,
+		JsonRpcID:     42,
+	}
+	client.mu.Unlock()
+
+	relay.EXPECT().Publish("pairing-topic", gomock.Any(), tagSessionProposeReject).Return(fmt.Errorf("publish failed"))
+
+	err := client.RejectSession("proposal1")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "publish reject")
+}
+
+func TestClient_RespondToWCSessionRequest_Success(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	relay := NewMockRelay(ctrl)
+	client := newTestClient(relay)
+
+	symKey := "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+	client.mu.Lock()
+	client.activeSessions["topic"] = symKey
+	client.mu.Unlock()
+
+	relay.EXPECT().Publish("topic", gomock.Any(), tagSessionRequestResponse).Return(nil)
+
+	err := client.RespondToWCSessionRequest("topic", 999, "0xsignature")
+	require.NoError(t, err)
+}
+
+func TestClient_RespondToWCSessionRequest_PublishError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	relay := NewMockRelay(ctrl)
+	client := newTestClient(relay)
+
+	symKey := "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+	client.mu.Lock()
+	client.activeSessions["topic"] = symKey
+	client.mu.Unlock()
+
+	relay.EXPECT().Publish("topic", gomock.Any(), tagSessionRequestResponse).Return(fmt.Errorf("publish failed"))
+
+	err := client.RespondToWCSessionRequest("topic", 999, "0xsig")
+	require.Error(t, err)
+}
+
+func TestClient_RejectWCSessionRequest_Success(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	relay := NewMockRelay(ctrl)
+	client := newTestClient(relay)
+
+	symKey := "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+	client.mu.Lock()
+	client.activeSessions["topic"] = symKey
+	client.mu.Unlock()
+
+	relay.EXPECT().Publish("topic", gomock.Any(), tagSessionRequestResponse).Return(nil)
+
+	err := client.RejectWCSessionRequest("topic", 999, 4001, "User rejected")
+	require.NoError(t, err)
+}
+
+func TestClient_RejectWCSessionRequest_NoSession(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	relay := NewMockRelay(ctrl)
+	client := newTestClient(relay)
+
+	err := client.RejectWCSessionRequest("nonexistent-topic", 999, 4001, "rejected")
+	require.Error(t, err)
+	require.ErrorIs(t, err, ErrSessionNotFound)
+}
+
+func TestClient_RejectWCSessionRequest_PublishError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	relay := NewMockRelay(ctrl)
+	client := newTestClient(relay)
+
+	symKey := "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+	client.mu.Lock()
+	client.activeSessions["topic"] = symKey
+	client.mu.Unlock()
+
+	relay.EXPECT().Publish("topic", gomock.Any(), tagSessionRequestResponse).Return(fmt.Errorf("publish failed"))
+
+	err := client.RejectWCSessionRequest("topic", 999, 4001, "rejected")
+	require.Error(t, err)
+}
+
+func TestClient_SendSessionDelete_SessionNotFound(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	relay := NewMockRelay(ctrl)
+	client := newTestClient(relay)
+
+	// No Publish expected — session not in activeSessions
+	err := client.SendSessionDelete(context.Background(), "nonexistent-topic")
+	require.NoError(t, err)
+}
+
+func TestClient_SendSessionDelete_PublishError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	relay := NewMockRelay(ctrl)
+	client := newTestClient(relay)
+
+	symKey := "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+	client.mu.Lock()
+	client.activeSessions["topic"] = symKey
+	client.mu.Unlock()
+
+	relay.EXPECT().Publish("topic", gomock.Any(), tagSessionDelete).Return(fmt.Errorf("publish failed"))
+
+	err := client.SendSessionDelete(context.Background(), "topic")
+	require.Error(t, err)
+
+	_, ok := client.getSymKeyForTopic("topic")
+	require.False(t, ok, "session should be removed even when publish fails")
+}
+
+func TestClient_SendSessionDelete_Success(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	relay := NewMockRelay(ctrl)
+	client := newTestClient(relay)
+
+	symKey := "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+	client.mu.Lock()
+	client.activeSessions["topic"] = symKey
+	client.mu.Unlock()
+
+	relay.EXPECT().Publish("topic", gomock.Any(), tagSessionDelete).
+		DoAndReturn(func(topic, msg string, tag int) error {
+			autoAckOnPublish(client)(topic, msg, tag)
+			return nil
+		})
+
+	err := client.SendSessionDelete(context.Background(), "topic")
+	require.NoError(t, err)
+
+	_, ok := client.getSymKeyForTopic("topic")
+	require.False(t, ok)
+}
+
+func TestClient_SendSessionUpdate_NoSession(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	relay := NewMockRelay(ctrl)
+	client := newTestClient(relay)
+
+	err := client.SendSessionUpdate("nonexistent-topic", map[string]Namespace{})
+	require.Error(t, err)
+	require.ErrorIs(t, err, ErrSessionNotFound)
+}
+
+func TestClient_SendSessionUpdate_PublishError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	relay := NewMockRelay(ctrl)
+	client := newTestClient(relay)
+
+	symKey := "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+	client.mu.Lock()
+	client.activeSessions["topic"] = symKey
+	client.mu.Unlock()
+
+	relay.EXPECT().Publish("topic", gomock.Any(), tagSessionUpdate).Return(fmt.Errorf("publish failed"))
+
+	err := client.SendSessionUpdate("topic", map[string]Namespace{})
+	require.Error(t, err)
+}
+
+func TestClient_SendSessionUpdate_Success(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	relay := NewMockRelay(ctrl)
+	client := newTestClient(relay)
+
+	symKey := "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+	client.mu.Lock()
+	client.activeSessions["topic"] = symKey
+	client.mu.Unlock()
+
+	relay.EXPECT().Publish("topic", gomock.Any(), tagSessionUpdate).
+		DoAndReturn(func(topic, msg string, tag int) error {
+			autoAckOnPublish(client)(topic, msg, tag)
+			return nil
+		})
+
+	ns := map[string]Namespace{
+		"eip155": {Chains: []string{"eip155:1"}, Methods: []string{"personal_sign"}, Events: []string{"accountsChanged"}},
+	}
+	err := client.SendSessionUpdate("topic", ns)
+	require.NoError(t, err)
+}
+
+func TestClient_SendSessionEvent_Success(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	relay := NewMockRelay(ctrl)
+	client := newTestClient(relay)
+
+	symKey := "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+	client.mu.Lock()
+	client.activeSessions["topic"] = symKey
+	client.mu.Unlock()
+
+	relay.EXPECT().Publish("topic", gomock.Any(), tagSessionEvent).
+		DoAndReturn(func(topic, msg string, tag int) error {
+			autoAckOnPublish(client)(topic, msg, tag)
+			return nil
+		})
+
+	err := client.SendSessionEvent("topic", SessionEvent{Name: "accountsChanged", Data: []string{"0x123"}}, "eip155:1")
+	require.NoError(t, err)
+}
+
+func TestClient_SendSessionEvent_PublishError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	relay := NewMockRelay(ctrl)
+	client := newTestClient(relay)
+
+	symKey := "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+	client.mu.Lock()
+	client.activeSessions["topic"] = symKey
+	client.mu.Unlock()
+
+	relay.EXPECT().Publish("topic", gomock.Any(), tagSessionEvent).Return(fmt.Errorf("publish failed"))
+
+	err := client.SendSessionEvent("topic", SessionEvent{Name: "accountsChanged"}, "eip155:1")
+	require.Error(t, err)
+}
+
+func TestClient_ApproveSession_InvalidProposalParams(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	relay := NewMockRelay(ctrl)
+	client := newTestClient(relay)
+
+	client.mu.Lock()
+	client.pendingProposals["proposal1"] = &pairingContext{
+		PairingTopic:   "pairing-topic",
+		PairingSymKey:  "symkey",
+		ProposerPubKey: "abcd1234",
+		JsonRpcID:      1,
+		ProposalParams: json.RawMessage(`not-valid-json`),
+	}
+	client.mu.Unlock()
+
+	_, err := client.ApproveSession(context.Background(), "proposal1", SessionMetadata{Account: "0x1234", ChainID: 1})
+	require.Error(t, err)
+}
+
+func TestClient_ApproveSession_InvalidProposerKey(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	relay := NewMockRelay(ctrl)
+	client := newTestClient(relay)
+
+	client.mu.Lock()
+	client.pendingProposals["proposal1"] = &pairingContext{
+		PairingTopic:   "pairing-topic",
+		PairingSymKey:  "symkey",
+		ProposerPubKey: "not-valid-hex!!!",
+		JsonRpcID:      1,
+		ProposalParams: json.RawMessage(`{}`),
+	}
+	client.mu.Unlock()
+
+	_, err := client.ApproveSession(context.Background(), "proposal1", SessionMetadata{Account: "0x1234", ChainID: 1})
+	require.Error(t, err)
+}
+
+func TestClient_ApproveSession_ProposalResponsePublishError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	relay := NewMockRelay(ctrl)
+	client := newTestClient(relay)
+
+	_, proposerPub, err := GenerateX25519KeyPair()
+	require.NoError(t, err)
+
+	pairingSymKey := "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+	client.mu.Lock()
+	client.pendingProposals["proposal1"] = &pairingContext{
+		PairingTopic:   "pairing-topic",
+		PairingSymKey:  pairingSymKey,
+		ProposerPubKey: hex.EncodeToString(proposerPub),
+		JsonRpcID:      1,
+		ProposalParams: json.RawMessage(`{}`),
+	}
+	client.mu.Unlock()
+
+	relay.EXPECT().Publish("pairing-topic", gomock.Any(), tagSessionProposeResult).Return(fmt.Errorf("publish failed"))
+
+	_, err = client.ApproveSession(context.Background(), "proposal1", SessionMetadata{Account: "0x1234", ChainID: 1, Chains: []int64{1}})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "send proposal response")
+}
+
+func TestClient_ApproveSession_SubscribeError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	relay := NewMockRelay(ctrl)
+	client := newTestClient(relay)
+
+	_, proposerPub, err := GenerateX25519KeyPair()
+	require.NoError(t, err)
+
+	pairingSymKey := "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+	client.mu.Lock()
+	client.pendingProposals["proposal1"] = &pairingContext{
+		PairingTopic:   "pairing-topic",
+		PairingSymKey:  pairingSymKey,
+		ProposerPubKey: hex.EncodeToString(proposerPub),
+		JsonRpcID:      1,
+		ProposalParams: json.RawMessage(`{}`),
+	}
+	client.mu.Unlock()
+
+	// Proposal response publish succeeds, session subscribe fails
+	relay.EXPECT().Publish("pairing-topic", gomock.Any(), tagSessionProposeResult).Return(nil)
+	relay.EXPECT().Subscribe(gomock.Any()).Return("", fmt.Errorf("subscribe failed"))
+
+	_, err = client.ApproveSession(context.Background(), "proposal1", SessionMetadata{Account: "0x1234", ChainID: 1, Chains: []int64{1}})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "subscribe to session topic")
+}
+
+func TestClient_ApproveSession_Success(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	relay := NewMockRelay(ctrl)
+	client := newTestClient(relay)
+
+	_, proposerPub, err := GenerateX25519KeyPair()
+	require.NoError(t, err)
+
+	pairingSymKey := "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+	client.mu.Lock()
+	client.pendingProposals["proposal1"] = &pairingContext{
+		PairingTopic:   "pairing-topic",
+		PairingSymKey:  pairingSymKey,
+		ProposerPubKey: hex.EncodeToString(proposerPub),
+		JsonRpcID:      1,
+		ProposalParams: json.RawMessage(`{
+			"relays": [{"protocol":"irn"}],
+			"proposer": {"publicKey":"` + hex.EncodeToString(proposerPub) + `","metadata":{"name":"Test","url":"https://test.com","description":"","icons":["https://test.com/icon.png"]}},
+			"requiredNamespaces": {}
+		}`),
+	}
+	client.mu.Unlock()
+
+	// 1. sendProposalResponse → Publish on pairing topic
+	relay.EXPECT().Publish("pairing-topic", gomock.Any(), tagSessionProposeResult).Return(nil)
+	// 2. Subscribe to session topic
+	relay.EXPECT().Subscribe(gomock.Any()).Return("sub-session", nil)
+	// 3. sendSessionSettle → Publish on session topic (with autoAck)
+	relay.EXPECT().Publish(gomock.Any(), gomock.Any(), tagSessionSettle).
+		DoAndReturn(func(topic, msg string, tag int) error {
+			autoAckOnPublish(client)(topic, msg, tag)
+			return nil
+		})
+
+	result, err := client.ApproveSession(context.Background(), "proposal1",
+		SessionMetadata{Account: "0x1234567890abcdef1234567890abcdef12345678", ChainID: 1, Chains: []int64{1}})
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.NotEmpty(t, result.Topic)
+	require.Equal(t, "pairing-topic", result.PairingTopic)
+	require.NotEmpty(t, result.SessionJSON)
+	require.NotEmpty(t, result.SymKey)
+
+	client.mu.Lock()
+	_, exists := client.pendingProposals["proposal1"]
+	client.mu.Unlock()
+	require.False(t, exists)
+
+	_, ok := client.getSymKeyForTopic(result.Topic)
+	require.True(t, ok)
+}
+
+func TestClient_sendAckResponse_PublishesSuccessfully(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	relay := NewMockRelay(ctrl)
+	client := newTestClient(relay)
+
+	symKey := "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+	relay.EXPECT().Publish("topic", gomock.Any(), tagSessionPingResponse).Return(nil)
+
+	err := client.sendAckResponse("topic", symKey, 1, tagSessionPingResponse)
+	require.NoError(t, err)
+}
+
+func TestClient_HandleRelayMessage_InvalidID(t *testing.T) {
+	client, _ := NewClient("test")
+
+	symKey := "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+	client.mu.Lock()
+	client.activeSessions["topic"] = symKey
+	client.mu.Unlock()
+
+	payload := map[string]any{
+		"id":     []string{"not", "an", "id"},
+		"method": "wc_sessionPing",
+		"params": map[string]any{},
+	}
+	payloadJSON, _ := json.Marshal(payload)
+	encrypted, _ := EncryptType0Envelope(symKey, payloadJSON)
+
+	require.NotPanics(t, func() {
+		client.handleRelayMessage("topic", encrypted, tagSessionPing)
+	})
+}
+
+func TestClient_HandleRelayMessage_SessionProposal_MissingPublicKey(t *testing.T) {
+	client, _ := NewClient("test")
+
+	symKey := "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+	client.mu.Lock()
+	client.pairingTopics["topic"] = symKey
+	client.mu.Unlock()
+
+	proposal := map[string]any{
+		"id":     int64(1),
+		"method": "wc_sessionPropose",
+		"params": map[string]any{"proposer": map[string]any{"publicKey": ""}},
+	}
+	payloadJSON, _ := json.Marshal(proposal)
+	encrypted, _ := EncryptType0Envelope(symKey, payloadJSON)
+
+	require.NotPanics(t, func() {
+		client.handleRelayMessage("topic", encrypted, tagSessionPropose)
+	})
+}
+
+func TestClient_HandleRelayMessage_SessionProposal_NoHandler_UsesSignal(t *testing.T) {
+	client, _ := NewClient("test")
+
+	symKey := "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+	client.mu.Lock()
+	client.pairingTopics["topic"] = symKey
+	client.mu.Unlock()
+
+	proposal := map[string]any{
+		"id":     int64(42),
+		"method": "wc_sessionPropose",
+		"params": map[string]any{"proposer": map[string]any{"publicKey": "abcd1234"}},
+	}
+	payloadJSON, _ := json.Marshal(proposal)
+	encrypted, _ := EncryptType0Envelope(symKey, payloadJSON)
+
+	require.NotPanics(t, func() {
+		client.handleRelayMessage("topic", encrypted, tagSessionPropose)
+	})
+
+	time.Sleep(10 * time.Millisecond)
+
+	client.mu.Lock()
+	_, exists := client.pendingProposals["42"]
+	client.mu.Unlock()
+	require.True(t, exists)
+}
+
+func TestClient_HandleRelayMessage_JSONRPCResponse_UnknownID(t *testing.T) {
+	client, _ := NewClient("test")
+
+	symKey := "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+	client.mu.Lock()
+	client.activeSessions["topic"] = symKey
+	client.mu.Unlock()
+
+	resp := map[string]any{"jsonrpc": "2.0", "id": int64(9999), "result": true}
+	respJSON, _ := json.Marshal(resp)
+	encrypted, _ := EncryptType0Envelope(symKey, respJSON)
+
+	require.NotPanics(t, func() {
+		client.handleRelayMessage("topic", encrypted, tagSessionSettleResponse)
+	})
+}
+
+func TestClient_HandleRelayMessage_JSONRPCResponse_WithError(t *testing.T) {
+	client, _ := NewClient("test")
+
+	symKey := "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+	client.mu.Lock()
+	client.activeSessions["topic"] = symKey
+	client.mu.Unlock()
+
+	ch := client.registerPending(777)
+
+	resp := map[string]any{
+		"jsonrpc": "2.0",
+		"id":      int64(777),
+		"error":   map[string]any{"code": 5000, "message": "rejected"},
+	}
+	respJSON, _ := json.Marshal(resp)
+	encrypted, _ := EncryptType0Envelope(symKey, respJSON)
+
+	client.handleRelayMessage("topic", encrypted, tagSessionSettleResponse)
+
+	select {
+	case r := <-ch:
+		require.NotNil(t, r.Error)
+		require.Equal(t, "rejected", r.Error.Message)
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("expected error response")
+	}
+}
+
+func TestClient_HandleRelayMessage_SessionRequest_NoHandler_UsesSignal(t *testing.T) {
+	client, _ := NewClient("test")
+
+	symKey := "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+	client.mu.Lock()
+	client.activeSessions["topic"] = symKey
+	client.mu.Unlock()
+
+	req := map[string]any{
+		"id":     int64(1),
+		"method": "wc_sessionRequest",
+		"params": map[string]any{"request": map[string]any{"method": "personal_sign"}},
+	}
+	reqJSON, _ := json.Marshal(req)
+	encrypted, _ := EncryptType0Envelope(symKey, reqJSON)
+
+	require.NotPanics(t, func() {
+		client.handleRelayMessage("topic", encrypted, tagSessionRequest)
+	})
+}
+
+func TestClient_HandleRelayMessage_UnknownMethod(t *testing.T) {
+	client, _ := NewClient("test")
+
+	symKey := "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+	client.mu.Lock()
+	client.activeSessions["topic"] = symKey
+	client.mu.Unlock()
+
+	msg := map[string]any{
+		"id":     int64(1),
+		"method": "wc_unknownFutureMethod",
+		"params": map[string]any{},
+	}
+	msgJSON, _ := json.Marshal(msg)
+	encrypted, _ := EncryptType0Envelope(symKey, msgJSON)
+
+	require.NotPanics(t, func() {
+		client.handleRelayMessage("topic", encrypted, 9999)
+	})
+}
+
+func TestClient_HandleRelayMessage_InvalidJSON(t *testing.T) {
+	client, _ := NewClient("test")
+
+	symKey := "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+	client.mu.Lock()
+	client.activeSessions["topic"] = symKey
+	client.mu.Unlock()
+
+	encrypted, _ := EncryptType0Envelope(symKey, []byte("not-json"))
+
+	require.NotPanics(t, func() {
+		client.handleRelayMessage("topic", encrypted, tagSessionRequest)
+	})
+}
+
+func TestClient_Publish(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	relay := NewMockRelay(ctrl)
+	client := newTestClient(relay)
+
+	relay.EXPECT().Publish("topic", "message", tagSessionEvent).Return(nil)
+
+	err := client.Publish("topic", "message", tagSessionEvent)
+	require.NoError(t, err)
 }

--- a/services/connector/walletconnect/helpers.go
+++ b/services/connector/walletconnect/helpers.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"time"
+
+	"go.uber.org/zap"
 )
 
 // sessionKeys holds the cryptographic keys for a session
@@ -80,8 +82,9 @@ func (c *Client) sendProposalResponse(pc *pairingContext, keys *sessionKeys) err
 	return c.relay.Publish(pc.PairingTopic, encrypted, tagSessionProposeResult)
 }
 
-// buildNamespaces constructs the session namespaces from metadata and proposal
-func buildNamespaces(meta SessionMetadata, proposal *ProposalParams) (map[string]Namespace, []string, []string) {
+// BuildNamespaces constructs the session namespaces from metadata and proposal.
+// Exported for use in session updates.
+func BuildNamespaces(meta SessionMetadata, proposal *ProposalParams) (map[string]Namespace, []string, []string) {
 	// Deduplicate chain IDs
 	chainIDsSet := make(map[int64]bool)
 	for _, id := range meta.Chains {
@@ -172,6 +175,7 @@ func (c *Client) sendSessionSettle(keys *sessionKeys, proposal *ProposalParams, 
 		Namespaces: map[string]Namespace{
 			"eip155": {
 				Accounts: eip155Ns.Accounts,
+				Chains:   eip155Ns.Chains,
 				Methods:  eip155Ns.Methods,
 				Events:   eip155Ns.Events,
 			},
@@ -182,6 +186,7 @@ func (c *Client) sendSessionSettle(keys *sessionKeys, proposal *ProposalParams, 
 	}
 
 	settleID := payloadID()
+	ch := c.registerPending(settleID)
 	settlePayload := JSONRPCRequest{
 		ID:      settleID,
 		JSONRPC: "2.0",
@@ -199,7 +204,21 @@ func (c *Client) sendSessionSettle(keys *sessionKeys, proposal *ProposalParams, 
 		return fmt.Errorf("encrypt settle: %w", err)
 	}
 
-	return c.relay.Publish(keys.SessionTopic, encrypted, tagSessionSettle)
+	if err := c.relay.Publish(keys.SessionTopic, encrypted, tagSessionSettle); err != nil {
+		return err
+	}
+
+	select {
+	case resp := <-ch:
+		if resp.Error != nil {
+			c.logger.Warn("dapp rejected settle", zap.Int("code", resp.Error.Code), zap.String("message", resp.Error.Message))
+			return fmt.Errorf("settle rejected: %s", resp.Error.Message)
+		}
+	case <-time.After(15 * time.Second):
+		c.cancelPending(settleID)
+		c.logger.Debug("settle response timeout (non-fatal)")
+	}
+	return nil
 }
 
 // buildSessionObject creates the final Session object for persistence

--- a/services/connector/walletconnect/helpers_test.go
+++ b/services/connector/walletconnect/helpers_test.go
@@ -1,0 +1,372 @@
+package walletconnect
+
+import (
+	"encoding/hex"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// --- BuildNamespaces tests ---
+
+func TestBuildNamespaces_DefaultMethodsAndEvents(t *testing.T) {
+	meta := SessionMetadata{
+		Account: "0x1234567890abcdef1234567890abcdef12345678",
+		ChainID: 1,
+		Chains:  []int64{1},
+	}
+	proposal := &ProposalParams{}
+
+	namespaces, chains, accounts := BuildNamespaces(meta, proposal)
+
+	require.Contains(t, namespaces, "eip155")
+	ns := namespaces["eip155"]
+	require.Contains(t, ns.Methods, "eth_sendTransaction")
+	require.Contains(t, ns.Methods, "personal_sign")
+	require.Contains(t, ns.Methods, "eth_signTypedData")
+	require.Contains(t, ns.Methods, "eth_signTypedData_v4")
+	require.Contains(t, ns.Events, "accountsChanged")
+	require.Contains(t, ns.Events, "chainChanged")
+	require.Contains(t, chains, "eip155:1")
+	require.Contains(t, accounts, "eip155:1:"+meta.Account)
+}
+
+func TestBuildNamespaces_OverridesMethodsFromRequiredNamespaces(t *testing.T) {
+	meta := SessionMetadata{
+		Account: "0xabc",
+		ChainID: 1,
+		Chains:  []int64{1},
+	}
+	proposal := &ProposalParams{
+		RequiredNamespaces: map[string]Namespace{
+			"eip155": {
+				Methods: []string{"custom_method_a", "custom_method_b"},
+				Events:  []string{"custom_event"},
+			},
+		},
+	}
+
+	namespaces, _, _ := BuildNamespaces(meta, proposal)
+
+	ns := namespaces["eip155"]
+	require.Equal(t, []string{"custom_method_a", "custom_method_b"}, ns.Methods)
+	require.Equal(t, []string{"custom_event"}, ns.Events)
+}
+
+func TestBuildNamespaces_EmptyRequiredMethodsKeepsDefaults(t *testing.T) {
+	meta := SessionMetadata{
+		Account: "0x1234",
+		ChainID: 1,
+		Chains:  []int64{1},
+	}
+	proposal := &ProposalParams{
+		RequiredNamespaces: map[string]Namespace{
+			"eip155": {
+				Methods: []string{}, // empty — should keep defaults
+				Events:  []string{}, // empty — should keep defaults
+			},
+		},
+	}
+
+	namespaces, _, _ := BuildNamespaces(meta, proposal)
+
+	ns := namespaces["eip155"]
+	require.Contains(t, ns.Methods, "eth_sendTransaction")
+	require.Contains(t, ns.Events, "accountsChanged")
+}
+
+func TestBuildNamespaces_DeduplicatesChainIDs(t *testing.T) {
+	meta := SessionMetadata{
+		Account: "0x1234",
+		ChainID: 1,                // same as first element in Chains
+		Chains:  []int64{1, 1, 2}, // 1 appears twice
+	}
+	proposal := &ProposalParams{}
+
+	namespaces, chains, accounts := BuildNamespaces(meta, proposal)
+
+	ns := namespaces["eip155"]
+	require.Len(t, ns.Chains, 2, "should deduplicate chain IDs")
+	require.Len(t, chains, 2)
+	require.Len(t, accounts, 2)
+}
+
+func TestBuildNamespaces_MultipleChains(t *testing.T) {
+	meta := SessionMetadata{
+		Account: "0xABCdef",
+		ChainID: 10,
+		Chains:  []int64{1, 137}, // 10 + 1 + 137 = 3 unique
+	}
+	proposal := &ProposalParams{}
+
+	namespaces, chains, accounts := BuildNamespaces(meta, proposal)
+
+	ns := namespaces["eip155"]
+	require.Len(t, ns.Chains, 3)
+	require.Len(t, chains, 3)
+	require.Len(t, accounts, 3)
+	for _, acc := range ns.Accounts {
+		require.Contains(t, acc, "0xABCdef")
+	}
+}
+
+// --- computeExpiry tests ---
+
+func TestComputeExpiry_WithPositiveExpiry(t *testing.T) {
+	requested := int64(1000000000)
+	result := computeExpiry(requested)
+	require.Equal(t, requested, result)
+}
+
+func TestComputeExpiry_WithZeroUsesDefault(t *testing.T) {
+	before := time.Now().Unix()
+	result := computeExpiry(0)
+	after := time.Now().Unix()
+
+	require.GreaterOrEqual(t, result, before+defaultSessionExpirySecs)
+	require.LessOrEqual(t, result, after+defaultSessionExpirySecs)
+}
+
+// --- buildSessionObject tests ---
+
+func makeTestSessionKeys(t *testing.T, proposerPub []byte) *sessionKeys {
+	t.Helper()
+
+	priv, pub, err := GenerateX25519KeyPair()
+	require.NoError(t, err)
+
+	sharedSecret, err := DeriveSharedSecret(priv, proposerPub)
+	require.NoError(t, err)
+
+	sessionSymKey, err := DeriveSymmetricKey(sharedSecret)
+	require.NoError(t, err)
+
+	return &sessionKeys{
+		PrivateKey:       priv,
+		PublicKey:        pub,
+		SharedSecret:     sharedSecret,
+		SessionSymKey:    sessionSymKey,
+		SessionSymKeyHex: hex.EncodeToString(sessionSymKey),
+		PublicKeyHex:     hex.EncodeToString(pub),
+		SessionTopic:     DeriveSessionTopic(sessionSymKey),
+	}
+}
+
+func TestBuildSessionObject_Basic(t *testing.T) {
+	_, proposerPub, err := GenerateX25519KeyPair()
+	require.NoError(t, err)
+
+	keys := makeTestSessionKeys(t, proposerPub)
+
+	pc := &pairingContext{
+		PairingTopic:   "pairing-topic-xyz",
+		PairingSymKey:  "pairing-sym-key",
+		ProposerPubKey: hex.EncodeToString(proposerPub),
+		JsonRpcID:      42,
+	}
+
+	proposal := &ProposalParams{
+		Relays: []RelayProtocol{{Protocol: "irn"}},
+		Proposer: SessionParticipant{
+			PublicKey: hex.EncodeToString(proposerPub),
+			Metadata: PeerMetadata{
+				Name:        "Test DApp",
+				URL:         "https://testdapp.com",
+				Description: "A test dapp",
+				Icons:       []string{"https://testdapp.com/icon.png"},
+			},
+		},
+	}
+
+	meta := SessionMetadata{
+		Account: "0x1234567890abcdef",
+		ChainID: 1,
+		Chains:  []int64{1},
+	}
+
+	namespaces, _, _ := BuildNamespaces(meta, proposal)
+	expiry := int64(9999999999)
+
+	session, err := buildSessionObject(pc, keys, proposal, meta, namespaces, expiry)
+	require.NoError(t, err)
+	require.NotNil(t, session)
+	require.Equal(t, keys.SessionTopic, session.Topic)
+	require.Equal(t, "pairing-topic-xyz", session.PairingTopic)
+	require.Equal(t, "irn", session.Relay.Protocol)
+	require.Equal(t, keys.PublicKeyHex, session.Self.PublicKey)
+	require.Equal(t, "Status", session.Self.Metadata.Name)
+	require.Equal(t, "https://status.im", session.Self.Metadata.URL)
+	require.Equal(t, hex.EncodeToString(proposerPub), session.Peer.PublicKey)
+	require.Equal(t, "Test DApp", session.Peer.Metadata.Name)
+	require.Equal(t, "https://testdapp.com/icon.png", session.Peer.Metadata.Icons[0])
+	require.Equal(t, expiry, session.Expiry)
+	require.False(t, session.Acknowledged)
+	require.Equal(t, keys.PublicKeyHex, session.Controller)
+}
+
+func TestBuildSessionObject_UsesDAppIconFallback(t *testing.T) {
+	_, proposerPub, err := GenerateX25519KeyPair()
+	require.NoError(t, err)
+
+	keys := makeTestSessionKeys(t, proposerPub)
+
+	pc := &pairingContext{
+		PairingTopic:   "pairing-topic",
+		ProposerPubKey: hex.EncodeToString(proposerPub),
+	}
+
+	proposal := &ProposalParams{
+		Proposer: SessionParticipant{
+			Metadata: PeerMetadata{
+				Icons: []string{}, // no icons from proposer
+			},
+		},
+	}
+
+	meta := SessionMetadata{
+		Account:  "0x1234",
+		ChainID:  1,
+		Chains:   []int64{1},
+		DAppIcon: "https://fallback-icon.com/icon.png",
+	}
+
+	namespaces, _, _ := BuildNamespaces(meta, proposal)
+	session, err := buildSessionObject(pc, keys, proposal, meta, namespaces, 0)
+	require.NoError(t, err)
+	require.Equal(t, []string{"https://fallback-icon.com/icon.png"}, session.Peer.Metadata.Icons)
+}
+
+func TestBuildSessionObject_DefaultRelayProtocol(t *testing.T) {
+	_, proposerPub, err := GenerateX25519KeyPair()
+	require.NoError(t, err)
+
+	keys := makeTestSessionKeys(t, proposerPub)
+
+	pc := &pairingContext{
+		PairingTopic:   "topic",
+		ProposerPubKey: hex.EncodeToString(proposerPub),
+	}
+
+	// No relays in proposal — should default to "irn"
+	proposal := &ProposalParams{}
+
+	meta := SessionMetadata{ChainID: 1, Chains: []int64{1}}
+	namespaces, _, _ := BuildNamespaces(meta, proposal)
+
+	session, err := buildSessionObject(pc, keys, proposal, meta, namespaces, 0)
+	require.NoError(t, err)
+	require.Equal(t, "irn", session.Relay.Protocol)
+}
+
+func TestBuildSessionObject_ProposalRelayProtocolUsed(t *testing.T) {
+	_, proposerPub, err := GenerateX25519KeyPair()
+	require.NoError(t, err)
+
+	keys := makeTestSessionKeys(t, proposerPub)
+
+	pc := &pairingContext{
+		PairingTopic:   "topic",
+		ProposerPubKey: hex.EncodeToString(proposerPub),
+	}
+
+	proposal := &ProposalParams{
+		Relays: []RelayProtocol{{Protocol: "custom-relay"}},
+	}
+
+	meta := SessionMetadata{ChainID: 1, Chains: []int64{1}}
+	namespaces, _, _ := BuildNamespaces(meta, proposal)
+
+	session, err := buildSessionObject(pc, keys, proposal, meta, namespaces, 0)
+	require.NoError(t, err)
+	require.Equal(t, "custom-relay", session.Relay.Protocol)
+}
+
+func TestBuildSessionObject_RequiredNamespacesExcludesAccounts(t *testing.T) {
+	_, proposerPub, err := GenerateX25519KeyPair()
+	require.NoError(t, err)
+
+	keys := makeTestSessionKeys(t, proposerPub)
+
+	pc := &pairingContext{
+		PairingTopic:   "topic",
+		ProposerPubKey: hex.EncodeToString(proposerPub),
+	}
+
+	proposal := &ProposalParams{}
+	meta := SessionMetadata{Account: "0xabc", ChainID: 1, Chains: []int64{1}}
+	namespaces, _, _ := BuildNamespaces(meta, proposal)
+
+	session, err := buildSessionObject(pc, keys, proposal, meta, namespaces, 0)
+	require.NoError(t, err)
+
+	// RequiredNamespaces should have chains, methods, events but NOT accounts
+	reqNs := session.RequiredNamespaces["eip155"]
+	require.Empty(t, reqNs.Accounts)
+	require.NotEmpty(t, reqNs.Chains)
+	require.NotEmpty(t, reqNs.Methods)
+
+	// Namespaces (full) should have accounts
+	fullNs := session.Namespaces["eip155"]
+	require.NotEmpty(t, fullNs.Accounts)
+}
+
+// --- performKeyExchange tests ---
+
+func TestPerformKeyExchange_InvalidHex(t *testing.T) {
+	client, err := NewClient("test")
+	require.NoError(t, err)
+
+	_, err = client.performKeyExchange("not-valid-hex!!!")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "decode proposer public key")
+}
+
+func TestPerformKeyExchange_WrongLength(t *testing.T) {
+	client, err := NewClient("test")
+	require.NoError(t, err)
+
+	// 16 bytes = valid hex but wrong key length for X25519
+	shortKeyHex := hex.EncodeToString(make([]byte, 16))
+	_, err = client.performKeyExchange(shortKeyHex)
+	require.Error(t, err)
+	require.ErrorIs(t, err, ErrInvalidPublicKey)
+}
+
+func TestPerformKeyExchange_Valid(t *testing.T) {
+	client, err := NewClient("test")
+	require.NoError(t, err)
+
+	_, proposerPub, err := GenerateX25519KeyPair()
+	require.NoError(t, err)
+
+	keys, err := client.performKeyExchange(hex.EncodeToString(proposerPub))
+	require.NoError(t, err)
+	require.NotNil(t, keys)
+	require.Len(t, keys.PrivateKey, 32)
+	require.Len(t, keys.PublicKey, 32)
+	require.Len(t, keys.SharedSecret, 32)
+	require.Len(t, keys.SessionSymKey, 32)
+	require.NotEmpty(t, keys.SessionSymKeyHex)
+	require.NotEmpty(t, keys.PublicKeyHex)
+	require.NotEmpty(t, keys.SessionTopic)
+}
+
+func TestPerformKeyExchange_DifferentCallsProduceDifferentKeys(t *testing.T) {
+	client, err := NewClient("test")
+	require.NoError(t, err)
+
+	_, proposerPub, err := GenerateX25519KeyPair()
+	require.NoError(t, err)
+
+	proposerPubHex := hex.EncodeToString(proposerPub)
+
+	keys1, err := client.performKeyExchange(proposerPubHex)
+	require.NoError(t, err)
+
+	keys2, err := client.performKeyExchange(proposerPubHex)
+	require.NoError(t, err)
+
+	// Different ephemeral keys should produce different session topics
+	require.NotEqual(t, keys1.SessionTopic, keys2.SessionTopic)
+}

--- a/services/connector/walletconnect/interfaces.go
+++ b/services/connector/walletconnect/interfaces.go
@@ -1,0 +1,15 @@
+package walletconnect
+
+//go:generate go tool mockgen -source=interfaces.go -destination=relay_mock_test.go -package=walletconnect
+
+// Relay is the interface for the WalletConnect relay transport.
+// It is implemented by RelayClient and can be substituted with a mock in tests.
+type Relay interface {
+	Connect() error
+	Close() error
+	Subscribe(topic string) (string, error)
+	Publish(topic, message string, tag int) error
+	FetchMessages(topic string) ([]RelayMessage, bool, error)
+	SetMessageHandler(handler MessageHandler)
+	SetReconnectedHandler(handler ReconnectedHandler)
+}

--- a/services/connector/walletconnect/relay.go
+++ b/services/connector/walletconnect/relay.go
@@ -91,18 +91,23 @@ func (r *jsonRPCResponse) idString() string {
 // MessageHandler is called when a subscription message is received.
 type MessageHandler func(topic, message string, tag int)
 
+// ReconnectedHandler is called after a successful reconnection.
+type ReconnectedHandler func()
+
 // RelayClient implements the WalletConnect IRN relay protocol over WebSocket.
 type RelayClient struct {
-	url            string
-	conn           *websocket.Conn
-	mu             sync.Mutex
-	pending        map[string]chan *jsonRPCResponse
-	messageHandler MessageHandler
-	logger         *zap.Logger
-	projectID      string
-	auth           *Auth
-	done           chan struct{}  // signals shutdown
-	wg             sync.WaitGroup // tracks active goroutines
+	url                 string
+	conn                *websocket.Conn
+	mu                  sync.Mutex
+	pending             map[string]chan *jsonRPCResponse
+	messageHandler      MessageHandler
+	reconnectedHandler  ReconnectedHandler
+	logger              *zap.Logger
+	projectID           string
+	auth                *Auth
+	done                chan struct{}  // signals shutdown
+	disconnectRequested bool           // true if Close() was called intentionally
+	wg                  sync.WaitGroup // tracks active goroutines
 }
 
 // NewRelayClient creates a new relay client.
@@ -149,7 +154,6 @@ func (r *RelayClient) Connect() error {
 	if err != nil {
 		return fmt.Errorf("dial relay: %w", err)
 	}
-
 	r.conn = conn
 
 	r.wg.Add(1)
@@ -161,11 +165,13 @@ func (r *RelayClient) Connect() error {
 func (r *RelayClient) Close() error {
 	r.mu.Lock()
 	if r.conn == nil {
+		r.disconnectRequested = true
 		r.mu.Unlock()
 		return nil
 	}
 	conn := r.conn
 	r.conn = nil
+	r.disconnectRequested = true
 	r.mu.Unlock()
 
 	// Signal shutdown
@@ -250,6 +256,14 @@ func (r *RelayClient) SetMessageHandler(handler MessageHandler) {
 	r.messageHandler = handler
 }
 
+// SetReconnectedHandler sets the callback that is invoked after a successful reconnection.
+// The handler should re-subscribe to all active topics.
+func (r *RelayClient) SetReconnectedHandler(handler ReconnectedHandler) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.reconnectedHandler = handler
+}
+
 func (r *RelayClient) call(method string, params any) (json.RawMessage, error) {
 	// Generate WalletConnect-compliant numeric ID with 19 digits of entropy
 	id := payloadID()
@@ -308,15 +322,39 @@ func (r *RelayClient) readLoop() {
 	for {
 		r.mu.Lock()
 		conn := r.conn
+		disconnectRequested := r.disconnectRequested
 		r.mu.Unlock()
-		if conn == nil {
+
+		if conn == nil || disconnectRequested {
 			return
 		}
 
 		_, msg, err := conn.ReadMessage()
 		if err != nil {
 			r.logger.Debug("relay read error", zap.Error(err))
-			return
+
+			r.mu.Lock()
+			wasIntentional := r.disconnectRequested
+			r.mu.Unlock()
+
+			if wasIntentional {
+				return
+			}
+
+			r.mu.Lock()
+			if r.conn != nil {
+				r.conn.Close()
+				r.conn = nil
+			}
+			r.mu.Unlock()
+
+			r.logger.Info("attempting to reconnect to relay")
+			if reconnectErr := r.reconnect(); reconnectErr != nil {
+				r.logger.Error("failed to reconnect, exiting readLoop", zap.Error(reconnectErr))
+				return
+			}
+
+			continue
 		}
 
 		var resp jsonRPCResponse
@@ -355,4 +393,66 @@ func (r *RelayClient) readLoop() {
 		}
 		r.mu.Unlock()
 	}
+}
+
+// reconnect attempts to reconnect to the relay with exponential backoff.
+func (r *RelayClient) reconnect() error {
+	backoff := 1 * time.Second
+	maxBackoff := 60 * time.Second
+	maxAttempts := 10
+
+	for attempt := 1; attempt <= maxAttempts; attempt++ {
+		r.logger.Info("reconnect attempt", zap.Int("attempt", attempt), zap.Duration("backoff", backoff))
+
+		r.mu.Lock()
+		if r.disconnectRequested {
+			r.mu.Unlock()
+			return fmt.Errorf("disconnect requested during reconnect")
+		}
+		r.mu.Unlock()
+
+		select {
+		case <-time.After(backoff):
+		case <-r.done:
+			return fmt.Errorf("disconnect requested during reconnect")
+		}
+
+		jwt, err := r.auth.GenerateJWT(r.url)
+		if err != nil {
+			r.logger.Debug("failed to generate JWT for reconnect", zap.Error(err))
+			backoff = min(backoff*2, maxBackoff)
+			continue
+		}
+
+		u, err := url.Parse(r.url)
+		if err != nil {
+			r.logger.Error("failed to parse relay URL", zap.Error(err))
+			return fmt.Errorf("parse relay url: %w", err)
+		}
+		q := u.Query()
+		q.Set("auth", jwt)
+		q.Set("projectId", r.projectID)
+		u.RawQuery = q.Encode()
+
+		conn, _, err := websocket.DefaultDialer.Dial(u.String(), nil)
+		if err != nil {
+			r.logger.Debug("failed to dial relay", zap.Error(err), zap.Int("attempt", attempt))
+			backoff = min(backoff*2, maxBackoff)
+			continue
+		}
+
+		r.mu.Lock()
+		r.conn = conn
+		reconnectedHandler := r.reconnectedHandler
+		r.mu.Unlock()
+
+		r.logger.Info("successfully reconnected to relay")
+
+		if reconnectedHandler != nil {
+			reconnectedHandler()
+		}
+
+		return nil
+	}
+	return fmt.Errorf("failed to reconnect after %d attempts", maxAttempts)
 }

--- a/services/connector/walletconnect/relay_test.go
+++ b/services/connector/walletconnect/relay_test.go
@@ -207,3 +207,37 @@ func TestPayloadID_UniqueAcrossCalls(t *testing.T) {
 		seen[id] = true
 	}
 }
+
+func TestRelayClient_SetReconnectedHandler(t *testing.T) {
+	client, _ := NewRelayClient("test")
+
+	called := false
+	handler := func() {
+		called = true
+	}
+
+	client.SetReconnectedHandler(handler)
+
+	client.mu.Lock()
+	h := client.reconnectedHandler
+	client.mu.Unlock()
+
+	require.NotNil(t, h)
+	h()
+	require.True(t, called)
+}
+
+func TestRelayClient_DisconnectRequested(t *testing.T) {
+	client, _ := NewRelayClient("test")
+
+	require.False(t, client.disconnectRequested)
+
+	err := client.Close()
+	require.NoError(t, err)
+
+	client.mu.Lock()
+	requested := client.disconnectRequested
+	client.mu.Unlock()
+
+	require.True(t, requested)
+}

--- a/services/connector/walletconnect/types.go
+++ b/services/connector/walletconnect/types.go
@@ -82,6 +82,12 @@ type Session struct {
 	RequiredNamespaces map[string]Namespace `json:"requiredNamespaces"`
 }
 
+// SessionEvent represents a WC session event (e.g., accountsChanged, chainChanged).
+type SessionEvent struct {
+	Name string `json:"name"`
+	Data any    `json:"data"`
+}
+
 // JSONRPCRequest represents a JSON-RPC 2.0 request
 type JSONRPCRequest struct {
 	JSONRPC string `json:"jsonrpc"`

--- a/signal/events_connector.go
+++ b/signal/events_connector.go
@@ -16,6 +16,7 @@ const (
 	// WalletConnect (via connector)
 	EventWCSessionProposal = "connector.wcSessionProposal"
 	EventWCSessionRequest  = "connector.wcSessionRequest"
+	EventWCSessionDelete   = "connector.wcSessionDelete"
 )
 
 type WCSessionProposalSignal struct {
@@ -43,6 +44,18 @@ func SendWCSessionRequest(topic string, requestID int64, requestJSON string) {
 		Topic:       topic,
 		RequestID:   requestID,
 		RequestJSON: requestJSON,
+	})
+}
+
+type WCSessionDeleteSignal struct {
+	Topic   string `json:"topic"`
+	DAppURL string `json:"dappUrl"`
+}
+
+func SendWCSessionDelete(topic, dappURL string) {
+	send(EventWCSessionDelete, WCSessionDeleteSignal{
+		Topic:   topic,
+		DAppURL: dappURL,
 	})
 }
 


### PR DESCRIPTION
- Disconnecting WC sessions from the client
- Connector now listens for `wc_sessionDelete` events from the relay
- Active sessions are restored from the database and reconnected to the relay automatically
- `ApproveWCSession` now accepts a list of supported chains alongside the primary chain
- `UpdateWCSessionChains` API to update the chain list on an existing session without re-pairing
- Unit tests 

* fix `make test-unit`

Fixes status-im/status-app#19954
linked with https://github.com/status-im/status-app/pull/20023