### PR TITLE
chore: setting up AdditionalAddressesForNativeToken for zkSync

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -101,7 +101,7 @@ require (
 	github.com/prometheus/client_model v0.6.1
 	github.com/schollz/peerdiscovery v1.7.0
 	github.com/status-im/extkeys v1.4.0
-	github.com/status-im/go-wallet-sdk v0.0.0-20260312164506-d7611e385cfd
+	github.com/status-im/go-wallet-sdk v0.0.0-20260428172609-d99313975e5c
 	github.com/waku-org/go-waku v0.10.2-0.20260421101052-de84ba47f9b0
 	github.com/waku-org/sds-go-bindings v0.0.0-20251222164514-d5b47a911904
 	github.com/wk8/go-ordered-map/v2 v2.1.7

--- a/go.sum
+++ b/go.sum
@@ -2286,8 +2286,8 @@ github.com/status-im/go-generate-fast v0.0.0-20250916164518-c78009bcfa9e h1:GV7a
 github.com/status-im/go-generate-fast v0.0.0-20250916164518-c78009bcfa9e/go.mod h1:iktiTcPdK+nuL47hn+7UL12uIkgJYyOAh99jdA6ruGw=
 github.com/status-im/go-sqlcipher/v4 v4.5.4-status.3 h1:/73h1w1hUfb3wVyTlNrUIwahZxatgesCHa6lwO57C2M=
 github.com/status-im/go-sqlcipher/v4 v4.5.4-status.3/go.mod h1:mF2UmIpBnzFeBdu/ypTDb/LdbS0nk0dfSN1WUsWTjMA=
-github.com/status-im/go-wallet-sdk v0.0.0-20260312164506-d7611e385cfd h1:5DY0vsA0TDn3zYkvTCvEzaAZWmTXuU6eYrn98t/7tEQ=
-github.com/status-im/go-wallet-sdk v0.0.0-20260312164506-d7611e385cfd/go.mod h1:E4E1D0mflc2pcjsutZpvMYSjI+a231uBHQf8UjdT1Ug=
+github.com/status-im/go-wallet-sdk v0.0.0-20260428172609-d99313975e5c h1:8lFggO3KQvtCX/nbNNtd+FVy8O2ZvpGwNKeodfvDtnc=
+github.com/status-im/go-wallet-sdk v0.0.0-20260428172609-d99313975e5c/go.mod h1:E4E1D0mflc2pcjsutZpvMYSjI+a231uBHQf8UjdT1Ug=
 github.com/status-im/gomoji v1.1.3-0.20220213022530-e5ac4a8732d4 h1:CtobZoiNdHpx+xurFxnuJ1xsGm3oKMfcZkB3vmomJmA=
 github.com/status-im/gomoji v1.1.3-0.20220213022530-e5ac4a8732d4/go.mod h1:hmpnZzkzSZJbFYWAUkrPV8I36x7mdYiPhPqnALP4fKA=
 github.com/status-im/goroutine-defer-guard v0.3.1 h1:cZhcJ3gO6OgMYBOfEaAAUZaZgKZeSzMlGNEjMyejuRo=

--- a/nix/pkgs/status-go/library/default.nix
+++ b/nix/pkgs/status-go/library/default.nix
@@ -11,7 +11,7 @@ let
 in pkgs.buildGoModule {
   pname = "status-go";
   src = builtins.path { path = ./../../../..; name = "status-go-library"; };
-  vendorHash = "sha256-0+QLuanbCpzl1Yfeo7hnpixUfhNKnUa81TO/mJfNe40=";
+  vendorHash = "sha256-IIuv1pePG8LO+qXL7STLbxxHepS2BGHCO5ORNjG37kk=";
 
   inherit meta version;
 

--- a/services/wallet/common/const.go
+++ b/services/wallet/common/const.go
@@ -137,6 +137,11 @@ const (
 	ContractTypeERC1155
 )
 
+// Based on documentation: https://docs.zksync.io/zk-stack/customizations/custom-base-tokens#custom-base-token-setup
+func ZkSyncETHTokenAddress() common.Address {
+	return common.HexToAddress("0x000000000000000000000000000000000000800a")
+}
+
 func ZeroAddress() common.Address {
 	return common.Address{}
 }

--- a/services/wallet/token/token.go
+++ b/services/wallet/token/token.go
@@ -239,6 +239,11 @@ func setUpTokenListsManager(mng *Manager, walletDB *sql.DB, enabledChains []uint
 		Chains: enabledChains,
 
 		SkippedTokenKeys: walletcommon.SkippedTokenKeys(),
+
+		AdditionalAddressesForNativeToken: map[uint64][]common.Address{
+			walletcommon.ZkSyncMainnet: {walletcommon.ZkSyncETHTokenAddress()},
+			walletcommon.ZkSyncSepolia: {walletcommon.ZkSyncETHTokenAddress()},
+		},
 	}
 
 	return manager.New(config, wsdkFetcher, contentStore, customTokenStore)


### PR DESCRIPTION
Add ZkSyncETHTokenAddress function for custom base token setup and provide it to the token manager.

Corresponding `go-wallet-sdk` PR:
- https://github.com/status-im/go-wallet-sdk/pull/42