### PR TITLE
feat(market): support demo/pro coingecko keys

### DIFF
--- a/mobile/status.go
+++ b/mobile/status.go
@@ -751,7 +751,7 @@ func sendTransactionV2(requestJSON string) string {
 	if err != nil {
 		return prepareJSONResponseWithCode(nil, err, codeFailedParseParams)
 	}
-	hash, err := statusBackend.SendTransaction(request.TxArgs, request.Password)
+	hash, err := statusBackend.SendTransactionWithChainID(request.TxArgs.FromChainID, request.TxArgs, request.Password)
 	code := codeUnknown
 	if c, ok := errToCodeMap[err]; ok {
 		code = c

--- a/params/config.go
+++ b/params/config.go
@@ -229,6 +229,8 @@ type WalletConfig struct {
 	InfuraAPIKeySecret        security.SensitiveString `json:"InfuraAPIKeySecret"`
 	StatusProxyMarketUser     security.SensitiveString `json:"StatusProxyMarketUser"`
 	StatusProxyMarketPassword security.SensitiveString `json:"StatusProxyMarketPassword"`
+	CoingeckoAPIKey           security.SensitiveString `json:"CoingeckoAPIKey"`
+	CoingeckoDemoAPIKey       security.SensitiveString `json:"CoingeckoDemoAPIKey"`
 	MarketDataProxyConfig     MarketDataProxyConfig    `json:"MarketDataProxyConfig"`
 	NftProxyConfig            NftProxyConfig           `json:"NftProxyConfig"`
 

--- a/pkg/backend/backend_test.go
+++ b/pkg/backend/backend_test.go
@@ -1148,6 +1148,8 @@ func TestWalletConfigOnLoginAccount(t *testing.T) {
 	alchemyAPIKey := fakeToken()
 	raribleMainnetAPIKey := fakeToken()
 	raribleTestnetAPIKey := fakeToken()
+	coingeckoAPIKey := fakeToken()
+	coingeckoDemoAPIKey := fakeToken()
 
 	createAccountRequest := &requests.CreateAccount{
 		DisplayName:        "some-display-name",
@@ -1180,6 +1182,8 @@ func TestWalletConfigOnLoginAccount(t *testing.T) {
 			AlchemyAPIKey:        alchemyAPIKey,
 			RaribleMainnetAPIKey: raribleMainnetAPIKey,
 			RaribleTestnetAPIKey: raribleTestnetAPIKey,
+			CoingeckoAPIKey:      coingeckoAPIKey,
+			CoingeckoDemoAPIKey:  coingeckoDemoAPIKey,
 		},
 	}
 
@@ -1198,6 +1202,8 @@ func TestWalletConfigOnLoginAccount(t *testing.T) {
 	require.Equal(t, walletConfig.AlchemyAPIKey, alchemyAPIKey)
 	require.Equal(t, walletConfig.RaribleMainnetAPIKey, raribleMainnetAPIKey)
 	require.Equal(t, walletConfig.RaribleTestnetAPIKey, raribleTestnetAPIKey)
+	require.Equal(t, walletConfig.CoingeckoAPIKey, coingeckoAPIKey)
+	require.Equal(t, walletConfig.CoingeckoDemoAPIKey, coingeckoDemoAPIKey)
 
 	require.NoError(t, testContext.backend.Logout())
 }

--- a/pkg/backend/defaults.go
+++ b/pkg/backend/defaults.go
@@ -192,6 +192,12 @@ func buildWalletConfig(walletRequest *requests.WalletConfig, request *requests.W
 	if !request.MarketDataProxyUrl.Empty() {
 		walletConfig.MarketDataProxyConfig.UrlOverride = request.MarketDataProxyUrl
 	}
+	if !request.CoingeckoAPIKey.Empty() {
+		walletConfig.CoingeckoAPIKey = request.CoingeckoAPIKey
+	}
+	if !request.CoingeckoDemoAPIKey.Empty() {
+		walletConfig.CoingeckoDemoAPIKey = request.CoingeckoDemoAPIKey
+	}
 	if request.StatusProxyStageName != "" {
 		walletConfig.MarketDataProxyConfig.StageName = request.StatusProxyStageName
 	}

--- a/protocol/requests/create_account.go
+++ b/protocol/requests/create_account.go
@@ -119,6 +119,9 @@ type WalletSecretsConfig struct {
 	MarketDataProxyUser     security.SensitiveString `json:"marketDataProxyUser"`
 	MarketDataProxyPassword security.SensitiveString `json:"marketDataProxyPassword"`
 
+	CoingeckoAPIKey     security.SensitiveString `json:"coingeckoApiKey"`
+	CoingeckoDemoAPIKey security.SensitiveString `json:"coingeckoDemoApiKey"`
+
 	StatusProxyUser     security.SensitiveString `json:"statusProxyBlockchainUser"`
 	StatusProxyPassword security.SensitiveString `json:"statusProxyBlockchainPassword"`
 

--- a/services/wallet/collectibles/service_test.go
+++ b/services/wallet/collectibles/service_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
+	"go.uber.org/zap"
 	"go.uber.org/zap/zaptest"
 
 	"github.com/status-im/status-go/internal/crypto/types"
@@ -57,7 +58,7 @@ func TestServiceShouldTriggerLoadFetchIfNotCachedSkipsWhenLoaderExists(t *testin
 		nil,
 		fetcher,
 		pubsub.NewPublisher(),
-		zaptest.NewLogger(t),
+		zap.NewNop(),
 	)
 	ownershipController.StartWithLoaderParams(ownership.PeriodicalLoaderParams{
 		StartDelay:   0,

--- a/services/wallet/service.go
+++ b/services/wallet/service.go
@@ -158,7 +158,10 @@ func NewService(
 		}
 
 		cryptoCompare := cryptocompare.NewClient()
-		coingeckoClient := coingecko.NewClient()
+		coingeckoClient := coingecko.NewClientWithParams(coingecko.Params{
+			CoingeckoAPIKey:     config.WalletConfig.CoingeckoAPIKey,
+			CoingeckoDemoAPIKey: config.WalletConfig.CoingeckoDemoAPIKey,
+		})
 		coingeckoProxy := createCoingeckoProxyClient(config.WalletConfig.MarketDataProxyConfig)
 		cryptoCompareProxy := cryptocompare.NewClientWithParams(cryptocompare.Params{
 			ID:       fmt.Sprintf("%s-proxy", cryptoCompare.ID()),

--- a/services/wallet/thirdparty/market/coingecko/client.go
+++ b/services/wallet/thirdparty/market/coingecko/client.go
@@ -28,15 +28,19 @@ const (
 )
 
 type Client struct {
-	httpClient *thirdparty.HTTPClient
-	baseURL    string
-	creds      *thirdparty.BasicCreds
+	httpClient       *thirdparty.HTTPClient
+	baseURL          string
+	creds            *thirdparty.BasicCreds
+	coingeckoProKey  security.SensitiveString
+	coingeckoDemoKey security.SensitiveString
 }
 
 type Params struct {
-	URL      string
-	User     security.SensitiveString
-	Password security.SensitiveString
+	URL                 string
+	User                security.SensitiveString
+	Password            security.SensitiveString
+	CoingeckoAPIKey     security.SensitiveString
+	CoingeckoDemoAPIKey security.SensitiveString
 }
 
 func NewClient() *Client {
@@ -73,9 +77,11 @@ func NewClientWithParams(params Params) *Client {
 	}
 
 	return &Client{
-		httpClient: httpClient,
-		baseURL:    clientBaseURL,
-		creds:      creds,
+		httpClient:       httpClient,
+		baseURL:          clientBaseURL,
+		creds:            creds,
+		coingeckoProKey:  params.CoingeckoAPIKey,
+		coingeckoDemoKey: params.CoingeckoDemoAPIKey,
 	}
 }
 
@@ -350,10 +356,24 @@ func (c *Client) FetchHistoricalDailyPrices(token *tokentypes.Token, currency st
 	return aggregatePrices(result, aggregate), nil
 }
 
+func (c *Client) mergeCoingeckoQueryKey(params url.Values) url.Values {
+	out := url.Values{}
+	for k, vs := range params {
+		out[k] = append([]string(nil), vs...)
+	}
+	if !c.coingeckoProKey.Empty() {
+		out.Set("x_cg_pro_api_key", c.coingeckoProKey.Reveal())
+	} else if !c.coingeckoDemoKey.Empty() {
+		out.Set("x_cg_demo_api_key", c.coingeckoDemoKey.Reveal())
+	}
+	return out
+}
+
 // doGetRequestWithOptionalAuth performs a GET request, using credentials if they are available
 func (c *Client) doGetRequestWithOptionalAuth(ctx context.Context, url string, params url.Values) ([]byte, error) {
+	q := c.mergeCoingeckoQueryKey(params)
 	if c.creds != nil {
-		return c.httpClient.DoGetRequestWithCredentials(ctx, url, params, c.creds)
+		return c.httpClient.DoGetRequestWithCredentials(ctx, url, q, c.creds)
 	}
-	return c.httpClient.DoGetRequest(ctx, url, params)
+	return c.httpClient.DoGetRequest(ctx, url, q)
 }

--- a/services/wallet/thirdparty/market/coingecko/client_test.go
+++ b/services/wallet/thirdparty/market/coingecko/client_test.go
@@ -1,6 +1,7 @@
 package coingecko
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -13,11 +14,50 @@ import (
 	"github.com/status-im/go-wallet-sdk/pkg/tokens/builder"
 	"github.com/status-im/go-wallet-sdk/pkg/tokens/types"
 
+	"github.com/status-im/status-go/pkg/security"
 	"github.com/status-im/status-go/services/wallet/thirdparty"
 	tokentypes "github.com/status-im/status-go/services/wallet/token/types"
 
 	"github.com/stretchr/testify/require"
 )
+
+func TestCoingeckoAPIKeyInQueryProOverDemo(t *testing.T) {
+	var sawQuery string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		sawQuery = r.URL.RawQuery
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`[]`))
+	}))
+	t.Cleanup(srv.Close)
+
+	client := NewClientWithParams(Params{
+		URL:                 srv.URL,
+		CoingeckoAPIKey:     security.NewSensitiveString("pro-secret"),
+		CoingeckoDemoAPIKey: security.NewSensitiveString("demo-secret"),
+	})
+	_, err := client.fetchTokens(context.Background())
+	require.NoError(t, err)
+	require.Contains(t, sawQuery, "x_cg_pro_api_key=pro-secret")
+	require.NotContains(t, sawQuery, "demo-secret")
+}
+
+func TestCoingeckoAPIKeyInQueryDemoWhenNoPro(t *testing.T) {
+	var sawQuery string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		sawQuery = r.URL.RawQuery
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`[]`))
+	}))
+	t.Cleanup(srv.Close)
+
+	client := NewClientWithParams(Params{
+		URL:                 srv.URL,
+		CoingeckoDemoAPIKey: security.NewSensitiveString("demo-only"),
+	})
+	_, err := client.fetchTokens(context.Background())
+	require.NoError(t, err)
+	require.Contains(t, sawQuery, "x_cg_demo_api_key=demo-only")
+}
 
 func setupTest(t *testing.T, response []byte) (*httptest.Server, func()) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
* support `coingeckoApiKey` (or `coingeckoDemoApiKey`) in the login payload when starting status-backend
* If proxy credentials are configured, expect requests to go through proxy first
* fixed SendTransactionV2 API method

fixes #7399

<img width="660" height="567" alt="image" src="https://github.com/user-attachments/assets/d3876f58-f675-4ec2-8b73-4f4177d1789f" />
