### PR TITLE
feat: Implement UR:CRYPTO-HDKEY to xpub conversion and extend account generation capabilities

### DIFF
--- a/internal/accounts-management/common/hdkey.go
+++ b/internal/accounts-management/common/hdkey.go
@@ -1,0 +1,433 @@
+package common
+
+import (
+	"bytes"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"hash/crc32"
+	"strings"
+
+	"github.com/status-im/extkeys"
+)
+
+// URCryptoHDKeyToXPub converts a UR:CRYPTO-HDKEY encoded extended public key string to a standard BIP32 xpub string
+//
+// The UR:CRYPTO-HDKEY format follows the Blockchain Commons specification:
+// https://github.com/BlockchainCommons/Research/blob/master/papers/bcr-2020-007-hdkey.md
+//
+// Only public keys (xpub) are supported. Returns an error if the UR contains a private key.
+func URCryptoHDKeyToXPub(urString string) (string, error) {
+	const urPrefix = "UR:CRYPTO-HDKEY/"
+	if !strings.HasPrefix(strings.ToUpper(urString), urPrefix) {
+		return "", errors.New("invalid UR: expected UR:CRYPTO-HDKEY/ prefix")
+	}
+
+	encoded := strings.ToLower(urString[len(urPrefix):])
+
+	raw, err := bytewordsDecode(encoded)
+	if err != nil {
+		return "", fmt.Errorf("bytewords decode: %w", err)
+	}
+
+	if len(raw) < 5 {
+		return "", errors.New("decoded data too short")
+	}
+
+	payload := raw[:len(raw)-4]
+	storedChecksum := raw[len(raw)-4:]
+
+	var computedChecksum [4]byte
+	binary.BigEndian.PutUint32(computedChecksum[:], crc32.ChecksumIEEE(payload))
+	if !bytes.Equal(storedChecksum, computedChecksum[:]) {
+		return "", errors.New("CRC32 checksum mismatch")
+	}
+
+	keyData, chainCode, depth, parentFP, childNum, isPrivate, err := parseCryptoHDKeyCBOR(payload)
+	if err != nil {
+		return "", fmt.Errorf("CBOR parse: %w", err)
+	}
+
+	if isPrivate {
+		return "", errors.New("UR contains a private key; only extended public keys (xpub) are supported")
+	}
+
+	fingerPrint := make([]byte, 4)
+	binary.BigEndian.PutUint32(fingerPrint, parentFP)
+
+	extKey := &extkeys.ExtendedKey{
+		Version:     extkeys.PublicKeyVersion,
+		KeyData:     keyData,
+		ChainCode:   chainCode,
+		FingerPrint: fingerPrint,
+		Depth:       depth,
+		ChildNumber: childNum,
+		IsPrivate:   false,
+	}
+
+	return extKey.String(), nil
+}
+
+// bytewordsDecode decodes a bytewords minimal-encoded string to bytes.
+// Each pair of characters (first+last letter of a bytewords word) represents one byte.
+// Word list: https://github.com/BlockchainCommons/Research/blob/master/papers/bcr-2020-012-bytewords.md
+func bytewordsDecode(s string) ([]byte, error) {
+	if len(s)%2 != 0 {
+		return nil, errors.New("bytewords: odd-length input")
+	}
+
+	result := make([]byte, len(s)/2)
+	for i := 0; i < len(s); i += 2 {
+		a, b := s[i], s[i+1]
+		if a < 'a' || a > 'z' || b < 'a' || b > 'z' {
+			return nil, fmt.Errorf("bytewords: invalid characters at position %d: %q", i, s[i:i+2])
+		}
+		val, ok := bytewordsLookup[int(a-'a')*26+int(b-'a')]
+		if !ok {
+			return nil, fmt.Errorf("bytewords: unknown word pair %q at position %d", s[i:i+2], i)
+		}
+		result[i/2] = val
+	}
+
+	return result, nil
+}
+
+// bytewordsLookup maps (first-'a')*26+(last-'a') → byte value.
+// Built from the official 256-word BC bytewords list (each word is exactly 4 letters).
+var bytewordsLookup = func() map[int]byte {
+	words := [256]string{
+		"able", "acid", "also", "apex", "aqua", "arch", "atom", "aunt",
+		"away", "axis", "back", "bald", "barn", "belt", "beta", "bias",
+		"blue", "body", "brag", "brew", "bulb", "buzz", "calm", "cash",
+		"cats", "chef", "city", "claw", "code", "cola", "cook", "cost",
+		"crux", "curl", "cusp", "cyan", "dark", "data", "days", "deli",
+		"dice", "diet", "door", "down", "draw", "drop", "drum", "dull",
+		"duty", "each", "easy", "echo", "edge", "epic", "even", "exam",
+		"exit", "eyes", "fact", "fair", "fern", "figs", "film", "fish",
+		"fizz", "flap", "flew", "flux", "foxy", "free", "frog", "fuel",
+		"fund", "gala", "game", "gear", "gems", "gift", "girl", "glow",
+		"good", "gray", "grim", "guru", "gush", "gyro", "half", "hang",
+		"hard", "hawk", "heat", "help", "high", "hill", "holy", "hope",
+		"horn", "huts", "iced", "idea", "idle", "inch", "inky", "into",
+		"iris", "iron", "item", "jade", "jazz", "join", "jolt", "jowl",
+		"judo", "jugs", "jump", "junk", "jury", "keep", "keno", "kept",
+		"keys", "kick", "kiln", "king", "kite", "kiwi", "knob", "lamb",
+		"lava", "lazy", "leaf", "legs", "liar", "limp", "lion", "list",
+		"logo", "loud", "love", "luau", "luck", "lung", "main", "many",
+		"math", "maze", "memo", "menu", "meow", "mild", "mint", "miss",
+		"monk", "nail", "navy", "need", "news", "next", "noon", "note",
+		"numb", "obey", "oboe", "omit", "onyx", "open", "oval", "owls",
+		"paid", "part", "peck", "play", "plus", "poem", "pool", "pose",
+		"puff", "puma", "purr", "quad", "quiz", "race", "ramp", "real",
+		"redo", "rich", "road", "rock", "roof", "ruby", "ruin", "runs",
+		"rust", "safe", "saga", "scar", "sets", "silk", "skew", "slot",
+		"soap", "solo", "song", "stub", "surf", "swan", "taco", "task",
+		"taxi", "tent", "tied", "time", "tiny", "toil", "tomb", "toys",
+		"trip", "tuna", "twin", "ugly", "undo", "unit", "urge", "user",
+		"vast", "very", "veto", "vial", "vibe", "view", "visa", "void",
+		"vows", "wall", "wand", "warm", "wasp", "wave", "waxy", "webs",
+		"what", "when", "whiz", "wolf", "work", "yank", "yawn", "yell",
+		"yoga", "yurt", "zaps", "zero", "zest", "zinc", "zone", "zoom",
+	}
+
+	m := make(map[int]byte, 256)
+	for i, w := range words {
+		key := int(w[0]-'a')*26 + int(w[3]-'a')
+		m[key] = byte(i)
+	}
+	return m
+}()
+
+// cborReader is a minimal CBOR reader for the crypto-hdkey structure.
+type cborReader struct {
+	data []byte
+	pos  int
+}
+
+func (r *cborReader) readByte() (byte, error) {
+	if r.pos >= len(r.data) {
+		return 0, errors.New("CBOR: unexpected end of data")
+	}
+	b := r.data[r.pos]
+	r.pos++
+	return b, nil
+}
+
+func (r *cborReader) readUintArg(info byte) (uint64, error) {
+	switch info {
+	case 24:
+		b, err := r.readByte()
+		return uint64(b), err
+	case 25:
+		if r.pos+2 > len(r.data) {
+			return 0, errors.New("CBOR: unexpected end reading 2-byte uint")
+		}
+		v := binary.BigEndian.Uint16(r.data[r.pos:])
+		r.pos += 2
+		return uint64(v), nil
+	case 26:
+		if r.pos+4 > len(r.data) {
+			return 0, errors.New("CBOR: unexpected end reading 4-byte uint")
+		}
+		v := binary.BigEndian.Uint32(r.data[r.pos:])
+		r.pos += 4
+		return uint64(v), nil
+	default:
+		return uint64(info), nil
+	}
+}
+
+func (r *cborReader) readBytes() ([]byte, error) {
+	b, err := r.readByte()
+	if err != nil {
+		return nil, err
+	}
+	if b>>5 != 2 {
+		return nil, fmt.Errorf("CBOR: expected bytes type, got major type %d", b>>5)
+	}
+	n, err := r.readUintArg(b & 0x1f)
+	if err != nil {
+		return nil, err
+	}
+	if r.pos+int(n) > len(r.data) {
+		return nil, errors.New("CBOR: unexpected end reading bytes")
+	}
+	v := r.data[r.pos : r.pos+int(n)]
+	r.pos += int(n)
+	return v, nil
+}
+
+func (r *cborReader) readUint() (uint64, error) {
+	b, err := r.readByte()
+	if err != nil {
+		return 0, err
+	}
+	if b>>5 != 0 {
+		return 0, fmt.Errorf("CBOR: expected uint type, got major type %d (byte 0x%02x)", b>>5, b)
+	}
+	return r.readUintArg(b & 0x1f)
+}
+
+func (r *cborReader) skipItem() error {
+	b, err := r.readByte()
+	if err != nil {
+		return err
+	}
+	majorType := b >> 5
+	info := b & 0x1f
+
+	switch majorType {
+	case 0, 1: // uint, negint
+		_, err = r.readUintArg(info)
+		return err
+	case 2, 3: // bytes, text
+		n, err := r.readUintArg(info)
+		if err != nil {
+			return err
+		}
+		r.pos += int(n)
+	case 4: // array
+		n, err := r.readUintArg(info)
+		if err != nil {
+			return err
+		}
+		for i := uint64(0); i < n; i++ {
+			if err := r.skipItem(); err != nil {
+				return err
+			}
+		}
+	case 5: // map
+		n, err := r.readUintArg(info)
+		if err != nil {
+			return err
+		}
+		for i := uint64(0); i < n*2; i++ {
+			if err := r.skipItem(); err != nil {
+				return err
+			}
+		}
+	case 6: // tag
+		_, err := r.readUintArg(info)
+		if err != nil {
+			return err
+		}
+		return r.skipItem()
+	case 7: // float/simple
+		// only handle false(0xf4) and true(0xf5) which have no extra bytes
+	}
+	return nil
+}
+
+// parseCryptoHDKeyCBOR parses the CBOR payload of a crypto-hdkey UR and extracts
+// the fields needed to reconstruct a BIP32 xpub.
+func parseCryptoHDKeyCBOR(data []byte) (keyData, chainCode []byte, depth byte, parentFP, childNum uint32, isPrivate bool, err error) {
+	r := &cborReader{data: data}
+
+	// Outer structure must be a CBOR map
+	b, err := r.readByte()
+	if err != nil {
+		return nil, nil, 0, 0, 0, false, err
+	}
+	if b>>5 != 5 {
+		return nil, nil, 0, 0, 0, false, fmt.Errorf("CBOR: expected map at root, got major type %d", b>>5)
+	}
+	mapLen, err := r.readUintArg(b & 0x1f)
+	if err != nil {
+		return nil, nil, 0, 0, 0, false, err
+	}
+
+	for i := uint64(0); i < mapLen; i++ {
+		key, err := r.readUint()
+		if err != nil {
+			return nil, nil, 0, 0, 0, false, fmt.Errorf("CBOR: reading map key %d: %w", i, err)
+		}
+
+		switch key {
+		case 2: // is-private (bool)
+			vb, err := r.readByte()
+			if err != nil {
+				return nil, nil, 0, 0, 0, false, err
+			}
+			isPrivate = vb == 0xf5 // true
+
+		case 3: // key-data (bytes, 33-byte compressed public key)
+			keyData, err = r.readBytes()
+			if err != nil {
+				return nil, nil, 0, 0, 0, false, fmt.Errorf("CBOR: reading key-data: %w", err)
+			}
+			if len(keyData) != 33 {
+				return nil, nil, 0, 0, 0, false, fmt.Errorf("CBOR: key-data must be 33 bytes, got %d", len(keyData))
+			}
+
+		case 4: // chain-code (bytes, 32 bytes)
+			chainCode, err = r.readBytes()
+			if err != nil {
+				return nil, nil, 0, 0, 0, false, fmt.Errorf("CBOR: reading chain-code: %w", err)
+			}
+			if len(chainCode) != 32 {
+				return nil, nil, 0, 0, 0, false, fmt.Errorf("CBOR: chain-code must be 32 bytes, got %d", len(chainCode))
+			}
+
+		case 6: // origin (tag(304) crypto-keypath)
+			depth, childNum, err = readCryptoKeypath(r)
+			if err != nil {
+				return nil, nil, 0, 0, 0, false, fmt.Errorf("CBOR: reading origin: %w", err)
+			}
+
+		case 8: // parent-fingerprint (uint32)
+			v, err := r.readUint()
+			if err != nil {
+				return nil, nil, 0, 0, 0, false, fmt.Errorf("CBOR: reading parent-fingerprint: %w", err)
+			}
+			parentFP = uint32(v)
+
+		default:
+			if err := r.skipItem(); err != nil {
+				return nil, nil, 0, 0, 0, false, fmt.Errorf("CBOR: skipping value for key %d: %w", key, err)
+			}
+		}
+	}
+
+	if keyData == nil {
+		return nil, nil, 0, 0, 0, false, errors.New("CBOR: missing key-data (field 3)")
+	}
+	if chainCode == nil {
+		return nil, nil, 0, 0, 0, false, errors.New("CBOR: missing chain-code (field 4)")
+	}
+
+	return keyData, chainCode, depth, parentFP, childNum, isPrivate, nil
+}
+
+// readCryptoKeypath reads a tag(304) crypto-keypath from the CBOR stream and returns
+// the depth and last child number (used as the child number in the BIP32 serialization).
+func readCryptoKeypath(r *cborReader) (depth byte, childNum uint32, err error) {
+	// Expect tag(304)
+	b, err := r.readByte()
+	if err != nil {
+		return 0, 0, err
+	}
+	if b>>5 != 6 {
+		return 0, 0, fmt.Errorf("CBOR: expected tag for crypto-keypath, got major type %d", b>>5)
+	}
+	tag, err := r.readUintArg(b & 0x1f)
+	if err != nil {
+		return 0, 0, err
+	}
+	if tag != 304 {
+		return 0, 0, fmt.Errorf("CBOR: expected tag 304 (crypto-keypath), got %d", tag)
+	}
+
+	// Inner map
+	mb, err := r.readByte()
+	if err != nil {
+		return 0, 0, err
+	}
+	if mb>>5 != 5 {
+		return 0, 0, fmt.Errorf("CBOR: expected map inside crypto-keypath, got major type %d", mb>>5)
+	}
+	innerLen, err := r.readUintArg(mb & 0x1f)
+	if err != nil {
+		return 0, 0, err
+	}
+
+	for i := uint64(0); i < innerLen; i++ {
+		key, err := r.readUint()
+		if err != nil {
+			return 0, 0, err
+		}
+
+		switch key {
+		case 1: // path components: flat array alternating [index, hardened, index, hardened, ...]
+			ab, err := r.readByte()
+			if err != nil {
+				return 0, 0, err
+			}
+			if ab>>5 != 4 {
+				return 0, 0, fmt.Errorf("CBOR: expected array for path components, got major type %d", ab>>5)
+			}
+			arrLen, err := r.readUintArg(ab & 0x1f)
+			if err != nil {
+				return 0, 0, err
+			}
+			if arrLen == 0 || arrLen%2 != 0 {
+				return 0, 0, fmt.Errorf("CBOR: path components array length must be even and non-zero, got %d", arrLen)
+			}
+
+			var lastIndex uint64
+			var lastHardened bool
+			for j := uint64(0); j < arrLen; j++ {
+				if j%2 == 0 {
+					lastIndex, err = r.readUint()
+					if err != nil {
+						return 0, 0, fmt.Errorf("CBOR: reading path index at %d: %w", j, err)
+					}
+				} else {
+					hb, err := r.readByte()
+					if err != nil {
+						return 0, 0, err
+					}
+					lastHardened = hb == 0xf5 // true
+				}
+			}
+
+			childNum = uint32(lastIndex)
+			if lastHardened {
+				childNum += 0x80000000
+			}
+
+		case 3: // depth (uint)
+			v, err := r.readUint()
+			if err != nil {
+				return 0, 0, err
+			}
+			depth = byte(v)
+
+		default:
+			if err := r.skipItem(); err != nil {
+				return 0, 0, fmt.Errorf("CBOR: skipping keypath value for key %d: %w", key, err)
+			}
+		}
+	}
+
+	return depth, childNum, nil
+}

--- a/internal/accounts-management/common/hdkey_test.go
+++ b/internal/accounts-management/common/hdkey_test.go
@@ -1,0 +1,47 @@
+package common
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The UR:CRYPTO-HDKEY below was exported from a Keycard shell for path m/44'/60'/0'
+// from seed phrase "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about".
+const testURCryptoHDKey = "UR:CRYPTO-HDKEY/OSAOWKAXHDCLAOWDVEROKOPDINHSEEROISYALKSAYKCTJSHEDPRNUYJYFGROVAWEWFTYGHCEGLRPKGAAHDCXTPLFJSLUKNFWLAISAXWYPALBJYLSWZAMCXHSCYUYLOZTMWFNLDLGSKPYPTGSDECFAMTAADDYOTADLNCSDWYKCSFNYKAEYKAOCYJKSKTNBKAXAXAYCYTEDMFEAYASJNGRIHKKIAHSJPIECXGUISIHJZJZBKJOHSIAIAJLKPJTJYDMJKJYHSJTIEHSJPIEMWLAGLZM"
+
+// testXPub is the BIP32 xpub reconstructed from the testURCryptoHDKey, path m/44'/60'/0'
+const testXPub = "xpub6DCoCpSuQZB2jawqnGMEPS63ePKWkwWPH4TU45Q7LPXWuNd8TMtVxRrgjtEshuqpK3mdhaWHPFsBngh5GFZaM6si3yZdUsT8ddYM3PwnATt"
+
+func TestURCryptoHDKeyToXPub(t *testing.T) {
+	t.Run("converts UR:CRYPTO-HDKEY to xpub", func(t *testing.T) {
+		xpub, err := URCryptoHDKeyToXPub(testURCryptoHDKey)
+		require.NoError(t, err)
+		assert.Equal(t, testXPub, xpub)
+	})
+
+	t.Run("handles lowercase UR prefix", func(t *testing.T) {
+		lower := "ur:crypto-hdkey/" + testURCryptoHDKey[len("UR:CRYPTO-HDKEY/"):]
+		xpub, err := URCryptoHDKeyToXPub(lower)
+		require.NoError(t, err)
+		assert.Equal(t, testXPub, xpub)
+	})
+
+	t.Run("returns error for wrong UR type", func(t *testing.T) {
+		_, err := URCryptoHDKeyToXPub("UR:CRYPTO-SEED/abc123")
+		assert.Error(t, err)
+	})
+
+	t.Run("returns error for invalid bytewords", func(t *testing.T) {
+		_, err := URCryptoHDKeyToXPub("UR:CRYPTO-HDKEY/!!invalid!!")
+		assert.Error(t, err)
+	})
+
+	t.Run("returns error for checksum mismatch", func(t *testing.T) {
+		// Corrupt the last character
+		corrupted := testURCryptoHDKey[:len(testURCryptoHDKey)-1] + "a"
+		_, err := URCryptoHDKeyToXPub(corrupted)
+		assert.Error(t, err)
+	})
+}

--- a/internal/accounts-management/generator/errors.go
+++ b/internal/accounts-management/generator/errors.go
@@ -22,15 +22,19 @@ const (
 	ErrCodeInvalidDerivationIndex
 	ErrCodeUnexpectedToken
 	ErrCodeUnexpectedEOF
+	ErrCodeExtendedKeyParsingFailed
+	ErrCodeExtendedPrivateKeyNotAllowed
+	ErrCodePublicKeyDerivationFailed
 )
 
 var (
-	ErrInvalidKeystoreExtendedKey = errors.NewError(ErrCodeInvalidKeystoreExtendedKey, "PrivateKey and ExtendedKey are different", getErrorCategory)
-	ErrZeroedExtendedKey          = errors.NewError(ErrCodeZeroedExtendedKey, "can not derive child account from zeroed extended key", getErrorCategory)
-	ErrPathParsingFailed          = errors.NewError(ErrCodePathParsingFailed, "error parsing derivation path", getErrorCategory)
-	ErrInvalidDerivationIndex     = errors.NewError(ErrCodeInvalidDerivationIndex, "index must be lower than 2^31", getErrorCategory)
-	ErrUnexpectedToken            = errors.NewError(ErrCodeUnexpectedToken, "unexpected token in derivation path", getErrorCategory)
-	ErrUnexpectedEOF              = errors.NewError(ErrCodeUnexpectedEOF, "unexpected end of derivation path", getErrorCategory)
+	ErrInvalidKeystoreExtendedKey   = errors.NewError(ErrCodeInvalidKeystoreExtendedKey, "PrivateKey and ExtendedKey are different", getErrorCategory)
+	ErrZeroedExtendedKey            = errors.NewError(ErrCodeZeroedExtendedKey, "can not derive child account from zeroed extended key", getErrorCategory)
+	ErrPathParsingFailed            = errors.NewError(ErrCodePathParsingFailed, "error parsing derivation path", getErrorCategory)
+	ErrInvalidDerivationIndex       = errors.NewError(ErrCodeInvalidDerivationIndex, "index must be lower than 2^31", getErrorCategory)
+	ErrUnexpectedToken              = errors.NewError(ErrCodeUnexpectedToken, "unexpected token in derivation path", getErrorCategory)
+	ErrUnexpectedEOF                = errors.NewError(ErrCodeUnexpectedEOF, "unexpected end of derivation path", getErrorCategory)
+	ErrExtendedPrivateKeyNotAllowed = errors.NewError(ErrCodeExtendedPrivateKeyNotAllowed, "extended private key (xprv) not allowed; use an extended public key (xpub)", getErrorCategory)
 )
 
 func ErrMnemonicCreationFailed(err error) *errors.AccountsError {
@@ -61,6 +65,14 @@ func ErrChildAccountDerivationFailed(err error) *errors.AccountsError {
 	return errors.WrapError(ErrCodeChildAccountDerivationFailed, "can not derive child account from path", err, getErrorCategory)
 }
 
+func ErrExtendedKeyParsingFailed(err error) *errors.AccountsError {
+	return errors.WrapError(ErrCodeExtendedKeyParsingFailed, "can not parse extended key string", err, getErrorCategory)
+}
+
+func ErrPublicKeyDerivationFailed(err error) *errors.AccountsError {
+	return errors.WrapError(ErrCodePublicKeyDerivationFailed, "can not derive public key from extended key", err, getErrorCategory)
+}
+
 func getErrorCategory(code errors.ErrorCode) errors.ErrorCategory {
 	switch code {
 	case ErrCodeInvalidKeystoreExtendedKey,
@@ -75,7 +87,10 @@ func getErrorCategory(code errors.ErrorCode) errors.ErrorCategory {
 		ErrCodePathParsingFailed,
 		ErrCodeInvalidDerivationIndex,
 		ErrCodeUnexpectedToken,
-		ErrCodeUnexpectedEOF:
+		ErrCodeUnexpectedEOF,
+		ErrCodeExtendedKeyParsingFailed,
+		ErrCodeExtendedPrivateKeyNotAllowed,
+		ErrCodePublicKeyDerivationFailed:
 		return ErrorCategoryGenerator
 	default:
 		return errors.ErrorCategoryUnknown

--- a/internal/accounts-management/generator/generator.go
+++ b/internal/accounts-management/generator/generator.go
@@ -1,11 +1,19 @@
 package generator
 
 import (
+	"crypto/ecdsa"
+	"crypto/hmac"
+	"crypto/sha512"
+	"encoding/binary"
+	"errors"
 	"strings"
+
+	"github.com/status-im/extkeys"
 
 	"github.com/status-im/status-go/internal/accounts-management/common"
 	"github.com/status-im/status-go/internal/accounts-management/types"
 	"github.com/status-im/status-go/internal/crypto"
+	cryptotypes "github.com/status-im/status-go/internal/crypto/types"
 )
 
 // CreateAccountFromMnemonic creates an account from a mnemonic phrase.
@@ -99,6 +107,76 @@ func DeriveChildrenFromAccount(acc *Account, pathStrings []string) (map[string]*
 	}
 
 	return pathAccounts, nil
+}
+
+// derivePublicChildKey performs BIP32 non-hardened public child key derivation using go-ethereum's secp256k1 primitives
+func derivePublicChildKey(parentPubKeyBytes, chainCode []byte, index uint32) (childPubKeyBytes, childChainCode []byte, err error) {
+	if index >= 0x80000000 {
+		return nil, nil, errors.New("hardened child derivation not supported from public key")
+	}
+	data := make([]byte, 37)
+	copy(data[:33], parentPubKeyBytes)
+	binary.BigEndian.PutUint32(data[33:], index)
+
+	mac := hmac.New(sha512.New, chainCode)
+	_, _ = mac.Write(data)
+	I := mac.Sum(nil)
+	IL, IR := I[:32], I[32:]
+
+	curve := crypto.S256()
+	x1, y1 := curve.ScalarBaseMult(IL)
+	parentKey, err := crypto.DecompressPubkey(parentPubKeyBytes)
+	if err != nil {
+		return nil, nil, err
+	}
+	x, y := curve.Add(x1, y1, parentKey.X, parentKey.Y)
+	if x.Sign() == 0 && y.Sign() == 0 {
+		return nil, nil, errors.New("derived key is point at infinity")
+	}
+	childPubKey := &ecdsa.PublicKey{Curve: curve, X: x, Y: y}
+	return crypto.CompressPubkey(childPubKey), IR, nil
+}
+
+// DeriveAccountsPublicInfoFromExtendedPublicKeyForPaths derives public accounts from an extended public key (xpub) for the given paths.
+// Paths are relative to the provided xpub.
+func DeriveAccountsPublicInfoFromExtendedPublicKeyForPaths(xpubString string, paths []string) (map[string]AccountPublicInfo, error) {
+	extKey, err := extkeys.NewKeyFromString(xpubString)
+	if err != nil {
+		return nil, ErrExtendedKeyParsingFailed(err)
+	}
+
+	if extKey.IsPrivate {
+		return nil, ErrExtendedPrivateKeyNotAllowed
+	}
+
+	result := make(map[string]AccountPublicInfo)
+	for _, pathString := range paths {
+		_, path, err := decodePath(pathString)
+		if err != nil {
+			return nil, ErrPathDecodingFailed(err)
+		}
+
+		pubKeyBytes := extKey.KeyData
+		chainCode := extKey.ChainCode
+		for _, index := range path {
+			pubKeyBytes, chainCode, err = derivePublicChildKey(pubKeyBytes, chainCode, index)
+			if err != nil {
+				return nil, ErrExtendedKeyDerivationFailed(err)
+			}
+		}
+
+		pubKey, err := crypto.DecompressPubkey(pubKeyBytes)
+		if err != nil {
+			return nil, ErrPublicKeyDerivationFailed(err)
+		}
+
+		result[pathString] = AccountPublicInfo{
+			PublicKey: cryptotypes.EncodeHex(crypto.FromECDSAPub(pubKey)),
+			Address:   crypto.PubkeyToAddress(*pubKey).Hex(),
+		}
+	}
+
+	return result, nil
 }
 
 func CreateAndDeriveAccountsFromMnemonic(mnemonic string, paths []string, bip39Passphrase string) (*Account, map[string]*Account, error) {

--- a/internal/accounts-management/generator/generator_test.go
+++ b/internal/accounts-management/generator/generator_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/status-im/extkeys"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/status-im/status-go/internal/accounts-management/types"
 )
@@ -156,4 +157,54 @@ func TestGenerator_DeriveChildrenFromAccount(t *testing.T) {
 	assert.Equal(t, testData.childAccount1.address, children[testData.childAccount1.path].ToIdentifiedAccountInfo().Address)
 	assert.Equal(t, testData.childAccount1.publicKey, children[testData.childAccount1.path].ToIdentifiedAccountInfo().PublicKey)
 	assert.Equal(t, testData.childAccount1.privateKey, children[testData.childAccount1.path].ToIdentifiedAccountInfo().PrivateKey)
+}
+
+func xpubAtPath(t *testing.T, mnemonic, passphrase, path string) string {
+	t.Helper()
+	acc, err := CreateAccountFromMnemonic(mnemonic, passphrase)
+	require.NoError(t, err)
+	derived, err := DeriveChildFromAccount(acc, path)
+	require.NoError(t, err)
+	xpub, err := derived.ExtendedKey().Neuter()
+	require.NoError(t, err)
+	return xpub.String()
+}
+
+func TestDerivePublicKeyInfoFromExtendedPublicKey(t *testing.T) {
+	const hardenedPath = "m/44'/60'/0'" // hardened derivation path for the wallet
+	xpub := xpubAtPath(t, testData.mnemonic, testData.bip39Passphrase, hardenedPath)
+
+	t.Run("derives correct public key and address for single path", func(t *testing.T) {
+		result, err := DeriveAccountsPublicInfoFromExtendedPublicKeyForPaths(xpub, []string{"0/0"})
+		assert.NoError(t, err)
+		assert.Equal(t, testData.childAccount0.publicKey, result["0/0"].PublicKey)
+		assert.Equal(t, testData.childAccount0.address, result["0/0"].Address)
+	})
+
+	t.Run("derives correct public key and address for multiple paths", func(t *testing.T) {
+		result, err := DeriveAccountsPublicInfoFromExtendedPublicKeyForPaths(xpub, []string{"0/0", "0/1"})
+		assert.NoError(t, err)
+		assert.Equal(t, testData.childAccount0.publicKey, result["0/0"].PublicKey)
+		assert.Equal(t, testData.childAccount0.address, result["0/0"].Address)
+		assert.Equal(t, testData.childAccount1.publicKey, result["0/1"].PublicKey)
+		assert.Equal(t, testData.childAccount1.address, result["0/1"].Address)
+	})
+
+	t.Run("rejects extended private key", func(t *testing.T) {
+		acc, err := CreateAccountFromMnemonic(testData.mnemonic, testData.bip39Passphrase)
+		require.NoError(t, err)
+		xprv := acc.ExtendedKey().String()
+		_, err = DeriveAccountsPublicInfoFromExtendedPublicKeyForPaths(xprv, []string{"0/0"})
+		assert.ErrorIs(t, err, ErrExtendedPrivateKeyNotAllowed)
+	})
+
+	t.Run("returns error for hardened child path", func(t *testing.T) {
+		_, err := DeriveAccountsPublicInfoFromExtendedPublicKeyForPaths(xpub, []string{"0'"})
+		assert.Error(t, err)
+	})
+
+	t.Run("returns error for invalid xpub string", func(t *testing.T) {
+		_, err := DeriveAccountsPublicInfoFromExtendedPublicKeyForPaths("not-a-valid-xpub", []string{"0/0"})
+		assert.Error(t, err)
+	})
 }

--- a/internal/accounts-management/generator/path_decoder.go
+++ b/internal/accounts-management/generator/path_decoder.go
@@ -172,6 +172,12 @@ func (d *pathDecoder) saveSegment() error {
 func (d *pathDecoder) parseSeparator() error {
 	b, err := d.readByte()
 	if err != nil {
+		if err == io.EOF {
+			if saveErr := d.saveSegment(); saveErr != nil {
+				return saveErr
+			}
+			return io.EOF
+		}
 		return err
 	}
 

--- a/internal/accounts-management/generator/path_decoder_test.go
+++ b/internal/accounts-management/generator/path_decoder_test.go
@@ -53,6 +53,26 @@ func TestDecodePath(t *testing.T) {
 			expectedStartingPoint: startingPointMaster,
 		},
 		{
+			path:                  "m/44'/60'/0'/0/0",
+			expectedPath:          []uint32{2147483692, 2147483708, 2147483648, 0, 0},
+			expectedStartingPoint: startingPointMaster,
+		},
+		{
+			path:                  "m/43'/60'/1581'",
+			expectedPath:          []uint32{2147483691, 2147483708, 2147485229},
+			expectedStartingPoint: startingPointMaster,
+		},
+		{
+			path:                  "m/43'/60'/1581'/0'",
+			expectedPath:          []uint32{2147483691, 2147483708, 2147485229, 2147483648},
+			expectedStartingPoint: startingPointMaster,
+		},
+		{
+			path:                  "m/43'/60'/1581'/0'/0",
+			expectedPath:          []uint32{2147483691, 2147483708, 2147485229, 2147483648, 0},
+			expectedStartingPoint: startingPointMaster,
+		},
+		{
 			path: "m/",
 			err:  fmt.Errorf("error parsing derivation path m/; at position 2, expected number, got EOF"),
 		},

--- a/internal/accounts-management/generator/types.go
+++ b/internal/accounts-management/generator/types.go
@@ -80,9 +80,11 @@ func (a *Account) ToAccountInfo() AccountInfo {
 	addressHex := crypto.PubkeyToAddress(a.privateKey.PublicKey).Hex()
 
 	return AccountInfo{
+		AccountPublicInfo: AccountPublicInfo{
+			PublicKey: publicKeyHex,
+			Address:   addressHex,
+		},
 		PrivateKey: privateKeyHex,
-		PublicKey:  publicKeyHex,
-		Address:    addressHex,
 	}
 }
 
@@ -122,19 +124,39 @@ func (a *Account) ValidateExtendedKey() error {
 	return nil
 }
 
-type AccountInfo struct {
-	PrivateKey string `json:"privateKey"`
-	PublicKey  string `json:"publicKey"`
-	Address    string `json:"address"`
+type AccountPublicInfo struct {
+	PublicKey string `json:"publicKey"`
+	Address   string `json:"address"`
 }
 
-func (a AccountInfo) MarshalJSON() ([]byte, error) {
-	type Alias AccountInfo
-	ext, err := common.ExtendStructWithPubKeyData(a.PublicKey, Alias(a))
+func (p AccountPublicInfo) MarshalJSON() ([]byte, error) {
+	type Alias AccountPublicInfo
+	ext, err := common.ExtendStructWithPubKeyData(p.PublicKey, Alias(p))
 	if err != nil {
 		return nil, err
 	}
 	return json.Marshal(ext)
+}
+
+type AccountInfo struct {
+	AccountPublicInfo
+	PrivateKey string `json:"privateKey"`
+}
+
+func (a AccountInfo) MarshalJSON() ([]byte, error) {
+	pubJSON, err := a.AccountPublicInfo.MarshalJSON()
+	if err != nil {
+		return nil, err
+	}
+	type priv struct {
+		PrivateKey string `json:"privateKey"`
+	}
+	privJSON, err := json.Marshal(priv{PrivateKey: a.PrivateKey})
+	if err != nil {
+		return nil, err
+	}
+	privJSON[0] = ','
+	return append(pubJSON[:len(pubJSON)-1], privJSON...), nil
 }
 
 type IdentifiedAccountInfo struct {

--- a/mobile/multiaccount.go
+++ b/mobile/multiaccount.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"strings"
 
+	"github.com/status-im/status-go/internal/accounts-management/common"
 	generator2 "github.com/status-im/status-go/internal/accounts-management/generator"
 )
 
@@ -77,6 +78,46 @@ func CreateAccountFromMnemonicAndDeriveAccountsForPaths(paramsJSON string) strin
 	}
 
 	out, err := json.Marshal(generatedAndDerivedAccountsInfo)
+	if err != nil {
+		return makeJSONResponse(err)
+	}
+
+	return string(out)
+}
+
+// ConvertURCryptoHDKeyToXPub converts a UR:CRYPTO-HDKEY encoded string to a standard BIP32 xpub string.
+// The resulting xpub can be passed to DeriveAccountsPublicInfoFromExtendedPublicKeyForPaths.
+func ConvertURCryptoHDKeyToXPub(ur string) string {
+	xpub, err := common.URCryptoHDKeyToXPub(ur)
+	if err != nil {
+		return makeJSONResponse(err)
+	}
+	out, err := json.Marshal(xpub)
+	if err != nil {
+		return makeJSONResponse(err)
+	}
+	return string(out)
+}
+
+// DeriveAccountsPublicInfoFromExtendedPublicKeyForPaths derives accounts public info from an extended public key (xpub)
+// for the given derivation paths.Paths are relative to the provided xpub.
+func DeriveAccountsPublicInfoFromExtendedPublicKeyForPaths(paramsJSON string) string {
+	type Params struct {
+		ExtendedPublicKey string   `json:"extendedPublicKey"`
+		Paths             []string `json:"paths"`
+	}
+
+	var p Params
+	if err := json.Unmarshal([]byte(paramsJSON), &p); err != nil {
+		return makeJSONResponse(err)
+	}
+
+	result, err := generator2.DeriveAccountsPublicInfoFromExtendedPublicKeyForPaths(p.ExtendedPublicKey, p.Paths)
+	if err != nil {
+		return makeJSONResponse(err)
+	}
+
+	out, err := json.Marshal(result)
 	if err != nil {
 		return makeJSONResponse(err)
 	}

--- a/pkg/backend/geth_backend.go
+++ b/pkg/backend/geth_backend.go
@@ -1619,22 +1619,32 @@ func (b *StatusBackend) StartNodeWithChatKeyOrMnemonic(
 		masterAddress = keycardData.Address
 
 		derivedAddresses[common.PathWalletRoot] = generator2.AccountInfo{
-			Address: keycardData.WalletRootAddress,
+			AccountPublicInfo: generator2.AccountPublicInfo{
+				Address: keycardData.WalletRootAddress,
+			},
 		}
 		derivedAddresses[common.PathEIP1581Root] = generator2.AccountInfo{
-			Address: keycardData.Eip1581Address,
+			AccountPublicInfo: generator2.AccountPublicInfo{
+				Address: keycardData.Eip1581Address,
+			},
 		}
 		derivedAddresses[common.PathEIP1581Chat] = generator2.AccountInfo{
-			Address:    keycardData.WhisperAddress,
-			PublicKey:  keycardData.WhisperPublicKey,
+			AccountPublicInfo: generator2.AccountPublicInfo{
+				Address:   keycardData.WhisperAddress,
+				PublicKey: keycardData.WhisperPublicKey,
+			},
 			PrivateKey: keycardData.WhisperPrivateKey,
 		}
 		derivedAddresses[common.PathDefaultWalletAccount] = generator2.AccountInfo{
-			Address:   keycardData.WalletAddress,
-			PublicKey: keycardData.WalletPublicKey,
+			AccountPublicInfo: generator2.AccountPublicInfo{
+				Address:   keycardData.WalletAddress,
+				PublicKey: keycardData.WalletPublicKey,
+			},
 		}
 		derivedAddresses[common.PathEIP1581Encryption] = generator2.AccountInfo{
-			PublicKey: keycardData.EncryptionPublicKey,
+			AccountPublicInfo: generator2.AccountPublicInfo{
+				PublicKey: keycardData.EncryptionPublicKey,
+			},
 		}
 	} else {
 		genMasterAcc, err := generator2.CreateAccountFromMnemonic(mnemonic, "")

--- a/pkg/backend/test_helpers.go
+++ b/pkg/backend/test_helpers.go
@@ -90,8 +90,10 @@ func setupTestContext(t *testing.T, password string, storeProfile bool, storeMul
 		derivedAddresses := make(map[string]generator2.AccountInfo)
 		for path, acc := range derivedAccs {
 			derivedAddresses[path] = generator2.AccountInfo{
-				Address:   acc.Address().Hex(),
-				PublicKey: acc.PublicKeyHex(),
+				AccountPublicInfo: generator2.AccountPublicInfo{
+					Address:   acc.Address().Hex(),
+					PublicKey: acc.PublicKeyHex(),
+				},
 			}
 		}
 

--- a/tests-functional/resources/test_data/mnemonic_12.py
+++ b/tests-functional/resources/test_data/mnemonic_12.py
@@ -30,7 +30,7 @@ profile_data = {
     "currency": "usd",
     "networks/current-network": "",
     "dapps-address": "0xc43f4ab94ec965a3ee9815c5df07383057d261a8",
-    "eip1581-address": "0x803102f704324d4a4f2ddb1c47f6ab31339d0f70",
+    "eip1581-address": "0xc8bb785b71e826d6889e009a992f5ddb4a2d414e",
     "key-uid": "0x3231d92c94548d14f097173765a50bebe28fbad8f2267c9e08cc4433a6f219a4",
     "latest-derived-path": 0,
     "link-preview-request-enabled": True,

--- a/tests-functional/resources/test_data/mnemonic_15.py
+++ b/tests-functional/resources/test_data/mnemonic_15.py
@@ -28,7 +28,7 @@ accounts = [
 profile_data = {
     "address": "0x3644a8cc3860606fdee3b95c8825e17933a91647",
     "dapps-address": "0x685d7ec8e08769ca7020a6b65709887e38e68e6d",
-    "eip1581-address": "0xe98734898ff58ac33a1a9c28f732696ec3e6b580",
+    "eip1581-address": "0x8069b3f375504491addb13940b079611015b8e0c",
     "key-uid": "0x944c1ce03f83dd1750acee591745d6ef14da90723af86f97b2df7d7282e8dd97",
     "name": "Overcooked Lost Grayreefshark",
     "public-key": (

--- a/tests-functional/resources/test_data/mnemonic_24.py
+++ b/tests-functional/resources/test_data/mnemonic_24.py
@@ -28,7 +28,7 @@ accounts = [
 profile_data = {
     "address": "0xb47386b0074a9ddfd979540f134915d1df8dc3d0",
     "dapps-address": "0xf2d58ae5aa880f7c3f65d769296b1061c61e0955",
-    "eip1581-address": "0xf203f9c33afd10e2d3888289ad2cad81c4b017c4",
+    "eip1581-address": "0x0f25a48c91a45d9ead4e89ceee185cb52d451df2",
     "key-uid": "0xcf119f28496e4123dd6d5a4936c5f595ee1a873b11ead5f275098456eb8777c4",
     "name": "Selfassured Pesky Mayfly",
     "public-key": (


### PR DESCRIPTION
- `ConvertURCryptoHDKeyToXPub` - converts UR:CRYPTO-HDKEY encoded strings to BIP32 xpub strings
- `DeriveAccountsPublicInfoFromExtendedPublicKeyForPaths` - account generation deriving from extended public keys

Closes https://github.com/status-im/status-app/issues/20292