### PR TITLE
test: parametrize functional tests for light client mode

### DIFF
--- a/.github/workflows/test-reliability.yml
+++ b/.github/workflows/test-reliability.yml
@@ -57,7 +57,7 @@ jobs:
       run: |
         pytest --reruns 2 \
           -n auto \
-          -m "reliability" \
+          -m "reliability and not light_client_7393" \
           -c tests-functional/pytest.ini \
           --junit-xml=pytest_results.xml \
           --tb=short \

--- a/tests-functional/pytest.ini
+++ b/tests-functional/pytest.ini
@@ -25,3 +25,4 @@ markers =
     benchmark
     connector
     ens
+    light_client_7393: temporary marker for status-go#7393 filter subscription race; remove when fixed

--- a/tests-functional/resources/constants.py
+++ b/tests-functional/resources/constants.py
@@ -143,6 +143,10 @@ STATUS_MEDIA_SERVER_PORT = 8587
 
 NATIVE_TOKEN_ADDRESS = "0x0000000000000000000000000000000000000000"
 
+# Waku light client test IDs
+FULL_NODE = "wakuV2LightClient_False"
+LIGHT_CLIENT = "wakuV2LightClient_True"
+
 # Well-known burn address, used as a generic recipient in tests
 BURN_ADDRESS = "0x000000000000000000000000000000000000dEaD"
 

--- a/tests-functional/tests/reliability/test_contact_request.py
+++ b/tests-functional/tests/reliability/test_contact_request.py
@@ -5,18 +5,26 @@ from time import sleep
 from steps import messenger
 from clients.signals import SignalType
 from resources.enums import MessageContentType
-from resources.constants import USE_IPV6
+from resources.constants import USE_IPV6, FULL_NODE, LIGHT_CLIENT
 
 
 @pytest.mark.reliability
+@pytest.mark.parametrize(
+    "waku_light_client",
+    [
+        pytest.param(False, id=FULL_NODE),
+        pytest.param(True, id=LIGHT_CLIENT, marks=pytest.mark.xfail(reason="status-go#7393 filter subscription race", strict=False)),
+    ],
+    indirect=True,
+)
 class TestContactRequests:
     @pytest.fixture()
-    def sender(self, backend_new_profile):
-        return backend_new_profile("sender", bridge_network=True)
+    def sender(self, backend_new_profile, waku_light_client):
+        return backend_new_profile("sender", waku_light_client=waku_light_client, bridge_network=True)
 
     @pytest.fixture()
-    def receiver(self, backend_new_profile):
-        return backend_new_profile("receiver", bridge_network=True)
+    def receiver(self, backend_new_profile, waku_light_client):
+        return backend_new_profile("receiver", waku_light_client=waku_light_client, bridge_network=True)
 
     def _run_contact_request_baseline(self, sender, receiver, execution_number=None, network_condition=None):
         messenger.add_contact(

--- a/tests-functional/tests/reliability/test_contact_request.py
+++ b/tests-functional/tests/reliability/test_contact_request.py
@@ -13,7 +13,7 @@ from resources.constants import USE_IPV6, FULL_NODE, LIGHT_CLIENT
     "waku_light_client",
     [
         pytest.param(False, id=FULL_NODE),
-        pytest.param(True, id=LIGHT_CLIENT, marks=pytest.mark.xfail(reason="status-go#7393 filter subscription race", strict=False)),
+        pytest.param(True, id=LIGHT_CLIENT, marks=pytest.mark.light_client_7393),
     ],
     indirect=True,
 )

--- a/tests-functional/tests/reliability/test_create_private_groups.py
+++ b/tests-functional/tests/reliability/test_create_private_groups.py
@@ -3,19 +3,27 @@ from uuid import uuid4
 import pytest
 from steps import messenger
 from clients.signals import SignalType
-from resources.constants import USE_IPV6
+from resources.constants import USE_IPV6, FULL_NODE, LIGHT_CLIENT
 
 
 @pytest.mark.reliability
+@pytest.mark.parametrize(
+    "waku_light_client",
+    [
+        pytest.param(False, id=FULL_NODE),
+        pytest.param(True, id=LIGHT_CLIENT, marks=pytest.mark.xfail(reason="status-go#7393 filter subscription race", strict=False)),
+    ],
+    indirect=True,
+)
 class TestCreatePrivateGroups:
 
     @pytest.fixture()
-    def community_admin(self, backend_new_profile):
-        return backend_new_profile("community_admin", bridge_network=True)
+    def community_admin(self, backend_new_profile, waku_light_client):
+        return backend_new_profile("community_admin", waku_light_client=waku_light_client, bridge_network=True)
 
     @pytest.fixture()
-    def community_member(self, backend_new_profile):
-        return backend_new_profile("member", bridge_network=True)
+    def community_member(self, backend_new_profile, waku_light_client):
+        return backend_new_profile("member", waku_light_client=waku_light_client, bridge_network=True)
 
     def _run_create_private_group_baseline(self, community_admin, community_member, private_groups_count=1):
         messenger.make_contacts(community_admin, community_member)

--- a/tests-functional/tests/reliability/test_create_private_groups.py
+++ b/tests-functional/tests/reliability/test_create_private_groups.py
@@ -11,7 +11,7 @@ from resources.constants import USE_IPV6, FULL_NODE, LIGHT_CLIENT
     "waku_light_client",
     [
         pytest.param(False, id=FULL_NODE),
-        pytest.param(True, id=LIGHT_CLIENT, marks=pytest.mark.xfail(reason="status-go#7393 filter subscription race", strict=False)),
+        pytest.param(True, id=LIGHT_CLIENT, marks=pytest.mark.light_client_7393),
     ],
     indirect=True,
 )

--- a/tests-functional/tests/reliability/test_one_to_one_messages.py
+++ b/tests-functional/tests/reliability/test_one_to_one_messages.py
@@ -11,7 +11,7 @@ from resources.constants import USE_IPV6, FULL_NODE, LIGHT_CLIENT
     "waku_light_client",
     [
         pytest.param(False, id=FULL_NODE),
-        pytest.param(True, id=LIGHT_CLIENT, marks=pytest.mark.xfail(reason="status-go#7393 filter subscription race", strict=False)),
+        pytest.param(True, id=LIGHT_CLIENT, marks=pytest.mark.light_client_7393),
     ],
     indirect=True,
 )

--- a/tests-functional/tests/reliability/test_one_to_one_messages.py
+++ b/tests-functional/tests/reliability/test_one_to_one_messages.py
@@ -3,19 +3,27 @@ from uuid import uuid4
 import pytest
 from steps import messenger
 from clients.signals import SignalType
-from resources.constants import USE_IPV6
+from resources.constants import USE_IPV6, FULL_NODE, LIGHT_CLIENT
 
 
 @pytest.mark.reliability
+@pytest.mark.parametrize(
+    "waku_light_client",
+    [
+        pytest.param(False, id=FULL_NODE),
+        pytest.param(True, id=LIGHT_CLIENT, marks=pytest.mark.xfail(reason="status-go#7393 filter subscription race", strict=False)),
+    ],
+    indirect=True,
+)
 class TestOneToOneMessages:
 
     @pytest.fixture()
-    def sender(self, backend_new_profile):
-        return backend_new_profile("sender", bridge_network=True)
+    def sender(self, backend_new_profile, waku_light_client):
+        return backend_new_profile("sender", waku_light_client=waku_light_client, bridge_network=True)
 
     @pytest.fixture()
-    def receiver(self, backend_new_profile):
-        return backend_new_profile("receiver", bridge_network=True)
+    def receiver(self, backend_new_profile, waku_light_client):
+        return backend_new_profile("receiver", waku_light_client=waku_light_client, bridge_network=True)
 
     def _run_one_to_one_message_baseline(self, sender, receiver, message_count=1):
         messenger.one_to_one_message(message_count, sender=sender, receiver=receiver)

--- a/tests-functional/tests/reliability/test_private_groups_messages.py
+++ b/tests-functional/tests/reliability/test_private_groups_messages.py
@@ -3,19 +3,27 @@ from uuid import uuid4
 import pytest
 from steps import messenger
 from clients.signals import SignalType
-from resources.constants import USE_IPV6
+from resources.constants import USE_IPV6, FULL_NODE, LIGHT_CLIENT
 
 
 @pytest.mark.reliability
+@pytest.mark.parametrize(
+    "waku_light_client",
+    [
+        pytest.param(False, id=FULL_NODE),
+        pytest.param(True, id=LIGHT_CLIENT, marks=pytest.mark.xfail(reason="status-go#7393 filter subscription race", strict=False)),
+    ],
+    indirect=True,
+)
 class TestPrivateGroupMessages:
 
     @pytest.fixture()
-    def community_admin(self, backend_new_profile):
-        return backend_new_profile("community_admin", bridge_network=True)
+    def community_admin(self, backend_new_profile, waku_light_client):
+        return backend_new_profile("community_admin", waku_light_client=waku_light_client, bridge_network=True)
 
     @pytest.fixture()
-    def community_member(self, backend_new_profile):
-        return backend_new_profile("community_member", bridge_network=True)
+    def community_member(self, backend_new_profile, waku_light_client):
+        return backend_new_profile("community_member", waku_light_client=waku_light_client, bridge_network=True)
 
     def _run_private_group_messages_baseline(self, community_admin, community_member, message_count=1):
         messenger.make_contacts(community_admin, community_member)

--- a/tests-functional/tests/reliability/test_private_groups_messages.py
+++ b/tests-functional/tests/reliability/test_private_groups_messages.py
@@ -11,7 +11,7 @@ from resources.constants import USE_IPV6, FULL_NODE, LIGHT_CLIENT
     "waku_light_client",
     [
         pytest.param(False, id=FULL_NODE),
-        pytest.param(True, id=LIGHT_CLIENT, marks=pytest.mark.xfail(reason="status-go#7393 filter subscription race", strict=False)),
+        pytest.param(True, id=LIGHT_CLIENT, marks=pytest.mark.light_client_7393),
     ],
     indirect=True,
 )

--- a/tests-functional/tests/test_wakuext_contact_requests.py
+++ b/tests-functional/tests/test_wakuext_contact_requests.py
@@ -13,7 +13,7 @@ from clients.api import ApiResponseError
     "waku_light_client",
     [
         pytest.param(False, id=FULL_NODE),
-        pytest.param(True, id=LIGHT_CLIENT, marks=pytest.mark.xfail(reason="status-go#7393 filter subscription race", strict=False)),
+        pytest.param(True, id=LIGHT_CLIENT, marks=pytest.mark.light_client_7393),
     ],
     indirect=True,
 )

--- a/tests-functional/tests/test_wakuext_contact_requests.py
+++ b/tests-functional/tests/test_wakuext_contact_requests.py
@@ -1,6 +1,7 @@
 import re
 from uuid import uuid4
 import pytest
+from resources.constants import FULL_NODE, LIGHT_CLIENT
 from resources.enums import MessageContentType
 from steps import async_messenger
 from clients.api import ApiResponseError
@@ -8,7 +9,14 @@ from clients.api import ApiResponseError
 
 @pytest.mark.rpc
 @pytest.mark.asyncio
-@pytest.mark.parametrize("waku_light_client", [False, True], indirect=True, ids=["wakuV2LightClient_False", "wakuV2LightClient_True"])
+@pytest.mark.parametrize(
+    "waku_light_client",
+    [
+        pytest.param(False, id=FULL_NODE),
+        pytest.param(True, id=LIGHT_CLIENT, marks=pytest.mark.xfail(reason="status-go#7393 filter subscription race", strict=False)),
+    ],
+    indirect=True,
+)
 class TestContactRequests:
 
     @pytest.fixture

--- a/tests-functional/tests/test_wakuext_contact_verification.py
+++ b/tests-functional/tests/test_wakuext_contact_verification.py
@@ -14,7 +14,7 @@ from steps import async_messenger
     "waku_light_client",
     [
         pytest.param(False, id=FULL_NODE),
-        pytest.param(True, id=LIGHT_CLIENT, marks=pytest.mark.xfail(reason="status-go#7393 filter subscription race", strict=False)),
+        pytest.param(True, id=LIGHT_CLIENT, marks=pytest.mark.light_client_7393),
     ],
     indirect=True,
 )

--- a/tests-functional/tests/test_wakuext_contact_verification.py
+++ b/tests-functional/tests/test_wakuext_contact_verification.py
@@ -3,21 +3,30 @@ from uuid import uuid4
 import pytest
 
 from clients.signals import SignalType
+from resources.constants import FULL_NODE, LIGHT_CLIENT
 from resources.enums import ContactVerificationState, MessageContentType
 from steps import async_messenger
 
 
 @pytest.mark.rpc
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "waku_light_client",
+    [
+        pytest.param(False, id=FULL_NODE),
+        pytest.param(True, id=LIGHT_CLIENT, marks=pytest.mark.xfail(reason="status-go#7393 filter subscription race", strict=False)),
+    ],
+    indirect=True,
+)
 class TestContactVerification:
 
     @pytest.fixture
-    async def creator(self, async_backend_new_profile):
-        return await async_backend_new_profile("creator")
+    async def creator(self, async_backend_new_profile, waku_light_client):
+        return await async_backend_new_profile("creator", waku_light_client=waku_light_client)
 
     @pytest.fixture
-    async def member(self, async_backend_new_profile, creator):
-        m = await async_backend_new_profile("member")
+    async def member(self, async_backend_new_profile, waku_light_client, creator):
+        m = await async_backend_new_profile("member", waku_light_client=waku_light_client)
         await async_messenger.make_contacts(sender=creator, receiver=m)
         return m
 

--- a/tests-functional/tests/test_wakuext_group_chats.py
+++ b/tests-functional/tests/test_wakuext_group_chats.py
@@ -10,7 +10,7 @@ from resources.enums import MessageContentType
     "waku_light_client",
     [
         pytest.param(False, id=FULL_NODE),
-        pytest.param(True, id=LIGHT_CLIENT, marks=pytest.mark.xfail(reason="status-go#7393 filter subscription race", strict=False)),
+        pytest.param(True, id=LIGHT_CLIENT, marks=pytest.mark.light_client_7393),
     ],
     indirect=True,
 )

--- a/tests-functional/tests/test_wakuext_group_chats.py
+++ b/tests-functional/tests/test_wakuext_group_chats.py
@@ -1,19 +1,28 @@
 from uuid import uuid4
 import pytest
 from steps import messenger
+from resources.constants import FULL_NODE, LIGHT_CLIENT
 from resources.enums import MessageContentType
 
 
 @pytest.mark.rpc
+@pytest.mark.parametrize(
+    "waku_light_client",
+    [
+        pytest.param(False, id=FULL_NODE),
+        pytest.param(True, id=LIGHT_CLIENT, marks=pytest.mark.xfail(reason="status-go#7393 filter subscription race", strict=False)),
+    ],
+    indirect=True,
+)
 class TestCreatePrivateGroups:
 
     @pytest.fixture()
-    def community_admin(self, backend_new_profile):
-        return backend_new_profile("community_admin")
+    def community_admin(self, backend_new_profile, waku_light_client):
+        return backend_new_profile("community_admin", waku_light_client=waku_light_client)
 
     @pytest.fixture()
-    def community_member(self, backend_new_profile):
-        return backend_new_profile("community_member")
+    def community_member(self, backend_new_profile, waku_light_client):
+        return backend_new_profile("community_member", waku_light_client=waku_light_client)
 
     def test_create_group_chat_with_members(self, community_admin, community_member):
         messenger.make_contacts(community_admin, community_member)
@@ -60,8 +69,8 @@ class TestCreatePrivateGroups:
         assert len(members_after_leave) == 1
         assert community_admin.public_key not in str(members_after_leave)
 
-    def test_send_group_chat_invitation_request(self, community_admin, community_member, backend_new_profile):
-        third_node = backend_new_profile("third_node")
+    def test_send_group_chat_invitation_request(self, community_admin, community_member, backend_new_profile, waku_light_client):
+        third_node = backend_new_profile("third_node", waku_light_client=waku_light_client)
         messenger.make_contacts(community_admin, third_node)
 
         messenger.make_contacts(community_admin, community_member)
@@ -103,8 +112,8 @@ class TestCreatePrivateGroups:
         assert chats[0].get("invitationAdmin", "") == community_admin.public_key
         assert chats[0].get("name", "") == invitation_group
 
-    def test_add_members_to_group_chat(self, community_admin, community_member, backend_new_profile):
-        third_node = backend_new_profile("third_node")
+    def test_add_members_to_group_chat(self, community_admin, community_member, backend_new_profile, waku_light_client):
+        third_node = backend_new_profile("third_node", waku_light_client=waku_light_client)
         messenger.make_contacts(community_admin, third_node)
 
         messenger.make_contacts(community_admin, community_member)
@@ -146,8 +155,8 @@ class TestCreatePrivateGroups:
             message_pattern=f"@{community_member.public_key} left the group",
         )[0]
 
-    def test_remove_members_from_group_chat(self, community_admin, community_member, backend_new_profile):
-        third_node = backend_new_profile("third_node")
+    def test_remove_members_from_group_chat(self, community_admin, community_member, backend_new_profile, waku_light_client):
+        third_node = backend_new_profile("third_node", waku_light_client=waku_light_client)
         messenger.make_contacts(community_admin, third_node)
 
         messenger.make_contacts(community_admin, community_member)
@@ -211,8 +220,8 @@ class TestCreatePrivateGroups:
         assert chats[0].get("name", "") == new_group_name
 
     @pytest.mark.skip(reason="waiting for https://github.com/status-im/status-go/issues/6752 resolution")
-    def test_get_group_chat_invitations(self, community_admin, community_member, backend_new_profile):
-        third_node = backend_new_profile("third_node")
+    def test_get_group_chat_invitations(self, community_admin, community_member, backend_new_profile, waku_light_client):
+        third_node = backend_new_profile("third_node", waku_light_client=waku_light_client)
         messenger.make_contacts(community_admin, third_node)
 
         messenger.make_contacts(community_admin, community_member)
@@ -230,8 +239,8 @@ class TestCreatePrivateGroups:
         third_node.wakuext_service.get_group_chat_invitations()
         # TODO: Add more assertions on response
 
-    def test_send_group_chat_invitation_rejection(self, community_admin, community_member, backend_new_profile):
-        third_node = backend_new_profile("third_node")
+    def test_send_group_chat_invitation_rejection(self, community_admin, community_member, backend_new_profile, waku_light_client):
+        third_node = backend_new_profile("third_node", waku_light_client=waku_light_client)
         messenger.make_contacts(community_admin, third_node)
 
         messenger.make_contacts(community_admin, community_member)

--- a/tests-functional/tests/test_wakuext_message_reactions.py
+++ b/tests-functional/tests/test_wakuext_message_reactions.py
@@ -25,7 +25,7 @@ class TestMessageReactions:
         "waku_light_client",
         [
             pytest.param(False, id=FULL_NODE),
-            pytest.param(True, id=LIGHT_CLIENT, marks=pytest.mark.xfail(reason="status-go#7393 filter subscription race", strict=False)),
+            pytest.param(True, id=LIGHT_CLIENT, marks=pytest.mark.light_client_7393),
         ],
         indirect=True,
     )

--- a/tests-functional/tests/test_wakuext_message_reactions.py
+++ b/tests-functional/tests/test_wakuext_message_reactions.py
@@ -5,6 +5,7 @@ import pytest
 from clients.api import ApiResponseError
 from clients.signals import SignalType
 from resources.enums import MessageContentType
+from resources.constants import FULL_NODE, LIGHT_CLIENT
 from steps import async_messenger
 
 
@@ -20,7 +21,14 @@ class TestMessageReactions:
     async def receiver(self, async_backend_new_profile, waku_light_client):
         return await async_backend_new_profile("receiver", waku_light_client=waku_light_client)
 
-    @pytest.mark.parametrize("waku_light_client", [False, True], indirect=True, ids=["wakuV2LightClient_False", "wakuV2LightClient_True"])
+    @pytest.mark.parametrize(
+        "waku_light_client",
+        [
+            pytest.param(False, id=FULL_NODE),
+            pytest.param(True, id=LIGHT_CLIENT, marks=pytest.mark.xfail(reason="status-go#7393 filter subscription race", strict=False)),
+        ],
+        indirect=True,
+    )
     async def test_one_to_one_message_reactions(self, sender, receiver, waku_light_client):
         """Test message reactions with different wakuV2LightClient configurations"""
         await async_messenger.make_contacts(sender, receiver)
@@ -89,7 +97,13 @@ class TestMessageReactions:
                 )
             )
 
-    @pytest.mark.parametrize("waku_light_client", [False], indirect=True, ids=["wakuV2LightClient_False"])
+    @pytest.mark.parametrize(
+        "waku_light_client",
+        [
+            pytest.param(False, id=FULL_NODE),
+        ],
+        indirect=True,
+    )
     async def test_limit_of_20_reactions(self, sender, receiver, waku_light_client):
         """Test that you cannot send more than 20 message reactions on a single message"""
         await async_messenger.make_contacts(sender, receiver)

--- a/tests-functional/tests/test_wakuext_messages_fetching.py
+++ b/tests-functional/tests/test_wakuext_messages_fetching.py
@@ -9,7 +9,7 @@ from steps import messenger
     "waku_light_client",
     [
         pytest.param(False, id=FULL_NODE),
-        pytest.param(True, id=LIGHT_CLIENT, marks=pytest.mark.xfail(reason="status-go#7393 filter subscription race", strict=False)),
+        pytest.param(True, id=LIGHT_CLIENT, marks=pytest.mark.light_client_7393),
     ],
     indirect=True,
 )

--- a/tests-functional/tests/test_wakuext_messages_fetching.py
+++ b/tests-functional/tests/test_wakuext_messages_fetching.py
@@ -1,10 +1,18 @@
 import pytest
 
+from resources.constants import FULL_NODE, LIGHT_CLIENT
 from steps import messenger
 
 
 @pytest.mark.rpc
-@pytest.mark.parametrize("waku_light_client", [False, True], indirect=True, ids=["wakuV2LightClient_False", "wakuV2LightClient_True"])
+@pytest.mark.parametrize(
+    "waku_light_client",
+    [
+        pytest.param(False, id=FULL_NODE),
+        pytest.param(True, id=LIGHT_CLIENT, marks=pytest.mark.xfail(reason="status-go#7393 filter subscription race", strict=False)),
+    ],
+    indirect=True,
+)
 class TestFetchingChatMessages:
 
     @pytest.fixture()

--- a/tests-functional/tests/test_wakuext_messages_interacting.py
+++ b/tests-functional/tests/test_wakuext_messages_interacting.py
@@ -11,7 +11,7 @@ from clients.api import ApiResponseError
     "waku_light_client",
     [
         pytest.param(False, id=FULL_NODE),
-        pytest.param(True, id=LIGHT_CLIENT, marks=pytest.mark.xfail(reason="status-go#7393 filter subscription race", strict=False)),
+        pytest.param(True, id=LIGHT_CLIENT, marks=pytest.mark.light_client_7393),
     ],
     indirect=True,
 )

--- a/tests-functional/tests/test_wakuext_messages_interacting.py
+++ b/tests-functional/tests/test_wakuext_messages_interacting.py
@@ -1,12 +1,20 @@
 import re
 import pytest
+from resources.constants import FULL_NODE, LIGHT_CLIENT
 from steps import messenger
 from clients.services.wakuext import SendPinMessagePayload
 from clients.api import ApiResponseError
 
 
 @pytest.mark.rpc
-@pytest.mark.parametrize("waku_light_client", [False, True], indirect=True, ids=["wakuV2LightClient_False", "wakuV2LightClient_True"])
+@pytest.mark.parametrize(
+    "waku_light_client",
+    [
+        pytest.param(False, id=FULL_NODE),
+        pytest.param(True, id=LIGHT_CLIENT, marks=pytest.mark.xfail(reason="status-go#7393 filter subscription race", strict=False)),
+    ],
+    indirect=True,
+)
 class TestInteractingWithChatMessages:
 
     @pytest.fixture()

--- a/tests-functional/tests/test_wakuext_messages_sending.py
+++ b/tests-functional/tests/test_wakuext_messages_sending.py
@@ -15,7 +15,7 @@ from steps import async_messenger
     "waku_light_client",
     [
         pytest.param(False, id=FULL_NODE),
-        pytest.param(True, id=LIGHT_CLIENT, marks=pytest.mark.xfail(reason="status-go#7393 filter subscription race", strict=False)),
+        pytest.param(True, id=LIGHT_CLIENT, marks=pytest.mark.light_client_7393),
     ],
     indirect=True,
 )

--- a/tests-functional/tests/test_wakuext_messages_sending.py
+++ b/tests-functional/tests/test_wakuext_messages_sending.py
@@ -5,12 +5,20 @@ import pytest
 from clients.services.wakuext import SendChatMessagePayload
 from clients.signals import SignalType
 from resources.enums import MessageContentType
+from resources.constants import FULL_NODE, LIGHT_CLIENT
 from steps import async_messenger
 
 
 @pytest.mark.rpc
 @pytest.mark.asyncio
-@pytest.mark.parametrize("waku_light_client", [False, True], indirect=True, ids=["wakuV2LightClient_False", "wakuV2LightClient_True"])
+@pytest.mark.parametrize(
+    "waku_light_client",
+    [
+        pytest.param(False, id=FULL_NODE),
+        pytest.param(True, id=LIGHT_CLIENT, marks=pytest.mark.xfail(reason="status-go#7393 filter subscription race", strict=False)),
+    ],
+    indirect=True,
+)
 class TestSendingChatMessages:
 
     @pytest.fixture


### PR DESCRIPTION
  ### Summary
                                                                                                                                                                                                                               
  Adds `waku_light_client` parametrization to 11 functional test files so each test runs in both full Waku node and light client mode.                                                                                         
                                                                                                                                                                                                                               
  Light client is the transport layer for mobile. These tests previously only ran in full node mode, meaning light-client-specific failures were invisible to CI.                                                              
                                                                  
  ### Changes                                                                                                                                                                                                                  
                                                                  
  Each test class gets a `@pytest.mark.parametrize("waku_light_client", [False, True], indirect=True)` decorator. Per-class fixtures are updated to pass the parameter through to `backend_new_profile`. No test logic,        
  assertions, or timeouts are changed.
                                                                                                                                                                                                                               
  The light-client parametrize entry is tagged with `@pytest.mark.light_client_7393` (registered in `tests-functional/pytest.ini`) so the known filter-subscription race in #7393 doesn't poison the nightly. The nightly      
  selector becomes `-m "reliability and not light_client_7393"`. This follows the same convention introduced in #7412 — single grep target for cleanup once #7393 lands.
                                                                                                                                                                                                                               
  **Reliability files (run by `test-reliability.yml` nightly):**                                                                                                                                                               
  - `tests/reliability/test_one_to_one_messages.py`
  - `tests/reliability/test_private_groups_messages.py`                                                                                                                                                                        
  - `tests/reliability/test_create_private_groups.py`             
  - `tests/reliability/test_contact_request.py`                                                                                                                                                                                
                                                                                                                                                                                                                               
  **Wakuext files (parametrized for future coverage; not currently in any selector):**                                                                                                                                         
  - `tests/test_wakuext_group_chats.py`                                                                                                                                                                                        
  - `tests/test_wakuext_contact_verification.py`                                                                                                                                                                               
  - `tests/test_wakuext_contact_requests.py`                      
  - `tests/test_wakuext_message_reactions.py`                                                                                                                                                                                  
  - `tests/test_wakuext_messages_fetching.py`                     
  - `tests/test_wakuext_messages_interacting.py`                                                                                                                                                                               
  - `tests/test_wakuext_messages_sending.py`                      
                                                                                                                                                                                                                               
  ### Initial results                                             
                                                                                                                                                                                                                               
  Light client variants surface real failures. Across 4 CI runs (3 GitHub Actions 2-core, 1 Codespace 4-core):                                                                                                                 
  
  | Test file | Full node | Light client (range) |                                                                                                                                                                             
  |-----------|:---------:|:--------------------:|                
  | group_chats | 10/10 | 4-8/10 (flaky) |                                                                                                                                                                                     
  | contact_verification | 3/3 | 0-2/3 (flaky) |                                                                                                                                                                               
  | one_to_one_messages | 7/7 | 2-6/7 (flaky) |                                                                                                                                                                                
  | contact_request | 25/25 | 22-25/25 |                                                                                                                                                                                       
  | private_groups_messages | 7/7 | 0-2/7 |                                                                                                                                                                                    
  | create_private_groups | 4/4 | 0-2/4 |                                                                                                                                                                                      
                                                                                                                                                                                                                               
  All light client failures are `TimeoutError: Expected 1 signal(s) of type SignalType.MESSAGES_NEW, but got 0 in 60 seconds` — consistent with the filter subscription race in #7393. Private group message delivery is most  
  affected; contact requests are largely unaffected (they don't depend on the post-acceptance filter subscription path). Results are worse under resource pressure (2-core runner vs 4-core), potentially mirroring mobile
  device constraints.                                                                                                                                                                                                          
                                                                  
  ### Cleanup when #7393 lands

  `grep -rn light_client_7393 tests-functional/ .github/workflows/` finds:                                                                                                                                                     
  - The marker registration in `pytest.ini`
  - The `pytest.mark.light_client_7393` on each `LIGHT_CLIENT` parametrize entry                                                                                                                                               
  - The `not light_client_7393` exclusion in `test-reliability.yml`                                                                                                                                                            
                                                                                                                                                                                                                               
  Strip all three.                                                                                                                                                                                                             
                                                                                                                                                                                                                               
  ### Test plan                                                                                                                                                                                                                
  
  - [x] `pytest --collect-only` confirms expected counts:                                                                                                                                                                      
    - `-m "reliability"` → 100 tests (50 full + 50 light)         
    - `-m "reliability and not light_client_7393"` → 57 tests (full-node only)                                                                                                                                                 
    - `-m "light_client_7393"` → 91 tests (all light-client variants across reliability + wakuext)
  - [x] Full node variants pass (baseline unchanged)                                                                                                                                                                           
  - [x] Light client variants surface expected filter-related failures                                                                                                                                                         
  - [x] Verified across 4 runs 