### PR TITLE
feat: more descriptive local notification preview text

### DIFF
--- a/protocol/local_notifications.go
+++ b/protocol/local_notifications.go
@@ -110,6 +110,27 @@ func applyMessagePreview(title, message string, messagePreview int) (displayTitl
 	}
 }
 
+// getMessagePreviewText returns a simplified, notification-safe preview of the message text.
+// Uses GetSimplifiedText when possible, falls back to raw Text. Returns empty string if message is nil or extraction fails.
+func getMessagePreviewText(m *common.Message, canonicalNames map[string]string) string {
+	if m == nil {
+		return ""
+	}
+	text, err := m.GetSimplifiedText("", canonicalNames)
+	if err != nil {
+		return strings.TrimSpace(m.Text)
+	}
+	return strings.TrimSpace(text)
+}
+
+// timestampOrZero returns the message's WhisperTimestamp, or 0 if the message is nil.
+func timestampOrZero(m *common.Message) uint64 {
+	if m == nil {
+		return 0
+	}
+	return m.WhisperTimestamp
+}
+
 // applyAuthorPrivacy clears identity-revealing fields from a notification when the privacy
 // level is anonymous. In anonymous mode the OS notification must not expose who sent
 // the message: no sender name, no sender/community/chat icon.
@@ -282,10 +303,7 @@ func NewCommunityRequestToJoinNotification(id string, community *communities.Com
 // NewOutgoingMessageNotification creates a local notification for a message sent by the current user.
 func NewOutgoingMessageNotification(id string, message *common.Message, chat *Chat, community *communities.Community, authorName string, authorIcon string, authorID string) *localnotifications.Notification {
 	title := chat.Name
-	simplifiedText, err := message.GetSimplifiedText("", nil)
-	if err != nil {
-		simplifiedText = message.Text
-	}
+	simplifiedText := getMessagePreviewText(message, nil)
 	notif := &localnotifications.Notification{
 		ID:                  gethcommon.HexToHash(id),
 		BodyType:            localnotifications.TypeMessage,
@@ -389,7 +407,10 @@ func (n NotificationBody) toMessageNotification(id string, resolvePrimaryName fu
 
 func (n NotificationBody) toContactRequestNotification(id string, profilePicturesVisibility int, messagePreview int) (*localnotifications.Notification, error) {
 	title := n.Contact.PrimaryName() + " wants to connect"
-	message := n.Contact.PrimaryName() + " sent you a contact request"
+	message := getMessagePreviewText(n.Message, nil)
+	if message == "" {
+		message = n.Contact.PrimaryName() + " sent you a contact request"
+	}
 	displayTitle, displayMessage := applyMessagePreview(title, message, messagePreview)
 	notif := &localnotifications.Notification{
 		ID:             gethcommon.HexToHash(id),
@@ -407,7 +428,7 @@ func (n NotificationBody) toContactRequestNotification(id string, profilePicture
 			ID:   n.Contact.ID,
 		},
 		ConversationID: n.Chat.ID,
-		Timestamp:      n.Message.WhisperTimestamp,
+		Timestamp:      timestampOrZero(n.Message),
 		IsConversation: true,
 		Image:          "",
 	}
@@ -417,7 +438,10 @@ func (n NotificationBody) toContactRequestNotification(id string, profilePicture
 
 func (n NotificationBody) toPrivateGroupInviteNotification(id string, profilePicturesVisibility int, messagePreview int) *localnotifications.Notification {
 	title := n.Contact.PrimaryName() + " invited you to " + n.Chat.Name
-	message := n.Contact.PrimaryName() + " wants you to join group " + n.Chat.Name
+	message := getMessagePreviewText(n.Message, nil)
+	if message == "" {
+		message = n.Contact.PrimaryName() + " wants you to join group " + n.Chat.Name
+	}
 	displayTitle, displayMessage := applyMessagePreview(title, message, messagePreview)
 	notif := &localnotifications.Notification{
 		ID:             gethcommon.HexToHash(id),
@@ -443,7 +467,7 @@ func (n NotificationBody) toPrivateGroupInviteNotification(id string, profilePic
 
 func (n NotificationBody) toCommunityRequestToJoinNotification(id string, profilePicturesVisibility int, messagePreview int) *localnotifications.Notification {
 	title := n.Contact.PrimaryName() + " wants to join " + n.Community.Name()
-	message := n.Contact.PrimaryName() + " wants to join " + n.Community.Name()
+	message := getMessagePreviewText(n.Message, nil)
 	displayTitle, displayMessage := applyMessagePreview(title, message, messagePreview)
 	notif := &localnotifications.Notification{
 		ID:             gethcommon.HexToHash(id),

--- a/protocol/local_notifications_test.go
+++ b/protocol/local_notifications_test.go
@@ -76,6 +76,66 @@ func TestApplyMessagePreview(t *testing.T) {
 	})
 }
 
+func TestGetMessagePreviewTextNilMessage(t *testing.T) {
+	require.Equal(t, "", getMessagePreviewText(nil, nil))
+}
+
+func TestGetMessagePreviewTextTrimsMessageText(t *testing.T) {
+	msg := &common.Message{
+		ChatMessage: &protobuf.ChatMessage{
+			Text: "  hello world  ",
+		},
+	}
+	require.Equal(t, "hello world", getMessagePreviewText(msg, nil))
+}
+
+func TestTimestampOrZero(t *testing.T) {
+	require.Equal(t, uint64(0), timestampOrZero(nil))
+
+	msg := &common.Message{WhisperTimestamp: 42}
+	require.Equal(t, uint64(42), timestampOrZero(msg))
+}
+
+func TestToContactRequestNotificationFallbackMessageAndZeroTimestamp(t *testing.T) {
+	body := NotificationBody{
+		Contact: &contacts.Contact{
+			ID:          "0xabc",
+			DisplayName: "Alice",
+		},
+		Chat: &Chat{
+			ID:       "chat-1",
+			ChatType: ChatTypeOneToOne,
+		},
+	}
+
+	notif, err := body.toContactRequestNotification("0x1", 0, messagePreviewNameAndMessage)
+	require.NoError(t, err)
+	require.Equal(t, "Alice sent you a contact request", notif.Message)
+	require.Equal(t, uint64(0), notif.Timestamp)
+}
+
+func TestToPrivateGroupInviteNotificationUsesMessagePreviewWhenPresent(t *testing.T) {
+	body := NotificationBody{
+		Contact: &contacts.Contact{
+			ID:          "0xabc",
+			DisplayName: "Alice",
+		},
+		Chat: &Chat{
+			ID:       "group-1",
+			Name:     "Secret Group",
+			ChatType: ChatTypePrivateGroupChat,
+		},
+		Message: &common.Message{
+			ChatMessage: &protobuf.ChatMessage{
+				Text: "  please join us  ",
+			},
+		},
+	}
+
+	notif := body.toPrivateGroupInviteNotification("0x2", 0, messagePreviewNameAndMessage)
+	require.Equal(t, "please join us", notif.Message)
+}
+
 func TestShowMessageNotification_OneToOneChats(t *testing.T) {
 	key, _ := crypto.GenerateKey()
 	pkHex := types.EncodeHex(crypto.FromECDSAPub(&key.PublicKey))


### PR DESCRIPTION

Add getMessagePreviewText helper that uses GetSimplifiedText to produce notification-safe previews: strips markdown, resolves mention display names, and falls back to raw text.

Iterates https://github.com/status-im/status-app/issues/19532
