### PR TITLE
fix(login): put slow operations in go routines to speed up login

### DIFF
--- a/internal/timesource/ntp.go
+++ b/internal/timesource/ntp.go
@@ -12,7 +12,6 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/status-im/status-go/common"
-	gocommon "github.com/status-im/status-go/common"
 	"github.com/status-im/status-go/internal/logutils"
 )
 
@@ -214,10 +213,6 @@ func (s *ntpTimeSource) updateOffset() error {
 // runPeriodically runs periodically the given function based on ntpTimeSource
 // synchronization limits (fastNTPSyncPeriod / slowNTPSyncPeriod)
 func (s *ntpTimeSource) runPeriodically(ctx context.Context, fn func() error, starWithSlowSyncPeriod bool) {
-	if s.started {
-		return
-	}
-
 	period := s.fastNTPSyncPeriod
 	if starWithSlowSyncPeriod {
 		period = s.slowNTPSyncPeriod
@@ -290,9 +285,11 @@ func (s *ntpTimeSource) Start(ctx context.Context) error {
 	currentTime := s.now()
 	s.lastMonotonic = currentTime
 	ctx, cancel := context.WithCancel(ctx)
+	s.cancel = cancel
+	s.started = true
 
 	go func() {
-		defer gocommon.LogOnPanic()
+		defer common.LogOnPanic()
 		err := s.updateOffset()
 		if err != nil {
 			// Failure to update can occur if the node is offline.
@@ -300,16 +297,15 @@ func (s *ntpTimeSource) Start(ctx context.Context) error {
 			logutils.ZapLogger().Error("failed to update offset", zap.Error(err))
 		}
 		s.runPeriodically(ctx, s.updateOffset, err == nil)
-		s.started = true
 	}()
-
-	s.cancel = cancel
 
 	return nil
 }
 
 // Stop goroutine that updates time source.
 func (s *ntpTimeSource) Stop() {
+	s.stateMu.Lock()
+	defer s.stateMu.Unlock()
 	if s.cancel == nil {
 		return
 	}

--- a/internal/timesource/ntp.go
+++ b/internal/timesource/ntp.go
@@ -12,6 +12,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/status-im/status-go/common"
+	gocommon "github.com/status-im/status-go/common"
 	"github.com/status-im/status-go/internal/logutils"
 )
 
@@ -290,17 +291,18 @@ func (s *ntpTimeSource) Start(ctx context.Context) error {
 	s.lastMonotonic = currentTime
 	ctx, cancel := context.WithCancel(ctx)
 
-	// Attempt to update the offset synchronously so that user can have reliable messages right away
-	err := s.updateOffset()
-	if err != nil {
-		// Failure to update can occur if the node is offline.
-		// Instead of returning an error, continue with the process as the update will be retried periodically.
-		logutils.ZapLogger().Error("failed to update offset", zap.Error(err))
-	}
+	go func() {
+		defer gocommon.LogOnPanic()
+		err := s.updateOffset()
+		if err != nil {
+			// Failure to update can occur if the node is offline.
+			// Instead of returning an error, continue with the process as the update will be retried periodically.
+			logutils.ZapLogger().Error("failed to update offset", zap.Error(err))
+		}
+		s.runPeriodically(ctx, s.updateOffset, err == nil)
+		s.started = true
+	}()
 
-	s.runPeriodically(ctx, s.updateOffset, err == nil)
-
-	s.started = true
 	s.cancel = cancel
 
 	return nil

--- a/internal/timesource/ntp_test.go
+++ b/internal/timesource/ntp_test.go
@@ -274,6 +274,8 @@ func TestGetCurrentTimeInMillis(t *testing.T) {
 	}
 
 	expectedTime := convertToMillis(currentTime.Add(responseOffset))
+	err := ts.updateOffset()
+	require.NoError(t, err)
 	n := ts.GetCurrentTimeInMillis()
 	require.Equal(t, expectedTime, n)
 	// test repeat invoke GetCurrentTimeInMillis

--- a/services/wallet/currency/service.go
+++ b/services/wallet/currency/service.go
@@ -44,16 +44,19 @@ func NewService(db *sql.DB, walletFeed *event.Feed, tokenManager *token.Manager,
 }
 
 func (s *Service) Start(ctx context.Context) {
-	// Update all fiat currency formats in cache
-	fiatFormats, err := s.getAllFiatCurrencyFormats()
-	if err == nil {
-		_ = s.db.UpdateCachedFormats(fiatFormats)
-	}
+	go func() {
+		defer gocommon.LogOnPanic()
+		// Update all fiat currency formats in cache
+		fiatFormats, err := s.getAllFiatCurrencyFormats()
+		if err == nil {
+			_ = s.db.UpdateCachedFormats(fiatFormats)
+		}
 
-	fixedTokenFormats, err := s.getAllFixedTokenCurrencyFormats()
-	if err == nil {
-		_ = s.db.UpdateCachedFormats(fixedTokenFormats)
-	}
+		fixedTokenFormats, err := s.getAllFixedTokenCurrencyFormats()
+		if err == nil {
+			_ = s.db.UpdateCachedFormats(fixedTokenFormats)
+		}
+	}()
 
 	go func() {
 		defer gocommon.LogOnPanic()


### PR DESCRIPTION
Needed for https://github.com/status-im/status-app/issues/19856

During my investigation, I found that these two services take a long time to initiate and block the login process. Putting these calls in go routines fixes the issue

status-app PR: https://github.com/status-im/status-app/pull/20144
See the link above for videos