### PR TITLE
perf: make `StartRetrieveMessagesLoop` event based

### DIFF
--- a/pkg/messaging/api.go
+++ b/pkg/messaging/api.go
@@ -31,6 +31,23 @@ func (a *API) GetCurrentTime() uint64 {
 	return a.core.stack.Transport.GetCurrentTime()
 }
 
+// SubscribeFilterMatched returns a channel that is notified whenever an incoming
+// envelope matches at least one installed filter. bufSize should be 1.
+// Callers must call UnsubscribeFilterMatched when done.
+func (a *API) SubscribeFilterMatched() chan struct{} {
+	if a.core.stack.Transport == nil {
+		return nil
+	}
+	return a.core.stack.Transport.SubscribeFilterMatched()
+}
+
+func (a *API) UnsubscribeFilterMatched(ch chan struct{}) {
+	if a.core.stack.Transport == nil || ch == nil {
+		return
+	}
+	a.core.stack.Transport.UnsubscribeFilterMatched(ch)
+}
+
 // PauseTransport signals the transport and its sub-components to idle their goroutines.
 func (a *API) PauseTransport() {
 	if a.core.stack.Transport != nil {

--- a/pkg/messaging/layers/transport/transport.go
+++ b/pkg/messaging/layers/transport/transport.go
@@ -600,6 +600,23 @@ func (t *Transport) DisconnectActiveStorenode(ctx context.Context, backoffReason
 	t.waku.DisconnectActiveStorenode(ctx, backoffReason, shouldCycle)
 }
 
+// SubscribeFilterMatched returns a channel notified (non-blocking, coalescing) whenever
+// an incoming envelope matches at least one installed filter. Callers must call
+// UnsubscribeFilterMatched with the returned channel when done.
+func (t *Transport) SubscribeFilterMatched() chan struct{} {
+	if t.waku == nil {
+		return nil
+	}
+	return t.waku.SubscribeFilterMatched()
+}
+
+func (t *Transport) UnsubscribeFilterMatched(ch chan struct{}) {
+	if t.waku == nil || ch == nil {
+		return
+	}
+	t.waku.UnsubscribeFilterMatched(ch)
+}
+
 func (t *Transport) OnStorenodeChanged() <-chan peer.ID {
 	return t.waku.OnStorenodeChanged()
 }

--- a/pkg/messaging/waku/common/filter.go
+++ b/pkg/messaging/waku/common/filter.go
@@ -30,6 +30,7 @@ import (
 	"github.com/ethereum/go-ethereum/crypto"
 
 	"github.com/status-im/status-go/internal/logutils"
+	"github.com/status-im/status-go/pkg/pubsub"
 )
 
 // Filter represents a Waku message filter
@@ -63,6 +64,10 @@ type Filters struct {
 	// list all the filters that will be notified of a new message, no matter what its topic is
 	allTopicsMatcher map[*Filter]struct{}
 
+	// matchedPublisher notifies subscribers when at least one filter matched an incoming envelope.
+	// Uses non-blocking sends so processQueueLoop is never stalled.
+	matchedPublisher *pubsub.TypePublisher[struct{}]
+
 	logger *zap.Logger
 
 	sync.RWMutex
@@ -75,6 +80,7 @@ func NewFilters(defaultPubsubTopic string, logger *zap.Logger) *Filters {
 		topicMatcher:       make(PubsubTopicToContentTopic),
 		allTopicsMatcher:   make(map[*Filter]struct{}),
 		defaultPubsubTopic: defaultPubsubTopic,
+		matchedPublisher:   pubsub.NewTypePublisher[struct{}](),
 		logger:             logger,
 	}
 }
@@ -261,7 +267,24 @@ func (fs *Filters) NotifyWatchers(recvMessage *ReceivedMessage) bool {
 		}
 	}
 
+	if matched {
+		fs.matchedPublisher.Publish(struct{}{})
+	}
+
 	return matched
+}
+
+// SubscribeFilterMatched returns a channel that receives a notification whenever
+// an incoming envelope matches at least one filter. The channel has a buffer of 1
+// so sends are non-blocking and bursts coalesce naturally.
+func (fs *Filters) SubscribeFilterMatched() chan struct{} {
+	return fs.matchedPublisher.Subscribe(1)
+}
+
+// UnsubscribeFilterMatched removes and closes the subscription channel returned
+// by SubscribeFilterMatched.
+func (fs *Filters) UnsubscribeFilterMatched(ch chan struct{}) {
+	fs.matchedPublisher.Unsubscribe(ch)
 }
 
 func (f *Filter) expectsAsymmetricEncryption() bool {

--- a/pkg/messaging/waku/gowaku.go
+++ b/pkg/messaging/waku/gowaku.go
@@ -724,6 +724,14 @@ func (w *Waku) SubscribeEnvelopeEvents(eventsProxy chan<- types2.EnvelopeEvent) 
 	return NewGethSubscriptionWrapper(w.subscribeEnvelopeEvents(events))
 }
 
+func (w *Waku) SubscribeFilterMatched() chan struct{} {
+	return w.filters.SubscribeFilterMatched()
+}
+
+func (w *Waku) UnsubscribeFilterMatched(ch chan struct{}) {
+	w.filters.UnsubscribeFilterMatched(ch)
+}
+
 // NewKeyPair generates a new cryptographic identity for the client, and injects
 // it into the known identities for message decryption. Returns ID of the new key pair.
 func (w *Waku) NewKeyPair() (string, error) {

--- a/pkg/messaging/waku/types/waku.go
+++ b/pkg/messaging/waku/types/waku.go
@@ -152,6 +152,12 @@ type Waku interface {
 
 	SubscribeEnvelopeEvents(events chan<- EnvelopeEvent) Subscription
 
+	// SubscribeFilterMatched returns a channel that is notified (non-blocking, coalescing)
+	// whenever an incoming envelope matches at least one installed filter.
+	// Callers must call UnsubscribeFilterMatched when done to avoid a channel leak.
+	SubscribeFilterMatched() chan struct{}
+	UnsubscribeFilterMatched(ch chan struct{})
+
 	// AddKeyPair imports a asymmetric private key and returns a deterministic identifier.
 	AddKeyPair(key *ecdsa.PrivateKey) (string, error)
 	// DeleteKeyPair deletes the key with the specified ID if it exists.

--- a/protocol/messenger.go
+++ b/protocol/messenger.go
@@ -2742,17 +2742,40 @@ func (m *Messenger) RetrieveAll() (*MessengerResponse, error) {
 	return m.handleRetrievedMessages(chatWithMessages, true, false)
 }
 
-func (m *Messenger) StartRetrieveMessagesLoop(tick time.Duration, cancel <-chan struct{}) {
+// retrieveMessagesDebounceInterval coalesces bursts of matched envelopes
+// (e.g. storenode history fetch) into a single ProcessAllMessages call,
+// preserving the same ~1s latency as the previous polling loop.
+const retrieveMessagesDebounceInterval = time.Second
+
+func (m *Messenger) StartRetrieveMessagesLoop(_ time.Duration, cancel <-chan struct{}) {
 	m.shutdownWaitGroup.Add(1)
 	go func() {
 		defer gocommon.LogOnPanic()
 		defer m.shutdownWaitGroup.Done()
-		ticker := time.NewTicker(tick)
-		defer ticker.Stop()
+
+		matchedCh := m.messaging.SubscribeFilterMatched()
+		defer m.messaging.UnsubscribeFilterMatched(matchedCh)
+
+		var debounceTimer *time.Timer
+		var debounceCh <-chan time.Time
+
 		for {
 			select {
-			case <-ticker.C:
+			case <-matchedCh:
+				// Reset the debounce window on every new match to coalesce bursts.
+				if debounceTimer != nil && !debounceTimer.Stop() {
+					select {
+					case <-debounceTimer.C:
+					default:
+					}
+				}
+				debounceTimer = time.NewTimer(retrieveMessagesDebounceInterval)
+				debounceCh = debounceTimer.C
+
+			case <-debounceCh:
+				debounceCh = nil
 				m.ProcessAllMessages()
+
 			case <-cancel:
 				return
 			case <-m.quit:


### PR DESCRIPTION
`StartRetrieveMessagesLoop` used to run every 1 second even if there's no message in the queue. This commit adds new infra for a subscription mechanism from `filter.go` all the way to `messenger.go`. `StartRetrieveMessagesLoop` will now subscribe to the filterMatched and call `processAllMessages` only when there's something to process.

Needs https://github.com/status-im/status-go/pull/7391, https://github.com/status-im/status-go/pull/7390, https://github.com/status-im/status-go/pull/7387, #7394
Iterates https://github.com/status-im/status-app/issues/20227
