### PR TITLE
fix(Identity): Skip display name dupe check when name is empty

### DIFF
--- a/protocol/messenger_identity.go
+++ b/protocol/messenger_identity.go
@@ -34,13 +34,15 @@ func (m *Messenger) SetDisplayName(displayName string) error {
 		return err
 	}
 
-	isDupe, err := m.IsDisplayNameDupeOfCommunityMember(displayName)
-	if err != nil {
-		return err
-	}
+	if displayName != "" {
+		isDupe, err := m.IsDisplayNameDupeOfCommunityMember(displayName)
+		if err != nil {
+			return err
+		}
 
-	if isDupe {
-		return ErrDisplayNameDupeOfCommunityMember
+		if isDupe {
+			return ErrDisplayNameDupeOfCommunityMember
+		}
 	}
 
 	m.account.Name = displayName

--- a/protocol/messenger_identity_display_name_test.go
+++ b/protocol/messenger_identity_display_name_test.go
@@ -225,6 +225,31 @@ func (s *MessengerProfileDisplayNameHandlerSuite) TestDisplayNameRestrictions() 
 	s.Require().Equal("name with space", displayName)
 }
 
+func (s *MessengerProfileDisplayNameHandlerSuite) TestSetEmptyDisplayNameSkipsDupeCheck() {
+	// add profile keypair
+	profileKp, _, _, err := accounts.GetProfileKeypairForTest(true, false, false)
+	s.Require().NoError(err)
+	profileKp.KeyUID = s.m.account.KeyUID
+	profileKp.Name = DefaultProfileDisplayName
+	profileKp.Accounts[0].KeyUID = s.m.account.KeyUID
+
+	err = s.m.settings.SaveOrUpdateKeypair(profileKp)
+	s.Require().NoError(err)
+
+	// save account will create the account
+	err = s.m.multiAccounts.SaveAccount(*s.m.account)
+	s.Require().NoError(err)
+
+	// Setting an empty display name should succeed without triggering
+	// the community member dupe check (ErrDisplayNameDupeOfCommunityMember).
+	err = s.m.SetDisplayName("")
+	s.Require().NoError(err)
+
+	displayName, err := s.m.settings.DisplayName()
+	s.Require().NoError(err)
+	s.Require().Equal("", displayName)
+}
+
 func (s *MessengerProfileDisplayNameHandlerSuite) TestSaveAccountWhenEnsNameIsSet() {
 	// try to manually set display name to ens name (will fail)
 	err := s.m.SetDisplayName("godfrain.stateofus.eth")


### PR DESCRIPTION
Part of  [#20161](https://github.com/status-im/status-app/issues/20161)

## Description

Updates the **display name validation** logic to allow _empty display names._

Previously, the duplicate check was always performed regardless of the display name value. This change introduces a guard clause that skips the duplicate validation when the display name is empty, reflecting the updated requirement that empty display names are now a valid state for community members.

**App related PR:** https://github.com/status-im/status-app/pull/20211


