### PR TITLE
fix(wallet): missing mapping from BNB token to CoinGecko ID

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -320,8 +320,10 @@ status-backend: ##@build Build status-backend to run status-go as HTTP server
 status-backend: build/bin/status-backend
 
 run-status-backend: PORT ?= 0
+run-status-backend: $(LIBSDS)
 run-status-backend: generate
 run-status-backend: ##@run Start status-backend server listening to localhost:PORT
+	LD_LIBRARY_PATH="$(NIM_SDS_LIB_DIR)" CGO_LDFLAGS="$(CGO_LDFLAGS)" CGO_CFLAGS="$(CGO_CFLAGS)" \
 	go run -mod=mod ./cmd/status-backend --address localhost:${PORT}
 
 push-notification-server: ##@build Build push-notification-server

--- a/services/wallet/multistandardbalance/fetcher.go
+++ b/services/wallet/multistandardbalance/fetcher.go
@@ -15,7 +15,9 @@ import (
 	"github.com/status-im/status-go/internal/rpc/chain/ethclient"
 )
 
-const DefaultBatchSize = 10000
+// DefaultBatchSize is the maximum number of Multicall3 calls per RPC request.
+// More than 2700 calls produces >1MB request body and proxy returns 413
+const DefaultBatchSize = 2500
 
 type EthClientGetter interface {
 	EthClient(chainID uint64) (ethclient.EthClientInterface, error)

--- a/services/wallet/thirdparty/market/coingecko/client.go
+++ b/services/wallet/thirdparty/market/coingecko/client.go
@@ -96,8 +96,12 @@ func (c *Client) getCoingeckoTokensByTokenKey() (map[string]GeckoToken, error) {
 	for _, chainID := range walletcommon.AllChainIDsAsUint64() {
 		token := tokentypes.Token{Token: &types.Token{ChainID: chainID}}
 
-		// native token for BSC chain doesn't have the coingecko ID, so skip it
 		if chainID == walletcommon.BSCMainnet || chainID == walletcommon.BSCTestnet {
+			coingeckoTokensByTokenKey[token.Key()] = GeckoToken{
+				ID:     nativeBNBTokenID,
+				Name:   builder.BinanceSmartChainNativeName,
+				Symbol: builder.BinanceSmartChainNativeSymbol,
+			}
 			continue
 		}
 

--- a/services/wallet/thirdparty/market/coingecko/client_test.go
+++ b/services/wallet/thirdparty/market/coingecko/client_test.go
@@ -67,8 +67,12 @@ func TestGetTokensSuccess(t *testing.T) {
 	for _, chainID := range common.AllChains {
 		token := tokentypes.Token{Token: &types.Token{ChainID: chainID}}
 
-		// native token for BSC chain doesn't have the coingecko ID, so skip it
 		if chainID == common.BSCMainnet || chainID == common.BSCTestnet {
+			expectedMap[token.Key()] = GeckoToken{
+				ID:     nativeBNBTokenID,
+				Name:   builder.BinanceSmartChainNativeName,
+				Symbol: builder.BinanceSmartChainNativeSymbol,
+			}
 			continue
 		}
 

--- a/services/wallet/thirdparty/market/coingecko/request_coins_list.go
+++ b/services/wallet/thirdparty/market/coingecko/request_coins_list.go
@@ -18,6 +18,7 @@ const (
 	coinsListURL = "%s/coins/list"
 
 	nativeEthTokenID = "ethereum"
+	nativeBNBTokenID = "binancecoin"
 )
 
 type GeckoToken struct {


### PR DESCRIPTION
BNB balance always showed $0 in the wallet even though the raw on-chain
balance was non-zero. `wallet_fetchPrices` returned `{"usd": 0}` for
the native BSC token (`56-0x0000...`)

1) Fix price fetching: Added mapping BSC native token to CoinGecko ID `binancecoin`
2) Fix multicall 413 errors 
3) unrelated: fixed `make run-status-backend`

<img width="1212" height="686" alt="image" src="https://github.com/user-attachments/assets/64ec3632-76c5-4c25-b678-1f41261421e5" />


fixes status-im/status-app#20004 