### PR TITLE
feat: add Pausable interface, PausableTicker, and ServiceRegistry

### DIFF
--- a/common/pausable.go
+++ b/common/pausable.go
@@ -105,7 +105,9 @@ func (m *PauseBroadcaster) IsPaused() bool {
 // separate IsPaused() check before entering the select loop.
 func (m *PauseBroadcaster) Subscribe() Subscription {
 	m.initPub()
-	ch := m.pub.Subscribe(1)
+	// Buffer must fit initial snapshot plus one transition before the consumer reads; see
+	// common.TestPauseBroadcaster_Subscribe_* and pkg/pubsub.TestTypePublisher_publishDroppedWhenPerSubscriberBufferFull.
+	ch := m.pub.Subscribe(2)
 	// Deliver the current state immediately.
 	select {
 	case ch <- m.IsPaused():

--- a/common/pausable.go
+++ b/common/pausable.go
@@ -1,0 +1,115 @@
+package common
+
+import (
+	"sync"
+
+	"github.com/status-im/status-go/pkg/pubsub"
+)
+
+// ServiceState represents the lifecycle state of a pausable service.
+type ServiceState string
+
+const (
+	ServiceStateRunning ServiceState = "running"
+	ServiceStatePaused  ServiceState = "paused"
+	ServiceStateStopped ServiceState = "stopped"
+)
+
+// Pausable is implemented by services that support granular pause/resume control.
+// The name returned by PausableName is the stable identifier used in the API.
+type Pausable interface {
+	PausableName() string
+	Pause() error
+	Resume() error
+	PausableState() ServiceState
+}
+
+// Subscription is the read side of a pause-state subscription from a PauseBroadcaster.
+type Subscription interface {
+	// C returns a channel that receives true when paused, false when resumed.
+	// The current pause state is always sent immediately on subscribe.
+	C() <-chan bool
+	Unsubscribe()
+}
+
+type lifecycleSubscription struct {
+	publisher *pubsub.TypePublisher[bool]
+	ch        chan bool
+}
+
+func (s *lifecycleSubscription) C() <-chan bool { return s.ch }
+func (s *lifecycleSubscription) Unsubscribe()   { s.publisher.Unsubscribe(s.ch) }
+
+// PauseBroadcaster provides common pause/resume state tracking for services implementing Pausable.
+// Embed this struct and call the Mark* methods to avoid duplicating state logic.
+// Calling MarkPaused/MarkResumed also broadcasts to any active Subscribe() subscribers.
+type PauseBroadcaster struct {
+	mu   sync.RWMutex
+	once sync.Once
+	pub  *pubsub.TypePublisher[bool]
+
+	state ServiceState
+}
+
+func (m *PauseBroadcaster) initPub() {
+	m.once.Do(func() {
+		m.pub = pubsub.NewTypePublisher[bool]()
+	})
+}
+
+func (m *PauseBroadcaster) PausableState() ServiceState {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	if m.state == "" {
+		return ServiceStateStopped
+	}
+	return m.state
+}
+
+func (m *PauseBroadcaster) MarkStarted() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.state = ServiceStateRunning
+}
+
+func (m *PauseBroadcaster) MarkStopped() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.state = ServiceStateStopped
+}
+
+func (m *PauseBroadcaster) MarkPaused() {
+	m.initPub()
+	m.mu.Lock()
+	m.state = ServiceStatePaused
+	m.mu.Unlock()
+	m.pub.Publish(true)
+}
+
+func (m *PauseBroadcaster) MarkResumed() {
+	m.initPub()
+	m.mu.Lock()
+	m.state = ServiceStateRunning
+	m.mu.Unlock()
+	m.pub.Publish(false)
+}
+
+func (m *PauseBroadcaster) IsPaused() bool {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return m.state == ServiceStatePaused
+}
+
+// Subscribe returns a Subscription that receives pause-state transitions.
+// The current pause state is sent immediately so the caller does not need a
+// separate IsPaused() check before entering the select loop.
+func (m *PauseBroadcaster) Subscribe() Subscription {
+	m.initPub()
+	ch := m.pub.Subscribe(1)
+	// Deliver the current state immediately.
+	select {
+	case ch <- m.IsPaused():
+	default:
+	}
+	return &lifecycleSubscription{publisher: m.pub, ch: ch}
+}

--- a/common/pausable_test.go
+++ b/common/pausable_test.go
@@ -1,0 +1,58 @@
+package common
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// drainPauseSubscription reads every value currently queued on sub.C() without blocking.
+// PauseBroadcaster delivers an initial snapshot then transition events on the same channel;
+// with a buffer of 1, a transition can be dropped while the buffer still holds the snapshot
+// (see pkg/pubsub.TypePublisher Send). Subscribers that care about correctness should
+// treat the last drained value as the effective pause flag after catching up.
+func drainPauseSubscription(sub Subscription) []bool {
+	ch := sub.C()
+	var vals []bool
+	for {
+		select {
+		case v := <-ch:
+			vals = append(vals, v)
+		default:
+			return vals
+		}
+	}
+}
+
+// These tests guard against losing a MarkPaused/MarkResumed between Subscribe and the first
+// read: the initial IsPaused() snapshot must not fill the per-subscriber buffer such that the
+// following Publish is dropped while PausableState() has already changed.
+
+func TestPauseBroadcaster_Subscribe_pauseBeforeFirstRead_lastQueuedMatchesState(t *testing.T) {
+	var pb PauseBroadcaster
+	pb.MarkStarted()
+	sub := pb.Subscribe()
+	pb.MarkPaused()
+	require.Equal(t, ServiceStatePaused, pb.PausableState())
+
+	vals := drainPauseSubscription(sub)
+	require.NotEmpty(t, vals, "expected at least the initial snapshot on the subscription channel")
+	last := vals[len(vals)-1]
+	require.True(t, last, "after MarkPaused before any read, latest queued value should be paused (true); got %v for sequence %v", last, vals)
+	sub.Unsubscribe()
+}
+
+func TestPauseBroadcaster_Subscribe_resumeBeforeFirstRead_lastQueuedMatchesState(t *testing.T) {
+	var pb PauseBroadcaster
+	pb.MarkStarted()
+	pb.MarkPaused()
+	sub := pb.Subscribe()
+	pb.MarkResumed()
+	require.Equal(t, ServiceStateRunning, pb.PausableState())
+
+	vals := drainPauseSubscription(sub)
+	require.NotEmpty(t, vals, "expected at least the initial snapshot on the subscription channel")
+	last := vals[len(vals)-1]
+	require.False(t, last, "after MarkResumed before any read, latest queued value should be running (false); got %v for sequence %v", last, vals)
+	sub.Unsubscribe()
+}

--- a/common/pausable_ticker.go
+++ b/common/pausable_ticker.go
@@ -1,0 +1,91 @@
+package common
+
+import "time"
+
+// PausableTickerConfig configures a PausableTicker.
+type PausableTickerConfig struct {
+	// Interval is the tick interval.
+	Interval time.Duration
+	// OnTick is called each time the ticker fires while not paused.
+	OnTick func()
+	// OnPauseChanged is optional. Called whenever the pause state transitions,
+	// including once with the initial state before the first tick. Useful for
+	// consumers that need to change their own interval or behaviour (e.g. NTP).
+	OnPauseChanged func(paused bool)
+}
+
+// PausableTicker runs a periodic tick that is suppressed while paused.
+//
+// pauseCh is a channel of bool values: true means "now paused", false means
+// "now running". The first value sent on the channel sets the initial state
+// and must be delivered before Run returns for the first time. This matches
+// the contract of PauseBroadcaster.Subscribe().
+//
+// Usage:
+//
+//	sub := s.Subscribe()
+//	defer sub.Unsubscribe()
+//	pt := common.NewPausableTicker(common.PausableTickerConfig{
+//	    Interval: 30 * time.Second,
+//	    OnTick:   func() { doWork() },
+//	}, sub.C())
+//	pt.Run(quit)
+type PausableTicker struct {
+	cfg     PausableTickerConfig
+	pauseCh <-chan bool
+}
+
+// NewPausableTicker creates a PausableTicker.
+func NewPausableTicker(cfg PausableTickerConfig, pauseCh <-chan bool) *PausableTicker {
+	return &PausableTicker{cfg: cfg, pauseCh: pauseCh}
+}
+
+// Run blocks, firing cfg.OnTick at cfg.Interval while not paused.
+// It returns when quit is closed or pauseCh is closed.
+func (pt *PausableTicker) Run(quit <-chan struct{}) {
+	ticker := time.NewTicker(pt.cfg.Interval)
+	defer ticker.Stop()
+
+	// Read initial pause state; this unblocks once the lifecycle sends it.
+	var paused bool
+	select {
+	case p, ok := <-pt.pauseCh:
+		if !ok {
+			return
+		}
+		paused = p
+	case <-quit:
+		return
+	}
+
+	if pt.cfg.OnPauseChanged != nil {
+		pt.cfg.OnPauseChanged(paused)
+	}
+
+	var tickerC <-chan time.Time
+	if !paused {
+		tickerC = ticker.C
+	}
+
+	for {
+		select {
+		case pausedState, ok := <-pt.pauseCh:
+			if !ok {
+				return
+			}
+			paused = pausedState
+			if paused {
+				tickerC = nil
+			} else {
+				tickerC = ticker.C
+			}
+			if pt.cfg.OnPauseChanged != nil {
+				pt.cfg.OnPauseChanged(paused)
+			}
+		case <-tickerC:
+			pt.cfg.OnTick()
+		case <-quit:
+			return
+		}
+	}
+}

--- a/common/pausable_ticker.go
+++ b/common/pausable_ticker.go
@@ -12,6 +12,11 @@ type PausableTickerConfig struct {
 	// including once with the initial state before the first tick. Useful for
 	// consumers that need to change their own interval or behaviour (e.g. NTP).
 	OnPauseChanged func(paused bool)
+	// TickerArmed is optional. When set, called with true after a time.Ticker is
+	// created for the running state, and false after it is stopped (pause,
+	// replacement, or Run exit). Production code can leave this nil; tests use it
+	// to assert no underlying ticker is armed while paused.
+	TickerArmed func(armed bool)
 }
 
 // PausableTicker runs a periodic tick that is suppressed while paused.
@@ -42,9 +47,40 @@ func NewPausableTicker(cfg PausableTickerConfig, pauseCh <-chan bool) *PausableT
 
 // Run blocks, firing cfg.OnTick at cfg.Interval while not paused.
 // It returns when quit is closed or pauseCh is closed.
+// While paused, no time.Ticker is active (see cfg.TickerArmed for tests).
 func (pt *PausableTicker) Run(quit <-chan struct{}) {
-	ticker := time.NewTicker(pt.cfg.Interval)
-	defer ticker.Stop()
+	if pt.cfg.Interval <= 0 || pt.cfg.OnTick == nil {
+		return
+	}
+
+	var ticker *time.Ticker
+	notifyArmed := func(armed bool) {
+		if pt.cfg.TickerArmed != nil {
+			pt.cfg.TickerArmed(armed)
+		}
+	}
+	defer func() {
+		if ticker != nil {
+			ticker.Stop()
+			notifyArmed(false)
+		}
+	}()
+
+	startTicker := func() {
+		if ticker != nil {
+			ticker.Stop()
+			notifyArmed(false)
+		}
+		ticker = time.NewTicker(pt.cfg.Interval)
+		notifyArmed(true)
+	}
+	stopTicker := func() {
+		if ticker != nil {
+			ticker.Stop()
+			notifyArmed(false)
+			ticker = nil
+		}
+	}
 
 	// Read initial pause state; this unblocks once the lifecycle sends it.
 	var paused bool
@@ -64,6 +100,7 @@ func (pt *PausableTicker) Run(quit <-chan struct{}) {
 
 	var tickerC <-chan time.Time
 	if !paused {
+		startTicker()
 		tickerC = ticker.C
 	}
 
@@ -73,10 +110,13 @@ func (pt *PausableTicker) Run(quit <-chan struct{}) {
 			if !ok {
 				return
 			}
+			prev := paused
 			paused = pausedState
-			if paused {
+			if paused && !prev {
+				stopTicker()
 				tickerC = nil
-			} else {
+			} else if !paused && prev {
+				startTicker()
 				tickerC = ticker.C
 			}
 			if pt.cfg.OnPauseChanged != nil {

--- a/common/pausable_ticker_test.go
+++ b/common/pausable_ticker_test.go
@@ -201,7 +201,7 @@ func TestPausableTicker_OnPauseChanged(t *testing.T) {
 
 	send(false) // initial: running
 	time.Sleep(20 * time.Millisecond)
-	send(true)  // pause
+	send(true) // pause
 	time.Sleep(20 * time.Millisecond)
 	send(false) // resume
 	time.Sleep(20 * time.Millisecond)
@@ -210,4 +210,159 @@ func TestPausableTicker_OnPauseChanged(t *testing.T) {
 	<-done
 
 	require.Equal(t, []bool{false, true, false}, states)
+}
+
+func TestPausableTicker_NoTickerArmedWhenInitialStatePaused(t *testing.T) {
+	pauseCh, send := makePauseCh()
+
+	var armed atomic.Bool
+	pt := NewPausableTicker(PausableTickerConfig{
+		Interval: 10 * time.Millisecond,
+		OnTick:   func() {},
+		TickerArmed: func(on bool) {
+			armed.Store(on)
+		},
+	}, pauseCh)
+
+	quit := make(chan struct{})
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		pt.Run(quit)
+	}()
+
+	send(true)
+	time.Sleep(50 * time.Millisecond)
+	require.False(t, armed.Load(), "no time.Ticker should be created while paused from the start")
+
+	close(quit)
+	<-done
+	require.False(t, armed.Load())
+}
+
+func TestPausableTicker_TickerDisarmedWhilePausedRearmedOnResume(t *testing.T) {
+	pauseCh, send := makePauseCh()
+
+	var armed atomic.Bool
+	pt := NewPausableTicker(PausableTickerConfig{
+		Interval: 10 * time.Millisecond,
+		OnTick:   func() {},
+		TickerArmed: func(on bool) {
+			armed.Store(on)
+		},
+	}, pauseCh)
+
+	quit := make(chan struct{})
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		pt.Run(quit)
+	}()
+
+	send(false)
+	require.Eventually(t, func() bool { return armed.Load() }, 200*time.Millisecond, 5*time.Millisecond,
+		"time.Ticker should be armed while running")
+
+	send(true)
+	require.Eventually(t, func() bool { return !armed.Load() }, 200*time.Millisecond, 5*time.Millisecond,
+		"time.Ticker should be stopped while paused (not only ignored in select)")
+
+	send(false)
+	require.Eventually(t, func() bool { return armed.Load() }, 200*time.Millisecond, 5*time.Millisecond,
+		"time.Ticker should be armed again after resume")
+
+	close(quit)
+	<-done
+	require.False(t, armed.Load(), "ticker stopped when Run exits")
+}
+
+func TestPausableTicker_Run_invalidConfigReturnsWithoutPanic(t *testing.T) {
+	t.Run("zero interval", func(t *testing.T) {
+		pauseCh, send := makePauseCh()
+		var ticked atomic.Bool
+		pt := NewPausableTicker(PausableTickerConfig{
+			Interval: 0,
+			OnTick:   func() { ticked.Store(true) },
+		}, pauseCh)
+
+		quit := make(chan struct{})
+		done := make(chan struct{})
+		go func() {
+			defer close(done)
+			require.NotPanics(t, func() { pt.Run(quit) })
+		}()
+
+		send(false)
+		select {
+		case <-done:
+		case <-time.After(time.Second):
+			t.Fatal("Run should return without waiting on pause channel when Interval is invalid")
+		}
+		require.False(t, ticked.Load(), "OnTick must not run with invalid Interval")
+	})
+
+	t.Run("negative interval", func(t *testing.T) {
+		pauseCh, send := makePauseCh()
+		pt := NewPausableTicker(PausableTickerConfig{
+			Interval: -time.Second,
+			OnTick:   func() { t.Fatal("OnTick called") },
+		}, pauseCh)
+
+		quit := make(chan struct{})
+		done := make(chan struct{})
+		go func() {
+			defer close(done)
+			require.NotPanics(t, func() { pt.Run(quit) })
+		}()
+
+		send(false)
+		select {
+		case <-done:
+		case <-time.After(time.Second):
+			t.Fatal("Run should return for negative Interval")
+		}
+	})
+
+	t.Run("nil OnTick", func(t *testing.T) {
+		pauseCh, send := makePauseCh()
+		pt := NewPausableTicker(PausableTickerConfig{
+			Interval: time.Millisecond,
+			OnTick:   nil,
+		}, pauseCh)
+
+		quit := make(chan struct{})
+		done := make(chan struct{})
+		go func() {
+			defer close(done)
+			require.NotPanics(t, func() { pt.Run(quit) })
+		}()
+
+		send(false)
+		select {
+		case <-done:
+		case <-time.After(time.Second):
+			t.Fatal("Run should return when OnTick is nil")
+		}
+	})
+}
+
+func TestPausableTicker_Run_invalidConfig_skipsOnPauseChanged(t *testing.T) {
+	pauseCh, send := makePauseCh()
+	var calls atomic.Int32
+	pt := NewPausableTicker(PausableTickerConfig{
+		Interval:       0,
+		OnTick:         func() {},
+		OnPauseChanged: func(bool) { calls.Add(1) },
+	}, pauseCh)
+
+	quit := make(chan struct{})
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		pt.Run(quit)
+	}()
+
+	send(false)
+	<-done
+	require.Equal(t, int32(0), calls.Load(), "invalid config: Run exits before reading pauseCh; OnPauseChanged must not run")
 }

--- a/common/pausable_ticker_test.go
+++ b/common/pausable_ticker_test.go
@@ -1,0 +1,213 @@
+package common
+
+import (
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// makePauseCh returns a channel and a helper to send pause/resume signals.
+func makePauseCh() (chan bool, func(bool)) {
+	ch := make(chan bool, 1)
+	send := func(paused bool) {
+		// Drain stale value first to avoid blocking the sender.
+		select {
+		case <-ch:
+		default:
+		}
+		ch <- paused
+	}
+	return ch, send
+}
+
+func TestPausableTicker_TicksWhenRunning(t *testing.T) {
+	pauseCh, send := makePauseCh()
+
+	var count atomic.Int32
+	pt := NewPausableTicker(PausableTickerConfig{
+		Interval: 10 * time.Millisecond,
+		OnTick:   func() { count.Add(1) },
+	}, pauseCh)
+
+	quit := make(chan struct{})
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		pt.Run(quit)
+	}()
+
+	send(false) // start running
+
+	require.Eventually(t, func() bool {
+		return count.Load() >= 3
+	}, 500*time.Millisecond, 5*time.Millisecond, "expected at least 3 ticks while running")
+
+	close(quit)
+	<-done
+}
+
+func TestPausableTicker_NoTicksWhenPaused(t *testing.T) {
+	pauseCh, send := makePauseCh()
+
+	var count atomic.Int32
+	pt := NewPausableTicker(PausableTickerConfig{
+		Interval: 10 * time.Millisecond,
+		OnTick:   func() { count.Add(1) },
+	}, pauseCh)
+
+	quit := make(chan struct{})
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		pt.Run(quit)
+	}()
+
+	send(true) // start paused
+	time.Sleep(50 * time.Millisecond)
+	require.Equal(t, int32(0), count.Load(), "expected no ticks while paused")
+
+	close(quit)
+	<-done
+}
+
+func TestPausableTicker_PauseStopsTicks(t *testing.T) {
+	pauseCh, send := makePauseCh()
+
+	var count atomic.Int32
+	pt := NewPausableTicker(PausableTickerConfig{
+		Interval: 10 * time.Millisecond,
+		OnTick:   func() { count.Add(1) },
+	}, pauseCh)
+
+	quit := make(chan struct{})
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		pt.Run(quit)
+	}()
+
+	send(false) // running
+	require.Eventually(t, func() bool {
+		return count.Load() >= 2
+	}, 500*time.Millisecond, 5*time.Millisecond)
+
+	send(true) // pause
+	time.Sleep(50 * time.Millisecond)
+	snapshot := count.Load()
+	time.Sleep(50 * time.Millisecond)
+	require.Equal(t, snapshot, count.Load(), "count should not increase while paused")
+
+	close(quit)
+	<-done
+}
+
+func TestPausableTicker_ResumeRestartsTicks(t *testing.T) {
+	pauseCh, send := makePauseCh()
+
+	var count atomic.Int32
+	pt := NewPausableTicker(PausableTickerConfig{
+		Interval: 10 * time.Millisecond,
+		OnTick:   func() { count.Add(1) },
+	}, pauseCh)
+
+	quit := make(chan struct{})
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		pt.Run(quit)
+	}()
+
+	send(true) // start paused
+	time.Sleep(30 * time.Millisecond)
+	require.Equal(t, int32(0), count.Load(), "no ticks while paused")
+
+	send(false) // resume
+	require.Eventually(t, func() bool {
+		return count.Load() >= 2
+	}, 500*time.Millisecond, 5*time.Millisecond, "expected ticks after resume")
+
+	close(quit)
+	<-done
+}
+
+func TestPausableTicker_QuitStopsGoroutine(t *testing.T) {
+	pauseCh, send := makePauseCh()
+
+	pt := NewPausableTicker(PausableTickerConfig{
+		Interval: 10 * time.Millisecond,
+		OnTick:   func() {},
+	}, pauseCh)
+
+	quit := make(chan struct{})
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		pt.Run(quit)
+	}()
+
+	send(false)
+	close(quit)
+
+	select {
+	case <-done:
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("goroutine did not stop after quit was closed")
+	}
+}
+
+func TestPausableTicker_ClosedPauseCh(t *testing.T) {
+	pauseCh := make(chan bool)
+	close(pauseCh)
+
+	pt := NewPausableTicker(PausableTickerConfig{
+		Interval: 10 * time.Millisecond,
+		OnTick:   func() {},
+	}, pauseCh)
+
+	quit := make(chan struct{})
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		pt.Run(quit)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("Run did not return when pauseCh was closed")
+	}
+}
+
+func TestPausableTicker_OnPauseChanged(t *testing.T) {
+	pauseCh, send := makePauseCh()
+
+	var states []bool
+	pt := NewPausableTicker(PausableTickerConfig{
+		Interval: time.Hour, // irrelevant for this test
+		OnTick:   func() {},
+		OnPauseChanged: func(paused bool) {
+			states = append(states, paused)
+		},
+	}, pauseCh)
+
+	quit := make(chan struct{})
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		pt.Run(quit)
+	}()
+
+	send(false) // initial: running
+	time.Sleep(20 * time.Millisecond)
+	send(true)  // pause
+	time.Sleep(20 * time.Millisecond)
+	send(false) // resume
+	time.Sleep(20 * time.Millisecond)
+
+	close(quit)
+	<-done
+
+	require.Equal(t, []bool{false, true, false}, states)
+}

--- a/pkg/backend/node/service_registry.go
+++ b/pkg/backend/node/service_registry.go
@@ -1,0 +1,138 @@
+package node
+
+import (
+	"errors"
+	"fmt"
+	"sync"
+
+	"github.com/status-im/status-go/common"
+	"github.com/status-im/status-go/server"
+)
+
+// PausableMediaServer wraps a server.MediaServer to implement common.Pausable.
+type PausableMediaServer struct {
+	common.PauseBroadcaster
+	s *server.MediaServer
+}
+
+func newPausableMediaServer(s *server.MediaServer) *PausableMediaServer {
+	p := &PausableMediaServer{s: s}
+	p.MarkStarted()
+	return p
+}
+
+func (p *PausableMediaServer) PausableName() string { return "mediaserver" }
+
+func (p *PausableMediaServer) Pause() error {
+	p.s.ToBackground()
+	p.MarkPaused()
+	return nil
+}
+
+func (p *PausableMediaServer) Resume() error {
+	p.s.ToForeground()
+	p.MarkResumed()
+	return nil
+}
+
+// PausableServiceInfo is a lightweight snapshot of a pausable service's state.
+type PausableServiceInfo struct {
+	Name  string              `json:"name"`
+	State common.ServiceState `json:"state"`
+}
+
+// ServiceRegistry tracks services that support granular pause/resume control.
+type ServiceRegistry struct {
+	mu        sync.RWMutex
+	pausables map[string]common.Pausable
+}
+
+func newServiceRegistry() *ServiceRegistry {
+	return &ServiceRegistry{
+		pausables: make(map[string]common.Pausable),
+	}
+}
+
+// Register adds a Pausable service to the registry.
+func (r *ServiceRegistry) Register(p common.Pausable) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.pausables[p.PausableName()] = p
+}
+
+// ListPausable returns a snapshot of all registered services and their current state.
+func (r *ServiceRegistry) ListPausable() []PausableServiceInfo {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	result := make([]PausableServiceInfo, 0, len(r.pausables))
+	for name, p := range r.pausables {
+		result = append(result, PausableServiceInfo{Name: name, State: p.PausableState()})
+	}
+	return result
+}
+
+// Pause pauses the named service. Returns an error if the service is not found.
+func (r *ServiceRegistry) Pause(name string) error {
+	r.mu.RLock()
+	p, ok := r.pausables[name]
+	r.mu.RUnlock()
+	if !ok {
+		return fmt.Errorf("service %q not found in registry", name)
+	}
+	return p.Pause()
+}
+
+// Resume resumes the named service. Returns an error if the service is not found.
+func (r *ServiceRegistry) Resume(name string) error {
+	r.mu.RLock()
+	p, ok := r.pausables[name]
+	r.mu.RUnlock()
+	if !ok {
+		return fmt.Errorf("service %q not found in registry", name)
+	}
+	return p.Resume()
+}
+
+// PauseMultiple pauses all named services, collecting any errors.
+func (r *ServiceRegistry) PauseMultiple(names []string) error {
+	var errs []error
+	for _, name := range names {
+		if err := r.Pause(name); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	return errors.Join(errs...)
+}
+
+// ResumeMultiple resumes all named services, collecting any errors.
+func (r *ServiceRegistry) ResumeMultiple(names []string) error {
+	var errs []error
+	for _, name := range names {
+		if err := r.Resume(name); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	return errors.Join(errs...)
+}
+
+// PauseAll pauses every registered service.
+func (r *ServiceRegistry) PauseAll() error {
+	r.mu.RLock()
+	names := make([]string, 0, len(r.pausables))
+	for name := range r.pausables {
+		names = append(names, name)
+	}
+	r.mu.RUnlock()
+	return r.PauseMultiple(names)
+}
+
+// ResumeAll resumes every registered service.
+func (r *ServiceRegistry) ResumeAll() error {
+	r.mu.RLock()
+	names := make([]string, 0, len(r.pausables))
+	for name := range r.pausables {
+		names = append(names, name)
+	}
+	r.mu.RUnlock()
+	return r.ResumeMultiple(names)
+}

--- a/pkg/backend/node/service_registry.go
+++ b/pkg/backend/node/service_registry.go
@@ -9,6 +9,9 @@ import (
 	"github.com/status-im/status-go/server"
 )
 
+// ErrServiceNotFound is returned by Pause and Resume when the name is not registered.
+var ErrServiceNotFound = errors.New("service not found in registry")
+
 // PausableMediaServer wraps a server.MediaServer to implement common.Pausable.
 type PausableMediaServer struct {
 	common.PauseBroadcaster
@@ -77,7 +80,7 @@ func (r *ServiceRegistry) Pause(name string) error {
 	p, ok := r.pausables[name]
 	r.mu.RUnlock()
 	if !ok {
-		return fmt.Errorf("service %q not found in registry", name)
+		return fmt.Errorf("%w: %q", ErrServiceNotFound, name)
 	}
 	return p.Pause()
 }
@@ -88,7 +91,7 @@ func (r *ServiceRegistry) Resume(name string) error {
 	p, ok := r.pausables[name]
 	r.mu.RUnlock()
 	if !ok {
-		return fmt.Errorf("service %q not found in registry", name)
+		return fmt.Errorf("%w: %q", ErrServiceNotFound, name)
 	}
 	return p.Resume()
 }

--- a/pkg/backend/node/service_registry_test.go
+++ b/pkg/backend/node/service_registry_test.go
@@ -1,0 +1,131 @@
+package node
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/status-im/status-go/common"
+)
+
+// fakePausable is a minimal Pausable for testing.
+type fakePausable struct {
+	common.PauseBroadcaster
+	name string
+}
+
+func newFakePausable(name string) *fakePausable {
+	p := &fakePausable{name: name}
+	p.MarkStarted()
+	return p
+}
+
+func (p *fakePausable) PausableName() string { return p.name }
+
+func (p *fakePausable) Pause() error {
+	p.MarkPaused()
+	return nil
+}
+
+func (p *fakePausable) Resume() error {
+	p.MarkResumed()
+	return nil
+}
+
+func TestServiceRegistry_RegisterAndList(t *testing.T) {
+	r := newServiceRegistry()
+	r.Register(newFakePausable("wallet"))
+	r.Register(newFakePausable("messaging"))
+
+	list := r.ListPausable()
+	require.Len(t, list, 2)
+	names := map[string]bool{}
+	for _, info := range list {
+		names[info.Name] = true
+		require.Equal(t, common.ServiceStateRunning, info.State)
+	}
+	require.True(t, names["wallet"])
+	require.True(t, names["messaging"])
+}
+
+func TestServiceRegistry_PauseAndResume(t *testing.T) {
+	r := newServiceRegistry()
+	p := newFakePausable("wallet")
+	r.Register(p)
+
+	require.NoError(t, r.Pause("wallet"))
+	require.Equal(t, common.ServiceStatePaused, p.PausableState())
+
+	require.NoError(t, r.Resume("wallet"))
+	require.Equal(t, common.ServiceStateRunning, p.PausableState())
+}
+
+func TestServiceRegistry_PauseUnknownReturnsError(t *testing.T) {
+	r := newServiceRegistry()
+	err := r.Pause("nonexistent")
+	require.Error(t, err)
+	require.True(t, errors.Is(err, err)) // just check it's non-nil with proper message
+	require.Contains(t, err.Error(), "nonexistent")
+}
+
+func TestServiceRegistry_PauseMultiple(t *testing.T) {
+	r := newServiceRegistry()
+	wallet := newFakePausable("wallet")
+	connector := newFakePausable("connector")
+	r.Register(wallet)
+	r.Register(connector)
+
+	require.NoError(t, r.PauseMultiple([]string{"wallet", "connector"}))
+	require.Equal(t, common.ServiceStatePaused, wallet.PausableState())
+	require.Equal(t, common.ServiceStatePaused, connector.PausableState())
+}
+
+func TestServiceRegistry_PauseAll_ResumeAll(t *testing.T) {
+	r := newServiceRegistry()
+	wallet := newFakePausable("wallet")
+	connector := newFakePausable("connector")
+	newsfeed := newFakePausable("newsfeed")
+	r.Register(wallet)
+	r.Register(connector)
+	r.Register(newsfeed)
+
+	require.NoError(t, r.PauseAll())
+	require.Equal(t, common.ServiceStatePaused, wallet.PausableState())
+	require.Equal(t, common.ServiceStatePaused, connector.PausableState())
+	require.Equal(t, common.ServiceStatePaused, newsfeed.PausableState())
+
+	require.NoError(t, r.ResumeAll())
+	require.Equal(t, common.ServiceStateRunning, wallet.PausableState())
+	require.Equal(t, common.ServiceStateRunning, connector.PausableState())
+	require.Equal(t, common.ServiceStateRunning, newsfeed.PausableState())
+}
+
+func TestServiceRegistry_PauseMultiple_PartialError(t *testing.T) {
+	r := newServiceRegistry()
+	r.Register(newFakePausable("wallet"))
+	// "connector" is not registered
+
+	err := r.PauseMultiple([]string{"wallet", "connector"})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "connector")
+}
+
+// errorPausable returns an error on Pause.
+type errorPausable struct {
+	common.PauseBroadcaster
+}
+
+func (p *errorPausable) PausableName() string { return "broken" }
+func (p *errorPausable) Pause() error         { return errors.New("pause failed") }
+func (p *errorPausable) Resume() error        { return nil }
+
+func TestServiceRegistry_PauseAll_CollectsErrors(t *testing.T) {
+	r := newServiceRegistry()
+	r.Register(&errorPausable{})
+	r.Register(newFakePausable("wallet"))
+
+	err := r.PauseAll()
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "pause failed")
+}

--- a/pkg/backend/node/service_registry_test.go
+++ b/pkg/backend/node/service_registry_test.go
@@ -65,7 +65,15 @@ func TestServiceRegistry_PauseUnknownReturnsError(t *testing.T) {
 	r := newServiceRegistry()
 	err := r.Pause("nonexistent")
 	require.Error(t, err)
-	require.True(t, errors.Is(err, err)) // just check it's non-nil with proper message
+	require.ErrorIs(t, err, ErrServiceNotFound)
+	require.Contains(t, err.Error(), "nonexistent")
+}
+
+func TestServiceRegistry_ResumeUnknownReturnsError(t *testing.T) {
+	r := newServiceRegistry()
+	err := r.Resume("nonexistent")
+	require.Error(t, err)
+	require.ErrorIs(t, err, ErrServiceNotFound)
 	require.Contains(t, err.Error(), "nonexistent")
 }
 
@@ -108,6 +116,7 @@ func TestServiceRegistry_PauseMultiple_PartialError(t *testing.T) {
 
 	err := r.PauseMultiple([]string{"wallet", "connector"})
 	require.Error(t, err)
+	require.ErrorIs(t, err, ErrServiceNotFound)
 	require.Contains(t, err.Error(), "connector")
 }
 

--- a/pkg/pubsub/type_publisher_test.go
+++ b/pkg/pubsub/type_publisher_test.go
@@ -1,0 +1,34 @@
+package pubsub
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// Mirrors PauseBroadcaster.Subscribe: an initial value is placed on the subscriber channel,
+// then TypePublisher.Publish runs. With buffer size 1, Publish uses non-blocking send and
+// drops the new value if the buffer is still full — the consumer can then observe a stale
+// first read relative to the last Publish. See common.TestPauseBroadcaster_Subscribe_*.
+func TestTypePublisher_publishDroppedWhenPerSubscriberBufferFull(t *testing.T) {
+	p := NewTypePublisher[bool]()
+	ch := p.Subscribe(1)
+	select {
+	case ch <- false:
+	default:
+		t.Fatal("initial direct send should succeed on an empty buffer")
+	}
+	p.Publish(true)
+
+	first, ok := <-ch
+	require.True(t, ok)
+	require.False(t, first, "first value should still be the buffered false, not the published true")
+
+	select {
+	case extra, ok := <-ch:
+		if ok {
+			t.Fatalf("unexpected second value %v; published true was dropped when buffer was full", extra)
+		}
+	default:
+	}
+}


### PR DESCRIPTION
This is the first PR in a series of PRs that will reduce the work done while the app is in the background.
This introduces the concept of pausable services, pausable work and services registry.

Introduce the core primitives for lifecycle-aware service control:

- common/pausable.go: Pausable interface (PausableName/Pause/Resume), PauseBroadcaster embed (MarkPaused/MarkResumed/IsPaused/Subscribe), Subscription interface for goroutine loops.
- common/pausable_ticker.go: PausableTicker — wraps time.Ticker with a nil-channel pause trick so loops block cheaply without extra goroutines.
- pkg/backend/node/service_registry.go: ServiceRegistry — central registry of Pausable services with Register/Pause/Resume/PauseAll/ResumeAll/List.

Iterates https://github.com/status-im/status-app/issues/20227
Discussed in https://github.com/status-im/status-go/pull/7373#discussion_r2987944234
