### PR TITLE
chore: delete keystore file for the master address only if it's set

### DIFF
--- a/internal/accounts-management/keystore_operations.go
+++ b/internal/accounts-management/keystore_operations.go
@@ -182,7 +182,7 @@ func (m *AccountsManager) deleteKeystoreFileForAccountInternally(address cryptot
 
 			if acc.Type != types.AccountTypeKey {
 				lastAcccountOfKeypairWithTheSameKey := len(kp.Accounts) == 1
-				if lastAcccountOfKeypairWithTheSameKey {
+				if lastAcccountOfKeypairWithTheSameKey && kp.DerivedFrom != "" {
 					err = m.deleteAccountFromKeystoreIfExists(cryptotypes.HexToAddress(kp.DerivedFrom), password)
 					if err != nil {
 						return err
@@ -232,7 +232,7 @@ func (m *AccountsManager) deleteKeystoreFilesForKeypairInternally(keypair *types
 		}
 	}
 
-	if anyAccountFullyOrPartiallyOperable && keypair.Type != types.KeypairTypeKey {
+	if anyAccountFullyOrPartiallyOperable && keypair.Type != types.KeypairTypeKey && keypair.DerivedFrom != "" {
 		err = m.deleteAccountFromKeystoreIfExists(cryptotypes.HexToAddress(keypair.DerivedFrom), password)
 		if err != nil {
 			return err
@@ -272,9 +272,11 @@ func (m *AccountsManager) CleanKeystoreFiles(password string) error {
 				}
 			}
 
-			err = m.deleteAccountFromKeystoreIfExists(cryptotypes.HexToAddress(kp.DerivedFrom), password)
-			if err != nil {
-				return err
+			if kp.DerivedFrom != "" {
+				err = m.deleteAccountFromKeystoreIfExists(cryptotypes.HexToAddress(kp.DerivedFrom), password)
+				if err != nil {
+					return err
+				}
 			}
 			continue
 		}


### PR DESCRIPTION
A new keycard approach (that is aligned with keycard shell) allows account derivations under the wallet root `m/44'/60'/0'`. That means no custom derivations from `m` path and that's why `DerivedFrom` field can be empty.