### PR TITLE
feat: make media server restartable for pause/resume

### DIFF
--- a/server/handlers_test.go
+++ b/server/handlers_test.go
@@ -53,7 +53,7 @@ func (s *HandlersSuite) SetupTest() {
 
 	s.server = &MediaServer{
 		db: s.db,
-		Server: Server{
+		Server: &Server{
 			logger: s.logger,
 		},
 	}

--- a/server/lifecycle_test.go
+++ b/server/lifecycle_test.go
@@ -1,0 +1,46 @@
+package server
+
+import (
+	"net/netip"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+func TestGetBindAddrPortUsesCachedPortForEphemeralConfig(t *testing.T) {
+	s := NewServer(zap.NewNop(), &Config{
+		AddrPort: netip.MustParseAddrPort("127.0.0.1:0"),
+	})
+	s.cachedPort = 45678
+
+	require.Equal(t, netip.MustParseAddrPort("127.0.0.1:45678"), s.getBindAddrPort())
+}
+
+func TestServerToBackgroundToForegroundReusesEphemeralPort(t *testing.T) {
+	s := NewServer(zap.NewNop(), &Config{
+		AddrPort: netip.MustParseAddrPort("127.0.0.1:0"),
+	})
+
+	require.NoError(t, s.Start())
+	require.Eventually(t, func() bool {
+		return s.GetPort() != 0
+	}, time.Second, 10*time.Millisecond)
+
+	firstPort := s.GetPort()
+	require.NotZero(t, firstPort)
+
+	s.ToBackground()
+	require.Eventually(t, func() bool {
+		return !s.IsRunning()
+	}, time.Second, 10*time.Millisecond)
+
+	s.ToForeground()
+	require.Eventually(t, func() bool {
+		return s.IsRunning() && s.GetPort() != 0
+	}, time.Second, 10*time.Millisecond)
+
+	require.Equal(t, firstPort, s.GetPort())
+	require.NoError(t, s.Stop())
+}

--- a/server/listen_control_unix.go
+++ b/server/listen_control_unix.go
@@ -1,0 +1,9 @@
+//go:build !windows
+
+package server
+
+import "syscall"
+
+func setReuseAddr(fd uintptr) error {
+	return syscall.SetsockoptInt(int(fd), syscall.SOL_SOCKET, syscall.SO_REUSEADDR, 1)
+}

--- a/server/listen_control_windows.go
+++ b/server/listen_control_windows.go
@@ -1,0 +1,9 @@
+//go:build windows
+
+package server
+
+import "syscall"
+
+func setReuseAddr(fd uintptr) error {
+	return syscall.SetsockoptInt(syscall.Handle(fd), syscall.SOL_SOCKET, syscall.SO_REUSEADDR, 1)
+}

--- a/server/pairing/server.go
+++ b/server/pairing/server.go
@@ -29,7 +29,7 @@ import (
 */
 
 type BaseServer struct {
-	server.Server
+	*server.Server
 	challengeGiver *ChallengeGiver
 
 	config ServerConfig

--- a/server/server.go
+++ b/server/server.go
@@ -9,11 +9,30 @@ import (
 	"net/netip"
 	"net/url"
 	"strconv"
+	"sync"
+	"sync/atomic"
+	"syscall"
 
 	"go.uber.org/zap"
 
 	"github.com/status-im/status-go/common"
 )
+
+// tcpListenConfig sets SO_REUSEADDR so that after the previous listener is fully
+// closed, the kernel can allow binding the same cached ephemeral port again (e.g.
+// TIME_WAIT) without a long delay. It does not help if Stop returns before that
+// socket is closed — Stop waits on serveWg for that ordering.
+var tcpListenConfig = net.ListenConfig{
+	Control: func(network, address string, c syscall.RawConn) error {
+		var optErr error
+		if err := c.Control(func(fd uintptr) {
+			optErr = setReuseAddr(fd)
+		}); err != nil {
+			return err
+		}
+		return optErr
+	},
+}
 
 type Config struct {
 	Cert     *tls.Certificate
@@ -26,6 +45,8 @@ type Config struct {
 }
 
 type Server struct {
+	mu sync.Mutex
+
 	listener net.Listener
 	server   *http.Server
 	logger   *zap.Logger
@@ -36,14 +57,23 @@ type Server struct {
 	// address is the host and port the server is listening on
 	address *net.TCPAddr
 
-	// isRunning is true if the server was started and is running
-	isRunning bool
+	// running is true if the server was started and Serve is active; read via IsRunning().
+	running atomic.Bool
+
+	// cachedPort stores the port from the first successful bind when AddrPort used port 0 (ephemeral).
+	// Reused on pause/resume so URLs remain valid across ToBackground/ToForeground cycles.
+	cachedPort int
+
+	// serveWg waits for the serve goroutine to finish all defers after http.Server.Serve returns,
+	// so Stop does not return while the previous listener may still be tearing down (avoids EADDRINUSE
+	// when rebinding the same cached ephemeral port).
+	serveWg sync.WaitGroup
 
 	*timeoutManager
 }
 
-func NewServer(logger *zap.Logger, config *Config) Server {
-	return Server{
+func NewServer(logger *zap.Logger, config *Config) *Server {
+	return &Server{
 		logger:         logger,
 		config:         config,
 		timeoutManager: newTimeoutManager(),
@@ -91,14 +121,29 @@ func (s *Server) GetLogger() *zap.Logger {
 	return s.logger
 }
 
+// getBindAddrPort returns the address to bind to. When config used port 0 (ephemeral)
+// and we have a cached port from a previous run, reuse it so URLs stay stable across pause/resume.
+func (s *Server) getBindAddrPort() netip.AddrPort {
+	if s.cachedPort != 0 && s.config.AddrPort.Port() == 0 {
+		return netip.AddrPortFrom(s.config.AddrPort.Addr(), uint16(s.cachedPort))
+	}
+	return s.config.AddrPort
+}
+
 func (s *Server) createListener() (net.Listener, error) {
-	if s.config.Cert == nil {
-		// HTTP mode
-		return net.Listen("tcp", s.config.AddrPort.String())
+	addr := s.getBindAddrPort()
+	addrStr := addr.String()
+
+	ln, err := tcpListenConfig.Listen(context.Background(), "tcp", addrStr)
+	if err != nil {
+		return nil, err
 	}
 
-	// HTTPS mode
-	serverName := s.config.AddrPort.Addr().String()
+	if s.config.Cert == nil {
+		return ln, nil
+	}
+
+	serverName := addr.Addr().String()
 	if len(s.config.Cert.Leaf.DNSNames) > 0 {
 		serverName = s.config.Cert.Leaf.DNSNames[0]
 	}
@@ -108,7 +153,7 @@ func (s *Server) createListener() (net.Listener, error) {
 		ServerName:   serverName,
 		MinVersion:   tls.VersionTLS12,
 	}
-	return tls.Listen("tcp", s.config.AddrPort.String(), cfg)
+	return tls.NewListener(ln, cfg), nil
 }
 
 func (s *Server) listen() error {
@@ -122,6 +167,9 @@ func (s *Server) listen() error {
 	}
 
 	s.address = s.listener.Addr().(*net.TCPAddr)
+	if s.config.AddrPort.Port() == 0 {
+		s.cachedPort = s.address.Port
+	}
 
 	s.StartTimeout(func() {
 		err := s.Stop()
@@ -133,16 +181,22 @@ func (s *Server) listen() error {
 	return nil
 }
 
-func (s *Server) serve() {
+func (s *Server) serve(currentServer *http.Server, currentListener net.Listener) {
 	defer common.LogOnPanic()
 
-	s.isRunning = true
 	defer func() {
-		s.isRunning = false
-		s.address = nil
+		s.mu.Lock()
+		defer s.mu.Unlock()
+
+		// If a newer Start() already replaced server/listener, do not clobber
+		// the latest running instance state.
+		if s.server == currentServer && s.listener == currentListener {
+			s.running.Store(false)
+			s.address = nil
+		}
 	}()
 
-	err := s.server.Serve(s.listener)
+	err := currentServer.Serve(currentListener)
 	if errors.Is(err, http.ErrServerClosed) {
 		return
 	}
@@ -171,7 +225,10 @@ func (s *Server) applyHandlers() {
 }
 
 func (s *Server) Start() error {
-	if s.isRunning {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.running.Load() {
 		return nil
 	}
 
@@ -184,38 +241,52 @@ func (s *Server) Start() error {
 		return err
 	}
 
-	go s.serve()
+	// Mark running synchronously to avoid pause/play races where ToBackground
+	// can run before serve() goroutine has a chance to set the state.
+	s.running.Store(true)
+	s.serveWg.Add(1)
+	go func() {
+		defer common.LogOnPanic()
+		defer s.serveWg.Done()
+		s.serve(s.server, s.listener)
+	}()
 	return nil
 }
 
 func (s *Server) Stop() error {
+	s.mu.Lock()
 	s.StopTimeout()
-	if s.server != nil {
-		return s.server.Shutdown(context.Background())
+	if !s.running.Load() || s.server == nil {
+		s.mu.Unlock()
+		return nil
 	}
 
-	return nil
+	// Capture the current instance and release the lock before Shutdown.
+	// Shutdown waits for Serve() to return, and Serve() may update state in
+	// its defer path under the same mutex.
+	currentServer := s.server
+	s.running.Store(false)
+	s.mu.Unlock()
+
+	err := currentServer.Shutdown(context.Background())
+	s.serveWg.Wait()
+	return err
 }
 
 func (s *Server) IsRunning() bool {
-	return s.isRunning
+	return s.running.Load()
 }
 
 func (s *Server) ToForeground() {
-	if !s.isRunning && (s.server != nil) {
-		err := s.Start()
-		if err != nil {
-			s.logger.Error("server start failed during foreground transition", zap.Error(err))
-		}
+	if err := s.Start(); err != nil {
+		s.logger.Error("server start failed during foreground transition", zap.Error(err))
 	}
 }
 
 func (s *Server) ToBackground() {
-	if s.isRunning {
-		err := s.Stop()
-		if err != nil {
-			s.logger.Error("server stop failed during background transition", zap.Error(err))
-		}
+	err := s.Stop()
+	if err != nil {
+		s.logger.Error("server stop failed during background transition", zap.Error(err))
 	}
 }
 

--- a/server/server_media.go
+++ b/server/server_media.go
@@ -60,7 +60,7 @@ type MediaServerConfig struct {
 }
 
 type MediaServer struct {
-	Server
+	*Server
 
 	db                          *sql.DB
 	downloader                  *ipfs.Downloader

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -28,7 +28,7 @@ func (s *ServerURLSuite) SetupTest() {
 	s.baseURL = fmt.Sprintf("http://%s:%d", ip, port)
 
 	s.server = &MediaServer{
-		Server: Server{
+		Server: &Server{
 			address: &net.TCPAddr{
 				IP:   net.ParseIP(ip),
 				Port: port,


### PR DESCRIPTION
- Add SO_REUSEADDR via tcpListenConfig so the server can quickly rebind the same port after Stop/Start without TIME_WAIT delays.
- Add sync.Mutex + atomic.Bool for thread-safe Start/Stop/serve to prevent races when toggling between foreground and background.
- Cache the ephemeral port from the first bind so URLs remain stable across pause/resume (ToBackground/ToForeground) cycles.
- BaseServer in pairing now uses *server.Server (pointer) since Server contains a mutex and must not be copied.


Iterates https://github.com/status-im/status-app/issues/20227 - Needed for service pause/resume
Fixing https://github.com/status-im/status-app/issues/19868
