### PR TITLE
refactor(wallet): enhance transactions history

### DIFF
--- a/services/wallet/activity/activity_v2.go
+++ b/services/wallet/activity/activity_v2.go
@@ -237,20 +237,20 @@ func getEntriesByTransactionIDs(ctx context.Context, deps FilterDependencies, tx
 }
 
 // mergeAndOrderEntries combines entries from sent and fetched sources
-func mergeAndOrderEntries(sentEntries, fetchedEntries map[string]Entry, orderedIDs []OrderedTransactionID) []Entry {
-	entries := make([]Entry, 0, len(orderedIDs))
+func mergeAndOrderEntries(sentEntries, fetchedEntries map[string][]Entry, orderedIDs []OrderedTransactionID) []Entry {
+	allEntries := make([]Entry, 0)
 
 	for _, txID := range orderedIDs {
 		key := txID.Key()
 
-		if entry, exists := sentEntries[key]; exists {
-			entries = append(entries, entry)
-		} else if entry, exists := fetchedEntries[key]; exists {
-			entries = append(entries, entry)
+		if entries, exists := sentEntries[key]; exists {
+			allEntries = append(allEntries, entries...)
+		} else if entries, exists := fetchedEntries[key]; exists {
+			allEntries = append(allEntries, entries...)
 		}
 	}
 
-	return entries
+	return allEntries
 }
 
 func getFinalizationPeriod(chainID wCommon.ChainID) int64 {

--- a/services/wallet/activity/activity_v2_test.go
+++ b/services/wallet/activity/activity_v2_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/status-im/status-go/services/wallet/pendingtxtracker"
 	"github.com/status-im/status-go/services/wallet/requests"
 	"github.com/status-im/status-go/services/wallet/routeexecution/storage"
+	pathProcessorCommon "github.com/status-im/status-go/services/wallet/router/pathprocessor/common"
 	"github.com/status-im/status-go/services/wallet/router/routes"
 	"github.com/status-im/status-go/services/wallet/thirdparty/activity/alchemy"
 	tokentypes "github.com/status-im/status-go/services/wallet/token/types"
@@ -117,6 +118,7 @@ func createTransactionData(fromAddr eth.Address, toAddr eth.Address, value *big.
 // createRouterPath creates a router path for testing
 func createRouterPath(fromToken, toToken *tokentypes.Token, value *big.Int) *routes.Path {
 	return &routes.Path{
+		ProcessorName: pathProcessorCommon.ProcessorTransferName,
 		FromChain: &params.Network{
 			ChainID: fromToken.ChainID,
 		},
@@ -840,6 +842,123 @@ func TestGetTransactionsOrder_SameHashDifferentChains(t *testing.T) {
 
 	require.True(t, foundEthereumTx, "Should find Ethereum transaction")
 	require.True(t, foundPolygonTx, "Should find Polygon transaction")
+}
+
+func newTestFilterDeps(db *sql.DB) FilterDependencies {
+	return FilterDependencies{
+		db:               db,
+		tokenSymbol:      func(_ ac.Token) string { return "" },
+		currentTimestamp: func() int64 { return time.Now().Unix() },
+	}
+}
+
+func countEntriesByType(entries []Entry, t ac.Type) int {
+	n := 0
+	for _, e := range entries {
+		if e.activityType == t {
+			n++
+		}
+	}
+	return n
+}
+
+// TestGetActivityEntries_SelfSend_SuccessProducesTwoEntries verifies that a successful
+// self-send transaction (sender == recipient) produces both a SendAT and a ReceiveAT entry.
+//
+// When a wallet sends ETH to itself (same address on the same chain), the activity list
+// should show the transaction twice — once as a send and once as a receive.
+// This only applies to confirmed (Success) transactions; pending ones only show SendAT.
+func TestGetActivityEntries_SelfSend_SuccessProducesTwoEntries(t *testing.T) {
+	db, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	selfAddr := TestSenderAddr
+	timestamp := int64(1757333323)
+	weiValue := new(big.Int).Mul(big.NewInt(1), big.NewInt(gethParams.Ether/1000)) // 0.001 ETH
+
+	txHash := createEthereumTransaction(selfAddr, weiValue).Hash()
+
+	// Sent transaction (success) where from == to
+	insertTestSavedTransaction(t, db, txHash, selfAddr, selfAddr, weiValue, TestEthereumChainToken, TestEthereumChainToken, timestamp, "self-send-success-uuid")
+	// Corresponding Alchemy transfer (single row for address == selfAddr)
+	insertTestAlchemyTransfer(t, db, selfAddr, txHash, timestamp, 0.001, TestEthereumChainToken, selfAddr, selfAddr)
+
+	addresses := []eth.Address{selfAddr}
+	chainIDs := []walletCommon.ChainID{walletCommon.ChainID(TestEthereumChainToken.ChainID)}
+
+	txIDs, err := getTransactionsOrder(context.Background(), db, addresses, chainIDs, Filter{}, DefaultOffset, DefaultLimit)
+	require.NoError(t, err)
+	require.Len(t, txIDs, 1, "Self-send should yield 1 ordered transaction ID")
+	require.Equal(t, SentTransaction, txIDs[0].Source, "Sent tx should take priority over fetched")
+
+	entries, err := getEntriesByTransactionIDs(context.Background(), newTestFilterDeps(db), txIDs)
+	require.NoError(t, err)
+	require.Len(t, entries, 2, "Successful self-send must produce 2 entries (send + receive)")
+	require.Equal(t, 1, countEntriesByType(entries, ac.SendAT), "Should have exactly 1 SendAT entry")
+	require.Equal(t, 1, countEntriesByType(entries, ac.ReceiveAT), "Should have exactly 1 ReceiveAT entry")
+}
+
+// TestGetActivityEntries_SelfSend_PendingProducesOneEntry verifies that a pending
+// self-send only produces a single SendAT entry.
+//
+// Until a transaction is confirmed, the wallet cannot guarantee the funds were received,
+// so only the outgoing side is shown.
+func TestGetActivityEntries_SelfSend_PendingProducesOneEntry(t *testing.T) {
+	db, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	selfAddr := TestSenderAddr
+	timestamp := int64(1757333323)
+	weiValue := new(big.Int).Mul(big.NewInt(1), big.NewInt(gethParams.Ether/1000))
+
+	txHash := createEthereumTransaction(selfAddr, weiValue).Hash()
+
+	// Pending transaction where from == to (not yet confirmed)
+	insertTestPendingTransaction(t, db, TestEthereumChainToken.ChainID, txHash, selfAddr, selfAddr, weiValue, TestEthereumChainToken, TestEthereumChainToken, timestamp, "self-send-pending-uuid")
+
+	addresses := []eth.Address{selfAddr}
+	chainIDs := []walletCommon.ChainID{walletCommon.ChainID(TestEthereumChainToken.ChainID)}
+
+	txIDs, err := getTransactionsOrder(context.Background(), db, addresses, chainIDs, Filter{}, DefaultOffset, DefaultLimit)
+	require.NoError(t, err)
+	require.Len(t, txIDs, 1)
+
+	entries, err := getEntriesByTransactionIDs(context.Background(), newTestFilterDeps(db), txIDs)
+	require.NoError(t, err)
+	require.Len(t, entries, 1, "Pending self-send must produce only 1 entry (no receive until confirmed)")
+	require.Equal(t, ac.SendAT, entries[0].activityType, "The single entry must be SendAT")
+}
+
+// TestGetActivityEntries_SelfSend_FetchedOnlyProducesTwoEntries verifies that a self-send
+// fetched from Alchemy (with no corresponding sent_transaction row) also produces two entries.
+//
+// This covers the case where the transaction was sent from outside the app (e.g. another
+// wallet) to the same address. The single Alchemy row for the account produces both a
+// SendAT and a ReceiveAT.
+func TestGetActivityEntries_SelfSend_FetchedOnlyProducesTwoEntries(t *testing.T) {
+	db, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	selfAddr := TestSenderAddr
+	txHash := eth.HexToHash("0x5678567856785678567856785678567856785678567856785678567856785678")
+	timestamp := int64(1757333323)
+
+	// Only an Alchemy transfer — no sent_transaction row
+	insertTestAlchemyTransfer(t, db, selfAddr, txHash, timestamp, 0.001, TestEthereumChainToken, selfAddr, selfAddr)
+
+	addresses := []eth.Address{selfAddr}
+	chainIDs := []walletCommon.ChainID{walletCommon.ChainID(TestEthereumChainToken.ChainID)}
+
+	txIDs, err := getTransactionsOrder(context.Background(), db, addresses, chainIDs, Filter{}, DefaultOffset, DefaultLimit)
+	require.NoError(t, err)
+	require.Len(t, txIDs, 1, "Should have 1 ordered transaction ID")
+	require.Equal(t, FetchedTransaction, txIDs[0].Source, "Should be fetched transaction")
+
+	entries, err := getEntriesByTransactionIDs(context.Background(), newTestFilterDeps(db), txIDs)
+	require.NoError(t, err)
+	require.Len(t, entries, 2, "Fetched self-send must produce 2 entries (send + receive)")
+	require.Equal(t, 1, countEntriesByType(entries, ac.SendAT), "Should have exactly 1 SendAT entry")
+	require.Equal(t, 1, countEntriesByType(entries, ac.ReceiveAT), "Should have exactly 1 ReceiveAT entry")
 }
 
 // TestGetTransactionsOrder_EmptyChainList tests validation when no chain IDs are provided.

--- a/services/wallet/activity/fetched_entries.go
+++ b/services/wallet/activity/fetched_entries.go
@@ -21,10 +21,10 @@ import (
 
 // getFetchedEntriesByIDs fetches Alchemy transaction details by IDs
 // Returns a map keyed by "chainID-hash-address" string
-func getFetchedEntriesByIDs(ctx context.Context, deps FilterDependencies, txIDs []OrderedTransactionID) (map[string]Entry, error) {
+func getFetchedEntriesByIDs(ctx context.Context, deps FilterDependencies, txIDs []OrderedTransactionID) (map[string][]Entry, error) {
 
 	if len(txIDs) == 0 {
-		return make(map[string]Entry), nil
+		return make(map[string][]Entry), nil
 	}
 
 	var chainIDs []wCommon.ChainID
@@ -40,7 +40,7 @@ func getFetchedEntriesByIDs(ctx context.Context, deps FilterDependencies, txIDs 
 	}
 
 	if len(hashStrings) == 0 {
-		return make(map[string]Entry), nil
+		return make(map[string][]Entry), nil
 	}
 
 	for chainID := range chainIDSet {
@@ -75,7 +75,7 @@ func getFetchedEntriesByIDs(ctx context.Context, deps FilterDependencies, txIDs 
 		return nil, fmt.Errorf("failed to convert rows to transfers: %w", err)
 	}
 
-	result := make(map[string]Entry)
+	result := make(map[string][]Entry)
 	for chainID, addressMap := range transfersMap {
 		for address, transfers := range addressMap {
 			var activityEntries []thirdparty.ActivityEntry = alchemy.TransfersToThirdpartyActivityEntries(transfers, uint64(chainID), address)
@@ -87,7 +87,7 @@ func getFetchedEntriesByIDs(ctx context.Context, deps FilterDependencies, txIDs 
 						entry.transaction.ChainID,
 						entry.transaction.Hash.Hex(),
 						address.Hex())
-					result[key] = entry
+					result[key] = append(result[key], entry)
 				}
 			}
 		}

--- a/services/wallet/activity/sent_entries.go
+++ b/services/wallet/activity/sent_entries.go
@@ -43,10 +43,10 @@ func newSentEntryDataV2() *sentEntryDataV2 {
 
 // getSentEntriesByIDs fetches sent transaction details by IDs
 // Returns a map keyed by "chainID-hash-address" string
-func getSentEntriesByIDs(ctx context.Context, deps FilterDependencies, txIDs []OrderedTransactionID) (map[string]Entry, error) {
+func getSentEntriesByIDs(ctx context.Context, deps FilterDependencies, txIDs []OrderedTransactionID) (map[string][]Entry, error) {
 
 	if len(txIDs) == 0 {
-		return make(map[string]Entry), nil
+		return make(map[string][]Entry), nil
 	}
 
 	var chainIDs []wCommon.ChainID
@@ -62,7 +62,7 @@ func getSentEntriesByIDs(ctx context.Context, deps FilterDependencies, txIDs []O
 	}
 
 	if len(hashes) == 0 {
-		return make(map[string]Entry), nil
+		return make(map[string][]Entry), nil
 	}
 
 	for chainID := range chainIDSet {
@@ -127,11 +127,11 @@ func getSentEntriesByIDs(ctx context.Context, deps FilterDependencies, txIDs []O
 	}
 
 	// Build the result map using ChainID-Hash-Address key format
-	result := make(map[string]Entry)
+	result := make(map[string][]Entry)
 	for _, entry := range entries {
 		if entry.transaction != nil {
 			key := entry.transaction.Key()
-			result[key] = entry
+			result[key] = append(result[key], entry) // multiple entries can have the same key if they are self-sends
 		}
 	}
 
@@ -236,6 +236,13 @@ func sentEntryDataToEntriesV2(deps FilterDependencies, data []*sentEntryDataV2) 
 
 		if entry.activityType == ac.ApproveAT {
 			entry.approvalSpender = d.Path.ApprovalContractAddress
+		}
+
+		// For self-send (sender == recipient) that succeeded, also generate a ReceiveAT entry
+		if entry.activityType == ac.SendAT && d.Status == ac.Success && d.RouteInputParams.AddrFrom == d.RouteInputParams.AddrTo {
+			receiveEntry := entry
+			receiveEntry.activityType = ac.ReceiveAT
+			ret = append(ret, receiveEntry)
 		}
 
 		ret = append(ret, entry)

--- a/services/wallet/thirdparty/activity/alchemy/conversions.go
+++ b/services/wallet/thirdparty/activity/alchemy/conversions.go
@@ -62,17 +62,42 @@ type TransferAnalytics struct {
 	inboundNonZeroTransfers  []Transfer
 }
 
+func (a TransferAnalytics) identifyTransfer(outgoing bool) *Transfer {
+	if len(a.externalTransfers) < 1 {
+		return nil
+	}
+
+	sender := a.externalTransfers[0].FromAddress
+
+	if outgoing {
+		for _, t := range a.outboundNonZeroTransfers {
+			if t.IsOutgoing(sender) {
+				return &t
+			}
+		}
+	} else {
+		for _, t := range a.inboundNonZeroTransfers {
+			if t.IsIncoming(sender) {
+				return &t
+			}
+		}
+	}
+
+	return nil
+}
+
 func (a TransferAnalytics) isContractDeployment() bool {
 	return len(a.externalTransfers) == 1 && a.externalTransfers[0].IsContractDeployment()
 }
 
 func (a TransferAnalytics) isSwapTransfer() bool {
+	outgoingTransfer := a.identifyTransfer(true)
+	inboundTransfer := a.identifyTransfer(false)
 
-	if len(a.externalTransfers) == 1 {
-		to := a.externalTransfers[0].ToAddress.Hex()
-		_, known := dexRouters[strings.ToLower(to)]
-		return known
+	if outgoingTransfer != nil && inboundTransfer != nil {
+		return outgoingTransfer.Asset != "" && inboundTransfer.Asset != "" && outgoingTransfer.Asset != inboundTransfer.Asset
 	}
+
 	return false
 }
 
@@ -86,7 +111,7 @@ func (a TransferAnalytics) isBridgeTransfer() bool {
 }
 
 func (a TransferAnalytics) isErc20Transfer() bool {
-	if len(a.externalTransfers) == 1 && len(a.tokenTransfers) == 1 {
+	if len(a.externalTransfers) == 1 && len(a.tokenTransfers) > 0 {
 		et := a.externalTransfers[0]
 		tt := a.tokenTransfers[0]
 
@@ -110,7 +135,8 @@ func analyzeTransfers(txTransfers []Transfer, chainID uint64, accountAddress com
 		if transfer.Value > 0 {
 			if transfer.IsIncoming(accountAddress) {
 				analytics.inboundNonZeroTransfers = append(analytics.inboundNonZeroTransfers, transfer)
-			} else {
+			}
+			if transfer.IsOutgoing(accountAddress) {
 				analytics.outboundNonZeroTransfers = append(analytics.outboundNonZeroTransfers, transfer)
 			}
 		}
@@ -128,8 +154,10 @@ func sameHashTransfersToThirdpartyActivityEntries(txTransfers []Transfer, chainI
 	if analytics.isContractDeployment() {
 		entries = transferToThirdpartyActivityEntries(analytics.externalTransfers[0], chainID, accountAddress)
 	} else if analytics.isSwapTransfer() {
-		if len(analytics.inboundNonZeroTransfers) == 1 && len(analytics.outboundNonZeroTransfers) == 1 {
-			entries = append(entries, makeSwapThirdpartyActivityEntry(analytics.outboundNonZeroTransfers[0], analytics.inboundNonZeroTransfers[0], chainID))
+		outgoingTransfer := analytics.identifyTransfer(true)
+		inboundTransfer := analytics.identifyTransfer(false)
+		if outgoingTransfer != nil && inboundTransfer != nil {
+			entries = append(entries, makeSwapThirdpartyActivityEntry(*outgoingTransfer, *inboundTransfer, chainID))
 		}
 	} else if analytics.isBridgeTransfer() {
 		if len(analytics.inboundNonZeroTransfers) == 0 && len(analytics.outboundNonZeroTransfers) == 1 {
@@ -218,20 +246,24 @@ func transferToThirdpartyActivityEntries(t Transfer, chainID uint64, accountAddr
 
 	entries := make([]thirdparty.ActivityEntry, 0, len(transfersTokenAndValue))
 	for _, td := range transfersTokenAndValue {
-		entry := baseEntry
 
 		if t.IsIncoming(accountAddress) {
+			entry := baseEntry
 			entry.ActivityType = ac.ReceiveAT
 			entry.ChainIDIn = &chainID
 			entry.TokenIn = &td.Token
 			entry.AmountIn = td.Value
-		} else {
+			entries = append(entries, entry)
+		}
+
+		if t.IsOutgoing(accountAddress) {
+			entry := baseEntry
 			entry.ActivityType = ac.SendAT
 			entry.ChainIDOut = &chainID
 			entry.TokenOut = &td.Token
 			entry.AmountOut = td.Value
+			entries = append(entries, entry)
 		}
-		entries = append(entries, entry)
 	}
 	return entries
 }

--- a/services/wallet/thirdparty/activity/alchemy/types.go
+++ b/services/wallet/thirdparty/activity/alchemy/types.go
@@ -74,8 +74,12 @@ func (t Transfer) IsContractDeployment() bool {
 	return t.Category == TransferCategoryExternal && t.ToAddress == nil
 }
 
+func (t Transfer) IsOutgoing(accountAddress common.Address) bool {
+	return t.FromAddress == accountAddress
+}
+
 func (t Transfer) IsIncoming(accountAddress common.Address) bool {
-	return t.FromAddress != accountAddress
+	return t.ToAddress != nil && *t.ToAddress == accountAddress
 }
 
 func (t Transfer) IsValid() bool {

--- a/services/wallet/thirdparty/activity/alchemy/types_test.go
+++ b/services/wallet/thirdparty/activity/alchemy/types_test.go
@@ -2,13 +2,18 @@ package alchemy_test
 
 import (
 	"encoding/json"
+	"math/big"
 	"testing"
+	"time"
 
 	"github.com/status-im/status-go/services/wallet/thirdparty/activity/alchemy"
 
 	"github.com/ethereum/go-ethereum/common"
 
 	"github.com/stretchr/testify/require"
+
+	ac "github.com/status-im/status-go/services/wallet/activity/common"
+	"github.com/status-im/status-go/services/wallet/bigint"
 )
 
 func TestGetAssetTransfers(t *testing.T) {
@@ -35,7 +40,7 @@ func TestTransferToCommon(t *testing.T) {
 	}
 	result := []int{
 		1000,
-		48,
+		50,
 	}
 	addresses := []common.Address{
 		common.HexToAddress("0xd8da6bf26964af9d7eed9e03e53415d37aa96045"),
@@ -48,6 +53,49 @@ func TestTransferToCommon(t *testing.T) {
 		commonResponse := alchemy.TransfersToThirdpartyActivityEntries(response.Transfers, 1, addresses[i])
 		require.Equal(t, result[i], len(commonResponse))
 	}
+}
+
+func TestTransfersToThirdpartyActivityEntries_SelfSend(t *testing.T) {
+	selfAddr := common.HexToAddress("0xabcdef1234567890abcdef1234567890abcdef12")
+	txHash := common.HexToHash("0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef")
+
+	toAddr := selfAddr
+	transfer := alchemy.Transfer{
+		Category:    alchemy.TransferCategoryExternal,
+		BlockNum:    &bigint.VarHexBigInt{Int: big.NewInt(1000)},
+		FromAddress: selfAddr,
+		ToAddress:   &toAddr,
+		Value:       1.0,
+		Asset:       "ETH",
+		UniqueID:    "self-send-unit-test",
+		Hash:        txHash,
+		RawContract: alchemy.RawContract{
+			Value: &bigint.VarHexBigInt{Int: new(big.Int).Mul(big.NewInt(1e15), big.NewInt(1))},
+		},
+		Metadata: alchemy.Metadata{
+			BlockTimestamp: time.Unix(1757333323, 0),
+		},
+	}
+
+	entries := alchemy.TransfersToThirdpartyActivityEntries([]alchemy.Transfer{transfer}, 1, selfAddr)
+
+	require.Len(t, entries, 2, "Self-send should produce 2 activity entries (send + receive)")
+
+	var sendCount, receiveCount int
+	for _, e := range entries {
+		switch e.ActivityType {
+		case ac.SendAT:
+			sendCount++
+			require.Equal(t, selfAddr, e.Sender, "SendAT sender must be selfAddr")
+			require.Equal(t, &selfAddr, e.Recipient, "SendAT recipient must be selfAddr")
+		case ac.ReceiveAT:
+			receiveCount++
+			require.Equal(t, selfAddr, e.Sender, "ReceiveAT sender must be selfAddr")
+			require.Equal(t, &selfAddr, e.Recipient, "ReceiveAT recipient must be selfAddr")
+		}
+	}
+	require.Equal(t, 1, sendCount, "Should have exactly 1 SendAT entry")
+	require.Equal(t, 1, receiveCount, "Should have exactly 1 ReceiveAT entry")
 }
 
 var malformedErc721Response = `{


### PR DESCRIPTION
- self-send transactions from and outside the app are identified as 2 entries in the activity (one for send, one for receive)
- a swap transaction made through the DApp via WalletConnect is identified the same way as the in-app made swap

Cases that we cannot improve without making 2 more requests for transaction are:
- identifying an approval tx made out of the app
- failed tx made out of the app

Refer to these comments:
- https://github.com/status-im/status-app/issues/20074#issuecomment-3973110462
- https://github.com/status-im/status-app/issues/20074#issuecomment-3973979595


Closes #https://github.com/status-im/status-app/issues/20074