### PR TITLE
fix(wallet): fix stop channel race causing goroutines to hang on pause/resume

### DIFF
--- a/services/wallet/collectibles/ownership/periodical_loader.go
+++ b/services/wallet/collectibles/ownership/periodical_loader.go
@@ -86,13 +86,17 @@ func (pl *PeriodicalLoader) Start(withDelay bool, waitForInterval bool) {
 	pl.Stop()
 	pl.stopCh = make(chan struct{})
 
+	// Capture stopCh once so the goroutine always sees the closed channel
+	// even after Stop() sets pl.stopCh = nil.
+	stopCh := pl.stopCh
+
 	// Trigger
 	go func() {
 		defer gocommon.LogOnPanic()
 
 		if withDelay && pl.params.StartDelay.Seconds() > 0 {
 			pl.state.Store(LoaderStateDelayed)
-			if cancelled := pl.waitFor(pl.params.StartDelay); cancelled {
+			if cancelled := pl.waitFor(stopCh, pl.params.StartDelay); cancelled {
 				pl.state.Store(LoaderStateIdle)
 				return
 			}
@@ -104,7 +108,7 @@ func (pl *PeriodicalLoader) Start(withDelay bool, waitForInterval bool) {
 				zap.Uint64("chain", uint64(pl.chainID)),
 				zap.String("account", gocommon.TruncateWithDot(pl.account.String())),
 			)
-			pl.triggerLoadAsync()
+			pl.triggerLoadAsync(stopCh)
 		}
 
 		ticker := time.NewTicker(pl.params.LoadInterval)
@@ -118,8 +122,8 @@ func (pl *PeriodicalLoader) Start(withDelay bool, waitForInterval bool) {
 					zap.Uint64("chain", uint64(pl.chainID)),
 					zap.String("account", gocommon.TruncateWithDot(pl.account.String())),
 				)
-				pl.triggerLoadAsync()
-			case <-pl.stopCh:
+				pl.triggerLoadAsync(stopCh)
+			case <-stopCh:
 				return
 			}
 		}
@@ -137,14 +141,14 @@ func (pl *PeriodicalLoader) GetState() LoaderState {
 	return pl.state.Load().(LoaderState)
 }
 
-func (pl *PeriodicalLoader) triggerLoadAsync() {
+func (pl *PeriodicalLoader) triggerLoadAsync(stopCh <-chan struct{}) {
 	go func() {
 		defer gocommon.LogOnPanic()
-		pl.triggerLoad()
+		pl.triggerLoad(stopCh)
 	}()
 }
 
-func (pl *PeriodicalLoader) triggerLoad() {
+func (pl *PeriodicalLoader) triggerLoad(stopCh <-chan struct{}) {
 	if pl.GetState() == LoaderStateUpdating {
 		// Another load is in progress which should've finished or have been cancelled at this point
 		pl.logger.Error("skipping Load because it's already in progress",
@@ -171,13 +175,9 @@ func (pl *PeriodicalLoader) triggerLoad() {
 	go func() {
 		defer gocommon.LogOnPanic()
 		defer cancelFn() // Cancel ctx if PeriodicalLoader is stopped
-		for {
-			select {
-			case <-pl.stopCh:
-				return
-			case <-ctx.Done():
-				return
-			}
+		select {
+		case <-stopCh:
+		case <-ctx.Done():
 		}
 	}()
 
@@ -189,13 +189,13 @@ func (pl *PeriodicalLoader) Load(ctx context.Context) (err error) {
 	return
 }
 
-func (pl *PeriodicalLoader) waitFor(delay time.Duration) (cancelled bool) {
+func (pl *PeriodicalLoader) waitFor(stopCh <-chan struct{}, delay time.Duration) (cancelled bool) {
 	delayTimer := time.NewTicker(delay)
 	defer delayTimer.Stop()
 	select {
 	case <-delayTimer.C:
 		break
-	case <-pl.stopCh:
+	case <-stopCh:
 		return true
 	}
 	return false

--- a/services/wallet/collectibles/ownership/periodical_loader_test.go
+++ b/services/wallet/collectibles/ownership/periodical_loader_test.go
@@ -1,0 +1,183 @@
+package ownership
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/status-im/status-go/pkg/pubsub"
+	walletCommon "github.com/status-im/status-go/services/wallet/common"
+	"github.com/status-im/status-go/services/wallet/thirdparty"
+
+	"go.uber.org/zap/zaptest"
+)
+
+// fakeFetcher blocks until its context is cancelled, allowing tests to observe
+// whether Stop properly propagates to in-flight loads.
+type fakeFetcher struct {
+	mu       sync.Mutex
+	calls    int
+	entered  chan struct{} // sent on each time a fetch begins
+	returned chan struct{} // closed after each FetchCollectibleOwnershipByOwner returns
+}
+
+func newFakeFetcher() *fakeFetcher {
+	return &fakeFetcher{
+		entered:  make(chan struct{}, 10),
+		returned: make(chan struct{}),
+	}
+}
+
+func (f *fakeFetcher) FetchCollectibleOwnershipByOwner(ctx context.Context, _ walletCommon.ChainID, _ common.Address, _ string, _ int, _ string) (*thirdparty.CollectibleOwnershipContainer, error) {
+	f.mu.Lock()
+	f.calls++
+	// Refresh the channel so each call gets its own signal.
+	ch := make(chan struct{})
+	f.returned = ch
+	f.mu.Unlock()
+
+	f.entered <- struct{}{}
+
+	// Block until context is cancelled (simulates a long-running fetch).
+	<-ctx.Done()
+
+	close(ch)
+	return nil, ctx.Err()
+}
+
+func (f *fakeFetcher) CallCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.calls
+}
+
+// waitForReturn waits until the most recent fetch call returns.
+func (f *fakeFetcher) waitForReturn(t *testing.T) {
+	t.Helper()
+	f.mu.Lock()
+	ch := f.returned
+	f.mu.Unlock()
+	select {
+	case <-ch:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for fetch to return")
+	}
+}
+
+// fakeStorage satisfies CollectibleOwnershipStorage with no-ops.
+type fakeStorage struct{}
+
+func (fakeStorage) GetOwnershipUpdateTimestamp(_ common.Address, _ walletCommon.ChainID) (int64, error) {
+	return 0, nil // non-initial load (timestamp != InvalidTimestamp)
+}
+
+func (fakeStorage) Update(_ walletCommon.ChainID, _ common.Address, _ []thirdparty.CollectibleIDBalance, _ int64) ([]thirdparty.CollectibleUniqueID, []thirdparty.CollectibleUniqueID, []thirdparty.CollectibleUniqueID, error) {
+	return nil, nil, nil, nil
+}
+
+func newTestLoader(t *testing.T, fetcher CollectibleOwnershipFetcher, storage CollectibleOwnershipStorage, params PeriodicalLoaderParams) *PeriodicalLoader {
+	t.Helper()
+	logger := zaptest.NewLogger(t)
+	publisher := pubsub.NewPublisher()
+	return NewPeriodicalLoader(
+		walletCommon.ChainID(1),
+		common.HexToAddress("0x1234"),
+		fetcher,
+		storage,
+		publisher,
+		params,
+		logger,
+	)
+}
+
+// TestPeriodicalLoaderStartStop verifies that Start followed by Stop cleanly
+// terminates the loader goroutines.
+func TestPeriodicalLoaderStartStop(t *testing.T) {
+	fetcher := newFakeFetcher()
+	params := PeriodicalLoaderParams{
+		LoadInterval: 1 * time.Second,
+		LoaderParams: LoaderParams{FetchLimit: 50},
+	}
+	pl := newTestLoader(t, fetcher, fakeStorage{}, params)
+
+	pl.Start(false, false)
+
+	// Wait a bit for the goroutine to spin up and trigger the fetch.
+	time.Sleep(100 * time.Millisecond)
+
+	pl.Stop()
+
+	// After Stop the state should eventually settle to idle or error (context cancelled).
+	// The key assertion is that Stop() returns without hanging.
+	require.NotEqual(t, LoaderStateDelayed, pl.GetState())
+}
+
+// TestPeriodicalLoaderRestartReleasesOldGoroutines verifies that calling
+// Start a second time (which internally calls Stop then Start) does not leave
+// the goroutines from the first Start hanging. This is the bug that the
+// stopCh-capture fix addresses: without the fix, the first goroutine would
+// read pl.stopCh (now nil after Stop) and block forever.
+func TestPeriodicalLoaderRestartReleasesOldGoroutines(t *testing.T) {
+	fetcher := newFakeFetcher()
+	params := PeriodicalLoaderParams{
+		LoadInterval: 1 * time.Second,
+		LoaderParams: LoaderParams{FetchLimit: 50},
+	}
+	pl := newTestLoader(t, fetcher, fakeStorage{}, params)
+
+	// First start — triggers an immediate load that blocks in the fetcher.
+	pl.Start(false, false)
+	// Wait for the first fetch to actually enter.
+	<-fetcher.entered
+
+	// Second start — internally calls Stop() then starts a new cycle.
+	// Without the fix, the first goroutine would hang here because it reads
+	// pl.stopCh which is now nil.
+	pl.Start(false, false)
+
+	// The first fetch should have been cancelled and returned.
+	fetcher.waitForReturn(t)
+
+	// Wait for the second fetch to enter.
+	select {
+	case <-fetcher.entered:
+	case <-time.After(5 * time.Second):
+		t.Fatal("second fetch was never triggered — old goroutine may be hanging")
+	}
+
+	// Verify both starts triggered fetches.
+	require.GreaterOrEqual(t, fetcher.CallCount(), 2, "expected at least 2 fetch calls after restart")
+
+	// Clean up
+	pl.Stop()
+}
+
+// TestPeriodicalLoaderStopDuringDelay verifies that Stop cancels the start
+// delay and the loader returns to idle state.
+func TestPeriodicalLoaderStopDuringDelay(t *testing.T) {
+	fetcher := newFakeFetcher()
+	params := PeriodicalLoaderParams{
+		StartDelay:   5 * time.Second,
+		LoadInterval: 1 * time.Second,
+		LoaderParams: LoaderParams{FetchLimit: 50},
+	}
+	pl := newTestLoader(t, fetcher, fakeStorage{}, params)
+
+	pl.Start(true, false)
+	time.Sleep(100 * time.Millisecond)
+
+	require.Equal(t, LoaderStateDelayed, pl.GetState())
+
+	pl.Stop()
+
+	// Give the goroutine time to react to the stop signal.
+	time.Sleep(100 * time.Millisecond)
+
+	require.Equal(t, LoaderStateIdle, pl.GetState())
+	require.Equal(t, 0, fetcher.CallCount(), "no fetch should have been triggered during delay")
+}

--- a/services/wallet/puzzleauth/solver.go
+++ b/services/wallet/puzzleauth/solver.go
@@ -45,12 +45,10 @@ func Solve(ctx context.Context, puzzle *Puzzle) (*Solution, error) {
 
 	// Try different nonces until we find one that meets the difficulty requirement
 	for nonce := uint64(0); nonce < maxAttempts; nonce++ {
-		if nonce%1000 == 0 {
-			select {
-			case <-ctx.Done():
-				return nil, ctx.Err()
-			default:
-			}
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		default:
 		}
 
 		// Create input: challenge + salt + nonce


### PR DESCRIPTION
PeriodicalLoader.Stop() nils out pl.stopCh, but goroutines spawned by Start() read the field directly. After Stop(), they see a nil channel (blocks forever on receive) instead of the closed one, so they never terminate.

Fix by capturing stopCh in a local variable at Start() time and threading it through to all goroutines and helper methods.

Also make the puzzleauth solver check for context cancellation on every nonce iteration instead of every 1000th, so it responds to pause/cancel immediately.

Iterates https://github.com/status-im/status-app/issues/20227
