### PR TITLE
feat: make system/app services pausable

### DIFF
--- a/internal/ipfs/ipfs.go
+++ b/internal/ipfs/ipfs.go
@@ -34,6 +34,8 @@ type taskRequest struct {
 }
 
 type Downloader struct {
+	common.PauseBroadcaster
+
 	ctx             context.Context
 	cancel          func()
 	ipfsDir         string
@@ -97,18 +99,22 @@ func (d *Downloader) worker() {
 
 func (d *Downloader) taskDispatcher() {
 	defer common.LogOnPanic()
-	ticker := time.NewTicker(time.Second / maxRequestsPerSecond)
-	defer ticker.Stop()
-
-	for {
-		<-ticker.C
-		request, ok := <-d.inputTaskChan
-		if !ok {
-			return
-		}
-		d.rateLimiterChan <- request
-
-	}
+	sub := d.Subscribe()
+	defer sub.Unsubscribe()
+	pt := common.NewPausableTicker(common.PausableTickerConfig{
+		Interval: time.Second / maxRequestsPerSecond,
+		OnTick: func() {
+			select {
+			case request, ok := <-d.inputTaskChan:
+				if !ok {
+					return
+				}
+				d.rateLimiterChan <- request
+			default:
+			}
+		},
+	}, sub.C())
+	pt.Run(d.quit)
 }
 
 func hashToCid(hash []byte) (string, error) {

--- a/internal/ipfs/ipfs_test.go
+++ b/internal/ipfs/ipfs_test.go
@@ -1,0 +1,39 @@
+package ipfs
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+)
+
+func TestTaskDispatcherPausesAndResumesByLifecycle(t *testing.T) {
+	d := &Downloader{
+		inputTaskChan:   make(chan taskRequest, 1),
+		rateLimiterChan: make(chan taskRequest, 1),
+		quit:            make(chan struct{}, 1),
+	}
+	d.MarkPaused()
+
+	go d.taskDispatcher()
+	defer close(d.quit)
+
+	req := taskRequest{cid: "cid-1", doneChan: make(chan taskResponse, 1)}
+	d.inputTaskChan <- req
+
+	select {
+	case <-d.rateLimiterChan:
+		t.Fatal("task was dispatched while paused")
+	case <-time.After(450 * time.Millisecond):
+	}
+
+	d.MarkResumed()
+
+	select {
+	case got := <-d.rateLimiterChan:
+		require.Equal(t, req.cid, got.cid)
+	case <-time.After(2 * time.Second):
+		t.Fatal("task was not dispatched after resume")
+	}
+}

--- a/internal/ipfs/ipfs_test.go
+++ b/internal/ipfs/ipfs_test.go
@@ -5,7 +5,6 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
-
 )
 
 func TestTaskDispatcherPausesAndResumesByLifecycle(t *testing.T) {

--- a/internal/ipfs/service_pausable.go
+++ b/internal/ipfs/service_pausable.go
@@ -1,0 +1,13 @@
+package ipfs
+
+func (d *Downloader) PausableName() string { return "ipfs" }
+
+func (d *Downloader) Pause() error {
+	d.MarkPaused()
+	return nil
+}
+
+func (d *Downloader) Resume() error {
+	d.MarkResumed()
+	return nil
+}

--- a/internal/rpc/chain/rpclimiter/rpc_limiter.go
+++ b/internal/rpc/chain/rpclimiter/rpc_limiter.go
@@ -231,7 +231,7 @@ type RPCRpsLimiter struct {
 	callersOnWaitForRequests      []callerOnWait
 	callersOnWaitForRequestsMutex sync.RWMutex
 
-	quit chan bool
+	quit chan struct{}
 }
 
 func NewRPCRpsLimiter() *RPCRpsLimiter {
@@ -239,7 +239,7 @@ func NewRPCRpsLimiter() *RPCRpsLimiter {
 	limiter := RPCRpsLimiter{
 		uuid:                 uuid.New(),
 		maxRequestsPerSecond: defaultMaxRequestsPerSecond,
-		quit:                 make(chan bool),
+		quit:                 make(chan struct{}),
 	}
 
 	limiter.start()
@@ -257,61 +257,61 @@ func (rl *RPCRpsLimiter) ReduceLimit() {
 }
 
 func (rl *RPCRpsLimiter) start() {
-	ticker := time.NewTicker(tickerInterval)
 	go func() {
 		defer gocommon.LogOnPanic()
+		ticker := time.NewTicker(tickerInterval)
+		defer ticker.Stop()
 		for {
 			select {
 			case <-ticker.C:
-				{
-					rl.requestsMadeWithinSecondMutex.Lock()
-					oldrequestsMadeWithinSecond := rl.requestsMadeWithinSecond
-					if rl.requestsMadeWithinSecond != 0 {
-						rl.requestsMadeWithinSecond = 0
-					}
-					rl.requestsMadeWithinSecondMutex.Unlock()
-					if oldrequestsMadeWithinSecond == 0 {
-						continue
-					}
-				}
-
-				rl.callersOnWaitForRequestsMutex.Lock()
-				numOfRequestsToMakeAvailable := rl.maxRequestsPerSecond
-				for {
-					if numOfRequestsToMakeAvailable == 0 || len(rl.callersOnWaitForRequests) == 0 {
-						break
-					}
-
-					var index = -1
-					for i := 0; i < len(rl.callersOnWaitForRequests); i++ {
-						if rl.callersOnWaitForRequests[i].requests <= numOfRequestsToMakeAvailable {
-							index = i
-							break
-						}
-					}
-
-					if index == -1 {
-						break
-					}
-
-					callerOnWait := rl.callersOnWaitForRequests[index]
-					numOfRequestsToMakeAvailable -= callerOnWait.requests
-					rl.callersOnWaitForRequests = append(rl.callersOnWaitForRequests[:index], rl.callersOnWaitForRequests[index+1:]...)
-
-					callerOnWait.ch <- true
-				}
-				rl.callersOnWaitForRequestsMutex.Unlock()
-
+				rl.onTick()
 			case <-rl.quit:
-				ticker.Stop()
 				return
 			}
 		}
 	}()
 }
 
+func (rl *RPCRpsLimiter) onTick() {
+	rl.requestsMadeWithinSecondMutex.Lock()
+	oldrequestsMadeWithinSecond := rl.requestsMadeWithinSecond
+	if rl.requestsMadeWithinSecond != 0 {
+		rl.requestsMadeWithinSecond = 0
+	}
+	rl.requestsMadeWithinSecondMutex.Unlock()
+	if oldrequestsMadeWithinSecond == 0 {
+		return
+	}
+
+	rl.callersOnWaitForRequestsMutex.Lock()
+	numOfRequestsToMakeAvailable := rl.maxRequestsPerSecond
+	for {
+		if numOfRequestsToMakeAvailable == 0 || len(rl.callersOnWaitForRequests) == 0 {
+			break
+		}
+
+		var index = -1
+		for i := 0; i < len(rl.callersOnWaitForRequests); i++ {
+			if rl.callersOnWaitForRequests[i].requests <= numOfRequestsToMakeAvailable {
+				index = i
+				break
+			}
+		}
+
+		if index == -1 {
+			break
+		}
+
+		callerOnWait := rl.callersOnWaitForRequests[index]
+		numOfRequestsToMakeAvailable -= callerOnWait.requests
+		rl.callersOnWaitForRequests = append(rl.callersOnWaitForRequests[:index], rl.callersOnWaitForRequests[index+1:]...)
+
+		callerOnWait.ch <- true
+	}
+	rl.callersOnWaitForRequestsMutex.Unlock()
+}
+
 func (rl *RPCRpsLimiter) Stop() {
-	rl.quit <- true
 	close(rl.quit)
 	for _, callerOnWait := range rl.callersOnWaitForRequests {
 		close(callerOnWait.ch)

--- a/internal/rpc/chain/rpclimiter/rpc_limiter_test.go
+++ b/internal/rpc/chain/rpclimiter/rpc_limiter_test.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
-
 )
 
 func setupTest() (*InMemRequestsMapStorage, RequestLimiter) {

--- a/internal/rpc/chain/rpclimiter/rpc_limiter_test.go
+++ b/internal/rpc/chain/rpclimiter/rpc_limiter_test.go
@@ -4,7 +4,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
+
 )
 
 func setupTest() (*InMemRequestsMapStorage, RequestLimiter) {
@@ -192,4 +194,26 @@ func TestAllowWhenLimitNotReachedForInfinitePeriod(t *testing.T) {
 
 	// Verify the result
 	require.True(t, allow)
+}
+
+func TestRPCRpsLimiterStartReleasesWaitingCallersOnTick(t *testing.T) {
+	waitCh := make(chan bool, 1)
+	rl := &RPCRpsLimiter{
+		uuid:                     uuid.New(),
+		maxRequestsPerSecond:     1,
+		requestsMadeWithinSecond: 1,
+		callersOnWaitForRequests: []callerOnWait{
+			{requests: 1, ch: waitCh},
+		},
+		quit: make(chan struct{}),
+	}
+
+	rl.start()
+	defer rl.Stop()
+
+	select {
+	case <-waitCh:
+	case <-time.After(2 * tickerInterval):
+		t.Fatal("limiter did not release callers after tick")
+	}
 }

--- a/internal/rpc/client.go
+++ b/internal/rpc/client.go
@@ -145,6 +145,15 @@ func (c *Client) Stop() {
 	c.signalsTransmitter.Stop()
 	c.networkManager.Stop()
 
+	c.rpsLimiterMutex.Lock()
+	for key, limiter := range c.limiterPerProvider {
+		if limiter != nil {
+			limiter.Stop()
+		}
+		delete(c.limiterPerProvider, key)
+	}
+	c.rpsLimiterMutex.Unlock()
+
 	c.rpcClientsMutex.Lock()
 	for _, client := range c.rpcClients {
 		client.Close()

--- a/internal/timesource/ntp.go
+++ b/internal/timesource/ntp.go
@@ -137,6 +137,8 @@ var defaultNTPTimeSource = &ntpTimeSource{
 // ntpTimeSource provides source of time that tries to be resistant to time skews.
 // It does so by periodically querying time offset from ntp servers.
 type ntpTimeSource struct {
+	common.PauseBroadcaster
+
 	servers           []string
 	allowedFailures   int
 	fastNTPSyncPeriod time.Duration
@@ -221,14 +223,52 @@ func (s *ntpTimeSource) runPeriodically(ctx context.Context, fn func() error, st
 	}
 	go func() {
 		defer common.LogOnPanic()
+		sub := s.Subscribe()
+		defer sub.Unsubscribe()
+
+		paused := <-sub.C()
+		if paused && period != s.slowNTPSyncPeriod {
+			period = s.slowNTPSyncPeriod
+		}
+
+		timer := time.NewTimer(period)
+		defer timer.Stop()
+
+		resetTimer := func(d time.Duration) {
+			if !timer.Stop() {
+				select {
+				case <-timer.C:
+				default:
+				}
+			}
+			timer.Reset(d)
+		}
+
 		for {
 			select {
-			case <-time.After(period):
+			case pausedState, ok := <-sub.C():
+				if !ok {
+					return
+				}
+				paused = pausedState
+				if paused && period != s.slowNTPSyncPeriod {
+					period = s.slowNTPSyncPeriod
+				}
+				resetTimer(period)
+			case <-timer.C:
+				if paused {
+					resetTimer(period)
+					continue
+				}
 				if err := fn(); err == nil {
 					period = s.slowNTPSyncPeriod
 				} else if period != s.slowNTPSyncPeriod {
 					period = s.fastNTPSyncPeriod
 				}
+				if paused && period != s.slowNTPSyncPeriod {
+					period = s.slowNTPSyncPeriod
+				}
+				resetTimer(period)
 
 			case <-ctx.Done():
 				return

--- a/internal/timesource/ntp_test.go
+++ b/internal/timesource/ntp_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/beevik/ntp"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
 )
 
 const (
@@ -285,6 +286,37 @@ func TestGetCurrentTimeInMillis(t *testing.T) {
 	n = ts.GetCurrentTimeInMillis()
 	require.Equal(t, expectedTime, n)
 	ts.Stop()
+}
+
+func TestRunPeriodicallyPausesAndResumesByLifecycle(t *testing.T) {
+	source := &ntpTimeSource{
+		fastNTPSyncPeriod: 20 * time.Millisecond,
+		slowNTPSyncPeriod: 120 * time.Millisecond,
+	}
+	source.MarkPaused()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	hitsCh := make(chan struct{}, 4)
+	source.runPeriodically(ctx, func() error {
+		hitsCh <- struct{}{}
+		return nil
+	}, false)
+
+	select {
+	case <-hitsCh:
+		t.Fatal("periodic function ran while paused")
+	case <-time.After(90 * time.Millisecond):
+	}
+
+	source.MarkResumed()
+
+	select {
+	case <-hitsCh:
+	case <-time.After(600 * time.Millisecond):
+		t.Fatal("periodic function did not run after resume")
+	}
 }
 
 func TestGetCurrentTimeOffline(t *testing.T) {

--- a/internal/timesource/ntp_test.go
+++ b/internal/timesource/ntp_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/beevik/ntp"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-
 )
 
 const (

--- a/internal/timesource/service_pausable.go
+++ b/internal/timesource/service_pausable.go
@@ -1,0 +1,13 @@
+package timesource
+
+func (s *ntpTimeSource) PausableName() string { return "ntp" }
+
+func (s *ntpTimeSource) Pause() error {
+	s.MarkPaused()
+	return nil
+}
+
+func (s *ntpTimeSource) Resume() error {
+	s.MarkResumed()
+	return nil
+}

--- a/services/connector/service.go
+++ b/services/connector/service.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"sync"
 	"time"
 
 	"go.uber.org/zap"
@@ -60,9 +61,17 @@ type Service struct {
 
 	rpcServer *gethrpc.Server
 	wsServer  *http.Server
+	mu        sync.Mutex
+	paused    bool
+	started   bool
 }
 
 func (s *Service) Start() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.started {
+		return nil
+	}
 	// Create an RPC server
 	s.rpcServer = gethrpc.NewServer()
 
@@ -98,19 +107,27 @@ func (s *Service) Start() error {
 		Handler:           handler,
 		ReadHeaderTimeout: time.Second * 10,
 	}
+	wsServer := s.wsServer
 
 	go func() {
 		defer common.LogOnPanic()
-		err := s.wsServer.ListenAndServe()
+		err := wsServer.ListenAndServe()
 		if !errors.Is(err, http.ErrServerClosed) {
 			s.logger.Error("connector server closed with error", zap.Error(err))
 		}
 	}()
-
+	s.started = true
+	s.paused = false
 	return nil
 }
 
 func (s *Service) Stop() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.stopLocked()
+}
+
+func (s *Service) stopLocked() error {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
 	defer cancel()
 
@@ -121,16 +138,22 @@ func (s *Service) Stop() error {
 	}
 
 	if s.wsServer == nil {
+		s.started = false
 		return nil
 	}
 
 	err := s.wsServer.Shutdown(ctx)
 	if err == nil {
+		s.wsServer = nil
+		s.started = false
 		return nil
 	}
 
 	s.logger.Error("failed to stop status connector server", zap.Error(err))
-	return s.wsServer.Close()
+	wsServer := s.wsServer
+	s.wsServer = nil
+	s.started = false
+	return wsServer.Close()
 }
 
 func (s *Service) APIs() []gethrpc.API {

--- a/services/connector/service.go
+++ b/services/connector/service.go
@@ -83,6 +83,7 @@ func (s *Service) Start() error {
 	}
 
 	if !s.config.WSEnabled {
+		s.started = true
 		return nil
 	}
 

--- a/services/connector/service_pausable.go
+++ b/services/connector/service_pausable.go
@@ -1,0 +1,42 @@
+package connector
+
+import statuscommon "github.com/status-im/status-go/common"
+
+func (s *Service) PausableName() string { return "connector" }
+
+func (s *Service) Pause() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.paused {
+		return nil
+	}
+	err := s.stopLocked()
+	if err == nil {
+		s.paused = true
+	}
+	return err
+}
+
+func (s *Service) Resume() error {
+	s.mu.Lock()
+	if !s.paused {
+		s.mu.Unlock()
+		return nil
+	}
+	s.paused = false
+	s.started = false
+	s.mu.Unlock()
+	return s.Start()
+}
+
+func (s *Service) PausableState() statuscommon.ServiceState {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if !s.started && !s.paused {
+		return statuscommon.ServiceStateStopped
+	}
+	if s.paused {
+		return statuscommon.ServiceStatePaused
+	}
+	return statuscommon.ServiceStateRunning
+}

--- a/services/connector/service_test.go
+++ b/services/connector/service_test.go
@@ -1,9 +1,13 @@
 package connector
 
 import (
+	"net"
+	"strconv"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestNewService(t *testing.T) {
@@ -51,4 +55,69 @@ func TestService_APIs(t *testing.T) {
 	assert.Equal(t, "connector", apis[0].Namespace)
 	assert.Equal(t, "0.1.0", apis[0].Version)
 	assert.NotNil(t, apis[0].Service)
+}
+
+func TestService_PauseResumeBackground(t *testing.T) {
+	state := setupTests(t)
+
+	// Pause/resume only affects the WS listener path; use a pre-assigned port so we can dial it.
+	host, port := freeLocalTCPPort(t)
+	addr := net.JoinHostPort(host, strconv.Itoa(port))
+	state.service.config.WSEnabled = true
+	state.service.config.WSHost = host
+	state.service.config.WSPort = port
+
+	t.Cleanup(func() { _ = state.service.Stop() })
+
+	err := state.service.Start()
+	require.NoError(t, err)
+	require.NotNil(t, state.service.wsServer)
+	waitUntilTCPAccepts(t, addr)
+
+	err = state.service.Pause()
+	require.NoError(t, err)
+	require.True(t, state.service.paused)
+	waitUntilTCPRefused(t, addr)
+
+	err = state.service.Resume()
+	require.NoError(t, err)
+	require.False(t, state.service.paused)
+	waitUntilTCPAccepts(t, addr)
+
+	err = state.service.Stop()
+	require.NoError(t, err)
+}
+
+// freeLocalTCPPort reserves an ephemeral TCP port on loopback for the test process.
+// There is a small race where another process could bind between Close and Start; acceptable for tests.
+func freeLocalTCPPort(t *testing.T) (host string, port int) {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	tcpAddr := ln.Addr().(*net.TCPAddr)
+	require.NoError(t, ln.Close())
+	return tcpAddr.IP.String(), tcpAddr.Port
+}
+
+func waitUntilTCPAccepts(t *testing.T, addr string) {
+	t.Helper()
+	require.Eventually(t, func() bool {
+		c, err := net.DialTimeout("tcp", addr, 50*time.Millisecond)
+		if err != nil {
+			return false
+		}
+		_ = c.Close()
+		return true
+	}, 5*time.Second, 10*time.Millisecond, "expected TCP accept on %s", addr)
+}
+
+func waitUntilTCPRefused(t *testing.T, addr string) {
+	t.Helper()
+	require.Eventually(t, func() bool {
+		c, err := net.DialTimeout("tcp", addr, 50*time.Millisecond)
+		if c != nil {
+			_ = c.Close()
+		}
+		return err != nil
+	}, 5*time.Second, 10*time.Millisecond, "expected no listener on %s after pause", addr)
 }

--- a/services/newsfeed/service.go
+++ b/services/newsfeed/service.go
@@ -29,6 +29,7 @@ func isNil(data interface{}) bool {
 }
 
 type Service struct {
+	gocommon.PauseBroadcaster
 	logger          *zap.Logger
 	storage         Persistence
 	ac              ActivityCenter
@@ -77,6 +78,8 @@ func (s *Service) Start() error {
 	if newsFeedEnabled {
 		s.newsFeedManager.StartPolling(context.Background())
 	}
+	s.started = true
+	s.MarkStarted()
 
 	return nil
 }
@@ -85,6 +88,8 @@ func (s *Service) Stop() error {
 	if s.newsFeedManager != nil {
 		s.newsFeedManager.StopPolling()
 	}
+	s.started = false
+	s.MarkStopped()
 	return nil
 }
 

--- a/services/newsfeed/service_pausable.go
+++ b/services/newsfeed/service_pausable.go
@@ -1,0 +1,15 @@
+package newsfeed
+
+func (s *Service) PausableName() string { return "newsfeed" }
+
+func (s *Service) Pause() error {
+	if s.newsFeedManager != nil {
+		s.newsFeedManager.StopPolling()
+	}
+	s.MarkPaused()
+	return nil
+}
+
+func (s *Service) Resume() error {
+	return s.Start()
+}

--- a/services/newsfeed/service_pausable.go
+++ b/services/newsfeed/service_pausable.go
@@ -6,10 +6,15 @@ func (s *Service) Pause() error {
 	if s.newsFeedManager != nil {
 		s.newsFeedManager.StopPolling()
 	}
+	s.started = false
 	s.MarkPaused()
 	return nil
 }
 
 func (s *Service) Resume() error {
-	return s.Start()
+	if err := s.Start(); err != nil {
+		return err
+	}
+	s.MarkResumed()
+	return nil
 }

--- a/services/newsfeed/service_test.go
+++ b/services/newsfeed/service_test.go
@@ -120,3 +120,17 @@ func (s *MessengerNewsFeedSuite) TestToggleSettings() {
 	s.service.newsFeedManager.StopPolling()
 	s.Require().False(s.service.newsFeedManager.IsPolling())
 }
+
+func (s *MessengerNewsFeedSuite) TestPauseResumeBackground() {
+	err := s.service.Start()
+	s.Require().NoError(err)
+	s.Require().True(s.service.started)
+
+	err = s.service.Pause()
+	s.Require().NoError(err)
+	s.Require().False(s.service.started)
+
+	err = s.service.Resume()
+	s.Require().NoError(err)
+	s.Require().True(s.service.started)
+}

--- a/services/wallet/reader.go
+++ b/services/wallet/reader.go
@@ -110,6 +110,10 @@ func (r *Reader) Stop() {
 	r.lastWalletTokenUpdateTimestamp = sync.Map{}
 }
 
+func (r *Reader) IsRunning() bool {
+	return r.stopCh != nil
+}
+
 func (r *Reader) triggerWalletReload() {
 	r.walletFeed.Send(walletevent.Event{
 		Type: EventWalletTickReload,

--- a/services/wallet/service.go
+++ b/services/wallet/service.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"sync"
 	"time"
 
 	"github.com/golang/protobuf/proto"
@@ -460,27 +461,30 @@ type Service struct {
 	leaderboardService             *leaderboard.MarketDataService
 	activityFetcherService         *activityfetcher.Service
 	started                        bool
+	paused                         bool
+	readerWasRunningBeforePause    bool
 
+	mu                     sync.Mutex
 	cancelWalletServiceCtx context.CancelFunc
 }
 
 // Start signals transmitter.
 func (s *Service) Start() error {
-	if ThirdpartyServicesEnabled(s.accountsDB) {
-		ctx, cancel := context.WithCancel(context.Background())
-		s.cancelWalletServiceCtx = cancel
+	s.mu.Lock()
+	defer s.mu.Unlock()
 
-		s.multistandardBalanceController.Start()
-		s.transferDetectorController.Start()
-		s.currency.Start(ctx)
-		err := s.signals.Start(ctx)
-		s.collectibles.Start(ctx)
-		s.leaderboardService.Start(ctx)
-		s.activityFetcherService.Start(ctx)
-		s.started = true
-		return err
+	if !ThirdpartyServicesEnabled(s.accountsDB) {
+		return nil
 	}
-	return nil
+	if s.started && !s.paused {
+		return nil
+	}
+	err := s.startBackgroundWorkersLocked()
+	if err == nil {
+		s.started = true
+		s.paused = false
+	}
+	return err
 }
 
 // Set external Collectibles community info provider
@@ -490,6 +494,9 @@ func (s *Service) SetWalletCommunityInfoProvider(provider thirdparty.CommunityIn
 
 // Stop reactor and close db.
 func (s *Service) Stop() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
 	logutils.ZapLogger().Info("wallet will be stopped")
 	s.router.Stop()
 	s.signals.Stop()
@@ -501,6 +508,7 @@ func (s *Service) Stop() error {
 	s.tokenManager.Stop()
 	s.leaderboardService.Stop()
 	s.started = false
+	s.paused = false
 	logutils.ZapLogger().Info("wallet stopped")
 
 	// Cancel wallet service context
@@ -510,6 +518,43 @@ func (s *Service) Stop() error {
 	}
 
 	return nil
+}
+
+func (s *Service) startBackgroundWorkersLocked() error {
+	if s.cancelWalletServiceCtx != nil {
+		return nil
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	s.cancelWalletServiceCtx = cancel
+
+	s.multistandardBalanceController.Start()
+	s.transferDetectorController.Start()
+	s.currency.Start(ctx)
+	err := s.signals.Start(ctx)
+	s.collectibles.Start(ctx)
+	s.leaderboardService.Start(ctx)
+	s.activityFetcherService.Start(ctx)
+	if s.readerWasRunningBeforePause {
+		_ = s.reader.Start()
+		s.readerWasRunningBeforePause = false
+	}
+	return err
+}
+
+func (s *Service) stopBackgroundWorkersLocked() {
+	s.readerWasRunningBeforePause = s.reader != nil && s.reader.IsRunning()
+	if s.readerWasRunningBeforePause {
+		s.reader.Stop()
+	}
+	s.signals.Stop()
+	s.multistandardBalanceController.Stop()
+	s.transferDetectorController.Stop()
+	s.collectibles.Stop()
+	s.leaderboardService.Stop()
+	if s.cancelWalletServiceCtx != nil {
+		s.cancelWalletServiceCtx()
+		s.cancelWalletServiceCtx = nil
+	}
 }
 
 // APIs returns list of available RPC APIs.

--- a/services/wallet/service.go
+++ b/services/wallet/service.go
@@ -462,10 +462,8 @@ type Service struct {
 	activityFetcherService         *activityfetcher.Service
 	started                        bool
 	paused                         bool
-	readerWasRunningBeforePause    bool
-
-	mu                     sync.Mutex
-	cancelWalletServiceCtx context.CancelFunc
+	mu                             sync.Mutex
+	cancelWalletServiceCtx         context.CancelFunc
 }
 
 // Start signals transmitter.
@@ -479,7 +477,7 @@ func (s *Service) Start() error {
 	if s.started && !s.paused {
 		return nil
 	}
-	err := s.startBackgroundWorkersLocked()
+	err := s.startBackgroundWorkers()
 	if err == nil {
 		s.started = true
 		s.paused = false
@@ -520,7 +518,7 @@ func (s *Service) Stop() error {
 	return nil
 }
 
-func (s *Service) startBackgroundWorkersLocked() error {
+func (s *Service) startBackgroundWorkers() error {
 	if s.cancelWalletServiceCtx != nil {
 		return nil
 	}
@@ -534,16 +532,14 @@ func (s *Service) startBackgroundWorkersLocked() error {
 	s.collectibles.Start(ctx)
 	s.leaderboardService.Start(ctx)
 	s.activityFetcherService.Start(ctx)
-	if s.readerWasRunningBeforePause {
+	if s.reader != nil && !s.reader.IsRunning() {
 		_ = s.reader.Start()
-		s.readerWasRunningBeforePause = false
 	}
 	return err
 }
 
-func (s *Service) stopBackgroundWorkersLocked() {
-	s.readerWasRunningBeforePause = s.reader != nil && s.reader.IsRunning()
-	if s.readerWasRunningBeforePause {
+func (s *Service) stopBackgroundWorkers() {
+	if s.reader != nil && s.reader.IsRunning() {
 		s.reader.Stop()
 	}
 	s.signals.Stop()

--- a/services/wallet/service_pausable.go
+++ b/services/wallet/service_pausable.go
@@ -11,7 +11,7 @@ func (s *Service) Pause() error {
 	if !s.started || s.paused {
 		return nil
 	}
-	s.stopBackgroundWorkersLocked()
+	s.stopBackgroundWorkers()
 	s.paused = true
 	return nil
 }
@@ -23,7 +23,7 @@ func (s *Service) Resume() error {
 	if !s.started || !s.paused {
 		return nil
 	}
-	if err := s.startBackgroundWorkersLocked(); err != nil {
+	if err := s.startBackgroundWorkers(); err != nil {
 		return err
 	}
 	s.paused = false

--- a/services/wallet/service_pausable.go
+++ b/services/wallet/service_pausable.go
@@ -1,0 +1,43 @@
+package wallet
+
+import statuscommon "github.com/status-im/status-go/common"
+
+func (s *Service) PausableName() string { return "wallet" }
+
+func (s *Service) Pause() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if !s.started || s.paused {
+		return nil
+	}
+	s.stopBackgroundWorkersLocked()
+	s.paused = true
+	return nil
+}
+
+func (s *Service) Resume() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if !s.started || !s.paused {
+		return nil
+	}
+	if err := s.startBackgroundWorkersLocked(); err != nil {
+		return err
+	}
+	s.paused = false
+	return nil
+}
+
+func (s *Service) PausableState() statuscommon.ServiceState {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if !s.started {
+		return statuscommon.ServiceStateStopped
+	}
+	if s.paused {
+		return statuscommon.ServiceStatePaused
+	}
+	return statuscommon.ServiceStateRunning
+}

--- a/services/wallet/service_pause_play_test.go
+++ b/services/wallet/service_pause_play_test.go
@@ -1,0 +1,33 @@
+package wallet
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestServicePauseNoopWhenNotStarted(t *testing.T) {
+	svc := &Service{}
+	require.NoError(t, svc.Pause())
+}
+
+func TestServicePauseNoopWhenAlreadyPaused(t *testing.T) {
+	svc := &Service{
+		started:          true,
+		paused: true,
+	}
+	require.NoError(t, svc.Pause())
+}
+
+func TestServiceResumeNoopWhenNotStarted(t *testing.T) {
+	svc := &Service{}
+	require.NoError(t, svc.Resume())
+}
+
+func TestServiceResumeNoopWhenNotPaused(t *testing.T) {
+	svc := &Service{
+		started:          true,
+		paused: false,
+	}
+	require.NoError(t, svc.Resume())
+}

--- a/services/wallet/service_pause_play_test.go
+++ b/services/wallet/service_pause_play_test.go
@@ -13,8 +13,8 @@ func TestServicePauseNoopWhenNotStarted(t *testing.T) {
 
 func TestServicePauseNoopWhenAlreadyPaused(t *testing.T) {
 	svc := &Service{
-		started:          true,
-		paused: true,
+		started: true,
+		paused:  true,
 	}
 	require.NoError(t, svc.Pause())
 }
@@ -26,8 +26,8 @@ func TestServiceResumeNoopWhenNotStarted(t *testing.T) {
 
 func TestServiceResumeNoopWhenNotPaused(t *testing.T) {
 	svc := &Service{
-		started:          true,
-		paused: false,
+		started: true,
+		paused:  false,
 	}
 	require.NoError(t, svc.Resume())
 }


### PR DESCRIPTION
Embed PauseBroadcaster and implement Pausable in wallet, connector, newsfeed, ipfs downloader, NTP time source, and RPC rate limiter.

Each service registers itself via service_pausable.go. Goroutine loops use PausableTicker or Subscription.C() to block while paused, reducing non-essential background work.


Needs https://github.com/status-im/status-go/pull/7390 https://github.com/status-im/status-go/pull/7387
Iterates Iterates https://github.com/status-im/status-app/issues/20227
