### PR TITLE
feat: make messaging services pausable

### DIFF
--- a/pkg/messaging/api.go
+++ b/pkg/messaging/api.go
@@ -30,3 +30,17 @@ func (a *API) Publisher() *pubsub.Publisher {
 func (a *API) GetCurrentTime() uint64 {
 	return a.core.stack.Transport.GetCurrentTime()
 }
+
+// PauseTransport signals the transport and its sub-components to idle their goroutines.
+func (a *API) PauseTransport() {
+	if a.core.stack.Transport != nil {
+		a.core.stack.Transport.Pause()
+	}
+}
+
+// ResumeTransport signals the transport and its sub-components to resume their goroutines.
+func (a *API) ResumeTransport() {
+	if a.core.stack.Transport != nil {
+		a.core.stack.Transport.Resume()
+	}
+}

--- a/pkg/messaging/layers/reliability/datasync/transport.go
+++ b/pkg/messaging/layers/reliability/datasync/transport.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"math"
 	"math/rand"
+	"sync"
 	"time"
 
 	"github.com/status-im/mvds/protobuf"
@@ -17,10 +18,23 @@ const backoffInterval = 60
 
 var errNotInitialized = errors.New("datasync transport not initialized")
 var DatasyncTicker = 300 * time.Millisecond
+var datasyncTickerMutex sync.RWMutex
 
-// It's easier to calculate nextEpoch if we consider seconds as a unit rather than
-// 300 ms, so we multiply the result by the ratio
-var offsetToSecond = uint64(time.Second / DatasyncTicker)
+func SetPaused(paused bool) {
+	datasyncTickerMutex.Lock()
+	defer datasyncTickerMutex.Unlock()
+	if paused {
+		DatasyncTicker = 2 * time.Second
+	} else {
+		DatasyncTicker = 300 * time.Millisecond
+	}
+}
+
+func currentOffsetToSecond() uint64 {
+	datasyncTickerMutex.RLock()
+	defer datasyncTickerMutex.RUnlock()
+	return uint64(math.Ceil(float64(time.Second) / float64(DatasyncTicker)))
+}
 
 type NodeTransport struct {
 	packets  chan transport.Packet
@@ -74,5 +88,5 @@ func (t *NodeTransport) Send(_ state.PeerID, peer state.PeerID, payload *protobu
 // at which a message should be sent.
 // We randomize it a bit so that not all messages are sent on the same epoch
 func CalculateSendTime(count uint64, time int64) int64 {
-	return time + int64(uint64(math.Exp2(float64(count-1)))*backoffInterval*offsetToSecond) + int64(rand.Intn(30)) // nolint: gosec
+	return time + int64(uint64(math.Exp2(float64(count-1)))*backoffInterval*currentOffsetToSecond()) + int64(rand.Intn(30)) // nolint: gosec
 }

--- a/pkg/messaging/layers/transport/envelopes_monitor.go
+++ b/pkg/messaging/layers/transport/envelopes_monitor.go
@@ -86,6 +86,8 @@ type monitoredEnvelope struct {
 
 // EnvelopesMonitor is responsible for monitoring waku envelopes state.
 type EnvelopesMonitor struct {
+	gocommon.PauseBroadcaster
+
 	w           types.Waku
 	api         types.PublicWakuAPI
 	handler     EnvelopeEventsHandler
@@ -328,17 +330,13 @@ func backoffDuration(attempts int) time.Duration {
 
 // retryLoop handles the retry logic to send envelope in a loop
 func (m *EnvelopesMonitor) retryLoop() {
-	ticker := time.NewTicker(500 * time.Millisecond) // Timer, triggers every 500 milliseconds
-	defer ticker.Stop()
-
-	for {
-		select {
-		case <-m.quit:
-			return
-		case <-ticker.C:
-			m.retryOnce()
-		}
-	}
+	sub := m.Subscribe()
+	defer sub.Unsubscribe()
+	pt := gocommon.NewPausableTicker(gocommon.PausableTickerConfig{
+		Interval: 500 * time.Millisecond,
+		OnTick:   m.retryOnce,
+	}, sub.C())
+	pt.Run(m.quit)
 }
 
 // retryOnce retries once

--- a/pkg/messaging/layers/transport/envelopes_monitor_test.go
+++ b/pkg/messaging/layers/transport/envelopes_monitor_test.go
@@ -242,9 +242,34 @@ func (s *EnvelopesMonitorSuite) TestRetryOnce() {
 	s.Require().Equal(envelope.envelopeHashID, s.monitor.envelopes[envelope.envelopeHashID].envelopeHashID)
 }
 
-type mockWakuAPI struct{}
+func (s *EnvelopesMonitorSuite) TestRetryLoopSkipsWhenPaused() {
+	s.monitor.MarkPaused()
+	defer s.monitor.MarkResumed()
+
+	mockAPI := &mockWakuAPI{}
+	s.monitor.api = mockAPI
+	err := s.monitor.Add(testIDs, testHashes, []*types2.NewMessage{{}})
+	s.Require().NoError(err)
+	envelope := s.monitor.envelopes[testHash]
+	envelope.attempts = 2
+	envelope.lastAttemptTime = time.Now().Add(-20 * time.Second)
+	s.monitor.retryQueue = append(s.monitor.retryQueue, envelope)
+
+	s.monitor.quit = make(chan struct{})
+	go s.monitor.retryLoop()
+	time.Sleep(1100 * time.Millisecond)
+	close(s.monitor.quit)
+	time.Sleep(50 * time.Millisecond)
+
+	s.Require().Equal(0, mockAPI.postCalls)
+}
+
+type mockWakuAPI struct {
+	postCalls int
+}
 
 func (m *mockWakuAPI) Post(ctx context.Context, msg types2.NewMessage) ([]byte, error) {
+	m.postCalls++
 	return []byte{0x01}, nil
 }
 

--- a/pkg/messaging/layers/transport/transport.go
+++ b/pkg/messaging/layers/transport/transport.go
@@ -71,6 +71,8 @@ type Option func(*Transport) error
 
 // Transport is a transport based on Whisper service.
 type Transport struct {
+	gocommon.PauseBroadcaster
+
 	waku        types.Waku
 	api         types.PublicWakuAPI // only PublicWakuAPI implements logic to send messages
 	keysManager *transportKeysManager
@@ -79,8 +81,27 @@ type Transport struct {
 	cache       ProcessedMessageIDsCachePersistence
 
 	envelopesMonitor *EnvelopesMonitor
+	cleanFiltersFn   func() error
 	quit             chan struct{}
 }
+
+// Pause signals Transport's internal goroutines to idle and cascades to EnvelopesMonitor.
+func (t *Transport) Pause() {
+	t.MarkPaused()
+	if t.envelopesMonitor != nil {
+		t.envelopesMonitor.MarkPaused()
+	}
+}
+
+// Resume signals Transport's internal goroutines to resume and cascades to EnvelopesMonitor.
+func (t *Transport) Resume() {
+	t.MarkResumed()
+	if t.envelopesMonitor != nil {
+		t.envelopesMonitor.MarkResumed()
+	}
+}
+
+var cleanFiltersLoopInterval = 5 * time.Minute
 
 // NewTransport returns a new Transport.
 // TODO: leaving a chat should verify that for a given public key
@@ -362,6 +383,12 @@ func (t *Transport) SendCommunityMessage(ctx context.Context, newMessage *types.
 }
 
 func (t *Transport) cleanFilters() error {
+	if t.cleanFiltersFn != nil {
+		return t.cleanFiltersFn()
+	}
+	if t.filters == nil {
+		return nil
+	}
 	return t.filters.RemoveNoListenFilters()
 }
 
@@ -428,22 +455,20 @@ func (t *Transport) Stop() error {
 // We therefore periodically clean them up so we don't receive unnecessary data.
 
 func (t *Transport) cleanFiltersLoop() {
-
-	ticker := time.NewTicker(5 * time.Minute)
 	go func() {
 		defer gocommon.LogOnPanic()
-		for {
-			select {
-			case <-t.quit:
-				ticker.Stop()
-				return
-			case <-ticker.C:
+		sub := t.Subscribe()
+		defer sub.Unsubscribe()
+		pt := gocommon.NewPausableTicker(gocommon.PausableTickerConfig{
+			Interval: cleanFiltersLoopInterval,
+			OnTick: func() {
 				err := t.cleanFilters()
 				if err != nil {
 					t.logger.Error("failed to clean up topics", zap.Error(err))
 				}
-			}
-		}
+			},
+		}, sub.C())
+		pt.Run(t.quit)
 	}()
 }
 

--- a/pkg/messaging/layers/transport/transport_test.go
+++ b/pkg/messaging/layers/transport/transport_test.go
@@ -1,7 +1,10 @@
 package transport
 
 import (
+	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	bindata "github.com/status-im/migrate/v4/source/go_bindata"
 	"github.com/stretchr/testify/require"
@@ -22,6 +25,49 @@ func TestNewTransport(t *testing.T) {
 	logger := testutils.MustCreateTestLogger()
 	defer func() { _ = logger.Sync() }()
 
-	_, err = NewTransport(nil, nil, NewSQLiteKeysPersistence(db), NewSQLiteProcessedMessageIDsCachePersistence(db), nil, logger)
+	tr, err := NewTransport(nil, nil, NewSQLiteKeysPersistence(db), NewSQLiteProcessedMessageIDsCachePersistence(db), nil, logger)
 	require.NoError(t, err)
+	// Stop the transport to prevent cleanFiltersLoop from leaking into later tests.
+	t.Cleanup(func() { _ = tr.Stop() })
+}
+
+func TestCleanFiltersLoopPausesAndResumesByLifecycle(t *testing.T) {
+	originalInterval := cleanFiltersLoopInterval
+	cleanFiltersLoopInterval = 20 * time.Millisecond
+	t.Cleanup(func() { cleanFiltersLoopInterval = originalInterval })
+
+	logger := testutils.MustCreateTestLogger()
+	defer func() { _ = logger.Sync() }()
+
+	quit := make(chan struct{})
+	var quitOnce sync.Once
+	shutdown := func() {
+		quitOnce.Do(func() { close(quit) })
+	}
+	defer shutdown()
+
+	var cleanCalls atomic.Int32
+	tr := &Transport{
+		logger: logger,
+		quit:   quit,
+		cleanFiltersFn: func() error {
+			cleanCalls.Add(1)
+			return nil
+		},
+	}
+	tr.MarkPaused()
+
+	tr.cleanFiltersLoop()
+
+	// While paused the ticker must not run: Never fails if cleanCalls becomes non-zero during the window.
+	pausedSoak := 3 * cleanFiltersLoopInterval
+	require.Never(t, func() bool { return cleanCalls.Load() > 0 }, pausedSoak, 5*time.Millisecond,
+		"ticks must not run while paused")
+
+	tr.MarkResumed()
+	require.Eventually(t, func() bool {
+		return cleanCalls.Load() > 0
+	}, time.Second, 20*time.Millisecond, "expected at least one tick after resume")
+
+	shutdown()
 }

--- a/pkg/messaging/waku/api.go
+++ b/pkg/messaging/waku/api.go
@@ -284,10 +284,16 @@ func (api *PublicWakuAPI) Messages(ctx context.Context, crit types2.Criteria) (*
 		// for now poll internally, refactor waku internal for channel support
 		ticker := time.NewTicker(250 * time.Millisecond)
 		defer ticker.Stop()
+		sub := api.w.PauseBroadcaster.Subscribe()
+		defer sub.Unsubscribe()
+		paused := <-sub.C()
 
-		for {
-			select {
-			case <-ticker.C:
+		runPausedPollingLoop(
+			paused,
+			sub.C(),
+			ticker.C,
+			rpcSub.Err(),
+			func() {
 				if filter := api.w.getFilter(id); filter != nil {
 					for _, rpcMessage := range toMessage(filter.Retrieve()) {
 						if err := notifier.Notify(rpcSub.ID, rpcMessage); err != nil {
@@ -295,14 +301,43 @@ func (api *PublicWakuAPI) Messages(ctx context.Context, crit types2.Criteria) (*
 						}
 					}
 				}
-			case <-rpcSub.Err():
+			},
+			func() {
 				_ = api.w.Unsubscribe(context.Background(), id)
-				return
-			}
-		}
+			},
+		)
 	}()
 
 	return rpcSub, nil
+}
+
+func runPausedPollingLoop(initialPaused bool, lifecycleCh <-chan bool, tickerCh <-chan time.Time, stopCh <-chan error, onTick func(), onStop func()) {
+	paused := initialPaused
+	var activeTicker <-chan time.Time
+	if !paused {
+		activeTicker = tickerCh
+	}
+
+	for {
+		select {
+		case pausedState, ok := <-lifecycleCh:
+			if !ok {
+				onStop()
+				return
+			}
+			paused = pausedState
+			if paused {
+				activeTicker = nil
+			} else {
+				activeTicker = tickerCh
+			}
+		case <-activeTicker:
+			onTick()
+		case <-stopCh:
+			onStop()
+			return
+		}
+	}
 }
 
 // ToWakuMessage converts an internal message into an API version.

--- a/pkg/messaging/waku/api_test.go
+++ b/pkg/messaging/waku/api_test.go
@@ -20,12 +20,105 @@ package wakuv2
 
 import (
 	"maps"
+	"sync/atomic"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/require"
 
 	"github.com/status-im/status-go/pkg/messaging/waku/common"
 	types2 "github.com/status-im/status-go/pkg/messaging/waku/types"
 )
+
+func TestRunPausedPollingLoopSkipsWhenPausedAndResumes(t *testing.T) {
+	lifecycleCh := make(chan bool, 2)
+	tickerCh := make(chan time.Time, 2)
+	stopCh := make(chan error, 1)
+
+	var ticks atomic.Int32
+	stopped := make(chan struct{}, 1)
+
+	go runPausedPollingLoop(
+		true,
+		lifecycleCh,
+		tickerCh,
+		stopCh,
+		func() {
+			ticks.Add(1)
+		},
+		func() {
+			stopped <- struct{}{}
+		},
+	)
+
+	tickerCh <- time.Now()
+	time.Sleep(50 * time.Millisecond)
+	if ticks.Load() != 0 {
+		t.Fatalf("expected no ticks while paused, got %d", ticks.Load())
+	}
+
+	lifecycleCh <- false
+	require.Eventually(t, func() bool {
+		select {
+		case tickerCh <- time.Now():
+		default:
+		}
+		return ticks.Load() >= 1
+	}, time.Second, 20*time.Millisecond)
+
+	stopCh <- nil
+	require.Eventually(t, func() bool {
+		return len(stopped) == 1
+	}, time.Second, 20*time.Millisecond)
+}
+
+func TestRunPausedPollingLoopStopsWhenLifecycleChannelCloses(t *testing.T) {
+	lifecycleCh := make(chan bool)
+	tickerCh := make(chan time.Time, 1)
+	stopCh := make(chan error, 1)
+
+	stopped := make(chan struct{}, 1)
+	go runPausedPollingLoop(
+		false,
+		lifecycleCh,
+		tickerCh,
+		stopCh,
+		func() {},
+		func() { stopped <- struct{}{} },
+	)
+
+	close(lifecycleCh)
+	require.Eventually(t, func() bool {
+		return len(stopped) == 1
+	}, time.Second, 20*time.Millisecond)
+}
+
+func TestRunPausedPollingLoopStopsOnStopSignal(t *testing.T) {
+	lifecycleCh := make(chan bool, 1)
+	tickerCh := make(chan time.Time, 1)
+	stopCh := make(chan error, 1)
+
+	var ticks atomic.Int32
+	stopped := make(chan struct{}, 1)
+	go runPausedPollingLoop(
+		false,
+		lifecycleCh,
+		tickerCh,
+		stopCh,
+		func() { ticks.Add(1) },
+		func() { stopped <- struct{}{} },
+	)
+
+	tickerCh <- time.Now()
+	require.Eventually(t, func() bool {
+		return ticks.Load() == 1
+	}, time.Second, 20*time.Millisecond)
+
+	stopCh <- nil
+	require.Eventually(t, func() bool {
+		return len(stopped) == 1
+	}, time.Second, 20*time.Millisecond)
+}
 
 func TestMultipleTopicCopyInNewMessageFilter(t *testing.T) {
 	w, err := New(nil, nil, nil, nil, nil, nil)

--- a/pkg/messaging/waku/gowaku.go
+++ b/pkg/messaging/waku/gowaku.go
@@ -98,6 +98,7 @@ const cacheTTL = 20 * time.Minute
 const maxRelayPeers = 300
 const randomPeersKeepAliveInterval = 5 * time.Second
 const allPeersKeepAliveInterval = 5 * time.Minute
+const pausedModePeerExchangeMinPeers = 3
 
 type SentEnvelope struct {
 	Envelope      *protocol.Envelope
@@ -128,6 +129,8 @@ type IMetricsHandler interface {
 // Waku represents a dark communication interface through the Ethereum
 // network, using its very own P2P communication layer.
 type Waku struct {
+	gocommon.PauseBroadcaster
+
 	node *node.WakuNode // reference to a libp2p waku node
 
 	dnsAddressCache             map[string][]dnsdisc.DiscoveredNode // Map to store the multiaddresses returned by dns discovery
@@ -590,13 +593,29 @@ func (w *Waku) runPeerExchangeLoop() {
 
 	ticker := time.NewTicker(time.Second * 5)
 	defer ticker.Stop()
+	sub := w.PauseBroadcaster.Subscribe()
+	defer sub.Unsubscribe()
+	paused := <-sub.C()
 
 	for {
 		select {
 		case <-w.ctx.Done():
 			w.logger.Debug("Peer exchange loop stopped")
 			return
+		case pausedState, ok := <-sub.C():
+			if !ok {
+				return
+			}
+			paused = pausedState
 		case <-ticker.C:
+			if paused {
+				peerCount := len(w.node.Host().Network().Peers())
+				if peerCount >= pausedModePeerExchangeMinPeers {
+					// In paused mode, avoid proactive peer exchange unless peer count
+					// drops below a minimal threshold needed to keep connectivity healthy.
+					continue
+				}
+			}
 			w.logger.Debug("Running peer exchange loop")
 			err := w.node.PeerExchange().Request(
 				w.ctx,
@@ -1054,11 +1073,28 @@ func (w *Waku) Start() error {
 		defer w.wg.Done()
 		ticker := time.NewTicker(5 * time.Second)
 		defer ticker.Stop()
+		sub := w.PauseBroadcaster.Subscribe()
+		defer sub.Unsubscribe()
+		paused := <-sub.C()
+		var tickerC <-chan time.Time
+		if !paused {
+			tickerC = ticker.C
+		}
 		for {
 			select {
 			case <-w.ctx.Done():
 				return
-			case <-ticker.C:
+			case pausedState, ok := <-sub.C():
+				if !ok {
+					return
+				}
+				paused = pausedState
+				if paused {
+					tickerC = nil
+				} else {
+					tickerC = ticker.C
+				}
+			case <-tickerC:
 				w.checkForConnectionChanges()
 			case <-w.topicHealthStatusChan:
 				// TODO: https://github.com/status-im/status-go/issues/4628
@@ -1076,6 +1112,13 @@ func (w *Waku) Start() error {
 			peerTelemetryTickerInterval := 10 * time.Second
 			peerTelemetryTicker := time.NewTicker(peerTelemetryTickerInterval)
 			defer peerTelemetryTicker.Stop()
+			sub := w.PauseBroadcaster.Subscribe()
+			defer sub.Unsubscribe()
+			paused := <-sub.C()
+			var telemetryTickerC <-chan time.Time
+			if !paused {
+				telemetryTickerC = peerTelemetryTicker.C
+			}
 
 			dialErrSub, err := w.node.Host().EventBus().Subscribe(new(utils.DialError))
 			if err != nil {
@@ -1099,7 +1142,17 @@ func (w *Waku) Start() error {
 				select {
 				case <-w.ctx.Done():
 					return
-				case <-peerTelemetryTicker.C:
+				case pausedState, ok := <-sub.C():
+					if !ok {
+						return
+					}
+					paused = pausedState
+					if paused {
+						telemetryTickerC = nil
+					} else {
+						telemetryTickerC = peerTelemetryTicker.C
+					}
+				case <-telemetryTickerC:
 					w.reportPeerMetrics()
 				case dialErr := <-dialErrSub.Out():
 					errors := common2.ParseDialErrors(dialErr.(utils.DialError).Err.Error())
@@ -1184,6 +1237,7 @@ func (w *Waku) Start() error {
 	w.wg.Add(1)
 	go w.seedBootnodesForDiscV5()
 
+	w.MarkStarted()
 	return nil
 }
 
@@ -1368,6 +1422,8 @@ func (w *Waku) Stop() error {
 
 	close(w.goingOnline)
 	w.wg.Wait()
+
+	w.MarkStopped()
 
 	_ = w.logger.Sync()
 
@@ -1686,6 +1742,13 @@ func (w *Waku) seedBootnodesForDiscV5() {
 
 	ticker := time.NewTicker(500 * time.Millisecond)
 	defer ticker.Stop()
+	sub := w.PauseBroadcaster.Subscribe()
+	defer sub.Unsubscribe()
+	paused := <-sub.C()
+	var tickerC <-chan time.Time
+	if !paused {
+		tickerC = ticker.C
+	}
 	var retries = 0
 
 	now := func() int64 {
@@ -1703,6 +1766,16 @@ func (w *Waku) seedBootnodesForDiscV5() {
 
 	for {
 		select {
+		case pausedState, ok := <-sub.C():
+			if !ok {
+				return
+			}
+			paused = pausedState
+			if paused {
+				tickerC = nil
+			} else {
+				tickerC = ticker.C
+			}
 		case <-w.dnsDiscAsyncRetrievedSignal:
 			if !canQuery() {
 				continue
@@ -1714,7 +1787,7 @@ func (w *Waku) seedBootnodesForDiscV5() {
 			}
 			retries = 0
 			lastTry = now()
-		case <-ticker.C:
+		case <-tickerC:
 			if w.seededBootnodesForDiscV5 && len(w.node.Host().Network().Peers()) > 3 {
 				w.logger.Debug("not querying bootnodes", zap.Bool("seeded", w.seededBootnodesForDiscV5), zap.Int("peer-count", len(w.node.Host().Network().Peers())))
 				continue

--- a/pkg/messaging/waku/gowaku_test.go
+++ b/pkg/messaging/waku/gowaku_test.go
@@ -21,7 +21,25 @@ import (
 	"github.com/ethereum/go-ethereum/p2p/enode"
 
 	"github.com/stretchr/testify/require"
+
+	gocommon "github.com/status-im/status-go/common"
 )
+
+func TestWakuLifecycleState(t *testing.T) {
+	// New() alone is safe to call with nil params; Start()/Stop() are not used
+	// here because they initialise the SDS library (requires a full node
+	// environment). The PauseBroadcaster state machine is validated directly.
+	w, err := New(nil, nil, nil, nil, nil, nil)
+	require.NoError(t, err)
+
+	require.Equal(t, gocommon.ServiceStateStopped, w.PausableState())
+
+	w.MarkStarted()
+	require.Equal(t, gocommon.ServiceStateRunning, w.PausableState())
+
+	w.MarkStopped()
+	require.Equal(t, gocommon.ServiceStateStopped, w.PausableState())
+}
 
 func TestHandlePeerAddress(t *testing.T) {
 	ctrl := gomock.NewController(t)

--- a/pkg/messaging/waku/service_pausable.go
+++ b/pkg/messaging/waku/service_pausable.go
@@ -1,0 +1,13 @@
+package wakuv2
+
+func (w *Waku) PausableName() string { return "waku" }
+
+func (w *Waku) Pause() error {
+	w.MarkPaused()
+	return nil
+}
+
+func (w *Waku) Resume() error {
+	w.MarkResumed()
+	return nil
+}

--- a/protocol/communities/manager.go
+++ b/protocol/communities/manager.go
@@ -196,6 +196,7 @@ type ArchiveFileService interface {
 type ArchiveService interface {
 	ArchiveFileService
 
+	SetPaused(paused bool)
 	SetOnline(bool)
 	SetTorrentConfig(*params.TorrentConfig)
 	StartTorrentClient() error

--- a/protocol/communities/manager_archive.go
+++ b/protocol/communities/manager_archive.go
@@ -57,6 +57,8 @@ type EncodedArchiveData struct {
 }
 
 type ArchiveManager struct {
+	common.PauseBroadcaster
+
 	torrentConfig                *params.TorrentConfig
 	torrentClient                *torrent.Client
 	torrentTasks                 map[string]metainfo.Hash
@@ -90,6 +92,14 @@ func NewArchiveManager(amc *ArchiveManagerConfig) *ArchiveManager {
 
 		publisher:          amc.Publisher,
 		ArchiveFileManager: NewArchiveFileManager(amc),
+	}
+}
+
+func (m *ArchiveManager) SetPaused(paused bool) {
+	if paused {
+		m.MarkPaused()
+	} else {
+		m.MarkResumed()
 	}
 }
 
@@ -331,11 +341,31 @@ func (m *ArchiveManager) StartHistoryArchiveTasksInterval(community *Community, 
 
 	ticker := time.NewTicker(interval)
 	defer ticker.Stop()
+	sub := m.Subscribe()
+	defer sub.Unsubscribe()
+	paused := <-sub.C()
+	var tickerC <-chan time.Time
+	if !paused {
+		tickerC = ticker.C
+	}
 
 	m.logger.Debug("starting history archive tasks interval", zap.String("id", id))
 	for {
 		select {
-		case <-ticker.C:
+		case pausedState, ok := <-sub.C():
+			if !ok {
+				m.UnseedHistoryArchiveTorrent(community.ID())
+				m.historyArchiveTasks.Delete(id)
+				m.historyArchiveTasksWaitGroup.Done()
+				return
+			}
+			paused = pausedState
+			if paused {
+				tickerC = nil
+			} else {
+				tickerC = ticker.C
+			}
+		case <-tickerC:
 			m.logger.Debug("starting archive task...", zap.String("id", id))
 			lastArchiveEndDateTimestamp, err := m.GetHistoryArchivePartitionStartTimestamp(community.ID())
 			if err != nil {
@@ -528,14 +558,31 @@ func (m *ArchiveManager) DownloadHistoryArchivesByMagnetlink(communityID types.H
 		m.logger.Debug("downloading history archive index")
 		ticker := time.NewTicker(100 * time.Millisecond)
 		defer ticker.Stop()
+		sub := m.Subscribe()
+		defer sub.Unsubscribe()
+		paused := <-sub.C()
+		var tickerC <-chan time.Time
+		if !paused {
+			tickerC = ticker.C
+		}
 
 		for {
 			select {
+			case pausedState, ok := <-sub.C():
+				if !ok {
+					return nil, errors.New("lifecycle subscription closed")
+				}
+				paused = pausedState
+				if paused {
+					tickerC = nil
+				} else {
+					tickerC = ticker.C
+				}
 			case <-cancelTask:
 				m.logger.Debug("cancelled downloading archive index")
 				downloadTaskInfo.Cancelled = true
 				return downloadTaskInfo, nil
-			case <-ticker.C:
+			case <-tickerC:
 				if indexFile.BytesCompleted() == indexFile.Length() {
 
 					index, err := m.ArchiveFileManager.LoadHistoryArchiveIndexFromFile(m.identity, communityID)
@@ -602,11 +649,25 @@ func (m *ArchiveManager) DownloadHistoryArchivesByMagnetlink(communityID types.H
 						psc := torrent.SubscribePieceStateChanges()
 						downloadTicker := time.NewTicker(1 * time.Second)
 						defer downloadTicker.Stop()
+						var downloadTickerC <-chan time.Time
+						if !paused {
+							downloadTickerC = downloadTicker.C
+						}
 
 					downloadLoop:
 						for {
 							select {
-							case <-downloadTicker.C:
+							case pausedState, ok := <-sub.C():
+								if !ok {
+									return nil, errors.New("lifecycle subscription closed")
+								}
+								paused = pausedState
+								if paused {
+									downloadTickerC = nil
+								} else {
+									downloadTickerC = downloadTicker.C
+								}
+							case <-downloadTickerC:
 								done := true
 								for i = startIndex; i < endIndex; i++ {
 									piecesCompleted[i] = torrent.PieceState(i).Complete

--- a/protocol/communities/manager_archive_nop.go
+++ b/protocol/communities/manager_archive_nop.go
@@ -25,6 +25,8 @@ func NewArchiveManager(amc *ArchiveManagerConfig) *ArchiveManagerNop {
 	}
 }
 
+func (tmm *ArchiveManagerNop) SetPaused(paused bool) {}
+
 func (tmm *ArchiveManagerNop) SetOnline(online bool) {}
 
 func (tmm *ArchiveManagerNop) SetTorrentConfig(*params.TorrentConfig) {}

--- a/protocol/communities/manager_test.go
+++ b/protocol/communities/manager_test.go
@@ -519,6 +519,33 @@ func (s *ManagerSuite) TestStartHistoryArchiveTasksInterval() {
 	s.Require().Equal(count, 0)
 }
 
+func (s *ManagerSuite) TestStartHistoryArchiveTasksInterval_RespectsPausedLifecycle() {
+	err := s.archiveManager.StartTorrentClient()
+	s.Require().NoError(err)
+	defer s.archiveManager.Stop() //nolint: errcheck
+
+	s.archiveManager.SetPaused(true)
+	defer s.archiveManager.SetPaused(false)
+
+	community, _, err := s.buildCommunityWithChat()
+	s.Require().NoError(err)
+
+	interval := 300 * time.Millisecond
+	go s.archiveManager.StartHistoryArchiveTasksInterval(community, interval)
+
+	time.Sleep(200 * time.Millisecond)
+	s.Require().Equal(1, s.getHistoryTasksCount())
+
+	// Unpause to exercise lifecycle transition handling in the running loop.
+	s.archiveManager.SetPaused(false)
+	time.Sleep(200 * time.Millisecond)
+	s.Require().Equal(1, s.getHistoryTasksCount())
+
+	s.archiveManager.StopHistoryArchiveTasksInterval(community.ID())
+	s.archiveManager.historyArchiveTasksWaitGroup.Wait()
+	s.Require().Equal(0, s.getHistoryTasksCount())
+}
+
 func (s *ManagerSuite) TestStopHistoryArchiveTasksIntervals() {
 	err := s.archiveManager.StartTorrentClient()
 	s.Require().NoError(err)

--- a/protocol/messenger.go
+++ b/protocol/messenger.go
@@ -12,6 +12,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/golang/protobuf/proto"
@@ -38,6 +39,7 @@ import (
 	"github.com/status-im/status-go/internal/images"
 	"github.com/status-im/status-go/internal/instrumentation/trace"
 	messaging2 "github.com/status-im/status-go/pkg/messaging"
+	datasync "github.com/status-im/status-go/pkg/messaging/layers/reliability/datasync"
 	types2 "github.com/status-im/status-go/pkg/messaging/types"
 	"github.com/status-im/status-go/protocol/contacts"
 
@@ -133,6 +135,7 @@ type Messenger struct {
 	httpServer                 *server.MediaServer
 
 	started           bool
+	paused            atomic.Bool
 	quit              chan struct{}
 	ctx               context.Context
 	cancel            context.CancelFunc
@@ -519,6 +522,7 @@ func (m *Messenger) processSentMessage(id string) error {
 }
 
 func (m *Messenger) ToForeground() {
+	m.SetPaused(false)
 	if m.httpServer != nil {
 		m.httpServer.ToForeground()
 	}
@@ -527,9 +531,36 @@ func (m *Messenger) ToForeground() {
 }
 
 func (m *Messenger) ToBackground() {
+	m.SetPaused(true)
 	if m.httpServer != nil {
 		m.httpServer.ToBackground()
 	}
+}
+
+func (m *Messenger) SetPaused(paused bool) {
+	m.paused.Store(paused)
+	datasync.SetPaused(paused)
+	if m.pushNotificationClient != nil {
+		if paused {
+			m.pushNotificationClient.Offline()
+		} else {
+			m.pushNotificationClient.Online()
+		}
+	}
+	if m.messaging != nil {
+		if paused {
+			m.messaging.PauseTransport()
+		} else {
+			m.messaging.ResumeTransport()
+		}
+	}
+	if m.archiveManager != nil {
+		m.archiveManager.SetPaused(paused)
+	}
+}
+
+func (m *Messenger) isPaused() bool {
+	return m.paused.Load()
 }
 
 func (m *Messenger) Start() (*MessengerResponse, error) {
@@ -1303,6 +1334,9 @@ func (m *Messenger) watchConnectionChange() {
 			case status := <-subscription.C():
 				processNewState(status.IsOnline)
 			case <-ticker.C:
+				if m.isPaused() {
+					continue
+				}
 				processNewState(m.Online())
 			case <-m.quit:
 				return
@@ -1331,6 +1365,15 @@ func (m *Messenger) watchChatsToUnmute() {
 		defer gocommon.LogOnPanic()
 		defer m.shutdownWaitGroup.Done()
 		for {
+			if m.isPaused() {
+				select {
+				case <-time.After(time.Minute):
+				case <-m.quit:
+					return
+				}
+				continue
+			}
+
 			// Execute the check immediately upon starting
 			response := &MessengerResponse{}
 			currTime := time.Now()
@@ -1395,6 +1438,9 @@ func (m *Messenger) watchCommunitiesToUnmute() {
 		for {
 			select {
 			case <-ticker.C:
+				if m.isPaused() {
+					continue
+				}
 				check()
 			case <-m.quit:
 				return
@@ -1459,6 +1505,9 @@ func (m *Messenger) watchPendingCommunityRequestToJoin() {
 		for {
 			select {
 			case <-time.After(time.Minute * 10):
+				if m.isPaused() {
+					continue
+				}
 				_, err := m.CheckAndDeletePendingRequestToJoinCommunity(context.Background(), false)
 				if err != nil {
 					m.logger.Error("failed to check and delete pending request to join community", zap.Error(err))

--- a/protocol/messenger_communities.go
+++ b/protocol/messenger_communities.go
@@ -467,6 +467,9 @@ func (m *Messenger) handleCommunitiesSubscription(c chan *communities.Subscripti
 				}
 
 			case <-ticker.C:
+				if m.isPaused() {
+					continue
+				}
 				// If we are not online, we don't even try
 				if !m.Online() {
 					continue
@@ -514,6 +517,9 @@ func (m *Messenger) updateCommunitiesActiveMembersPeriodically() {
 		for {
 			select {
 			case <-ticker.C:
+				if m.isPaused() {
+					continue
+				}
 				controlledCommunities, err := m.communitiesManager.Controlled()
 				if err != nil {
 					m.logger.Error("failed to update community active members count", zap.Error(err))
@@ -4330,6 +4336,9 @@ func (m *Messenger) startCommunityRekeyLoop() {
 		for {
 			select {
 			case <-ticker.C:
+				if m.isPaused() {
+					continue
+				}
 				m.rekeyCommunities(logger)
 			case <-m.quit:
 				ticker.Stop()
@@ -4783,6 +4792,9 @@ func (m *Messenger) startRequestMissingCommunityChannelsHRKeysLoop() {
 		for {
 			select {
 			case <-time.After(5 * time.Minute):
+				if m.isPaused() {
+					continue
+				}
 				communitiesChannels, err := m.communitiesManager.DetermineChannelsForHRKeysRequest()
 				if err != nil {
 					logger.Error("failed to determine channels for encryption keys request", zap.Error(err))

--- a/protocol/messenger_curated_communities.go
+++ b/protocol/messenger_curated_communities.go
@@ -44,6 +44,10 @@ func (m *Messenger) startCuratedCommunitiesUpdateLoop() {
 		for {
 			select {
 			case <-time.After(interval):
+				if m.isPaused() {
+					interval = curatedCommunitiesUpdateInterval
+					continue
+				}
 				// Immediate execution on first run, then set to regular interval
 				interval = curatedCommunitiesUpdateInterval
 

--- a/protocol/messenger_mailserver.go
+++ b/protocol/messenger_mailserver.go
@@ -340,6 +340,10 @@ func (m *Messenger) checkForMissingMessagesLoop() {
 
 		}
 
+		if m.isPaused() {
+			continue
+		}
+
 		filters := m.messaging.ChatFilters()
 		peerInfo := m.messaging.GetActiveStorenode()
 		m.messaging.SetCriteriaForMissingMessageVerification(peerInfo, filters)

--- a/protocol/messenger_pause_play_test.go
+++ b/protocol/messenger_pause_play_test.go
@@ -1,0 +1,17 @@
+package protocol
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSetPausedUpdatesMessengerFlag(t *testing.T) {
+	m := &Messenger{}
+
+	m.SetPaused(true)
+	require.True(t, m.isPaused())
+
+	m.SetPaused(false)
+	require.False(t, m.isPaused())
+}

--- a/protocol/messenger_raw_message_resend.go
+++ b/protocol/messenger_raw_message_resend.go
@@ -27,6 +27,9 @@ func (m *Messenger) watchExpiredMessages() {
 		for {
 			select {
 			case <-time.After(time.Second):
+				if m.isPaused() {
+					continue
+				}
 				if m.Online() {
 					err := m.resendExpiredMessages()
 					if err != nil {

--- a/protocol/messenger_status_updates.go
+++ b/protocol/messenger_status_updates.go
@@ -211,7 +211,9 @@ func (m *Messenger) broadcastLatestUserStatus() {
 		select {
 		// Ensure that we are connected before sending a message
 		case <-time.After(5 * time.Second):
-			m.sendCurrentUserStatus(ctx)
+			if !m.isPaused() {
+				m.sendCurrentUserStatus(ctx)
+			}
 		case <-m.quit:
 			return
 		}
@@ -219,6 +221,9 @@ func (m *Messenger) broadcastLatestUserStatus() {
 		for {
 			select {
 			case <-time.After(5 * time.Minute):
+				if m.isPaused() {
+					continue
+				}
 				m.sendCurrentUserStatus(ctx)
 			case <-m.quit:
 				return
@@ -329,6 +334,10 @@ func (m *Messenger) timeoutAutomaticStatusUpdates() {
 		for {
 			select {
 			case <-time.After(time.Duration(waitDuration) * time.Second):
+				if m.isPaused() {
+					waitDuration = fiveMinutes
+					continue
+				}
 				tempNextClock, err := m.persistence.NextHigherClockValueOfAutomaticStatusUpdates(referenceClock)
 
 				if err == nil {

--- a/services/backup/controller.go
+++ b/services/backup/controller.go
@@ -33,6 +33,8 @@ type Provider interface {
 }
 
 type Controller struct {
+	common.PauseBroadcaster
+
 	config Config
 	core   *core
 	logger *zap.Logger
@@ -82,30 +84,31 @@ func (c *Controller) Start() {
 	if !c.config.BackupEnabled {
 		return
 	}
+	c.MarkStarted()
 	c.wg.Add(1)
 
 	go func() {
 		defer common.LogOnPanic()
-		ticker := time.NewTicker(c.config.Interval)
-		defer ticker.Stop()
 		defer c.wg.Done()
-		for {
-			select {
-			case <-ticker.C:
+		sub := c.Subscribe()
+		defer sub.Unsubscribe()
+		pt := common.NewPausableTicker(common.PausableTickerConfig{
+			Interval: c.config.Interval,
+			OnTick: func() {
 				_, err := c.PerformBackup()
 				if err != nil {
-					c.logger.Error("Error performing backup: %v\n", zap.Error(err))
+					c.logger.Error("Error performing backup", zap.Error(err))
 				}
-			case <-c.quit:
-				return
-			}
-		}
+			},
+		}, sub.C())
+		pt.Run(c.quit)
 	}()
 }
 
 func (c *Controller) Stop() {
 	close(c.quit)
 	c.wg.Wait()
+	c.MarkStopped()
 }
 
 func (c *Controller) PerformBackup() (string, error) {

--- a/services/backup/controller_test.go
+++ b/services/backup/controller_test.go
@@ -4,7 +4,9 @@ import (
 	"encoding/json"
 	"encoding/xml"
 	"reflect"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/brianvoe/gofakeit/v6"
 	"go.uber.org/mock/gomock"
@@ -13,6 +15,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/status-im/status-go/common"
 	mock_backup_controller "github.com/status-im/status-go/services/backup/mock"
 )
 
@@ -99,4 +102,77 @@ func TestController(t *testing.T) {
 
 	require.True(t, reflect.DeepEqual(barProvider.bar, barFromBackup))
 	require.True(t, reflect.DeepEqual(fooProvider.foo, fooFromBackup))
+}
+
+type countingProvider struct {
+	hits *atomic.Int32
+}
+
+func (p countingProvider) ExportBackup() ([]byte, error) {
+	p.hits.Add(1)
+	return []byte(`{"ok":true}`), nil
+}
+
+func (p countingProvider) ImportBackup([]byte) error {
+	return nil
+}
+
+func TestControllerLifecycleState(t *testing.T) {
+	logger, err := zap.NewDevelopment()
+	require.NoError(t, err)
+
+	ctrl := gomock.NewController(t)
+	filenameProvider := mock_backup_controller.NewMockFilenameProvider(ctrl)
+	filenameProvider.EXPECT().GetBackupFilename().Return(t.TempDir()+"/lifecycle_backup.bak", nil).AnyTimes()
+
+	controller, err := NewController(Config{
+		FileNameProvider: filenameProvider,
+		PrivateKey:       []byte("0123456789abcdef0123456789abcdef"),
+		BackupEnabled:    true,
+		Interval:         time.Hour, // long interval so backup doesn't fire during test
+	}, logger)
+	require.NoError(t, err)
+
+	require.Equal(t, common.ServiceStateStopped, controller.PausableState())
+
+	controller.Start()
+	require.Equal(t, common.ServiceStateRunning, controller.PausableState())
+
+	controller.Stop()
+	require.Equal(t, common.ServiceStateStopped, controller.PausableState())
+}
+
+func TestControllerStartPausesAndResumesByLifecycle(t *testing.T) {
+	logger, err := zap.NewDevelopment()
+	require.NoError(t, err)
+
+	ctrl := gomock.NewController(t)
+	filenameProvider := mock_backup_controller.NewMockFilenameProvider(ctrl)
+	filenameProvider.EXPECT().GetBackupFilename().Return(t.TempDir()+"/pause_resume_backup.bak", nil).AnyTimes()
+
+	controller, err := NewController(Config{
+		FileNameProvider: filenameProvider,
+		PrivateKey:       []byte("0123456789abcdef0123456789abcdef"),
+		BackupEnabled:    true,
+		// Long enough that the first tick cannot fire before MarkPaused propagates.
+		Interval: time.Second,
+	}, logger)
+	require.NoError(t, err)
+
+	var hits atomic.Int32
+	controller.Register("counting", countingProvider{hits: &hits})
+	controller.Start()
+	// Pause immediately after Start. Subscribe() delivers the current pause
+	// state as a snapshot, so the PausableTicker goroutine will see "paused"
+	// regardless of whether it subscribes before or after this call.
+	controller.MarkPaused()
+	defer controller.Stop()
+
+	time.Sleep(150 * time.Millisecond)
+	require.Equal(t, int32(0), hits.Load())
+
+	controller.MarkResumed()
+	require.Eventually(t, func() bool {
+		return hits.Load() > 0
+	}, 3*time.Second, 20*time.Millisecond)
 }

--- a/services/backup/service_pausable.go
+++ b/services/backup/service_pausable.go
@@ -1,0 +1,13 @@
+package backup
+
+func (c *Controller) PausableName() string { return "backup" }
+
+func (c *Controller) Pause() error {
+	c.MarkPaused()
+	return nil
+}
+
+func (c *Controller) Resume() error {
+	c.MarkResumed()
+	return nil
+}

--- a/services/ext/service.go
+++ b/services/ext/service.go
@@ -66,6 +66,7 @@ type EnvelopeEventsHandler interface {
 
 // Service is a service that provides some additional API to whisper-based protocols like Whisper or Waku.
 type Service struct {
+	gocommon.PauseBroadcaster
 	messaging       *messaging2.API
 	messenger       *protocol.Messenger
 	cancelMessenger chan struct{}
@@ -239,6 +240,7 @@ func (s *Service) StartMessenger() (*protocol.MessengerResponse, error) {
 	if err != nil {
 		return nil, err
 	}
+	s.MarkStarted()
 	s.messenger.StartRetrieveMessagesLoop(time.Second, s.cancelMessenger)
 
 	if s.config.ShhextConfig.BandwidthStatsEnabled {
@@ -314,6 +316,7 @@ func (s *Service) Stop() error {
 		s.messaging = nil
 	}
 
+	s.MarkStopped()
 	return nil
 }
 

--- a/services/ext/service_pausable.go
+++ b/services/ext/service_pausable.go
@@ -1,0 +1,19 @@
+package ext
+
+func (s *Service) PausableName() string { return "messaging" }
+
+func (s *Service) Pause() error {
+	if s.messenger != nil {
+		s.messenger.SetPaused(true)
+	}
+	s.MarkPaused()
+	return nil
+}
+
+func (s *Service) Resume() error {
+	if s.messenger != nil {
+		s.messenger.SetPaused(false)
+	}
+	s.MarkResumed()
+	return nil
+}

--- a/services/ext/service_test.go
+++ b/services/ext/service_test.go
@@ -1,0 +1,28 @@
+package ext
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/status-im/status-go/common"
+	"github.com/status-im/status-go/protocol"
+)
+
+func TestServicePauseResumeBackgroundWithNilMessenger(t *testing.T) {
+	svc := &Service{}
+	require.NoError(t, svc.Pause())
+	require.Equal(t, common.ServiceStatePaused, svc.PausableState())
+	require.NoError(t, svc.Resume())
+	require.Equal(t, common.ServiceStateRunning, svc.PausableState())
+}
+
+func TestServicePauseResumeBackgroundWithMessenger(t *testing.T) {
+	svc := &Service{
+		messenger: &protocol.Messenger{},
+	}
+	require.NoError(t, svc.Pause())
+	require.Equal(t, common.ServiceStatePaused, svc.PausableState())
+	require.NoError(t, svc.Resume())
+	require.Equal(t, common.ServiceStateRunning, svc.PausableState())
+}


### PR DESCRIPTION
Embed PauseBroadcaster in waku, transport, envelopes monitor, datasync, backup controller, ext service, messenger, and communities archive manager.

Each service's goroutine loops subscribe to their owning service's PauseBroadcaster via PausableTicker or Subscription.C() and block while paused. Services declare themselves as Pausable via service_pausable.go.


Needs pausable infra https://github.com/status-im/status-go/pull/7387
Iterates https://github.com/status-im/status-app/issues/20227