### PR TITLE
docs: update IERC20 source link

### DIFF
--- a/internal/contracts/ierc20/README.md
+++ b/internal/contracts/ierc20/README.md
@@ -2,4 +2,4 @@ ERC20 interface
 ===============
 
 Can be used for interaction with any erc20 compatible token.
-Code was taken from [zeppelin libraries](https://github.com/OpenZeppelin/openzeppelin-solidity/blob/master/contracts/token/ERC20/IERC20.sol).
+Code was taken from [OpenZeppelin Contracts](https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/token/ERC20/IERC20.sol).


### PR DESCRIPTION
## Summary
- replace the old OpenZeppelin source repository link in the IERC20 README
- point the reference at the current OpenZeppelin Contracts repository

## Testing
- not run (documentation link update only)