### PR TITLE
fix: ConnectionStatusSubscription leaks goroutines

### DIFF
--- a/pkg/messaging/adapters/connection_status.go
+++ b/pkg/messaging/adapters/connection_status.go
@@ -8,14 +8,22 @@ import (
 
 type ConnectionStatusSubscription struct {
 	S *wakutypes.ConnStatusSubscription
+	c <-chan types.ConnectionStatus
+}
+
+func NewConnectionStatusSubscription(s *wakutypes.ConnStatusSubscription) *ConnectionStatusSubscription {
+	return &ConnectionStatusSubscription{
+		S: s,
+		c: utils.BridgeChannels(s.C, func(status wakutypes.ConnStatus) types.ConnectionStatus {
+			return types.ConnectionStatus{
+				IsOnline: status.IsOnline,
+			}
+		}),
+	}
 }
 
 func (c *ConnectionStatusSubscription) C() <-chan types.ConnectionStatus {
-	return utils.BridgeChannels(c.S.C, func(status wakutypes.ConnStatus) types.ConnectionStatus {
-		return types.ConnectionStatus{
-			IsOnline: status.IsOnline,
-		}
-	})
+	return c.c
 }
 
 func (c *ConnectionStatusSubscription) Unsubscribe() {

--- a/pkg/messaging/api_subscriptions.go
+++ b/pkg/messaging/api_subscriptions.go
@@ -10,7 +10,5 @@ func (a *API) SubscribeToConnStatusChanges() (types.ConnectionStatusSubscription
 	if err != nil {
 		return nil, err
 	}
-	return &adapters.ConnectionStatusSubscription{
-		S: sub,
-	}, nil
+	return adapters.NewConnectionStatusSubscription(sub), nil
 }


### PR DESCRIPTION
While working with pprof I've found that the number of goroutines keeps increasing due to ConnectionStatusSubscription.

A new goroutine is created every time ConnectionStatusSubscription.C is called.

With this commit we're creating the BridgeChannels in the constructor and return it on `ConnectionStatusSubscription.C`