### PR TITLE
fix(signal): fix incorrect comment for SendCommunityInfoFound function

### DIFF
--- a/signal/events_messenger.go
+++ b/signal/events_messenger.go
@@ -47,7 +47,7 @@ func SendMediaServerStarted(port int) {
 	send(EventMediaServerStarted, MediaServerStarted{Port: port})
 }
 
-// SendMessageDelivered notifies about delivered message
+// SendCommunityInfoFound notifies when community info is found
 func SendCommunityInfoFound(community interface{}) {
 	send(EventCommunityInfoFound, community)
 }


### PR DESCRIPTION
The comment for SendCommunityInfoFound was incorrectly copied from SendMessageDelivered. 

Updated it to accurately describe that the function notifies when community information is found, matching the actual function behavior and the EventCommunityInfoFound event.




Important changes:
- [x] Something worth noting for reviewers.

Closes #
