### PR TITLE
feat: add env var override for default fleet

### DIFF
--- a/mobile/status.go
+++ b/mobile/status.go
@@ -126,6 +126,13 @@ func initializeApplication(requestJSON string) string {
 		}
 	}
 
+	if envFleetConfig := os.Getenv("STATUS_FLEET_CONFIG_FILE"); envFleetConfig != "" && request.WakuFleetsConfigFilePath == "" {
+		err = params.LoadWakuFleetsFromFile(envFleetConfig)
+		if err != nil {
+			return makeJSONResponse(err)
+		}
+	}
+
 	if request.PushFleetsConfigFilePath != "" {
 		err = params.LoadPushFleetsFromFile(request.PushFleetsConfigFilePath)
 		if err != nil {
@@ -1343,7 +1350,7 @@ func convertFleets(fleetsMap params.FleetsMap) map[string]map[string][]string {
 
 func fleets() string {
 	fleets := FleetDescription{
-		DefaultFleet: backend.DefaultFleet,
+		DefaultFleet: backend.ResolveDefaultFleet(),
 		Fleets:       convertFleets(params.GetSupportedFleets()),
 	}
 

--- a/pkg/backend/defaults.go
+++ b/pkg/backend/defaults.go
@@ -41,7 +41,7 @@ var (
 	DefaultFleet = params.FleetStatusProd
 )
 
-func resolveDefaultFleet() string {
+func ResolveDefaultFleet() string {
 	if envFleet := os.Getenv("STATUS_FLEET"); envFleet != "" && params.IsFleetSupported(envFleet) {
 		return envFleet
 	}
@@ -330,7 +330,7 @@ func DefaultNodeConfig(installationID, keyUID string, request *requests.CreateAc
 
 	fleet := request.WakuV2Fleet
 	if fleet == "" {
-		fleet = resolveDefaultFleet()
+		fleet = ResolveDefaultFleet()
 	}
 
 	err := SetFleet(fleet, nodeConfig)

--- a/pkg/backend/defaults.go
+++ b/pkg/backend/defaults.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"math/big"
+	"os"
 	"path/filepath"
 
 	gocommon "github.com/status-im/status-go/common"
@@ -39,6 +40,13 @@ var (
 
 	DefaultFleet = params.FleetStatusProd
 )
+
+func resolveDefaultFleet() string {
+	if envFleet := os.Getenv("STATUS_FLEET"); envFleet != "" && params.IsFleetSupported(envFleet) {
+		return envFleet
+	}
+	return DefaultFleet
+}
 
 func defaultSettings(keyUID string, address string, derivedAddresses map[string]generator.AccountInfo) (*settings2.Settings, error) {
 	chatKeyString := derivedAddresses[accscommon.PathEIP1581Chat].PublicKey
@@ -322,7 +330,7 @@ func DefaultNodeConfig(installationID, keyUID string, request *requests.CreateAc
 
 	fleet := request.WakuV2Fleet
 	if fleet == "" {
-		fleet = DefaultFleet
+		fleet = resolveDefaultFleet()
 	}
 
 	err := SetFleet(fleet, nodeConfig)

--- a/pkg/backend/geth_backend.go
+++ b/pkg/backend/geth_backend.go
@@ -751,7 +751,7 @@ func (b *StatusBackend) UpdateNodeConfigFleet(acc multiaccounts.Account, passwor
 	fleet := accountSettings.GetFleet()
 
 	if !params.IsFleetSupported(fleet) {
-		effectiveDefault := resolveDefaultFleet()
+		effectiveDefault := ResolveDefaultFleet()
 		b.logger.Warn("fleet is not supported, overriding with default value",
 			zap.String("fleet", fleet),
 			zap.String("defaultFleet", effectiveDefault))

--- a/pkg/backend/geth_backend.go
+++ b/pkg/backend/geth_backend.go
@@ -751,10 +751,11 @@ func (b *StatusBackend) UpdateNodeConfigFleet(acc multiaccounts.Account, passwor
 	fleet := accountSettings.GetFleet()
 
 	if !params.IsFleetSupported(fleet) {
+		effectiveDefault := resolveDefaultFleet()
 		b.logger.Warn("fleet is not supported, overriding with default value",
 			zap.String("fleet", fleet),
-			zap.String("defaultFleet", DefaultFleet))
-		fleet = DefaultFleet
+			zap.String("defaultFleet", effectiveDefault))
+		fleet = effectiveDefault
 	}
 
 	err = SetFleet(fleet, config)


### PR DESCRIPTION
Allow overriding the default fleet via the STATUS_FLEET environment variable. This enables status-app E2E tests to use status.staging instead of status.prod, avoiding skewed production metrics, unnecessary load on prod hosts, and noise in prod storage DBs.

Priority order:
1. Explicit per-account fleet (from request or saved settings)
2. STATUS_FLEET env var (runtime override)
3. params.FleetStatusProd (hardcoded default)

- add STATUS_FLEET_CONFIG_FILE env var for custom fleet config

Allow loading a custom waku fleet configuration from a JSON file
via the STATUS_FLEET_CONFIG_FILE environment variable. This enables
E2E tests to spin up local waku nodes and point the app at them,
fully isolating tests from production and staging infrastructure.

Used together with STATUS_FLEET to select the fleet name from
the loaded config (e.g. STATUS_FLEET=status-go.test).

Reuses the existing LoadWakuFleetsFromFile mechanism already used
by the functional tests via wakuFleetsConfigFilePath.

https://github.com/status-im/status-app/issues/20126