### PR TITLE
fix(collectibles): per-chain status from real circuitbreaker outcomes

### DIFF
--- a/services/wallet/collectibles/collectibles_status.go
+++ b/services/wallet/collectibles/collectibles_status.go
@@ -1,0 +1,139 @@
+package collectibles
+
+import (
+	"context"
+	"errors"
+	"sync"
+
+	"github.com/ethereum/go-ethereum/event"
+	"go.uber.org/zap"
+
+	"github.com/status-im/status-go/internal/circuitbreaker"
+	"github.com/status-im/status-go/internal/healthmanager/provider_errors"
+	"github.com/status-im/status-go/internal/logutils"
+	"github.com/status-im/status-go/services/wallet/collectibles/ownership"
+	walletCommon "github.com/status-im/status-go/services/wallet/common"
+	"github.com/status-im/status-go/services/wallet/connection"
+	"github.com/status-im/status-go/services/wallet/walletevent"
+)
+
+const EventCollectiblesConnectionStatusChanged walletevent.EventType = "wallet-collectible-status-changed"
+
+// Reset connection status to trigger notifications
+// on the next status update
+func (o *Manager) ResetConnectionStatus() {
+	o.statuses.Range(func(key, value interface{}) bool {
+		value.(*connection.Status).ResetStateValue()
+		return true
+	})
+}
+
+func (o *Manager) recordChainOutcome(chainID walletCommon.ChainID, err error) {
+	if o.statuses == nil {
+		return
+	}
+	if err == nil {
+		o.setChainConnected(chainID, true)
+		return
+	}
+	if isCollectiblesIgnorableError(err) || errors.Is(err, ErrNoProvidersAvailableForChainID) {
+		return
+	}
+	o.setChainConnected(chainID, false)
+}
+
+func (o *Manager) applyCallStatuses(chainID walletCommon.ChainID, statuses []circuitbreaker.FunctorCallStatus) {
+	if len(statuses) == 0 {
+		return
+	}
+	var firstErr error
+	allIgnored := true
+	for _, s := range statuses {
+		if s.Err != nil && isCollectiblesIgnorableError(s.Err) {
+			continue
+		}
+		allIgnored = false
+		if s.Err == nil {
+			o.recordChainOutcome(chainID, nil)
+			return
+		}
+		if firstErr == nil {
+			firstErr = s.Err
+		}
+	}
+	if allIgnored {
+		return
+	}
+	o.recordChainOutcome(chainID, firstErr)
+}
+
+func (o *Manager) setChainConnected(chainID walletCommon.ChainID, connected bool) {
+	if o.statuses == nil {
+		return
+	}
+	key := chainID.String()
+	if v, ok := o.statuses.Load(key); ok {
+		v.(*connection.Status).SetIsConnected(connected)
+		return
+	}
+	st := connection.NewStatus()
+	st.SetIsConnected(connected)
+	if actual, loaded := o.statuses.LoadOrStore(key, st); loaded {
+		actual.(*connection.Status).SetIsConnected(connected)
+	} else {
+		o.updateStatusNotifier()
+	}
+}
+
+func isCollectiblesIgnorableError(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, context.Canceled) {
+		return true
+	}
+	if provider_errors.IsNonCriticalRpcError(err) {
+		return true
+	}
+	if provider_errors.IsNonCriticalProviderError(err) {
+		return true
+	}
+	return false
+}
+
+func logProviderSearchErr(method, providerID string, chainID walletCommon.ChainID, err error) {
+	logutils.ZapLogger().Error("collectibles search request failed",
+		zap.String("method", method),
+		zap.String("provider", providerID),
+		zap.Stringer("chainID", chainID),
+		zap.Error(err),
+	)
+}
+
+func (o *Manager) updateStatusNotifier() {
+	o.statusNotifier = createStatusNotifier(o.statuses, o.feed)
+}
+
+func initStatuses(ownershipDB ownership.OwnershipStorage) *sync.Map {
+	statuses := &sync.Map{}
+	for _, chainID := range walletCommon.AllChainIDs() {
+		status := connection.NewStatus()
+		state := status.GetState()
+		latestUpdateTimestamp, err := ownershipDB.GetLatestOwnershipUpdateTimestamp(chainID)
+		if err == nil {
+			state.LastSuccessAt = latestUpdateTimestamp
+			status.SetState(state)
+		}
+		statuses.Store(chainID.String(), status)
+	}
+
+	return statuses
+}
+
+func createStatusNotifier(statuses *sync.Map, feed *event.Feed) *connection.StatusNotifier {
+	return connection.NewStatusNotifier(
+		statuses,
+		EventCollectiblesConnectionStatusChanged,
+		feed,
+	)
+}

--- a/services/wallet/collectibles/manager.go
+++ b/services/wallet/collectibles/manager.go
@@ -37,8 +37,6 @@ import (
 const requestTimeout = 5 * time.Second
 const signalUpdatedCollectiblesDataPageSize = 10
 
-const EventCollectiblesConnectionStatusChanged walletevent.EventType = "wallet-collectible-status-changed"
-
 // ERC721 does not support function "TokenURI" if call
 // returns error starting with one of these strings
 var noTokenURIErrorPrefixes = []string{
@@ -220,8 +218,6 @@ func (o *Manager) FetchBalancesByOwnerAndContractAddress(ctx context.Context, ch
 }
 
 func (o *Manager) FetchAllAssetsByOwnerAndContractAddress(ctx context.Context, chainID walletCommon.ChainID, owner common.Address, contractAddresses []common.Address, cursor string, limit int, providerID string) (*thirdparty.FullCollectibleDataContainer, error) {
-	defer o.checkConnectionStatus(chainID)
-
 	cmd := circuitbreaker.NewCommand(ctx, nil)
 	for _, provider := range o.providers.AccountOwnershipProviders {
 		if !provider.IsChainSupported(chainID) {
@@ -251,6 +247,7 @@ func (o *Manager) FetchAllAssetsByOwnerAndContractAddress(ctx context.Context, c
 	}
 
 	cmdRes := o.circuitBreaker.Execute(cmd)
+	o.applyCallStatuses(chainID, cmdRes.FunctorCallStatuses())
 	if cmdRes.Error() != nil {
 		logutils.ZapLogger().Error("FetchAllAssetsByOwnerAndContractAddress failed for",
 			zap.Stringer("chainID", chainID),
@@ -270,8 +267,6 @@ func (o *Manager) FetchAllAssetsByOwnerAndContractAddress(ctx context.Context, c
 }
 
 func (o *Manager) FetchAllAssetsByOwner(ctx context.Context, chainID walletCommon.ChainID, owner common.Address, cursor string, limit int, providerID string) (*thirdparty.FullCollectibleDataContainer, error) {
-	defer o.checkConnectionStatus(chainID)
-
 	cmd := circuitbreaker.NewCommand(ctx, nil)
 	for _, provider := range o.providers.AccountOwnershipProviders {
 		if !provider.IsChainSupported(chainID) {
@@ -302,6 +297,7 @@ func (o *Manager) FetchAllAssetsByOwner(ctx context.Context, chainID walletCommo
 	}
 
 	cmdRes := o.circuitBreaker.Execute(cmd)
+	o.applyCallStatuses(chainID, cmdRes.FunctorCallStatuses())
 	if cmdRes.Error() != nil {
 		logutils.ZapLogger().Error("FetchAllAssetsByOwner failed for",
 			zap.Stringer("chainID", chainID),
@@ -463,8 +459,6 @@ func (o *Manager) FetchMissingAssetsByCollectibleUniqueID(ctx context.Context, u
 	group := async.NewAtomicGroup(ctx)
 	for chainID, idsToFetch := range missingIDsPerChainID {
 		group.Add(func(ctx context.Context) error {
-			defer o.checkConnectionStatus(chainID)
-
 			fetchedAssets, err := o.fetchMissingAssetsForChainByCollectibleUniqueID(ctx, chainID, idsToFetch)
 			if err != nil {
 				logutils.ZapLogger().Error("FetchMissingAssetsByCollectibleUniqueID failed for",
@@ -525,6 +519,7 @@ func (o *Manager) fetchMissingAssetsForChainByCollectibleUniqueID(ctx context.Co
 	}
 
 	cmdRes := o.circuitBreaker.Execute(cmd)
+	o.applyCallStatuses(chainID, cmdRes.FunctorCallStatuses())
 	if cmdRes.Error() != nil {
 		logutils.ZapLogger().Error("fetchMissingAssetsForChainByCollectibleUniqueID failed for",
 			zap.Stringer("chainID", chainID),
@@ -547,8 +542,6 @@ func (o *Manager) FetchCollectionsDataByContractID(ctx context.Context, ids []th
 	group := async.NewAtomicGroup(ctx)
 	for chainID, idsToFetch := range missingIDsPerChainID {
 		group.Add(func(ctx context.Context) error {
-			defer o.checkConnectionStatus(chainID)
-
 			cmd := circuitbreaker.NewCommand(ctx, nil)
 			for _, provider := range o.providers.CollectionDataProviders {
 				if !provider.IsChainSupported(chainID) {
@@ -567,6 +560,7 @@ func (o *Manager) FetchCollectionsDataByContractID(ctx context.Context, ids []th
 			}
 
 			cmdRes := o.circuitBreaker.Execute(cmd)
+			o.applyCallStatuses(chainID, cmdRes.FunctorCallStatuses())
 			if cmdRes.Error() != nil {
 				logutils.ZapLogger().Error("FetchCollectionsDataByContractID failed for",
 					zap.Stringer("chainID", chainID),
@@ -604,8 +598,6 @@ func (o *Manager) GetCollectibleOwnership(id thirdparty.CollectibleUniqueID) ([]
 }
 
 func (o *Manager) FetchCollectibleOwnersByContractAddress(ctx context.Context, chainID walletCommon.ChainID, contractAddress common.Address) (*thirdparty.CollectibleContractOwnership, error) {
-	defer o.checkConnectionStatus(chainID)
-
 	cmd := circuitbreaker.NewCommand(ctx, nil)
 	for _, provider := range o.providers.ContractOwnershipProviders {
 		if !provider.IsChainSupported(chainID) {
@@ -631,6 +623,7 @@ func (o *Manager) FetchCollectibleOwnersByContractAddress(ctx context.Context, c
 	}
 
 	cmdRes := o.circuitBreaker.Execute(cmd)
+	o.applyCallStatuses(chainID, cmdRes.FunctorCallStatuses())
 	if cmdRes.Error() != nil {
 		logutils.ZapLogger().Error("FetchCollectibleOwnersByContractAddress failed for",
 			zap.Stringer("chainID", chainID),
@@ -1022,37 +1015,6 @@ func (o *Manager) SetCollectibleTransferID(ownerAddress common.Address, id third
 	return nil
 }
 
-// Reset connection status to trigger notifications
-// on the next status update
-func (o *Manager) ResetConnectionStatus() {
-	o.statuses.Range(func(key, value interface{}) bool {
-		value.(*connection.Status).ResetStateValue()
-		return true
-	})
-}
-
-func (o *Manager) checkConnectionStatus(chainID walletCommon.ChainID) {
-	for _, provider := range o.providers.GetProviderList() {
-		if provider.IsChainSupported(chainID) && provider.IsConnected() {
-			if status, ok := o.statuses.Load(chainID.String()); ok {
-				status.(*connection.Status).SetIsConnected(true)
-			}
-			return
-		}
-	}
-
-	// If no chain in statuses, add it
-	statusVal, ok := o.statuses.Load(chainID.String())
-	if !ok {
-		status := connection.NewStatus()
-		status.SetIsConnected(false)
-		o.statuses.Store(chainID.String(), status)
-		o.updateStatusNotifier()
-	} else {
-		statusVal.(*connection.Status).SetIsConnected(false)
-	}
-}
-
 func (o *Manager) signalUpdatedCollectiblesData(ids []thirdparty.CollectibleUniqueID) {
 	// We limit how much collectibles data we send in each event to avoid problems on the client side
 	for startIdx := 0; startIdx < len(ids); startIdx += signalUpdatedCollectiblesDataPageSize {
@@ -1086,8 +1048,8 @@ func (o *Manager) signalUpdatedCollectiblesData(ids []thirdparty.CollectibleUniq
 	}
 }
 
-func (o *Manager) SearchCollectibles(ctx context.Context, chainID walletCommon.ChainID, text string, cursor string, limit int, providerID string) (*thirdparty.FullCollectibleDataContainer, error) {
-	defer o.checkConnectionStatus(chainID)
+func (o *Manager) SearchCollectibles(ctx context.Context, chainID walletCommon.ChainID, text string, cursor string, limit int, providerID string) (res *thirdparty.FullCollectibleDataContainer, err error) {
+	defer func() { o.recordChainOutcome(chainID, err) }()
 
 	anyProviderAvailable := false
 	for _, provider := range o.providers.SearchProviders {
@@ -1102,13 +1064,11 @@ func (o *Manager) SearchCollectibles(ctx context.Context, chainID walletCommon.C
 		// TODO (#13951): Be smarter about how we handle the user-entered string
 		collections := []common.Address{}
 
-		container, err := provider.SearchCollectibles(ctx, chainID, collections, text, cursor, limit)
-		if err != nil {
-			logutils.ZapLogger().Error("FetchAllAssetsByOwner failed for",
-				zap.String("provider", provider.ID()),
-				zap.Stringer("chainID", chainID),
-				zap.Error(err),
-			)
+		var container *thirdparty.FullCollectibleDataContainer
+		var perr error
+		container, perr = provider.SearchCollectibles(ctx, chainID, collections, text, cursor, limit)
+		if perr != nil {
+			logProviderSearchErr("SearchCollectibles", provider.ID(), chainID, perr)
 			continue
 		}
 
@@ -1116,18 +1076,19 @@ func (o *Manager) SearchCollectibles(ctx context.Context, chainID walletCommon.C
 		if err != nil {
 			return nil, err
 		}
-
 		return container, nil
 	}
 
 	if anyProviderAvailable {
-		return nil, ErrAllProvidersFailedForChainID
+		err = ErrAllProvidersFailedForChainID
+	} else {
+		err = ErrNoProvidersAvailableForChainID
 	}
-	return nil, ErrNoProvidersAvailableForChainID
+	return nil, err
 }
 
-func (o *Manager) SearchCollections(ctx context.Context, chainID walletCommon.ChainID, query string, cursor string, limit int, providerID string) (*thirdparty.CollectionDataContainer, error) {
-	defer o.checkConnectionStatus(chainID)
+func (o *Manager) SearchCollections(ctx context.Context, chainID walletCommon.ChainID, query string, cursor string, limit int, providerID string) (res *thirdparty.CollectionDataContainer, err error) {
+	defer func() { o.recordChainOutcome(chainID, err) }()
 
 	anyProviderAvailable := false
 	for _, provider := range o.providers.SearchProviders {
@@ -1140,34 +1101,31 @@ func (o *Manager) SearchCollections(ctx context.Context, chainID walletCommon.Ch
 		}
 
 		// TODO (#13951): Be smarter about how we handle the user-entered string
-		container, err := provider.SearchCollections(ctx, chainID, query, cursor, limit)
-		if err != nil {
-			logutils.ZapLogger().Error("FetchAllAssetsByOwner failed for",
-				zap.String("provider", provider.ID()),
-				zap.Stringer("chainID", chainID),
-				zap.Error(err),
-			)
+		var container *thirdparty.CollectionDataContainer
+		var perr error
+		container, perr = provider.SearchCollections(ctx, chainID, query, cursor, limit)
+		if perr != nil {
+			logProviderSearchErr("SearchCollections", provider.ID(), chainID, perr)
 			continue
 		}
 
-		err = o.processCollectionData(ctx, container.Items)
-		if err != nil {
+		if err = o.processCollectionData(ctx, container.Items); err != nil {
 			return nil, err
 		}
-
 		return container, nil
 	}
 
 	if anyProviderAvailable {
-		return nil, ErrAllProvidersFailedForChainID
+		err = ErrAllProvidersFailedForChainID
+	} else {
+		err = ErrNoProvidersAvailableForChainID
 	}
-	return nil, ErrNoProvidersAvailableForChainID
+	return nil, err
 }
 
 func (o *Manager) FetchCollectionSocialsAsync(contractID thirdparty.ContractID) error {
 	go func() {
 		defer gocommon.LogOnPanic()
-		defer o.checkConnectionStatus(contractID.ChainID)
 
 		socials, err := o.getOrFetchSocialsForCollection(context.Background(), contractID)
 		if err != nil || socials == nil {
@@ -1243,6 +1201,7 @@ func (o *Manager) fetchSocialsForCollection(ctx context.Context, contractID thir
 	}
 
 	cmdRes := o.circuitBreaker.Execute(cmd)
+	o.applyCallStatuses(contractID.ChainID, cmdRes.FunctorCallStatuses())
 	if cmdRes.Error() != nil {
 		logutils.ZapLogger().Error("fetchSocialsForCollection failed for",
 			zap.Stringer("chainID", contractID.ChainID),
@@ -1259,34 +1218,6 @@ func (o *Manager) fetchSocialsForCollection(ctx context.Context, contractID thir
 	}
 
 	return socials, cmdRes.Error()
-}
-
-func (o *Manager) updateStatusNotifier() {
-	o.statusNotifier = createStatusNotifier(o.statuses, o.feed)
-}
-
-func initStatuses(ownershipDB ownership.OwnershipStorage) *sync.Map {
-	statuses := &sync.Map{}
-	for _, chainID := range walletCommon.AllChainIDs() {
-		status := connection.NewStatus()
-		state := status.GetState()
-		latestUpdateTimestamp, err := ownershipDB.GetLatestOwnershipUpdateTimestamp(chainID)
-		if err == nil {
-			state.LastSuccessAt = latestUpdateTimestamp
-			status.SetState(state)
-		}
-		statuses.Store(chainID.String(), status)
-	}
-
-	return statuses
-}
-
-func createStatusNotifier(statuses *sync.Map, feed *event.Feed) *connection.StatusNotifier {
-	return connection.NewStatusNotifier(
-		statuses,
-		EventCollectiblesConnectionStatusChanged,
-		feed,
-	)
 }
 
 // Different providers have API keys per chain or per testnet/mainnet.

--- a/services/wallet/collectibles/manager.go
+++ b/services/wallet/collectibles/manager.go
@@ -1048,10 +1048,9 @@ func (o *Manager) signalUpdatedCollectiblesData(ids []thirdparty.CollectibleUniq
 	}
 }
 
-func (o *Manager) SearchCollectibles(ctx context.Context, chainID walletCommon.ChainID, text string, cursor string, limit int, providerID string) (res *thirdparty.FullCollectibleDataContainer, err error) {
-	defer func() { o.recordChainOutcome(chainID, err) }()
-
+func (o *Manager) SearchCollectibles(ctx context.Context, chainID walletCommon.ChainID, text string, cursor string, limit int, providerID string) (*thirdparty.FullCollectibleDataContainer, error) {
 	anyProviderAvailable := false
+	var firstNonIgnorablePerr error
 	for _, provider := range o.providers.SearchProviders {
 		if !provider.IsChainSupported(chainID) {
 			continue
@@ -1062,35 +1061,35 @@ func (o *Manager) SearchCollectibles(ctx context.Context, chainID walletCommon.C
 		}
 
 		// TODO (#13951): Be smarter about how we handle the user-entered string
-		collections := []common.Address{}
-
-		var container *thirdparty.FullCollectibleDataContainer
-		var perr error
-		container, perr = provider.SearchCollectibles(ctx, chainID, collections, text, cursor, limit)
+		container, perr := provider.SearchCollectibles(ctx, chainID, []common.Address{}, text, cursor, limit)
 		if perr != nil {
 			logProviderSearchErr("SearchCollectibles", provider.ID(), chainID, perr)
+			if firstNonIgnorablePerr == nil && !isCollectiblesIgnorableError(perr) {
+				firstNonIgnorablePerr = perr
+			}
 			continue
 		}
 
-		_, container.Items, err = o.processFullCollectibleData(ctx, container.Items, true)
-		if err != nil {
+		o.recordChainOutcome(chainID, nil)
+		var err error
+		if _, container.Items, err = o.processFullCollectibleData(ctx, container.Items, true); err != nil {
 			return nil, err
 		}
 		return container, nil
 	}
 
-	if anyProviderAvailable {
-		err = ErrAllProvidersFailedForChainID
-	} else {
-		err = ErrNoProvidersAvailableForChainID
+	if firstNonIgnorablePerr != nil {
+		o.recordChainOutcome(chainID, firstNonIgnorablePerr)
 	}
-	return nil, err
+	if anyProviderAvailable {
+		return nil, ErrAllProvidersFailedForChainID
+	}
+	return nil, ErrNoProvidersAvailableForChainID
 }
 
 func (o *Manager) SearchCollections(ctx context.Context, chainID walletCommon.ChainID, query string, cursor string, limit int, providerID string) (res *thirdparty.CollectionDataContainer, err error) {
-	defer func() { o.recordChainOutcome(chainID, err) }()
-
 	anyProviderAvailable := false
+	var firstNonIgnorablePerr error
 	for _, provider := range o.providers.SearchProviders {
 		if !provider.IsChainSupported(chainID) {
 			continue
@@ -1101,26 +1100,29 @@ func (o *Manager) SearchCollections(ctx context.Context, chainID walletCommon.Ch
 		}
 
 		// TODO (#13951): Be smarter about how we handle the user-entered string
-		var container *thirdparty.CollectionDataContainer
-		var perr error
-		container, perr = provider.SearchCollections(ctx, chainID, query, cursor, limit)
+		container, perr := provider.SearchCollections(ctx, chainID, query, cursor, limit)
 		if perr != nil {
 			logProviderSearchErr("SearchCollections", provider.ID(), chainID, perr)
+			if firstNonIgnorablePerr == nil && !isCollectiblesIgnorableError(perr) {
+				firstNonIgnorablePerr = perr
+			}
 			continue
 		}
 
+		o.recordChainOutcome(chainID, nil)
 		if err = o.processCollectionData(ctx, container.Items); err != nil {
 			return nil, err
 		}
 		return container, nil
 	}
 
-	if anyProviderAvailable {
-		err = ErrAllProvidersFailedForChainID
-	} else {
-		err = ErrNoProvidersAvailableForChainID
+	if firstNonIgnorablePerr != nil {
+		o.recordChainOutcome(chainID, firstNonIgnorablePerr)
 	}
-	return nil, err
+	if anyProviderAvailable {
+		return nil, ErrAllProvidersFailedForChainID
+	}
+	return nil, ErrNoProvidersAvailableForChainID
 }
 
 func (o *Manager) FetchCollectionSocialsAsync(contractID thirdparty.ContractID) error {

--- a/services/wallet/collectibles/manager_status_test.go
+++ b/services/wallet/collectibles/manager_status_test.go
@@ -1,0 +1,336 @@
+package collectibles
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"math/big"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/event"
+
+	mock_client "github.com/status-im/status-go/internal/rpc/chain/mock/client"
+	mock_rpcclient "github.com/status-im/status-go/internal/rpc/mock/client"
+	mock_collectibles "github.com/status-im/status-go/services/wallet/collectibles/mock"
+	mock_ownership "github.com/status-im/status-go/services/wallet/collectibles/ownership/mock"
+	mock_community "github.com/status-im/status-go/services/wallet/community/mock"
+	mock_thirdparty "github.com/status-im/status-go/services/wallet/thirdparty/mock"
+
+	"github.com/status-im/status-go/internal/circuitbreaker"
+	"github.com/status-im/status-go/services/wallet/bigint"
+	walletCommon "github.com/status-im/status-go/services/wallet/common"
+	"github.com/status-im/status-go/services/wallet/connection"
+	"github.com/status-im/status-go/services/wallet/thirdparty"
+)
+
+// TestCollectiblesStatus_SuccessfulFetchDoesNotRelyOnProviderIsConnected
+// Repro: a successful provider round-trip must mark the chain as connected even when
+// third-party health IsConnected() is false (async / out of sync with real calls).
+// Old code defers checkConnectionStatus which only looks at IsConnected and overwrites
+// a successful request with Disconnected.
+func TestCollectiblesStatus_SuccessfulFetchDoesNotRelyOnProviderIsConnected(t *testing.T) {
+	t.Parallel()
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	ctx := context.Background()
+	chainID := walletCommon.ChainID(1)
+	owner := common.HexToAddress("0x1234567890abcdef")
+	providerID := "test_provider"
+
+	chainClient := &CopyableMockChainClient{MockClientInterface: mock_client.NewMockClientInterface(mockCtrl)}
+	chainClient.EXPECT().CallContract(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
+	chainClient.EXPECT().CodeAt(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
+	rpcClient := mock_rpcclient.NewMockClientInterface(mockCtrl)
+	rpcClient.EXPECT().EthClient(gomock.Any()).Return(chainClient, nil).AnyTimes()
+
+	mockProvider := mock_thirdparty.NewMockCollectibleAccountOwnershipProvider(mockCtrl)
+	mockProvider.EXPECT().IsChainSupported(chainID).Return(true).AnyTimes()
+	// Intentionally false: simulates desync with actual fetch success
+	mockProvider.EXPECT().IsConnected().Return(false).AnyTimes()
+	mockProvider.EXPECT().ID().Return(providerID).AnyTimes()
+
+	mockAssetContainer := &thirdparty.FullCollectibleDataContainer{
+		Items: []thirdparty.FullCollectibleData{
+			{
+				CollectibleData: thirdparty.CollectibleData{
+					ID: thirdparty.CollectibleUniqueID{
+						ContractID: thirdparty.ContractID{
+							Address: common.HexToAddress("0x0000000000000000000000000000000000000001"),
+						},
+						TokenID: &bigint.BigInt{Int: big.NewInt(1)},
+					},
+				},
+			},
+		},
+	}
+	mockProvider.EXPECT().FetchAllAssetsByOwner(gomock.Any(), chainID, owner, "", 1).Return(mockAssetContainer, nil)
+
+	mockProviders := thirdparty.CollectibleProviders{
+		AccountOwnershipProviders: []thirdparty.CollectibleAccountOwnershipProvider{mockProvider},
+	}
+
+	manager := NewManager(nil, rpcClient, nil, mockProviders, nil, new(event.Feed))
+
+	chainKey := chainID.String()
+	statuses := &sync.Map{}
+	statuses.Store(chainKey, connection.NewStatus())
+	manager.statuses = statuses
+	manager.statusNotifier = createStatusNotifier(statuses, manager.feed)
+
+	collectiblesDataDB := mock_collectibles.NewMockCollectibleDataStorage(mockCtrl)
+	collectiblesDataDB.EXPECT().SetData(gomock.Any(), gomock.Any()).Return(nil)
+	collectiblesDataDB.EXPECT().GetData(gomock.Any()).DoAndReturn(func(ids []thirdparty.CollectibleUniqueID) (map[string]thirdparty.CollectibleData, error) {
+		ret := make(map[string]thirdparty.CollectibleData)
+		for _, id := range ids {
+			ret[id.HashKey()] = thirdparty.CollectibleData{ID: id}
+		}
+		return ret, nil
+	})
+	collectiblesDataDB.EXPECT().GetCommunityInfo(gomock.Any()).Return(&thirdparty.CollectibleCommunityInfo{}, nil).AnyTimes()
+	collectionsDataDB := mock_collectibles.NewMockCollectionDataStorage(mockCtrl)
+	collectionsDataDB.EXPECT().SetData(gomock.Any(), gomock.Any()).Return(nil)
+	collectionsDataDB.EXPECT().GetData(gomock.Any()).DoAndReturn(func(ids []thirdparty.ContractID) (map[string]thirdparty.CollectionData, error) {
+		ret := make(map[string]thirdparty.CollectionData)
+		for _, id := range ids {
+			ret[id.HashKey()] = thirdparty.CollectionData{ID: id}
+		}
+		return ret, nil
+	})
+	communityManager := mock_community.NewMockCommunityManagerInterface(mockCtrl)
+	communityManager.EXPECT().GetCommunityID(gomock.Any()).Return(providerID).AnyTimes()
+	communityManager.EXPECT().FillCollectiblesMetadata(gomock.Any(), gomock.Any()).Return(true, nil).AnyTimes()
+	communityManager.EXPECT().GetCommunityInfo(gomock.Any()).Return(&thirdparty.CommunityInfo{}, nil, nil).AnyTimes()
+	ownershipDB := mock_ownership.NewMockOwnershipStorage(mockCtrl)
+	ownershipDB.EXPECT().GetLatestOwnershipUpdateTimestamp(gomock.Any()).Return(int64(0), nil).AnyTimes()
+	ownershipDB.EXPECT().GetOwnership(gomock.Any()).Return([]thirdparty.AccountBalance{}, nil).AnyTimes()
+	manager.collectiblesDataDB = collectiblesDataDB
+	manager.collectionsDataDB = collectionsDataDB
+	manager.communityManager = communityManager
+	manager.ownershipDB = ownershipDB
+
+	_, err := manager.FetchAllAssetsByOwner(ctx, chainID, owner, "", 1, thirdparty.FetchFromAnyProvider)
+	require.NoError(t, err)
+
+	loaded, ok := manager.statuses.Load(chainKey)
+	require.True(t, ok, "status for chain should exist")
+	st := loaded.(*connection.Status)
+	// After fix, successful functor must mark the chain as connected; old code only looked at
+	// IsConnected() and would leave/force Disconnected.
+	assert.Equal(t, connection.StateValueConnected, st.GetStateValue(), "state should follow successful collectibles call, not provider IsConnected()")
+}
+
+// TestCollectiblesStatus_CanceledErrorDoesNotFlipToDisconnected
+// When the circuit breaker call fails with context.Canceled, we must not treat that as
+// a hard "providers down" signal (old checkConnectionStatus still forced Disconnected
+// if no provider was IsConnected() at defer time).
+func TestCollectiblesStatus_CanceledErrorDoesNotFlipToDisconnected(t *testing.T) {
+	t.Parallel()
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // all RPC-like calls are canceled
+	chainID := walletCommon.ChainID(1)
+	owner := common.HexToAddress("0x1234567890abcdef")
+	providerID := "test_provider_canceled"
+
+	chainClient := &CopyableMockChainClient{MockClientInterface: mock_client.NewMockClientInterface(mockCtrl)}
+	chainClient.EXPECT().CodeAt(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
+	rpcClient := mock_rpcclient.NewMockClientInterface(mockCtrl)
+	rpcClient.EXPECT().EthClient(gomock.Any()).Return(chainClient, nil).AnyTimes()
+
+	mockProvider := mock_thirdparty.NewMockCollectibleAccountOwnershipProvider(mockCtrl)
+	mockProvider.EXPECT().IsChainSupported(chainID).Return(true).AnyTimes()
+	mockProvider.EXPECT().IsConnected().Return(false).AnyTimes()
+	mockProvider.EXPECT().ID().Return(providerID).AnyTimes()
+	mockProvider.EXPECT().FetchAllAssetsByOwner(gomock.Any(), chainID, owner, "", 1).Return(
+		(*thirdparty.FullCollectibleDataContainer)(nil), context.Canceled)
+
+	mockProviders := thirdparty.CollectibleProviders{
+		AccountOwnershipProviders: []thirdparty.CollectibleAccountOwnershipProvider{mockProvider},
+	}
+	manager := NewManager(nil, rpcClient, nil, mockProviders, nil, new(event.Feed))
+	chainKey := chainID.String()
+	statuses := &sync.Map{}
+	statuses.Store(chainKey, connection.NewStatus())
+	manager.statuses = statuses
+	manager.statusNotifier = createStatusNotifier(statuses, manager.feed)
+	manager.collectiblesDataDB = mock_collectibles.NewMockCollectibleDataStorage(mockCtrl)
+	manager.collectionsDataDB = mock_collectibles.NewMockCollectionDataStorage(mockCtrl)
+	communityManager := mock_community.NewMockCommunityManagerInterface(mockCtrl)
+	manager.communityManager = communityManager
+	ownershipDB := mock_ownership.NewMockOwnershipStorage(mockCtrl)
+	ownershipDB.EXPECT().GetLatestOwnershipUpdateTimestamp(gomock.Any()).Return(int64(0), nil).AnyTimes()
+	ownershipDB.EXPECT().GetOwnership(gomock.Any()).Return([]thirdparty.AccountBalance{}, nil).AnyTimes()
+	manager.ownershipDB = ownershipDB
+
+	_, err := manager.FetchAllAssetsByOwner(ctx, chainID, owner, "", 1, thirdparty.FetchFromAnyProvider)
+	assert.Error(t, err)
+
+	loaded, ok := manager.statuses.Load(chainKey)
+	require.True(t, ok)
+	st := loaded.(*connection.Status)
+	assert.Equal(t, connection.StateValueUnknown, st.GetStateValue(), "canceled/ignored outcome must not mark chain as disconnected for collectibles")
+}
+
+// TestCollectiblesStatus_MultipleSuccessfulFetchesNoDisconnectedSpike
+// Two successful fetches in a row should not oscillate: second SetIsConnected(true) is a no-op.
+func TestCollectiblesStatus_MultipleSuccessfulFetchesNoDisconnectedSpike(t *testing.T) {
+	t.Parallel()
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	ctx := context.Background()
+	chainID := walletCommon.ChainID(1)
+	owner := common.HexToAddress("0xabcdefabcdefabcdefabcdefabcdefabcdefabcd")
+
+	chainClient := &CopyableMockChainClient{MockClientInterface: mock_client.NewMockClientInterface(mockCtrl)}
+	chainClient.EXPECT().CallContract(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
+	chainClient.EXPECT().CodeAt(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
+	rpcClient := mock_rpcclient.NewMockClientInterface(mockCtrl)
+	rpcClient.EXPECT().EthClient(gomock.Any()).Return(chainClient, nil).AnyTimes()
+
+	timestamp := time.Now().UnixNano()
+	mockProvider := mock_thirdparty.NewMockCollectibleAccountOwnershipProvider(mockCtrl)
+	mockProvider.EXPECT().IsChainSupported(chainID).Return(true).AnyTimes()
+	// Stale: still false while requests succeed; old defer path overwrites to disconnected each time
+	mockProvider.EXPECT().IsConnected().Return(false).AnyTimes()
+	mockProvider.EXPECT().ID().Return(fmt.Sprintf("m_%d", timestamp)).AnyTimes()
+
+	item := thirdparty.FullCollectibleData{
+		CollectibleData: thirdparty.CollectibleData{
+			ID: thirdparty.CollectibleUniqueID{
+				ContractID: thirdparty.ContractID{
+					Address: common.HexToAddress("0x0000000000000000000000000000000000000001"),
+					ChainID: chainID,
+				},
+				TokenID: &bigint.BigInt{Int: big.NewInt(1)},
+			},
+		},
+	}
+	mockContainer := &thirdparty.FullCollectibleDataContainer{Items: []thirdparty.FullCollectibleData{item}}
+	mockProvider.EXPECT().FetchAllAssetsByOwner(gomock.Any(), chainID, owner, "", 1).Return(mockContainer, nil).Times(2)
+
+	manager := NewManager(nil, rpcClient, nil, thirdparty.CollectibleProviders{
+		AccountOwnershipProviders: []thirdparty.CollectibleAccountOwnershipProvider{mockProvider},
+	}, nil, new(event.Feed))
+	chainKey := chainID.String()
+	statuses := &sync.Map{}
+	statuses.Store(chainKey, connection.NewStatus())
+	manager.statuses = statuses
+	manager.statusNotifier = createStatusNotifier(statuses, manager.feed)
+
+	// Databases + community
+	collectiblesDataDB := mock_collectibles.NewMockCollectibleDataStorage(mockCtrl)
+	collectiblesDataDB.EXPECT().SetData(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+	collectiblesDataDB.EXPECT().GetData(gomock.Any()).DoAndReturn(func(ids []thirdparty.CollectibleUniqueID) (map[string]thirdparty.CollectibleData, error) {
+		m := make(map[string]thirdparty.CollectibleData)
+		for _, id := range ids {
+			m[id.HashKey()] = thirdparty.CollectibleData{ID: id}
+		}
+		return m, nil
+	}).AnyTimes()
+	collectiblesDataDB.EXPECT().GetCommunityInfo(gomock.Any()).Return(&thirdparty.CollectibleCommunityInfo{}, nil).AnyTimes()
+	collectionsDataDB := mock_collectibles.NewMockCollectionDataStorage(mockCtrl)
+	collectionsDataDB.EXPECT().SetData(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+	collectionsDataDB.EXPECT().GetData(gomock.Any()).Return(map[string]thirdparty.CollectionData{}, nil).AnyTimes()
+	communityManager := mock_community.NewMockCommunityManagerInterface(mockCtrl)
+	communityManager.EXPECT().GetCommunityID(gomock.Any()).Return("c").AnyTimes()
+	communityManager.EXPECT().FillCollectiblesMetadata(gomock.Any(), gomock.Any()).Return(true, nil).AnyTimes()
+	communityManager.EXPECT().GetCommunityInfo(gomock.Any()).Return(&thirdparty.CommunityInfo{}, nil, nil).AnyTimes()
+	ownershipDB := mock_ownership.NewMockOwnershipStorage(mockCtrl)
+	ownershipDB.EXPECT().GetLatestOwnershipUpdateTimestamp(gomock.Any()).Return(int64(0), nil).AnyTimes()
+	ownershipDB.EXPECT().GetOwnership(gomock.Any()).Return([]thirdparty.AccountBalance{}, nil).AnyTimes()
+	manager.collectiblesDataDB = collectiblesDataDB
+	manager.collectionsDataDB = collectionsDataDB
+	manager.communityManager = communityManager
+	manager.ownershipDB = ownershipDB
+
+	_, err := manager.FetchAllAssetsByOwner(ctx, chainID, owner, "", 1, thirdparty.FetchFromAnyProvider)
+	require.NoError(t, err)
+	_, err = manager.FetchAllAssetsByOwner(ctx, chainID, owner, "", 1, thirdparty.FetchFromAnyProvider)
+	require.NoError(t, err)
+	loaded, _ := manager.statuses.Load(chainKey)
+	st := loaded.(*connection.Status)
+	assert.Equal(t, connection.StateValueConnected, st.GetStateValue())
+}
+
+func TestIsCollectiblesIgnorableError(t *testing.T) {
+	t.Parallel()
+	wrapped := fmt.Errorf("wrap: %w", context.Canceled)
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil", nil, false},
+		{"canceled", context.Canceled, true},
+		{"wrapped_canceled", wrapped, true},
+		{"other", errors.New("fail"), false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, isCollectiblesIgnorableError(tc.err))
+		})
+	}
+}
+
+func TestApplyCallStatuses_DoesNotChangeStateWhenAllIgnored(t *testing.T) {
+	t.Parallel()
+	chainID := walletCommon.ChainID(1)
+	m := &Manager{statuses: &sync.Map{}, feed: new(event.Feed)}
+	m.statuses.Store(chainID.String(), connection.NewStatus())
+	m.statusNotifier = createStatusNotifier(m.statuses, m.feed)
+
+	now := time.Now()
+	m.applyCallStatuses(chainID, []circuitbreaker.FunctorCallStatus{
+		{Name: "a", Err: context.Canceled, Timestamp: now, StartTime: now},
+		{Name: "b", Err: context.Canceled, Timestamp: now, StartTime: now},
+	})
+	st := mustConnStatus(t, m.statuses, chainID)
+	assert.Equal(t, connection.StateValueUnknown, st.GetStateValue())
+}
+
+func TestApplyCallStatuses_AllFailuresSetDisconnected(t *testing.T) {
+	t.Parallel()
+	chainID := walletCommon.ChainID(1)
+	m := &Manager{statuses: &sync.Map{}, feed: new(event.Feed)}
+	m.statuses.Store(chainID.String(), connection.NewStatus())
+	m.statusNotifier = createStatusNotifier(m.statuses, m.feed)
+	now := time.Now()
+	m.applyCallStatuses(chainID, []circuitbreaker.FunctorCallStatus{
+		{Name: "a", Err: errors.New("e1"), Timestamp: now, StartTime: now},
+	})
+	st := mustConnStatus(t, m.statuses, chainID)
+	assert.Equal(t, connection.StateValueDisconnected, st.GetStateValue())
+}
+
+func TestApplyCallStatuses_SuccessWinsInMixedList(t *testing.T) {
+	t.Parallel()
+	chainID := walletCommon.ChainID(1)
+	m := &Manager{statuses: &sync.Map{}, feed: new(event.Feed)}
+	m.statuses.Store(chainID.String(), connection.NewStatus())
+	m.statusNotifier = createStatusNotifier(m.statuses, m.feed)
+	now := time.Now()
+	m.applyCallStatuses(chainID, []circuitbreaker.FunctorCallStatus{
+		{Name: "a", Err: errors.New("failed"), Timestamp: now, StartTime: now},
+		{Name: "b", Err: nil, Timestamp: now, StartTime: now},
+	})
+	st := mustConnStatus(t, m.statuses, chainID)
+	assert.Equal(t, connection.StateValueConnected, st.GetStateValue())
+}
+
+func mustConnStatus(t *testing.T, statuses *sync.Map, chainID walletCommon.ChainID) *connection.Status {
+	t.Helper()
+	v, ok := statuses.Load(chainID.String())
+	require.True(t, ok)
+	return v.(*connection.Status)
+}

--- a/services/wallet/collectibles/manager_status_test.go
+++ b/services/wallet/collectibles/manager_status_test.go
@@ -334,3 +334,110 @@ func mustConnStatus(t *testing.T, statuses *sync.Map, chainID walletCommon.Chain
 	require.True(t, ok)
 	return v.(*connection.Status)
 }
+
+// testSearchProvider implements thirdparty.CollectibleSearchProvider for search status tests.
+type testSearchProvider struct {
+	id      string
+	chainID walletCommon.ChainID
+	scRes   *thirdparty.FullCollectibleDataContainer
+	scErr   error
+	scolRes *thirdparty.CollectionDataContainer
+	scolErr error
+}
+
+func (p *testSearchProvider) ID() string                                   { return p.id }
+func (p *testSearchProvider) IsConnected() bool                            { return true }
+func (p *testSearchProvider) IsChainSupported(c walletCommon.ChainID) bool { return c == p.chainID }
+func (p *testSearchProvider) SearchCollectibles(ctx context.Context, chainID walletCommon.ChainID, _ []common.Address, _, _ string, _ int) (*thirdparty.FullCollectibleDataContainer, error) {
+	_ = ctx
+	_ = chainID
+	if p.scRes != nil || p.scErr != nil {
+		return p.scRes, p.scErr
+	}
+	return &thirdparty.FullCollectibleDataContainer{}, nil
+}
+func (p *testSearchProvider) SearchCollections(ctx context.Context, chainID walletCommon.ChainID, _, _ string, _ int) (*thirdparty.CollectionDataContainer, error) {
+	_ = ctx
+	_ = chainID
+	if p.scolRes != nil || p.scolErr != nil {
+		return p.scolRes, p.scolErr
+	}
+	return &thirdparty.CollectionDataContainer{}, nil
+}
+
+// TestSearchCollectibles_OnlyIgnorableProviderErrors_DoesNotDisconnect
+// Repro: only context.Canceled (or other ignorable) perrs would leave the final
+// return as ErrAllProvidersFailedForChainID; that sentinel must not drive
+// connection state if every provider error was ignorable.
+func TestSearchCollectibles_OnlyIgnorableProviderErrors_DoesNotDisconnect(t *testing.T) {
+	t.Parallel()
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	chainID := walletCommon.ChainID(1)
+	sp := &testSearchProvider{id: "sp1", chainID: chainID, scErr: context.Canceled}
+	manager := NewManager(nil, nil, nil, thirdparty.CollectibleProviders{SearchProviders: []thirdparty.CollectibleSearchProvider{sp}}, nil, new(event.Feed))
+
+	chainKey := chainID.String()
+	statuses := &sync.Map{}
+	statuses.Store(chainKey, connection.NewStatus())
+	manager.statuses = statuses
+	manager.statusNotifier = createStatusNotifier(statuses, manager.feed)
+	cdb := mock_collectibles.NewMockCollectibleDataStorage(mockCtrl)
+	coldb := mock_collectibles.NewMockCollectionDataStorage(mockCtrl)
+	manager.collectiblesDataDB = cdb
+	manager.collectionsDataDB = coldb
+	manager.communityManager = mock_community.NewMockCommunityManagerInterface(mockCtrl)
+	odb := mock_ownership.NewMockOwnershipStorage(mockCtrl)
+	odb.EXPECT().GetLatestOwnershipUpdateTimestamp(gomock.Any()).Return(int64(0), nil).AnyTimes()
+	odb.EXPECT().GetOwnership(gomock.Any()).Return([]thirdparty.AccountBalance{}, nil).AnyTimes()
+	manager.ownershipDB = odb
+
+	_, err := manager.SearchCollectibles(context.Background(), chainID, "q", "", 10, thirdparty.FetchFromAnyProvider)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrAllProvidersFailedForChainID)
+
+	st := mustConnStatus(t, manager.statuses, chainID)
+	assert.Equal(t, connection.StateValueUnknown, st.GetStateValue(), "all-ignorable provider search failures must not mark disconnected")
+}
+
+// TestSearchCollections_ProviderSuccessSetDataError_StaysConnected
+// A successful provider response must set connected before processCollectionData;
+// a DB error there is not a provider connectivity issue.
+func TestSearchCollections_ProviderSuccessSetDataError_StaysConnected(t *testing.T) {
+	t.Parallel()
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	chainID := walletCommon.ChainID(1)
+	sp := &testSearchProvider{
+		id:      "sp1",
+		chainID: chainID,
+		scolRes: &thirdparty.CollectionDataContainer{
+			Items: []thirdparty.CollectionData{
+				{ID: thirdparty.ContractID{ChainID: chainID, Address: common.HexToAddress("0x1")}, Name: "a"},
+			},
+		},
+	}
+	manager := NewManager(nil, nil, nil, thirdparty.CollectibleProviders{SearchProviders: []thirdparty.CollectibleSearchProvider{sp}}, nil, new(event.Feed))
+	chainKey := chainID.String()
+	statuses := &sync.Map{}
+	statuses.Store(chainKey, connection.NewStatus())
+	manager.statuses = statuses
+	manager.statusNotifier = createStatusNotifier(statuses, manager.feed)
+	manager.collectiblesDataDB = mock_collectibles.NewMockCollectibleDataStorage(mockCtrl)
+	coldb := mock_collectibles.NewMockCollectionDataStorage(mockCtrl)
+	dbErr := errors.New("set failed")
+	coldb.EXPECT().SetData(gomock.Any(), gomock.Any()).Return(dbErr)
+	manager.collectionsDataDB = coldb
+	odb := mock_ownership.NewMockOwnershipStorage(mockCtrl)
+	odb.EXPECT().GetLatestOwnershipUpdateTimestamp(gomock.Any()).Return(int64(0), nil).AnyTimes()
+	odb.EXPECT().GetOwnership(gomock.Any()).Return([]thirdparty.AccountBalance{}, nil).AnyTimes()
+	manager.ownershipDB = odb
+	manager.communityManager = mock_community.NewMockCommunityManagerInterface(mockCtrl)
+
+	_, err := manager.SearchCollections(context.Background(), chainID, "q", "", 10, thirdparty.FetchFromAnyProvider)
+	require.ErrorIs(t, err, dbErr)
+	st := mustConnStatus(t, manager.statuses, chainID)
+	assert.Equal(t, connection.StateValueConnected, st.GetStateValue(), "local DB error after a successful search provider response must not flip to disconnected")
+}


### PR DESCRIPTION
fixes status-im/status-app#20327

Per-chain status was driven by polled `provider.IsConnected()` via `defer checkConnectionStatus(chainID)`. That flag ticks asynchronously from real requests, causing spurious 'collectibles is down' flips even while all calls succeed.

Switch the source of truth from poll to push using `circuitbreaker.CommandResult.FunctorCallStatuses()`. 


## Before

```mermaid
flowchart LR
    Fetch["Manager.Fetch*"] --> Exec["circuitBreaker.Execute"]
    Fetch --> Defer["defer checkConnectionStatus"]
    Defer --> Poll["provider.IsConnected() (async)"]
    Poll --> Statuses["o.statuses"]
    Statuses --> Event["wallet-collectible-status-changed"]
```

## After

```mermaid
flowchart LR
    Fetch["Manager.Fetch*"] --> Exec["circuitBreaker.Execute"]
    Exec --> Apply["applyCallStatuses(FunctorCallStatuses)"]
    Apply --> Statuses["o.statuses"]
    Statuses --> Event["wallet-collectible-status-changed (unchanged)"]
```


