### PR TITLE
fix: Keep `mention` and `reply` notifications visible after marking as read

### DIFF
--- a/protocol/activity_center_persistence.go
+++ b/protocol/activity_center_persistence.go
@@ -973,22 +973,47 @@ func (db sqlitePersistence) DismissAllActivityCenterNotificationsFromCommunity(c
 	inVector := strings.Repeat("?, ", chatIDsCount-1) + "?"
 
 	// nolint: gosec
-	query := fmt.Sprintf(`SELECT %s FROM activity_center_notifications WHERE chat_id IN (%s) AND NOT deleted`, allFieldsForTableActivityCenterNotification, inVector)
+	query := fmt.Sprintf(`SELECT %s FROM activity_center_notifications
+		WHERE chat_id IN (%s)
+		AND NOT deleted`,
+		allFieldsForTableActivityCenterNotification, inVector)
 	rows, err := tx.Query(query, args[1:]...)
 	if err != nil {
 		return nil, err
 	}
 	notifications, err := db.parseRowFromTableActivityCenterNotification(rows, func(notification *ActivityCenterNotification) {
 		notification.Read = true
-		notification.Dismissed = true
 		notification.UpdatedAt = updatedAt
+		if notification.Type != ActivityCenterNotificationTypeMention && notification.Type != ActivityCenterNotificationTypeReply {
+			notification.Dismissed = true
+		}
 	})
 	if err != nil {
 		return nil, err
 	}
 
-	query = "UPDATE activity_center_notifications SET read = 1, dismissed = 1, updated_at = ? WHERE chat_id IN (" + inVector + ") AND NOT deleted" // nolint: gosec
-	_, err = tx.Exec(query, args...)
+	// Dismiss everything except mentions and replies.
+	dismissArgs := append(args, ActivityCenterNotificationTypeMention, ActivityCenterNotificationTypeReply)
+	// nolint: gosec
+	_, err = tx.Exec(fmt.Sprintf(`
+		UPDATE activity_center_notifications
+		SET read = 1, dismissed = 1, updated_at = ?
+		WHERE chat_id IN (%s)
+		AND NOT deleted
+		AND notification_type NOT IN (?, ?)`, inVector), dismissArgs...)
+	if err != nil {
+		return nil, err
+	}
+
+	// Mark mentions and replies as read without dismissing them.
+	readArgs := append(args, ActivityCenterNotificationTypeMention, ActivityCenterNotificationTypeReply)
+	// nolint: gosec
+	_, err = tx.Exec(fmt.Sprintf(`
+		UPDATE activity_center_notifications
+		SET read = 1, updated_at = ?
+		WHERE chat_id IN (%s)
+		AND NOT deleted
+		AND notification_type IN (?, ?)`, inVector), readArgs...)
 	if err != nil {
 		return nil, err
 	}
@@ -1023,24 +1048,44 @@ func (db sqlitePersistence) DismissAllActivityCenterNotificationsFromChatID(chat
 	}
 	notifications, err := db.parseRowFromTableActivityCenterNotification(rows, func(notification *ActivityCenterNotification) {
 		notification.Read = true
-		notification.Dismissed = true
 		notification.UpdatedAt = updatedAt
+		if notification.Type != ActivityCenterNotificationTypeMention && notification.Type != ActivityCenterNotificationTypeReply {
+			notification.Dismissed = true
+		}
 	})
 	if err != nil {
 		return nil, err
 	}
 
-	// We exclude notifications related to contacts, since those we don't want to
-	// be cleared.
+	// Exclude contact requests, mentions and replies from dismissal — they must
+	// remain visible in the activity center after marking a chat as read.
 	query = `
 		UPDATE activity_center_notifications
 		SET read = 1, dismissed = 1, updated_at = ?
 		WHERE chat_id = ?
 		    AND NOT deleted
 			AND NOT accepted
-			AND notification_type != ?
+			AND notification_type NOT IN (?, ?, ?)
 	`
-	_, err = tx.Exec(query, updatedAt, chatID, ActivityCenterNotificationTypeContactRequest)
+	_, err = tx.Exec(query, updatedAt, chatID,
+		ActivityCenterNotificationTypeContactRequest,
+		ActivityCenterNotificationTypeMention,
+		ActivityCenterNotificationTypeReply)
+	if err != nil {
+		return nil, err
+	}
+
+	// Mark mentions and replies as read without dismissing them.
+	_, err = tx.Exec(`
+		UPDATE activity_center_notifications
+		SET read = 1, updated_at = ?
+		WHERE chat_id = ?
+		    AND NOT deleted
+			AND NOT accepted
+			AND notification_type IN (?, ?)
+	`, updatedAt, chatID,
+		ActivityCenterNotificationTypeMention,
+		ActivityCenterNotificationTypeReply)
 	if err != nil {
 		return nil, err
 	}

--- a/protocol/activity_center_persistence_test.go
+++ b/protocol/activity_center_persistence_test.go
@@ -627,6 +627,10 @@ func (s *ActivityCenterPersistenceTestSuite) Test_DismissAllActivityCenterNotifi
 			ChatID: chatID,
 			Type:   ActivityCenterNotificationTypeMention,
 		},
+		{
+			ChatID: chatID,
+			Type:   ActivityCenterNotificationTypeReply,
+		},
 	})
 
 	_, err = p.DismissAllActivityCenterNotificationsFromChatID(chatID, currentMilliseconds())
@@ -674,13 +678,90 @@ func (s *ActivityCenterPersistenceTestSuite) Test_DismissAllActivityCenterNotifi
 	s.Require().False(notif.Dismissed)
 	s.Require().False(notif.Deleted)
 
-	// Finally, dismiss and mark as read this one notification.
+	// Marks mention as read without dismissing — must stay visible in the AC.
 	notif, err = p.GetActivityCenterNotificationByID(notifications[5].ID)
 	s.Require().NoError(err)
 	s.Require().False(notif.Accepted)
 	s.Require().True(notif.Read)
+	s.Require().False(notif.Dismissed)
+	s.Require().False(notif.Deleted)
+
+	// Marks reply as read without dismissing — must stay visible in the AC.
+	notif, err = p.GetActivityCenterNotificationByID(notifications[6].ID)
+	s.Require().NoError(err)
+	s.Require().False(notif.Accepted)
+	s.Require().True(notif.Read)
+	s.Require().False(notif.Dismissed)
+	s.Require().False(notif.Deleted)
+}
+
+func (s *ActivityCenterPersistenceTestSuite) Test_DismissAllActivityCenterNotificationsFromCommunity() {
+	db, err := openTestDB()
+	s.Require().NoError(err)
+	p := newSQLitePersistence(db)
+
+	communityID := "community-1"
+	chatID1 := communityID + "-chat-1"
+	chatID2 := communityID + "-chat-2"
+
+	// Save two chats belonging to the community.
+	for _, chatID := range []string{chatID1, chatID2} {
+		chat := CreatePublicChat(chatID, &testTimeSource{})
+		chat.CommunityID = communityID
+		err = p.SaveChat(*chat)
+		s.Require().NoError(err)
+	}
+
+	notifications := s.createNotifications(p, []*ActivityCenterNotification{
+		// Regular notification in community chat — should be dismissed.
+		{ChatID: chatID1, Type: ActivityCenterNotificationTypeNewPrivateGroupChat},
+		// Mention in community chat — must stay visible (read only, not dismissed).
+		{ChatID: chatID1, Type: ActivityCenterNotificationTypeMention},
+		// Reply in community chat — must stay visible (read only, not dismissed).
+		{ChatID: chatID2, Type: ActivityCenterNotificationTypeReply},
+		// Notification from a different community — must not be touched.
+		{ChatID: "other-community-chat", Type: ActivityCenterNotificationTypeMention},
+		// Soft-deleted notification — must not be touched.
+		{ChatID: chatID1, Type: ActivityCenterNotificationTypeMention, Deleted: true},
+	})
+
+	_, err = p.DismissAllActivityCenterNotificationsFromCommunity(communityID, currentMilliseconds())
+	s.Require().NoError(err)
+
+	// Regular notification is dismissed.
+	notif, err := p.GetActivityCenterNotificationByID(notifications[0].ID)
+	s.Require().NoError(err)
+	s.Require().True(notif.Read)
 	s.Require().True(notif.Dismissed)
 	s.Require().False(notif.Deleted)
+
+	// Mention is marked read but NOT dismissed.
+	notif, err = p.GetActivityCenterNotificationByID(notifications[1].ID)
+	s.Require().NoError(err)
+	s.Require().True(notif.Read)
+	s.Require().False(notif.Dismissed)
+	s.Require().False(notif.Deleted)
+
+	// Reply is marked read but NOT dismissed.
+	notif, err = p.GetActivityCenterNotificationByID(notifications[2].ID)
+	s.Require().NoError(err)
+	s.Require().True(notif.Read)
+	s.Require().False(notif.Dismissed)
+	s.Require().False(notif.Deleted)
+
+	// Notification from a different community is untouched.
+	notif, err = p.GetActivityCenterNotificationByID(notifications[3].ID)
+	s.Require().NoError(err)
+	s.Require().False(notif.Read)
+	s.Require().False(notif.Dismissed)
+	s.Require().False(notif.Deleted)
+
+	// Soft-deleted notification is untouched.
+	notif, err = p.GetActivityCenterNotificationByID(notifications[4].ID)
+	s.Require().NoError(err)
+	s.Require().False(notif.Read)
+	s.Require().False(notif.Dismissed)
+	s.Require().True(notif.Deleted)
 }
 
 func (s *ActivityCenterPersistenceTestSuite) Test_ActiveContactRequestNotification() {


### PR DESCRIPTION
`Mentions` and `Replies` where automatically removed from the `Activity Center` after marked as read.

 ## Root cause                                                                                        
`MarkAllRead` calls `DismissAllActivityCenterNotificationsFromChatID`, which was setting `dismissed=1` on all notification types except `ContactRequest`. Same issue in `DismissAllActivityCenterNotificationsFromCommunity`, which had no exclusions at all.                                                                                  
                                                                                                      
  ## Fix                                                                                              
                                                                                                      
Exclude `Mention` and `Reply` from the dismiss queries in both functions. A separate `UPDATE` marks them as `read=1` only, so they remain visible in the **activity center** after the user reads them.              

Added additional tests coverage and updates.

Part of [#20253](https://github.com/status-im/status-app/issues/20253)
Status app PR: https://github.com/status-im/status-app/pull/20518