### PR TITLE
fix: slow app pause android

### DIFF
--- a/pkg/messaging/waku/gowaku.go
+++ b/pkg/messaging/waku/gowaku.go
@@ -1107,7 +1107,9 @@ func (w *Waku) Start() error {
 			case <-w.topicHealthStatusChan:
 				// TODO: https://github.com/status-im/status-go/issues/4628
 			case <-w.connectionNotifChan:
-				w.checkForConnectionChanges()
+				if !paused {
+					w.checkForConnectionChanges()
+				}
 			}
 		}
 	}()

--- a/server/lifecycle_test.go
+++ b/server/lifecycle_test.go
@@ -1,7 +1,14 @@
 package server
 
 import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
 	"net/netip"
+	"sync"
 	"testing"
 	"time"
 
@@ -43,4 +50,82 @@ func TestServerToBackgroundToForegroundReusesEphemeralPort(t *testing.T) {
 
 	require.Equal(t, firstPort, s.GetPort())
 	require.NoError(t, s.Stop())
+}
+
+func TestShouldForceCloseOnShutdownError(t *testing.T) {
+	require.False(t, shouldForceCloseOnShutdownError(nil))
+	require.True(t, shouldForceCloseOnShutdownError(context.DeadlineExceeded))
+	require.True(t, shouldForceCloseOnShutdownError(context.Canceled))
+	require.True(t, shouldForceCloseOnShutdownError(fmt.Errorf("wrapped: %w", context.DeadlineExceeded)))
+	require.False(t, shouldForceCloseOnShutdownError(errors.New("boom")))
+}
+
+func TestServerToBackgroundReturnsPromptlyAndStopsAcceptingConnections(t *testing.T) {
+	s := NewServer(zap.NewNop(), &Config{
+		AddrPort: netip.MustParseAddrPort("127.0.0.1:0"),
+	})
+
+	started := make(chan struct{})
+	release := make(chan struct{})
+	var startedOnce sync.Once
+	var releaseOnce sync.Once
+	s.SetHandlers(HandlerPatternMap{
+		"/block": func(w http.ResponseWriter, r *http.Request) {
+			startedOnce.Do(func() { close(started) })
+
+			select {
+			case <-release:
+			case <-r.Context().Done():
+			}
+
+			_, _ = io.WriteString(w, "ok")
+		},
+	})
+
+	require.NoError(t, s.Start())
+	t.Cleanup(func() {
+		releaseOnce.Do(func() { close(release) })
+		_ = s.Stop()
+	})
+
+	require.Eventually(t, func() bool {
+		return s.GetListeningAddrPort() != ""
+	}, time.Second, 10*time.Millisecond)
+
+	addr := s.GetListeningAddrPort()
+	reqErr := make(chan error, 1)
+	go func() {
+		resp, err := http.Get("http://" + addr + "/block")
+		if err == nil {
+			_, _ = io.Copy(io.Discard, resp.Body)
+			_ = resp.Body.Close()
+		}
+		reqErr <- err
+	}()
+
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for blocking request to start")
+	}
+
+	start := time.Now()
+	s.ToBackground()
+	elapsed := time.Since(start)
+
+	require.LessOrEqual(t, elapsed, backgroundShutdownTimeout+250*time.Millisecond)
+
+	conn, err := net.DialTimeout("tcp", addr, 100*time.Millisecond)
+	if err == nil {
+		_ = conn.Close()
+	}
+	require.Error(t, err)
+
+	releaseOnce.Do(func() { close(release) })
+
+	select {
+	case <-reqErr:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for blocked request to finish")
+	}
 }

--- a/server/server.go
+++ b/server/server.go
@@ -12,11 +12,16 @@ import (
 	"sync"
 	"sync/atomic"
 	"syscall"
+	"time"
 
 	"go.uber.org/zap"
 
 	"github.com/status-im/status-go/common"
 )
+
+// backgroundShutdownTimeout bounds how long Server.ToBackground waits for
+// active HTTP handlers to drain before force-closing remaining connections.
+const backgroundShutdownTimeout = 300 * time.Millisecond
 
 // tcpListenConfig sets SO_REUSEADDR so that after the previous listener is fully
 // closed, the kernel can allow binding the same cached ephemeral port again (e.g.
@@ -254,6 +259,16 @@ func (s *Server) Start() error {
 }
 
 func (s *Server) Stop() error {
+	return s.stopWith(context.Background())
+}
+
+// stopWith performs the graceful shutdown sequence bounded by ctx. If ctx
+// expires or is canceled before active connections drain, the server is
+// force-closed via Close so the caller isn't blocked by a slow or stuck
+// handler. Pass context.Background() for the unbounded behaviour expected at
+// teardown/shutdown; use a short deadline for lifecycle events like
+// pause/ToBackground.
+func (s *Server) stopWith(ctx context.Context) error {
 	s.mu.Lock()
 	s.StopTimeout()
 	if !s.running.Load() || s.server == nil {
@@ -268,9 +283,16 @@ func (s *Server) Stop() error {
 	s.running.Store(false)
 	s.mu.Unlock()
 
-	err := currentServer.Shutdown(context.Background())
+	err := currentServer.Shutdown(ctx)
+	if shouldForceCloseOnShutdownError(err) {
+		_ = currentServer.Close()
+	}
 	s.serveWg.Wait()
 	return err
+}
+
+func shouldForceCloseOnShutdownError(err error) bool {
+	return errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled)
 }
 
 func (s *Server) IsRunning() bool {
@@ -284,9 +306,16 @@ func (s *Server) ToForeground() {
 }
 
 func (s *Server) ToBackground() {
-	err := s.Stop()
-	if err != nil {
-		s.logger.Error("server stop failed during background transition", zap.Error(err))
+	ctx, cancel := context.WithTimeout(context.Background(), backgroundShutdownTimeout)
+	defer cancel()
+	if err := s.stopWith(ctx); err != nil {
+		if shouldForceCloseOnShutdownError(err) {
+			s.logger.Warn("server graceful shutdown did not complete in time; forced close",
+				zap.Error(err), zap.Duration("timeout", backgroundShutdownTimeout))
+			return
+		}
+
+		s.logger.Error("server shutdown failed during background transition", zap.Error(err))
 	}
 }
 


### PR DESCRIPTION

- https://github.com/status-im/status-go/commit/b1bba21687bfda91e3d731632c1bd41f1d7b95e1 
I've noticed the new app pause is really slow due to the http server and the thread is blocked (sometimes while trying to gracefully shut down). This commit gives the http server 300ms to shut down, otherwise it's forced closes.



- https://github.com/status-im/status-go/commit/cb72add903e5703acd3cb32f261b79b77d2ed212 Don't verify the connections (and ping peers) while the service is paused
