### PR TITLE
test(ci): check if macos nix-darwin host can handle macos build

### DIFF
--- a/_assets/ci/Jenkinsfile.desktop
+++ b/_assets/ci/Jenkinsfile.desktop
@@ -57,7 +57,7 @@ pipeline {
     )
     /* prevent sharing cache dir across different jobs */
     GO_GENERATE_FAST_DIR = "${env.WORKSPACE_TMP}/go-generate-fast"
-    /* fixes nim cache collision */
+    /* fixes nim cache collision*/
     XDG_CACHE_HOME = "${env.WORKSPACE_TMP}/.cache"
   }
 


### PR DESCRIPTION
Adjustments to the scripts to also work on the MacOS hosts where we configure them using nix-darwin.

Reason for this change is that we are in the process of removing homebrew from our MacOS CI hosts and replacing it with nix-darwin.
