### PR TITLE
fix(collectibles): reduce redundant nft fetches

### DIFF
--- a/services/wallet/collectibles/ownership/controller.go
+++ b/services/wallet/collectibles/ownership/controller.go
@@ -466,28 +466,28 @@ func (c *Controller) loadWithPeriodicalLoaderIfFound(ctx context.Context, chainI
 		_ = loader.Load(ctx)
 	}()
 
-	select {
-	case <-ctx.Done():
-		err = ctx.Err()
-		return
-	case finishedEvent, ok := <-finishedCh:
-		if !ok {
+	for {
+		select {
+		case <-ctx.Done():
+			err = ctx.Err()
 			return
-		}
-		if finishedEvent.ChainID == chainID && finishedEvent.Account == account {
-			return
-		}
-	case errEvent, ok := <-errCh:
-		if !ok {
-			return
-		}
-		if errEvent.ChainID == chainID && errEvent.Account == account {
-			err = errEvent.Error
-			return
+		case finishedEvent, ok := <-finishedCh:
+			if !ok {
+				return
+			}
+			if finishedEvent.ChainID == chainID && finishedEvent.Account == account {
+				return
+			}
+		case errEvent, ok := <-errCh:
+			if !ok {
+				return
+			}
+			if errEvent.ChainID == chainID && errEvent.Account == account {
+				err = errEvent.Error
+				return
+			}
 		}
 	}
-
-	return
 }
 
 func (c *Controller) checkPeriodicalLoaders() {

--- a/services/wallet/collectibles/ownership/controller_test.go
+++ b/services/wallet/collectibles/ownership/controller_test.go
@@ -3,12 +3,17 @@ package ownership_test
 import (
 	"context"
 	"math/big"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
+	coretypes "github.com/ethereum/go-ethereum/core/types"
 
 	"github.com/status-im/go-wallet-sdk/pkg/balance/multistandardfetcher"
+	"github.com/status-im/go-wallet-sdk/pkg/contracts/erc1155"
+	"github.com/status-im/go-wallet-sdk/pkg/contracts/erc721"
+	"github.com/status-im/go-wallet-sdk/pkg/eventlog"
 
 	"github.com/stretchr/testify/require"
 
@@ -25,6 +30,7 @@ import (
 	walletCommon "github.com/status-im/status-go/services/wallet/common"
 	"github.com/status-im/status-go/services/wallet/multistandardbalance"
 	"github.com/status-im/status-go/services/wallet/thirdparty"
+	"github.com/status-im/status-go/services/wallet/transferdetector"
 
 	"go.uber.org/mock/gomock"
 	"go.uber.org/zap"
@@ -804,4 +810,129 @@ func TestControllerPeriodicalLoads(t *testing.T) {
 	}, 1000*time.Millisecond, 100*time.Millisecond)
 
 	controller.Stop()
+}
+
+func TestControllerTransferDetectionEvents(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	accountsProvider := mock_ownership.NewMockAccountsProvider(mockCtrl)
+	fakeAddress := types.HexToAddress("0x123")
+	accountsProvider.EXPECT().GetWalletAddresses().Return([]types.Address{fakeAddress}, nil).AnyTimes()
+
+	accountsPublisher := pubsub.NewPublisher()
+	networksProvider := mock_ownership.NewMockNetworksProvider(mockCtrl)
+	networksPublisher := pubsub.NewPublisher()
+
+	networksProvider.EXPECT().GetActiveNetworks().Return([]*params.Network{
+		{ChainID: 1, IsActive: true},
+	}, nil).AnyTimes()
+	networksProvider.EXPECT().GetPublisher().Return(networksPublisher).AnyTimes()
+
+	walletDB, err := testutils.SetupTestMemorySQLDB(walletdatabase.DbInitializer{})
+	require.NoError(t, err)
+
+	emptyCollectiblesContainer := &thirdparty.CollectibleOwnershipContainer{
+		Items:          []thirdparty.CollectibleIDBalance{},
+		NextCursor:     "",
+		PreviousCursor: "",
+		Provider:       "mockProvider",
+	}
+	ownershipFetcher := mock_ownership.NewMockCollectibleOwnershipFetcher(mockCtrl)
+	ownershipFetcher.EXPECT().FetchCollectibleOwnershipByOwner(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+		func(ctx context.Context, chainID walletCommon.ChainID, owner common.Address, cursor string, limit int, providerID string) (*thirdparty.CollectibleOwnershipContainer, error) {
+			return emptyCollectiblesContainer, nil
+		}).AnyTimes()
+
+	multistandardBalancePublisher := pubsub.NewPublisher()
+	transferDetectorPublisher := pubsub.NewPublisher()
+	blockChainStateProvider := mock_ownership.NewMockBlockChainStateProvider(mockCtrl)
+	var estimatedBlockCalls atomic.Int32
+	blockChainStateProvider.EXPECT().GetEstimatedBlockTime(gomock.Any(), uint64(1), gomock.Any()).DoAndReturn(
+		func(ctx context.Context, chainID uint64, blockNumber uint64) (time.Time, error) {
+			estimatedBlockCalls.Add(1)
+			return time.Now(), nil
+		},
+	).AnyTimes()
+
+	publisher := pubsub.NewPublisher()
+	logger := zaptest.NewLogger(t).WithOptions(zap.AddCallerSkip(1))
+
+	controller := ownership.NewController(
+		ownership.NewOwnershipDB(walletDB),
+		accountsProvider,
+		accountsPublisher,
+		networksProvider,
+		multistandardBalancePublisher,
+		transferDetectorPublisher,
+		blockChainStateProvider,
+		ownershipFetcher,
+		publisher,
+		logger,
+	)
+
+	params := ownership.PeriodicalLoaderParams{
+		StartDelay:   1 * time.Second,
+		LoadInterval: 10 * time.Second,
+		LoaderParams: ownership.LoaderParams{
+			LoadDelay:  0 * time.Second,
+			FetchLimit: 50,
+		},
+	}
+	controller.StartWithLoaderParams(params)
+	defer controller.Stop()
+
+	// Ensure initial load completed so ownership timestamp exists.
+	require.Eventually(t, func() bool {
+		return controller.GetLoaderState(walletCommon.ChainID(1), common.Address(fakeAddress)) == ownership.LoaderStateIdle
+	}, 2*time.Second, 50*time.Millisecond)
+
+	otherAddress := common.HexToAddress("0x456")
+	msg := transferdetector.EventTransferDetectionFinished{
+		ChainID:   1,
+		Accounts:  []common.Address{common.Address(fakeAddress)},
+		FromBlock: 100,
+		ToBlock:   200,
+		Events: []eventlog.Event{
+			{
+				EventKey: eventlog.ERC721Transfer,
+				Unpacked: erc721.Erc721Transfer{
+					From: common.Address(fakeAddress),
+					To:   otherAddress,
+					Raw: coretypes.Log{
+						BlockNumber: 123,
+					},
+				},
+			},
+			{
+				EventKey: eventlog.ERC1155TransferSingle,
+				Unpacked: erc1155.Erc1155TransferSingle{
+					From: common.Address(fakeAddress),
+					To:   otherAddress,
+					Raw: coretypes.Log{
+						BlockNumber: 124,
+					},
+				},
+			},
+			{
+				EventKey: eventlog.ERC1155TransferBatch,
+				Unpacked: erc1155.Erc1155TransferBatch{
+					From: common.Address(fakeAddress),
+					To:   otherAddress,
+					Raw: coretypes.Log{
+						BlockNumber: 125,
+					},
+				},
+			},
+			{
+				EventKey: eventlog.ERC721Transfer,
+				Unpacked: struct{}{},
+			},
+		},
+	}
+	pubsub.Publish(transferDetectorPublisher, msg)
+
+	require.Eventually(t, func() bool {
+		return estimatedBlockCalls.Load() >= 3
+	}, 2*time.Second, 50*time.Millisecond)
 }

--- a/services/wallet/collectibles/service.go
+++ b/services/wallet/collectibles/service.go
@@ -212,24 +212,31 @@ func (s *Service) GetOwnedCollectibles(
 	}, err
 }
 
-func (s *Service) needsToFetch(chainID walletCommon.ChainID, address common.Address, fetchCriteria FetchCriteria) (bool, error) {
-	mustFetch := false
+func (s *Service) shouldTriggerLoad(chainID walletCommon.ChainID, address common.Address, fetchCriteria FetchCriteria) (bool, error) {
 	switch fetchCriteria.FetchType {
-	case FetchTypeAlwaysFetch:
-		mustFetch = true
 	case FetchTypeNeverFetch:
-		mustFetch = false
+		return false, nil
+	case FetchTypeAlwaysFetch:
+		return true, nil
 	case FetchTypeFetchIfNotCached, FetchTypeFetchIfCacheOld:
 		timestamp, err := s.ownershipDB.GetOwnershipUpdateTimestamp(address, chainID)
 		if err != nil {
 			return false, err
 		}
-		if timestamp == ownership.InvalidTimestamp ||
-			(fetchCriteria.FetchType == FetchTypeFetchIfCacheOld && timestamp+fetchCriteria.MaxCacheAgeSeconds < time.Now().Unix()) {
-			mustFetch = true
+		if timestamp != ownership.InvalidTimestamp &&
+			!(fetchCriteria.FetchType == FetchTypeFetchIfCacheOld && timestamp+fetchCriteria.MaxCacheAgeSeconds < time.Now().Unix()) {
+			return false, nil
 		}
+		// Skip duplicate load unless the loader is missing or errored
+		if fetchCriteria.FetchType == FetchTypeFetchIfNotCached {
+			state := s.ownershipController.GetLoaderState(chainID, address)
+			if state != ownership.LoaderStateNotAvailable && state != ownership.LoaderStateError {
+				return false, nil
+			}
+		}
+		return true, nil
 	}
-	return mustFetch, nil
+	return false, nil
 }
 
 func (s *Service) fetchOwnedCollectiblesIfNeeded(ctx context.Context, chainIDs []walletCommon.ChainID, addresses []common.Address, fetchCriteria FetchCriteria) error {
@@ -241,21 +248,20 @@ func (s *Service) fetchOwnedCollectiblesIfNeeded(ctx context.Context, chainIDs [
 	wgErr := atomic.NewError(nil)
 	for _, address := range addresses {
 		for _, chainID := range chainIDs {
-			mustFetch, err := s.needsToFetch(chainID, address, fetchCriteria)
-			if err != nil {
+			if ok, err := s.shouldTriggerLoad(chainID, address, fetchCriteria); err != nil {
 				return err
+			} else if !ok {
+				continue
 			}
-			if mustFetch {
-				wg.Add(1)
-				go func() {
-					defer gocommon.LogOnPanic()
-					defer wg.Done()
-					err := s.ownershipController.TriggerLoad(ctx, chainID, address)
-					if err != nil {
-						wgErr.Store(err)
-					}
-				}()
-			}
+
+			wg.Add(1)
+			go func() {
+				defer gocommon.LogOnPanic()
+				defer wg.Done()
+				if err := s.ownershipController.TriggerLoad(ctx, chainID, address); err != nil {
+					wgErr.Store(err)
+				}
+			}()
 		}
 	}
 

--- a/services/wallet/collectibles/service_test.go
+++ b/services/wallet/collectibles/service_test.go
@@ -1,0 +1,161 @@
+package collectibles
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+	"go.uber.org/zap/zaptest"
+
+	"github.com/status-im/status-go/internal/crypto/types"
+	"github.com/status-im/status-go/params"
+	"github.com/status-im/status-go/pkg/pubsub"
+	"github.com/status-im/status-go/services/wallet/collectibles/ownership"
+	mock_ownership "github.com/status-im/status-go/services/wallet/collectibles/ownership/mock"
+	walletCommon "github.com/status-im/status-go/services/wallet/common"
+	"github.com/status-im/status-go/services/wallet/thirdparty"
+)
+
+func TestServiceShouldTriggerLoadFetchIfNotCachedSkipsWhenLoaderExists(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	chainID := walletCommon.ChainID(1)
+	address := common.HexToAddress("0x123")
+
+	storage := mock_ownership.NewMockOwnershipStorage(ctrl)
+	storage.EXPECT().GetOwnershipUpdateTimestamp(gomock.Any(), gomock.Any()).Return(ownership.InvalidTimestamp, nil).AnyTimes()
+	storage.EXPECT().Update(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil, nil, nil).AnyTimes()
+
+	accountsProvider := mock_ownership.NewMockAccountsProvider(ctrl)
+	accountsProvider.EXPECT().GetWalletAddresses().Return([]types.Address{types.Address(address)}, nil).AnyTimes()
+
+	networksProvider := mock_ownership.NewMockNetworksProvider(ctrl)
+	networksProvider.EXPECT().GetActiveNetworks().Return([]*params.Network{{ChainID: uint64(chainID), IsActive: true}}, nil).AnyTimes()
+	networksProvider.EXPECT().GetPublisher().Return(pubsub.NewPublisher()).AnyTimes()
+
+	fetcher := mock_ownership.NewMockCollectibleOwnershipFetcher(ctrl)
+	fetcher.EXPECT().FetchCollectibleOwnershipByOwner(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(&thirdparty.CollectibleOwnershipContainer{
+			Items:          []thirdparty.CollectibleIDBalance{},
+			NextCursor:     "",
+			PreviousCursor: "",
+			Provider:       "mock",
+		}, nil).AnyTimes()
+
+	ownershipController := ownership.NewController(
+		storage,
+		accountsProvider,
+		pubsub.NewPublisher(),
+		networksProvider,
+		nil,
+		nil,
+		nil,
+		fetcher,
+		pubsub.NewPublisher(),
+		zaptest.NewLogger(t),
+	)
+	ownershipController.StartWithLoaderParams(ownership.PeriodicalLoaderParams{
+		StartDelay:   0,
+		LoadInterval: time.Hour,
+		LoaderParams: ownership.LoaderParams{
+			LoadDelay:  0,
+			FetchLimit: 10,
+		},
+	})
+	defer ownershipController.Stop()
+
+	require.Eventually(t, func() bool {
+		return ownershipController.GetLoaderState(chainID, address) != ownership.LoaderStateNotAvailable
+	}, time.Second, 25*time.Millisecond)
+
+	s := &Service{
+		ownershipDB:         storage,
+		ownershipController: ownershipController,
+	}
+
+	trigger, err := s.shouldTriggerLoad(chainID, address, FetchCriteria{
+		FetchType: FetchTypeFetchIfNotCached,
+	})
+	require.NoError(t, err)
+	require.False(t, trigger)
+}
+
+func TestServiceShouldTriggerLoadFetchIfCacheOldRespectsAge(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	chainID := walletCommon.ChainID(1)
+	address := common.HexToAddress("0x123")
+
+	storage := mock_ownership.NewMockOwnershipStorage(ctrl)
+	now := time.Now().Unix()
+	gomock.InOrder(
+		storage.EXPECT().GetOwnershipUpdateTimestamp(address, chainID).Return(now, nil),
+		storage.EXPECT().GetOwnershipUpdateTimestamp(address, chainID).Return(now-10, nil),
+	)
+
+	s := &Service{
+		ownershipDB: storage,
+	}
+
+	trigger, err := s.shouldTriggerLoad(chainID, address, FetchCriteria{
+		FetchType:          FetchTypeFetchIfCacheOld,
+		MaxCacheAgeSeconds: 3600,
+	})
+	require.NoError(t, err)
+	require.False(t, trigger)
+
+	trigger, err = s.shouldTriggerLoad(chainID, address, FetchCriteria{
+		FetchType:          FetchTypeFetchIfCacheOld,
+		MaxCacheAgeSeconds: 1,
+	})
+	require.NoError(t, err)
+	require.True(t, trigger)
+}
+
+func TestServiceFetchOwnedCollectiblesIfNeededReturnsTriggerLoadError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	chainID := walletCommon.ChainID(1)
+	address := common.HexToAddress("0x123")
+	expectedErr := errors.New("fetch failed")
+
+	storage := mock_ownership.NewMockOwnershipStorage(ctrl)
+	storage.EXPECT().GetOwnershipUpdateTimestamp(gomock.Any(), gomock.Any()).Return(ownership.InvalidTimestamp, nil).AnyTimes()
+
+	fetcher := mock_ownership.NewMockCollectibleOwnershipFetcher(ctrl)
+	fetcher.EXPECT().FetchCollectibleOwnershipByOwner(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(nil, expectedErr).AnyTimes()
+
+	ownershipController := ownership.NewController(
+		storage,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		fetcher,
+		pubsub.NewPublisher(),
+		zaptest.NewLogger(t),
+	)
+
+	s := &Service{
+		ownershipController: ownershipController,
+		ownershipDB:         storage,
+	}
+
+	err := s.fetchOwnedCollectiblesIfNeeded(
+		context.Background(),
+		[]walletCommon.ChainID{chainID},
+		[]common.Address{address},
+		FetchCriteria{FetchType: FetchTypeAlwaysFetch},
+	)
+	require.ErrorIs(t, err, expectedErr)
+}

--- a/services/wallet/puzzleauth/solver.go
+++ b/services/wallet/puzzleauth/solver.go
@@ -45,12 +45,10 @@ func Solve(ctx context.Context, puzzle *Puzzle) (*Solution, error) {
 
 	// Try different nonces until we find one that meets the difficulty requirement
 	for nonce := uint64(0); nonce < maxAttempts; nonce++ {
-		if nonce%1000 == 0 {
-			select {
-			case <-ctx.Done():
-				return nil, ctx.Err()
-			default:
-			}
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		default:
 		}
 
 		// Create input: challenge + salt + nonce

--- a/services/wallet/thirdparty/collectibles/alchemy/client.go
+++ b/services/wallet/thirdparty/collectibles/alchemy/client.go
@@ -22,6 +22,8 @@ import (
 
 const nftMetadataBatchLimit = 100
 const contractMetadataBatchLimit = 100
+const fetchNoLimitMaxPages = 10
+const getNFTsForOwnerPageSize = 500
 
 type Params struct {
 	IsProxy          bool
@@ -211,6 +213,8 @@ func (o *Client) fetchOwnedAssets(ctx context.Context, chainID walletCommon.Chai
 	queryParams["owner"] = []string{owner.String()}
 	queryParams["withMetadata"] = []string{"true"}
 	queryParams["orderBy"] = []string{"transferTime"}
+	queryParams["pageSize"] = []string{fmt.Sprintf("%d", getNFTsForOwnerPageSize)}
+	queryParams["excludeFilters"] = []string{"SPAM"}
 
 	if len(cursor) > 0 {
 		queryParams["pageKey"] = []string{cursor}
@@ -222,6 +226,8 @@ func (o *Client) fetchOwnedAssets(ctx context.Context, chainID walletCommon.Chai
 	if err != nil {
 		return nil, err
 	}
+
+	pageCount := 0
 
 	for {
 		url := fmt.Sprintf("%s/getNFTsForOwner?%s", baseURL, queryParams.Encode())
@@ -254,17 +260,20 @@ func (o *Client) fetchOwnedAssets(ctx context.Context, chainID walletCommon.Chai
 		}
 
 		assets.Items = append(assets.Items, alchemyToCollectiblesData(chainID, container.OwnedNFTs, &owner)...)
+		pageCount++
 		assets.NextCursor = container.PageKey
 
-		if len(assets.NextCursor) == 0 {
+		if len(assets.NextCursor) == 0 ||
+			(limit != thirdparty.FetchNoLimit && len(assets.Items) >= limit) ||
+			(limit == thirdparty.FetchNoLimit && pageCount >= fetchNoLimitMaxPages) {
 			break
 		}
 
-		queryParams["cursor"] = []string{assets.NextCursor}
+		queryParams["pageKey"] = []string{assets.NextCursor}
+	}
 
-		if limit != thirdparty.FetchNoLimit && len(assets.Items) >= limit {
-			break
-		}
+	if limit != thirdparty.FetchNoLimit && len(assets.Items) > limit {
+		assets.Items = assets.Items[:limit]
 	}
 
 	return assets, nil

--- a/services/wallet/thirdparty/collectibles/alchemy/client_test.go
+++ b/services/wallet/thirdparty/collectibles/alchemy/client_test.go
@@ -1,17 +1,24 @@
 package alchemy
 
 import (
+	"context"
 	"encoding/json"
+	"fmt"
 	"math/big"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
 
+	"github.com/status-im/status-go/pkg/security"
 	"github.com/status-im/status-go/services/wallet/bigint"
 	w_common "github.com/status-im/status-go/services/wallet/common"
 	"github.com/status-im/status-go/services/wallet/thirdparty"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestUnmarshallCollection(t *testing.T) {
@@ -164,4 +171,188 @@ func TestUnmarshallOwnedCollectibles(t *testing.T) {
 	collectiblesData := alchemyToCollectiblesData(w_common.ChainID(w_common.EthereumMainnet), container.OwnedNFTs, &owner)
 
 	assert.Equal(t, expectedCollectiblesData, collectiblesData)
+}
+
+type testURLResolver struct {
+	baseURL string
+}
+
+func (r testURLResolver) GetNFTBaseURL(chainID w_common.ChainID) (string, error) {
+	return r.baseURL, nil
+}
+
+func (r testURLResolver) IsChainSupported(chainID w_common.ChainID) bool {
+	return true
+}
+
+func makeNFTResponse(t *testing.T, w http.ResponseWriter, nftCount int, nextPageKey string) {
+	t.Helper()
+
+	nfts := make([]map[string]any, 0, nftCount)
+	for i := range nftCount {
+		nfts = append(nfts, map[string]any{
+			"contract": map[string]any{
+				"address":   "0x0000000000000000000000000000000000000001",
+				"tokenType": "ERC721",
+			},
+			"tokenId": fmt.Sprintf("%d", i+1),
+			"name":    fmt.Sprintf("NFT #%d", i+1),
+			"raw": map[string]any{
+				"tokenUri":    "",
+				"metadata":    map[string]any{},
+				"error":       nil,
+				"rawMetadata": map[string]any{"attributes": []any{}},
+			},
+			"image": map[string]any{},
+		})
+	}
+
+	resp := map[string]any{
+		"ownedNfts": nfts,
+	}
+	if nextPageKey != "" {
+		resp["pageKey"] = nextPageKey
+	}
+
+	require.NoError(t, json.NewEncoder(w).Encode(resp))
+}
+
+func newTestClient(baseURL string) *Client {
+	client := NewClient(security.NewSensitiveString(""))
+	client.urlResolver = testURLResolver{baseURL: baseURL}
+	return client
+}
+
+var testOwner = common.HexToAddress("0x1234567890123456789012345678901234567890")
+
+func TestFetchOwnedAssetsSendsPageSizeAndExcludeFilters(t *testing.T) {
+	var called atomic.Bool
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called.Store(true)
+		assert.Equal(t, "/getNFTsForOwner", r.URL.Path)
+		assert.Equal(t, "500", r.URL.Query().Get("pageSize"))
+		assert.Equal(t, "SPAM", r.URL.Query().Get("excludeFilters"))
+		makeNFTResponse(t, w, 1, "")
+	}))
+	defer server.Close()
+
+	assets, err := newTestClient(server.URL).FetchAllAssetsByOwner(
+		context.Background(), w_common.ChainID(w_common.EthereumMainnet), testOwner, "", thirdparty.FetchNoLimit,
+	)
+	require.NoError(t, err)
+	require.NotNil(t, assets)
+	assert.True(t, called.Load())
+	assert.Len(t, assets.Items, 1)
+	assert.Empty(t, assets.NextCursor)
+}
+
+func TestFetchOwnedAssetsPagination(t *testing.T) {
+	tests := []struct {
+		name            string
+		limit           int
+		handler         func(t *testing.T, page int32, w http.ResponseWriter, r *http.Request)
+		expectedPages   int32
+		expectedItems   int
+		expectCursorSet bool
+	}{
+		{
+			name:  "stops on empty page key",
+			limit: thirdparty.FetchNoLimit,
+			handler: func(t *testing.T, page int32, w http.ResponseWriter, r *http.Request) {
+				if page < 3 {
+					makeNFTResponse(t, w, 2, fmt.Sprintf("page-%d", page))
+				} else {
+					makeNFTResponse(t, w, 1, "")
+				}
+			},
+			expectedPages:   3,
+			expectedItems:   5,
+			expectCursorSet: false,
+		},
+		{
+			name:  "stops at page cap for unbounded fetch",
+			limit: thirdparty.FetchNoLimit,
+			handler: func(t *testing.T, page int32, w http.ResponseWriter, r *http.Request) {
+				makeNFTResponse(t, w, 1, fmt.Sprintf("page-%d", page))
+			},
+			expectedPages:   int32(fetchNoLimitMaxPages),
+			expectedItems:   fetchNoLimitMaxPages,
+			expectCursorSet: true,
+		},
+		{
+			name:  "honors limit before page cap",
+			limit: 3,
+			handler: func(t *testing.T, page int32, w http.ResponseWriter, r *http.Request) {
+				makeNFTResponse(t, w, 1, fmt.Sprintf("page-%d", page))
+			},
+			expectedPages:   3,
+			expectedItems:   3,
+			expectCursorSet: true,
+		},
+		{
+			name:  "trims items to limit",
+			limit: 3,
+			handler: func(t *testing.T, _ int32, w http.ResponseWriter, r *http.Request) {
+				makeNFTResponse(t, w, 5, "next-page")
+			},
+			expectedPages:   1,
+			expectedItems:   3,
+			expectCursorSet: true,
+		},
+		{
+			name:  "single page no next cursor",
+			limit: thirdparty.FetchNoLimit,
+			handler: func(t *testing.T, _ int32, w http.ResponseWriter, r *http.Request) {
+				makeNFTResponse(t, w, 2, "")
+			},
+			expectedPages:   1,
+			expectedItems:   2,
+			expectCursorSet: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var requestCount atomic.Int32
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				page := requestCount.Add(1)
+				if page == 1 {
+					assert.Empty(t, r.URL.Query().Get("pageKey"))
+				} else {
+					assert.NotEmpty(t, r.URL.Query().Get("pageKey"))
+				}
+				tt.handler(t, page, w, r)
+			}))
+			defer server.Close()
+
+			assets, err := newTestClient(server.URL).FetchAllAssetsByOwner(
+				context.Background(), w_common.ChainID(w_common.EthereumMainnet), testOwner, "", tt.limit,
+			)
+			require.NoError(t, err)
+			require.NotNil(t, assets)
+			assert.Equal(t, tt.expectedPages, requestCount.Load())
+			assert.Len(t, assets.Items, tt.expectedItems)
+			if tt.expectCursorSet {
+				assert.NotEmpty(t, assets.NextCursor)
+			} else {
+				assert.Empty(t, assets.NextCursor)
+			}
+		})
+	}
+}
+
+func TestFetchOwnedAssetsRespectsContextCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		makeNFTResponse(t, w, 1, "next")
+	}))
+	defer server.Close()
+
+	_, err := newTestClient(server.URL).FetchAllAssetsByOwner(
+		ctx, w_common.ChainID(w_common.EthereumMainnet), testOwner, "", thirdparty.FetchNoLimit,
+	)
+	require.Error(t, err)
 }


### PR DESCRIPTION
Alchemy getNFTsForOwner improvements:
- Set `pageSize=500` (was default 100) and `excludeFilters=SPAM`
- Cap unbounded fetches (`FetchNoLimit`) at 10 pages (5000 tokens)
- Trim results to exact limit when a page returns excess items
- Fix pagination bug: use `pageKey` (not `cursor`) for subsequent page requests

Ownership loading fixes:
- `loadWithPeriodicalLoaderIfFound`: loop over events instead of returning on first unrelated event
- `shouldTriggerLoad`: skip load when periodical loader is already running (prevents duplicate fetches at startup)

fixes status-im/status-app#20307