### PR TITLE
fix: Status-go deadlocks when ConnectionChanged is spawned

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -102,7 +102,7 @@ require (
 	github.com/schollz/peerdiscovery v1.7.0
 	github.com/status-im/extkeys v1.4.0
 	github.com/status-im/go-wallet-sdk v0.0.0-20260312164506-d7611e385cfd
-	github.com/waku-org/go-waku v0.10.1
+	github.com/waku-org/go-waku v0.10.2-0.20260421101052-de84ba47f9b0
 	github.com/waku-org/sds-go-bindings v0.0.0-20251222164514-d5b47a911904
 	github.com/wk8/go-ordered-map/v2 v2.1.7
 	go.uber.org/atomic v1.11.0

--- a/go.sum
+++ b/go.sum
@@ -2416,8 +2416,8 @@ github.com/waku-org/go-libp2p-pubsub v0.13.1-gowaku h1:ovXh1m76i0yPWXt95Z9ZRyEk0
 github.com/waku-org/go-libp2p-pubsub v0.13.1-gowaku/go.mod h1:MKPU5vMI8RRFyTP0HfdsF9cLmL1nHAeJm44AxJGJx44=
 github.com/waku-org/go-libp2p-rendezvous v0.0.0-20240110193335-a67d1cc760a0 h1:R4YYx2QamhBRl/moIxkDCNW+OP7AHbyWLBygDc/xIMo=
 github.com/waku-org/go-libp2p-rendezvous v0.0.0-20240110193335-a67d1cc760a0/go.mod h1:EhZP9fee0DYjKH/IOQvoNSy1tSHp2iZadsHGphcAJgY=
-github.com/waku-org/go-waku v0.10.1 h1:05wNGVbUC4uP5JHPjBaHQywKvOgRkjJEcG8zL8/LKGo=
-github.com/waku-org/go-waku v0.10.1/go.mod h1:PDs4hlPbONeMQGsNyfArZV4R2Js1Zy5oqLBfw2VU278=
+github.com/waku-org/go-waku v0.10.2-0.20260421101052-de84ba47f9b0 h1:AXjJAIyEUQWJIjCGU+ZGSbat6lI1Gcrl0cD/vEVOFkQ=
+github.com/waku-org/go-waku v0.10.2-0.20260421101052-de84ba47f9b0/go.mod h1:PDs4hlPbONeMQGsNyfArZV4R2Js1Zy5oqLBfw2VU278=
 github.com/waku-org/go-zerokit-rln v0.1.14-0.20240102145250-fa738c0bdf59 h1:jisj+OCI6QydLtFq3Pyhu49wl9ytPN7oAHjMfepHDrA=
 github.com/waku-org/go-zerokit-rln v0.1.14-0.20240102145250-fa738c0bdf59/go.mod h1:1PdBdPzyTaKt3VnpAHk3zj+r9dXPFOr3IHZP9nFle6E=
 github.com/waku-org/go-zerokit-rln-apple v0.0.0-20230916172309-ee0ee61dde2b h1:KgZVhsLkxsj5gb/FfndSCQu6VYwALrCOgYI3poR95yE=

--- a/nix/pkgs/status-go/library/default.nix
+++ b/nix/pkgs/status-go/library/default.nix
@@ -11,7 +11,7 @@ let
 in pkgs.buildGoModule {
   pname = "status-go";
   src = builtins.path { path = ./../../../..; name = "status-go-library"; };
-  vendorHash = "sha256-lLiIZ70A9exgqpu2DZAC9mtk4oLfema/NaCJyvwJFEE=";
+  vendorHash = "sha256-0+QLuanbCpzl1Yfeo7hnpixUfhNKnUa81TO/mJfNe40=";
 
   inherit meta version;
 


### PR DESCRIPTION
Bump go-waku to include https://github.com/logos-messaging/logos-delivery-go/pull/1301

Closes #https://github.com/status-im/status-app/issues/20460

Status app PR: https://github.com/status-im/status-app/pull/20519
