### PR TITLE
fix(connector): parallel dapp requests races

### DIFF
--- a/services/connector/api.go
+++ b/services/connector/api.go
@@ -106,9 +106,10 @@ func NewAPI(s *Service) *API {
 	r.Register("wallet_switchEthereumChain", commands.NewSwitchEthereumChainCommand(s.db, s.nm))
 
 	// Permissions
-	r.Register("wallet_requestPermissions", commands.NewRequestPermissionsCommand(s.db))
+	r.Register("wallet_requestPermissions", commands.NewRequestPermissionsCommand(s.db, c))
 	r.Register("wallet_getPermissions", commands.NewGetPermissionsCommand(s.db))
 	r.Register("wallet_revokePermissions", commands.NewRevokePermissionsCommand(s.db, wcSessionDisconnector))
+	r.Register("wallet_getCapabilities", commands.NewGetCapabilitiesCommand())
 
 	changeAccountCommand := commands.NewChangeAccountCommand(s.db)
 

--- a/services/connector/api_test.go
+++ b/services/connector/api_test.go
@@ -102,6 +102,35 @@ func TestCallRPC_TrustedConnectionWithClientID(t *testing.T) {
 	require.NotNil(t, result)
 }
 
+func TestCallRPC_WalletGetCapabilities(t *testing.T) {
+	state := setupTests(t)
+	ctx := WithConnectionType(context.Background(), ConnectionTypeTrusted)
+
+	res, err := state.api.CallRPC(ctx, `{
+		"method": "wallet_getCapabilities",
+		"params": [],
+		"url": "https://example.com",
+		"name": "Example DApp",
+		"iconUrl": "https://example.com/icon.png",
+		"clientId": "status-desktop"
+	}`)
+	require.NoError(t, err)
+	m, ok := res.(map[string]any)
+	require.True(t, ok)
+	require.Empty(t, m)
+
+	_, err = state.api.CallRPC(ctx, `{
+		"method": "wallet_sendCalls",
+		"params": [],
+		"url": "https://example.com",
+		"name": "Example DApp",
+		"iconUrl": "https://example.com/icon.png",
+		"clientId": "status-desktop"
+	}`)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "not allowed")
+}
+
 func TestChangeAccount_UntrustedConnection(t *testing.T) {
 	state := setupTests(t)
 

--- a/services/connector/commands/accounts.go
+++ b/services/connector/commands/accounts.go
@@ -39,5 +39,13 @@ func (c *AccountsCommand) Execute(ctx context.Context, request RPCRequest) (inte
 		return []string{}, nil
 	}
 
+	has, err := persistence.PermissionExists(c.db, request.URL, request.ClientID, Method_EthAccounts)
+	if err != nil {
+		return "", err
+	}
+	if !has {
+		return []string{}, nil
+	}
+
 	return FormatAccountAddressToResponse(dApp.SharedAccount), nil
 }

--- a/services/connector/commands/accounts_test.go
+++ b/services/connector/commands/accounts_test.go
@@ -2,10 +2,12 @@ package commands
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 
 	"github.com/status-im/status-go/internal/crypto/types"
+	persistence "github.com/status-im/status-go/services/connector/database"
 )
 
 func TestFailToGetAccountWithMissingDAppFields(t *testing.T) {
@@ -40,6 +42,8 @@ func TestGetAccountForPermittedDApp(t *testing.T) {
 	sharedAccount := types.HexToAddress("0x6d0aa2a774b74bb1d36f97700315adf962c69fcg")
 
 	err := PersistDAppData(state.walletDb, testDAppData, sharedAccount, 0x123)
+	assert.NoError(t, err)
+	err = persistence.InsertPermission(state.walletDb, testDAppData.URL, testDAppData.ClientID, Method_EthAccounts, []persistence.Caveat{}, time.Now().Unix())
 	assert.NoError(t, err)
 
 	request, err := ConstructRPCRequest("eth_accounts", []interface{}{}, &testDAppData)

--- a/services/connector/commands/client_handler.go
+++ b/services/connector/commands/client_handler.go
@@ -7,6 +7,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -45,11 +46,19 @@ type Message struct {
 	Data interface{}
 }
 
+type sharePendingKey struct {
+	normalizedURL string
+	clientID      string
+}
+
 type ClientSideHandler struct {
 	Db                    *sql.DB
 	wcSessionDisconnector WCSessionDisconnector
 	responseChannel       chan Message
 	isRequestRunning      int32
+
+	sharePendingMu sync.Mutex
+	sharePending   map[sharePendingKey]chan struct{}
 }
 
 func NewClientSideHandler(db *sql.DB, wcClient *walletconnect.Client) *ClientSideHandler {
@@ -58,6 +67,63 @@ func NewClientSideHandler(db *sql.DB, wcClient *walletconnect.Client) *ClientSid
 		wcSessionDisconnector: NewWCSessionDisconnector(db, wcClient),
 		responseChannel:       make(chan Message, 1),
 		isRequestRunning:      0,
+		sharePending:          make(map[sharePendingKey]chan struct{}),
+	}
+}
+
+func (c *ClientSideHandler) sharePendingKey(url, clientID string) sharePendingKey {
+	return sharePendingKey{
+		normalizedURL: persistence.NormalizeURL(url),
+		clientID:      clientID,
+	}
+}
+
+// BeginPendingShareAccount marks that a share-account flow is in progress for this origin.
+// Called from shareAndUpsertDApp before RequestShareAccountForDApp; End runs after UpsertDApp.
+// At most one pending entry exists per (url, clientID) without ref-counting.
+func (c *ClientSideHandler) BeginPendingShareAccount(url, clientID string) {
+	key := c.sharePendingKey(url, clientID)
+	c.sharePendingMu.Lock()
+	defer c.sharePendingMu.Unlock()
+	if _, exists := c.sharePending[key]; exists {
+		return
+	}
+	c.sharePending[key] = make(chan struct{})
+}
+
+// EndPendingShareAccount clears the pending marker after the flow finished (including DB persist).
+func (c *ClientSideHandler) EndPendingShareAccount(url, clientID string) {
+	key := c.sharePendingKey(url, clientID)
+	c.sharePendingMu.Lock()
+	done, ok := c.sharePending[key]
+	if ok {
+		delete(c.sharePending, key)
+	}
+	c.sharePendingMu.Unlock()
+	if ok {
+		close(done)
+	}
+}
+
+// WaitForPendingShareAccount blocks until there is no in-flight share flow for this origin, or ctx is cancelled.
+// Returns true if a pending share entry was observed (the call may have blocked on it).
+func (c *ClientSideHandler) WaitForPendingShareAccount(ctx context.Context, url, clientID string) bool {
+	key := c.sharePendingKey(url, clientID)
+	sawPending := false
+	for {
+		c.sharePendingMu.Lock()
+		done := c.sharePending[key]
+		c.sharePendingMu.Unlock()
+		if done == nil {
+			return sawPending
+		}
+		sawPending = true
+		select {
+		case <-ctx.Done():
+			return sawPending
+		case <-done:
+			return sawPending
+		}
 	}
 }
 

--- a/services/connector/commands/get_capabilities_command.go
+++ b/services/connector/commands/get_capabilities_command.go
@@ -1,0 +1,19 @@
+package commands
+
+import (
+	"context"
+)
+
+// GetCapabilitiesCommand implements wallet_getCapabilities (EIP-5792) as an empty capabilities map.
+type GetCapabilitiesCommand struct{}
+
+func NewGetCapabilitiesCommand() *GetCapabilitiesCommand {
+	return &GetCapabilitiesCommand{}
+}
+
+func (*GetCapabilitiesCommand) Execute(ctx context.Context, request RPCRequest) (interface{}, error) {
+	if err := request.Validate(); err != nil {
+		return "", err
+	}
+	return map[string]any{}, nil
+}

--- a/services/connector/commands/get_capabilities_command_test.go
+++ b/services/connector/commands/get_capabilities_command_test.go
@@ -1,0 +1,22 @@
+package commands
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetCapabilitiesCommand(t *testing.T) {
+	cmd := NewGetCapabilitiesCommand()
+	_, err := cmd.Execute(context.Background(), RPCRequest{})
+	require.ErrorIs(t, err, ErrRequestMissingDAppData)
+
+	out, err := cmd.Execute(context.Background(), RPCRequest{
+		URL: testDAppData.URL, Name: testDAppData.Name, IconURL: testDAppData.IconURL,
+	})
+	require.NoError(t, err)
+	m, ok := out.(map[string]any)
+	require.True(t, ok)
+	require.Empty(t, m)
+}

--- a/services/connector/commands/request_accounts.go
+++ b/services/connector/commands/request_accounts.go
@@ -39,29 +39,17 @@ func (c *RequestAccountsCommand) Execute(ctx context.Context, request RPCRequest
 		return "", err
 	}
 
-	// FIXME: this may have a security issue in case some malicious software tries to fake the origin
-	if dApp == nil {
-		connectorDApp := signal.ConnectorDApp{
-			URL:      request.URL,
-			Name:     request.Name,
-			IconURL:  request.IconURL,
-			ClientID: request.ClientID,
-		}
-		account, chainID, err := c.clientHandler.RequestShareAccountForDApp(connectorDApp)
+	hasEthAccounts := false
+	if dApp != nil {
+		hasEthAccounts, err = persistence.PermissionExists(c.db, request.URL, request.ClientID, Method_EthAccounts)
 		if err != nil {
 			return "", err
 		}
+	}
 
-		dApp = &persistence.DApp{
-			URL:           request.URL,
-			Name:          request.Name,
-			IconURL:       request.IconURL,
-			ClientID:      request.ClientID,
-			SharedAccount: account,
-			ChainID:       chainID,
-		}
-
-		err = persistence.UpsertDApp(c.db, dApp)
+	// FIXME: this may have a security issue in case some malicious software tries to fake the origin
+	if dApp == nil || !hasEthAccounts {
+		dApp, err = shareAndUpsertDApp(c.db, c.clientHandler, request)
 		if err != nil {
 			return "", err
 		}
@@ -74,7 +62,7 @@ func (c *RequestAccountsCommand) Execute(ctx context.Context, request RPCRequest
 			return "", err
 		}
 
-		signal.SendConnectorDAppPermissionGranted(connectorDApp, account, []uint64{chainID})
+		signal.SendConnectorDAppPermissionGranted(connectorDAppFromRequest(request), dApp.SharedAccount, []uint64{dApp.ChainID})
 	}
 
 	return FormatAccountAddressToResponse(dApp.SharedAccount), nil

--- a/services/connector/commands/request_accounts_test.go
+++ b/services/connector/commands/request_accounts_test.go
@@ -143,6 +143,8 @@ func TestRequestAccountsWithExistingDApp(t *testing.T) {
 	}
 	err := persistence.UpsertDApp(state.walletDb, dApp)
 	assert.NoError(t, err)
+	err = persistence.InsertPermission(state.walletDb, testDAppData.URL, testDAppData.ClientID, Method_EthAccounts, []persistence.Caveat{}, time.Now().Unix())
+	assert.NoError(t, err)
 
 	request, err := ConstructRPCRequest("eth_requestAccounts", []interface{}{}, &testDAppData)
 	assert.NoError(t, err)

--- a/services/connector/commands/request_permissions.go
+++ b/services/connector/commands/request_permissions.go
@@ -7,15 +7,18 @@ import (
 	"time"
 
 	persistence "github.com/status-im/status-go/services/connector/database"
+	"github.com/status-im/status-go/signal"
 )
 
 type RequestPermissionsCommand struct {
-	db *sql.DB
+	db            *sql.DB
+	clientHandler ClientSideHandlerInterface
 }
 
-func NewRequestPermissionsCommand(db *sql.DB) *RequestPermissionsCommand {
+func NewRequestPermissionsCommand(db *sql.DB, clientHandler ClientSideHandlerInterface) *RequestPermissionsCommand {
 	return &RequestPermissionsCommand{
-		db: db,
+		db:            db,
+		clientHandler: clientHandler,
 	}
 }
 
@@ -74,6 +77,15 @@ func (c *RequestPermissionsCommand) getPermissionResponse(url string, methodName
 	}
 }
 
+func findCapability(perms []persistence.Permission, methodName string) ([]persistence.Caveat, bool) {
+	for i := range perms {
+		if perms[i].ParentCapability == methodName {
+			return perms[i].Caveats, true
+		}
+	}
+	return nil, false
+}
+
 func (c *RequestPermissionsCommand) Execute(ctx context.Context, request RPCRequest) (interface{}, error) {
 	err := request.Validate()
 	if err != nil {
@@ -91,10 +103,36 @@ func (c *RequestPermissionsCommand) Execute(ctx context.Context, request RPCRequ
 	if err != nil {
 		return "", err
 	}
+	waitedInFlightShare := false
+	if dApp == nil && c.clientHandler != nil {
+		waitedInFlightShare = c.clientHandler.WaitForPendingShareAccount(ctx, request.URL, request.ClientID)
+		dApp, err = persistence.SelectDApp(c.db, request.URL, request.ClientID)
+		if err != nil {
+			return "", err
+		}
+	}
+
+	// Auto-share only when the caller identifies with clientId (trusted in-process desktop). Untrusted
+	// HTTP callers never have ClientID (API strips/forbids it); parallel tests may finish eth_requestAccounts
+	// before we observe pending, so skipping auto-share avoids a second blocking share after reject.
+	autoShared := false
+	if dApp == nil && methodName == "eth_accounts" && !waitedInFlightShare && request.ClientID != "" {
+		dApp, err = shareAndUpsertDApp(c.db, c.clientHandler, request)
+		if err != nil {
+			return "", err
+		}
+		autoShared = true
+	}
 
 	if dApp == nil {
 		return "", ErrDAppNotFound
 	}
+
+	permsBefore, err := persistence.SelectPermissions(c.db, request.URL, request.ClientID)
+	if err != nil {
+		return "", err
+	}
+	existingCaveats, hadCapability := findCapability(permsBefore, methodName)
 
 	createdAt := time.Now().Unix()
 	err = persistence.InsertPermission(c.db, request.URL, request.ClientID, methodName, caveats, createdAt)
@@ -102,6 +140,16 @@ func (c *RequestPermissionsCommand) Execute(ctx context.Context, request RPCRequ
 		return "", err
 	}
 
-	// EIP-2255 - wallet_requestPermissions returns an array
-	return []persistence.Permission{c.getPermissionResponse(request.URL, methodName, caveats)}, nil
+	responseCaveats := caveats
+	if hadCapability {
+		responseCaveats = existingCaveats
+	}
+
+	// Notify UI after trusted auto-share created the dApp row (no prior eth_accounts permission existed).
+	if autoShared {
+		signal.SendConnectorDAppPermissionGranted(connectorDAppFromRequest(request), dApp.SharedAccount, []uint64{dApp.ChainID})
+	}
+
+	// EIP-2255 — return persisted caveats (InsertPermission is a no-op when row already exists).
+	return []persistence.Permission{c.getPermissionResponse(request.URL, methodName, responseCaveats)}, nil
 }

--- a/services/connector/commands/request_permissions_autoshare_test.go
+++ b/services/connector/commands/request_permissions_autoshare_test.go
@@ -1,0 +1,126 @@
+package commands
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	types2 "github.com/status-im/status-go/internal/crypto/types"
+	persistence "github.com/status-im/status-go/services/connector/database"
+	walletCommon "github.com/status-im/status-go/services/wallet/common"
+	"github.com/status-im/status-go/signal"
+)
+
+type overrideRequestShareHandler struct {
+	*ClientSideHandler
+	shareFn func(dApp signal.ConnectorDApp) (types2.Address, uint64, error)
+}
+
+func (o *overrideRequestShareHandler) RequestShareAccountForDApp(dApp signal.ConnectorDApp) (types2.Address, uint64, error) {
+	if o.shareFn != nil {
+		return o.shareFn(dApp)
+	}
+	return o.ClientSideHandler.RequestShareAccountForDApp(dApp)
+}
+
+func TestRequestPermissions_AutoShareWhenNoDApp(t *testing.T) {
+	rejectErr := errors.New("user dismissed share")
+	acc := types2.BytesToAddress(types2.FromHex("0x00000000000000000000000000000000000000a1"))
+
+	tests := []struct {
+		name             string
+		autoURL          string
+		clientID         string
+		shareFn          func(dApp signal.ConnectorDApp) (types2.Address, uint64, error)
+		wantGrantSignals int
+		wantDApp         bool
+		wantErr          error
+	}{
+		{
+			name:     "accept creates dapp and emits one grant",
+			autoURL:  "https://perm-autoshare-no-pending.test",
+			clientID: "status-desktop/dapp-browser",
+			shareFn: func(dApp signal.ConnectorDApp) (types2.Address, uint64, error) {
+				require.Equal(t, "https://perm-autoshare-no-pending.test", dApp.URL)
+				return acc, walletCommon.EthereumMainnet, nil
+			},
+			wantGrantSignals: 1,
+			wantDApp:         true,
+		},
+		{
+			name:     "reject propagates error and leaves no dapp",
+			autoURL:  "https://perm-autoshare-reject.test",
+			clientID: "c1",
+			shareFn: func(dApp signal.ConnectorDApp) (types2.Address, uint64, error) {
+				return types2.Address{}, 0, rejectErr
+			},
+			wantGrantSignals: 0,
+			wantDApp:         false,
+			wantErr:          rejectErr,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			state, closeFn := setupCommand(t, Method_RequestPermissions)
+			t.Cleanup(closeFn)
+
+			base := NewClientSideHandler(state.db, nil)
+			h := &overrideRequestShareHandler{ClientSideHandler: base, shareFn: tt.shareFn}
+			cmd := NewRequestPermissionsCommand(state.walletDb, h)
+
+			dAppSignal := signal.ConnectorDApp{
+				URL:      tt.autoURL,
+				Name:     "n",
+				IconURL:  "http://icon",
+				ClientID: tt.clientID,
+			}
+			params := []interface{}{map[string]interface{}{"eth_accounts": map[string]interface{}{}}}
+			req, err := ConstructRPCRequest(Method_RequestPermissions, params, &dAppSignal)
+			require.NoError(t, err)
+
+			var permissionGranted int
+			signal.SetMobileSignalHandler(signal.MobileSignalHandler(func(s []byte) {
+				var evt EventType
+				if err := json.Unmarshal(s, &evt); err != nil {
+					return
+				}
+				if evt.Type == signal.EventConnectorDAppPermissionGranted {
+					permissionGranted++
+				}
+			}))
+			t.Cleanup(signal.ResetMobileSignalHandler)
+
+			out, err := cmd.Execute(context.Background(), req)
+			if tt.wantErr != nil {
+				require.ErrorIs(t, err, tt.wantErr)
+				require.Equal(t, "", out)
+			} else {
+				require.NoError(t, err)
+				perms, ok := out.([]persistence.Permission)
+				require.True(t, ok)
+				require.Len(t, perms, 1)
+				require.Equal(t, persistence.NormalizeURL(tt.autoURL), perms[0].Invoker)
+				require.Equal(t, "eth_accounts", perms[0].ParentCapability)
+			}
+
+			dApp, err := persistence.SelectDApp(state.walletDb, tt.autoURL, tt.clientID)
+			require.NoError(t, err)
+			if tt.wantDApp {
+				require.NotNil(t, dApp)
+				require.Equal(t, acc, dApp.SharedAccount)
+				require.Equal(t, walletCommon.EthereumMainnet, dApp.ChainID)
+				dbPerms, err := persistence.SelectPermissions(state.walletDb, tt.autoURL, tt.clientID)
+				require.NoError(t, err)
+				require.Len(t, dbPerms, 1)
+				require.Equal(t, "eth_accounts", dbPerms[0].ParentCapability)
+			} else {
+				require.Nil(t, dApp)
+			}
+			require.Equal(t, tt.wantGrantSignals, permissionGranted)
+		})
+	}
+}

--- a/services/connector/commands/request_permissions_test.go
+++ b/services/connector/commands/request_permissions_test.go
@@ -198,10 +198,10 @@ func TestRequestPermissionsNoDAppFound(t *testing.T) {
 	state, close := setupCommand(t, Method_RequestPermissions)
 	t.Cleanup(close)
 
-	// Don't create a dApp, so it will fail with ErrDAppNotFound
+	// No dApp row: eth_accounts would auto-share (UI flow); use another capability to assert ErrDAppNotFound.
 	params := []interface{}{
 		map[string]interface{}{
-			"eth_accounts": struct{}{},
+			"personal_sign": map[string]interface{}{},
 		},
 	}
 

--- a/services/connector/commands/revoke_permissions.go
+++ b/services/connector/commands/revoke_permissions.go
@@ -20,6 +20,51 @@ func NewRevokePermissionsCommand(db *sql.DB, wcSessionDisconnector WCSessionDisc
 	}
 }
 
+// parseWalletRevokeParams mirrors EIP-2255-style params: [{ "eth_accounts": {} }, ...] or one or more maps
+// with capability keys. Empty params slice means full disconnect (legacy behaviour). All-empty maps
+// (e.g. [{}] or [{}, {}]) also mean full revoke. Any nil or non-map element is invalid.
+func parseWalletRevokeParams(params []interface{}) (fullRevoke bool, capabilities []string, err error) {
+	if len(params) == 0 {
+		return true, nil, nil
+	}
+	for _, p := range params {
+		if p == nil {
+			return false, nil, ErrInvalidParamType
+		}
+		m, ok := p.(map[string]interface{})
+		if !ok {
+			return false, nil, ErrInvalidParamType
+		}
+		for cap := range m {
+			capabilities = append(capabilities, cap)
+		}
+	}
+	if len(capabilities) == 0 {
+		return true, nil, nil
+	}
+	return false, capabilities, nil
+}
+
+func (c *RevokePermissionsCommand) fullRevoke(ctx context.Context, request RPCRequest, dApp *persistence.DApp) (interface{}, error) {
+	if c.wcSessionDisconnector != nil && dApp.ClientID == persistence.WCClientID {
+		sessions, err := persistence.SelectWCSessionsByDAppURL(c.db, dApp.URL)
+		if err == nil && len(sessions) > 0 {
+			for _, session := range sessions {
+				_ = c.wcSessionDisconnector.DisconnectSession(ctx, session.Topic)
+			}
+		}
+	}
+
+	err := persistence.DeleteDApp(c.db, dApp.URL, dApp.ClientID)
+	if err != nil {
+		return "", err
+	}
+
+	signal.SendConnectorDAppPermissionRevoked(connectorDAppFromRequest(request))
+
+	return nil, nil
+}
+
 func (c *RevokePermissionsCommand) Execute(ctx context.Context, request RPCRequest) (interface{}, error) {
 	err := request.Validate()
 	if err != nil {
@@ -35,27 +80,27 @@ func (c *RevokePermissionsCommand) Execute(ctx context.Context, request RPCReque
 		return "", ErrDAppIsNotPermittedByUser
 	}
 
-	// If this is a WalletConnect DApp, disconnect all WC sessions first
-	if c.wcSessionDisconnector != nil && dApp.ClientID == persistence.WCClientID {
-		sessions, err := persistence.SelectWCSessionsByDAppURL(c.db, dApp.URL)
-		if err == nil && len(sessions) > 0 {
-			for _, session := range sessions {
-				_ = c.wcSessionDisconnector.DisconnectSession(ctx, session.Topic)
-			}
-		}
+	// WalletConnect sessions are keyed to the whole dApp row; keep full teardown only.
+	if dApp.ClientID == persistence.WCClientID {
+		return c.fullRevoke(ctx, request, dApp)
 	}
 
-	err = persistence.DeleteDApp(c.db, dApp.URL, dApp.ClientID)
+	fullRevoke, caps, err := parseWalletRevokeParams(request.Params)
 	if err != nil {
 		return "", err
 	}
+	if fullRevoke {
+		return c.fullRevoke(ctx, request, dApp)
+	}
 
-	signal.SendConnectorDAppPermissionRevoked(signal.ConnectorDApp{
-		URL:      request.URL,
-		Name:     request.Name,
-		IconURL:  request.IconURL,
-		ClientID: request.ClientID,
-	})
+	for _, cap := range caps {
+		if err := persistence.DeletePermission(c.db, dApp.URL, dApp.ClientID, cap); err != nil {
+			return "", err
+		}
+	}
 
+	// Intentionally keep the connector_dapps row when params name specific capabilities (e.g. Velora's
+	// wallet_revokePermissions [{"eth_accounts":{}}]) so forwarded chain RPCs still work; use empty
+	// params for a full disconnect (DeleteDApp + ConnectorDAppPermissionRevoked).
 	return nil, nil
 }

--- a/services/connector/commands/revoke_permissions_test.go
+++ b/services/connector/commands/revoke_permissions_test.go
@@ -3,6 +3,7 @@ package commands
 import (
 	"encoding/json"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 
@@ -10,6 +11,21 @@ import (
 	persistence "github.com/status-im/status-go/services/connector/database"
 	"github.com/status-im/status-go/signal"
 )
+
+func trackRevokedSignal(t *testing.T) *bool {
+	t.Helper()
+	revoked := false
+	signal.SetMobileSignalHandler(signal.MobileSignalHandler(func(s []byte) {
+		var evt EventType
+		err := json.Unmarshal(s, &evt)
+		assert.NoError(t, err)
+		if evt.Type == signal.EventConnectorDAppPermissionRevoked {
+			revoked = true
+		}
+	}))
+	t.Cleanup(signal.ResetMobileSignalHandler)
+	return &revoked
+}
 
 func TestFailToRevokePermissionsWithMissingDAppFields(t *testing.T) {
 	state, close := setupCommand(t, Method_RevokePermissions)
@@ -40,7 +56,7 @@ func TestRevokePermissionsSucceeded(t *testing.T) {
 	state, close := setupCommand(t, Method_RevokePermissions)
 	t.Cleanup(close)
 
-	sharedAccount := types2.BytesToAddress(types2.FromHex("0x6d0aa2a774b74bb1d36f97700315adf962c69fcg"))
+	sharedAccount := types2.BytesToAddress(types2.FromHex("0x6d0aa2a774b74bb1d36f97700315adf962c69fcf"))
 	dAppPermissionRevoked := false
 
 	signal.SetMobileSignalHandler(signal.MobileSignalHandler(func(s []byte) {
@@ -76,7 +92,7 @@ func TestRevokePermissionsDeletesWCSessions(t *testing.T) {
 	state, close := setupCommand(t, Method_RevokePermissions)
 	t.Cleanup(close)
 
-	sharedAccount := types2.BytesToAddress(types2.FromHex("0x6d0aa2a774b74bb1d36f97700315adf962c69fcg"))
+	sharedAccount := types2.BytesToAddress(types2.FromHex("0x6d0aa2a774b74bb1d36f97700315adf962c69fcf"))
 	wcDAppData := signal.ConnectorDApp{
 		URL:      "https://wc-test-dapp.com",
 		Name:     "WC Test DApp",
@@ -125,4 +141,117 @@ func TestRevokePermissionsDeletesWCSessions(t *testing.T) {
 	session2, err := persistence.SelectWCSession(state.walletDb, "topic2")
 	assert.NoError(t, err)
 	assert.Nil(t, session2)
+}
+
+func TestRevokePermissions_TargetedEthAccounts_KeepsDApp_NoRevokedSignal(t *testing.T) {
+	tests := []struct {
+		name         string
+		insertedPerm []string
+		expectedPerm []string
+	}{
+		{
+			name:         "keeps non-revoked permissions",
+			insertedPerm: []string{"eth_accounts", "personal_sign"},
+			expectedPerm: []string{"personal_sign"},
+		},
+		{
+			name:         "removes only permission when single capability exists",
+			insertedPerm: []string{"eth_accounts"},
+			expectedPerm: []string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			state, close := setupCommand(t, Method_RevokePermissions)
+			t.Cleanup(close)
+
+			sharedAccount := types2.BytesToAddress(types2.FromHex("0x6d0aa2a774b74bb1d36f97700315adf962c69fcf"))
+			revoked := trackRevokedSignal(t)
+
+			err := PersistDAppData(state.walletDb, testDAppData, sharedAccount, 0x123)
+			assert.NoError(t, err)
+			for i, perm := range tt.insertedPerm {
+				err = persistence.InsertPermission(state.walletDb, testDAppData.URL, testDAppData.ClientID, perm, []persistence.Caveat{}, time.Now().Unix()+int64(i))
+				assert.NoError(t, err)
+			}
+
+			params := []interface{}{
+				map[string]interface{}{
+					"eth_accounts": map[string]interface{}{},
+				},
+			}
+			request, err := ConstructRPCRequest("wallet_revokePermissions", params, &testDAppData)
+			assert.NoError(t, err)
+
+			_, err = state.cmd.Execute(state.ctx, request)
+			assert.NoError(t, err)
+
+			dApp, err := persistence.SelectDApp(state.walletDb, testDAppData.URL, testDAppData.ClientID)
+			assert.NoError(t, err)
+			assert.NotNil(t, dApp)
+
+			perms, err := persistence.SelectPermissions(state.walletDb, testDAppData.URL, testDAppData.ClientID)
+			assert.NoError(t, err)
+			assert.Len(t, perms, len(tt.expectedPerm))
+			actualPerms := make([]string, 0, len(perms))
+			for _, perm := range perms {
+				actualPerms = append(actualPerms, perm.ParentCapability)
+			}
+			assert.ElementsMatch(t, tt.expectedPerm, actualPerms)
+			assert.False(t, *revoked)
+		})
+	}
+}
+
+func TestRevokePermissions_MultiElementParams_RemovesAllCapabilities(t *testing.T) {
+	state, close := setupCommand(t, Method_RevokePermissions)
+	t.Cleanup(close)
+
+	sharedAccount := types2.BytesToAddress(types2.FromHex("0x6d0aa2a774b74bb1d36f97700315adf962c69fcf"))
+	revoked := trackRevokedSignal(t)
+
+	err := PersistDAppData(state.walletDb, testDAppData, sharedAccount, 0x123)
+	assert.NoError(t, err)
+	err = persistence.InsertPermission(state.walletDb, testDAppData.URL, testDAppData.ClientID, "eth_accounts", []persistence.Caveat{}, time.Now().Unix())
+	assert.NoError(t, err)
+	err = persistence.InsertPermission(state.walletDb, testDAppData.URL, testDAppData.ClientID, "personal_sign", []persistence.Caveat{}, time.Now().Unix()+1)
+	assert.NoError(t, err)
+
+	params := []interface{}{
+		map[string]interface{}{"eth_accounts": map[string]interface{}{}},
+		map[string]interface{}{"personal_sign": map[string]interface{}{}},
+	}
+	request, err := ConstructRPCRequest("wallet_revokePermissions", params, &testDAppData)
+	assert.NoError(t, err)
+
+	_, err = state.cmd.Execute(state.ctx, request)
+	assert.NoError(t, err)
+
+	dApp, err := persistence.SelectDApp(state.walletDb, testDAppData.URL, testDAppData.ClientID)
+	assert.NoError(t, err)
+	assert.NotNil(t, dApp)
+
+	perms, err := persistence.SelectPermissions(state.walletDb, testDAppData.URL, testDAppData.ClientID)
+	assert.NoError(t, err)
+	assert.Empty(t, perms)
+	assert.False(t, *revoked)
+}
+
+func TestRevokePermissions_InvalidParamsType(t *testing.T) {
+	state, close := setupCommand(t, Method_RevokePermissions)
+	t.Cleanup(close)
+
+	sharedAccount := types2.BytesToAddress(types2.FromHex("0x6d0aa2a774b74bb1d36f97700315adf962c69fcf"))
+	err := PersistDAppData(state.walletDb, testDAppData, sharedAccount, 0x123)
+	assert.NoError(t, err)
+	err = persistence.InsertPermission(state.walletDb, testDAppData.URL, testDAppData.ClientID, "eth_accounts", []persistence.Caveat{}, time.Now().Unix())
+	assert.NoError(t, err)
+
+	request, err := ConstructRPCRequest("wallet_revokePermissions", []interface{}{"not-a-map"}, &testDAppData)
+	assert.NoError(t, err)
+
+	_, err = state.cmd.Execute(state.ctx, request)
+	assert.Error(t, err)
+	assert.Equal(t, ErrInvalidParamType, err)
 }

--- a/services/connector/commands/rpc_traits.go
+++ b/services/connector/commands/rpc_traits.go
@@ -91,6 +91,12 @@ type ClientSideHandlerInterface interface {
 	RequestSign(dApp signal.ConnectorDApp, challenge, address string, method string) (string, error)
 	SignAccepted(args SignAcceptedArgs) error
 	SignRejected(args RejectedArgs) error
+
+	// BeginPendingShareAccount / EndPendingShareAccount bracket shareAndUpsertDApp (UI wait + UpsertDApp).
+	// wallet_requestPermissions uses WaitForPendingShareAccount to avoid racing ahead of that commit.
+	BeginPendingShareAccount(url, clientID string)
+	EndPendingShareAccount(url, clientID string)
+	WaitForPendingShareAccount(ctx context.Context, url, clientID string) bool
 }
 
 type NetworkManagerInterface interface {

--- a/services/connector/commands/share_flow.go
+++ b/services/connector/commands/share_flow.go
@@ -1,0 +1,46 @@
+package commands
+
+import (
+	"database/sql"
+
+	persistence "github.com/status-im/status-go/services/connector/database"
+	"github.com/status-im/status-go/signal"
+)
+
+func connectorDAppFromRequest(request RPCRequest) signal.ConnectorDApp {
+	return signal.ConnectorDApp{
+		URL:      request.URL,
+		Name:     request.Name,
+		IconURL:  request.IconURL,
+		ClientID: request.ClientID,
+	}
+}
+
+// shareAndUpsertDApp runs the connector share-account UI flow and persists the dApp row.
+// It does not insert EIP-2255 permission rows or emit ConnectorDAppPermissionGranted; callers do that.
+// Begin/EndPendingShareAccount bracket the UI wait and UpsertDApp so parallel wallet_requestPermissions
+// does not observe an empty DB row after the wait unblocks.
+func shareAndUpsertDApp(db *sql.DB, h ClientSideHandlerInterface, request RPCRequest) (*persistence.DApp, error) {
+	h.BeginPendingShareAccount(request.URL, request.ClientID)
+	defer h.EndPendingShareAccount(request.URL, request.ClientID)
+
+	connectorDApp := connectorDAppFromRequest(request)
+	account, chainID, err := h.RequestShareAccountForDApp(connectorDApp)
+	if err != nil {
+		return nil, err
+	}
+
+	dApp := &persistence.DApp{
+		URL:           request.URL,
+		Name:          request.Name,
+		IconURL:       request.IconURL,
+		ClientID:      request.ClientID,
+		SharedAccount: account,
+		ChainID:       chainID,
+	}
+
+	if err := persistence.UpsertDApp(db, dApp); err != nil {
+		return nil, err
+	}
+	return dApp, nil
+}

--- a/services/connector/commands/test_helpers.go
+++ b/services/connector/commands/test_helpers.go
@@ -111,7 +111,7 @@ func setupCommand(t *testing.T, method string) (state testState, close func()) {
 	case Method_EthSendTransaction:
 		state.cmd = NewSendTransactionCommand(state.walletDb, state.ethClientGetter, state.feeManager, state.handler)
 	case Method_RequestPermissions:
-		state.cmd = NewRequestPermissionsCommand(state.walletDb)
+		state.cmd = NewRequestPermissionsCommand(state.walletDb, state.handler)
 	case Method_RevokePermissions:
 		state.cmd = NewRevokePermissionsCommand(state.walletDb, wcSessionDisconnector)
 	case Method_SwitchEthereumChain:

--- a/services/connector/database/persistence.go
+++ b/services/connector/database/persistence.go
@@ -22,6 +22,7 @@ const insertPermissionQuery = "INSERT INTO connector_permissions (url, client_id
 const selectPermissionsQuery = "SELECT parent_capability, caveats FROM connector_permissions WHERE url = ? AND client_id = ?"
 const selectPermissionExistsQuery = "SELECT COUNT(*) FROM connector_permissions WHERE url = ? AND client_id = ? AND parent_capability = ?"
 const deletePermissionsQuery = "DELETE FROM connector_permissions WHERE url = ? AND client_id = ?"
+const deletePermissionQuery = "DELETE FROM connector_permissions WHERE url = ? AND client_id = ? AND parent_capability = ?"
 
 type DApp struct {
 	URL           string        `json:"url"`
@@ -152,6 +153,24 @@ func DeletePermissions(db *sql.DB, url string, clientID string) error {
 	normalizedURL := NormalizeURL(url)
 	_, err := db.Exec(deletePermissionsQuery, normalizedURL, clientID)
 	return err
+}
+
+// DeletePermission removes a single EIP-2255 capability row for the dApp.
+func DeletePermission(db *sql.DB, url string, clientID string, parentCapability string) error {
+	normalizedURL := NormalizeURL(url)
+	_, err := db.Exec(deletePermissionQuery, normalizedURL, clientID, parentCapability)
+	return err
+}
+
+// PermissionExists reports whether a parent_capability row exists for the origin.
+func PermissionExists(db *sql.DB, url string, clientID string, parentCapability string) (bool, error) {
+	normalizedURL := NormalizeURL(url)
+	var count int
+	err := db.QueryRow(selectPermissionExistsQuery, normalizedURL, clientID, parentCapability).Scan(&count)
+	if err != nil {
+		return false, err
+	}
+	return count > 0, nil
 }
 
 const (

--- a/services/connector/request_permissions_concurrency_test.go
+++ b/services/connector/request_permissions_concurrency_test.go
@@ -1,0 +1,172 @@
+package connector
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	types2 "github.com/status-im/status-go/internal/crypto/types"
+	"github.com/status-im/status-go/services/connector/commands"
+	persistence "github.com/status-im/status-go/services/connector/database"
+	"github.com/status-im/status-go/signal"
+)
+
+var concurrencyTestAccountAddress = types2.BytesToAddress(types2.FromHex("0x0000000000000000000000000000000000000001"))
+
+func recvRequestIDOrFatal(t *testing.T, ch <-chan string) string {
+	t.Helper()
+	timer := time.NewTimer(2 * time.Second)
+	defer timer.Stop()
+	select {
+	case rid := <-ch:
+		require.NotEmpty(t, rid)
+		return rid
+	case <-timer.C:
+	}
+	t.Fatal("timed out waiting for ConnectorSendRequestAccounts signal request ID")
+	return ""
+}
+
+func setupRequestAccountsRequestIDChan(t *testing.T) <-chan string {
+	t.Helper()
+	requestIDCh := make(chan string, 1)
+	signal.SetMobileSignalHandler(signal.MobileSignalHandler(func(s []byte) {
+		var evt commands.EventType
+		if err := json.Unmarshal(s, &evt); err != nil || evt.Type != signal.EventConnectorSendRequestAccounts {
+			return
+		}
+		var ev signal.ConnectorSendRequestAccountsSignal
+		if err := json.Unmarshal(evt.Event, &ev); err != nil {
+			return
+		}
+		select {
+		case requestIDCh <- ev.RequestID:
+		default:
+		}
+	}))
+	t.Cleanup(signal.ResetMobileSignalHandler)
+	return requestIDCh
+}
+
+func requestPermissionsReq(url, clientID, capability string) string {
+	clientIDJSON := ""
+	if clientID != "" {
+		clientIDJSON = `,"clientId":"` + clientID + `"`
+	}
+	return `{"jsonrpc":"2.0","id":2,"method":"wallet_requestPermissions","params":[{"` + capability + `":{}}],"url":"` + url + `","name":"n","iconUrl":"http://i"` + clientIDJSON + `}`
+}
+
+func requestAccountsReq(url, clientID string) string {
+	clientIDJSON := ""
+	if clientID != "" {
+		clientIDJSON = `,"clientId":"` + clientID + `"`
+	}
+	return `{"jsonrpc":"2.0","id":1,"method":"eth_requestAccounts","params":[],"url":"` + url + `","name":"n","iconUrl":"http://i"` + clientIDJSON + `}`
+}
+
+func TestWalletRequestPermissions_ParallelWithEthRequestAccounts(t *testing.T) {
+	cases := []struct {
+		name            string
+		url             string
+		clientID        string
+		acceptShare     bool
+		expectPerms     bool
+		expectedPermErr error
+		expectedEthErr  error
+	}{
+		{
+			name:            "approve path returns permissions",
+			url:             "https://parallel-wait-perm.test",
+			acceptShare:     true,
+			expectPerms:     true,
+			expectedPermErr: nil,
+			expectedEthErr:  nil,
+		},
+		{
+			name:            "rejected share returns dapp not found",
+			url:             "https://parallel-reject-perm.test",
+			acceptShare:     false,
+			expectPerms:     false,
+			expectedPermErr: commands.ErrDAppNotFound,
+			expectedEthErr:  commands.ErrRequestAccountsRejectedByUser,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			state := setupTests(t)
+			requestIDCh := setupRequestAccountsRequestIDChan(t)
+
+			ethReq := requestAccountsReq(tc.url, tc.clientID)
+			permReq := requestPermissionsReq(tc.url, tc.clientID, "eth_accounts")
+			callCtx := state.ctx
+			if tc.clientID != "" {
+				callCtx = WithConnectionType(context.Background(), ConnectionTypeTrusted)
+			}
+
+			ethErrCh := make(chan error, 1)
+			go func() {
+				_, err := state.api.CallRPC(callCtx, ethReq)
+				ethErrCh <- err
+			}()
+
+			rid := recvRequestIDOrFatal(t, requestIDCh)
+
+			permErrCh := make(chan error, 1)
+			permResCh := make(chan interface{}, 1)
+			go func() {
+				res, err := state.api.CallRPC(callCtx, permReq)
+				permErrCh <- err
+				permResCh <- res
+			}()
+
+			select {
+			case err := <-permErrCh:
+				t.Fatalf("wallet_requestPermissions completed before share resolution (likely race): %v", err)
+			case <-time.After(300 * time.Millisecond):
+			}
+
+			if tc.acceptShare {
+				require.NoError(t, state.api.RequestAccountsAccepted(commands.RequestAccountsAcceptedArgs{
+					RequestID: rid,
+					Account:   concurrencyTestAccountAddress,
+					ChainID:   1,
+				}))
+			} else {
+				require.NoError(t, state.api.RequestAccountsRejected(commands.RejectedArgs{RequestID: rid}))
+			}
+
+			if tc.expectedEthErr == nil {
+				require.NoError(t, <-ethErrCh)
+			} else {
+				require.ErrorIs(t, <-ethErrCh, tc.expectedEthErr)
+			}
+			if tc.expectedPermErr == nil {
+				require.NoError(t, <-permErrCh)
+			} else {
+				require.ErrorIs(t, <-permErrCh, tc.expectedPermErr)
+			}
+
+			if tc.expectPerms {
+				permRes := <-permResCh
+				perms, ok := permRes.([]persistence.Permission)
+				require.True(t, ok, "expected []persistence.Permission, got %T", permRes)
+				require.Len(t, perms, 1)
+				require.Equal(t, persistence.NormalizeURL(tc.url), perms[0].Invoker)
+				require.Equal(t, "eth_accounts", perms[0].ParentCapability)
+			}
+		})
+	}
+}
+
+func TestWalletRequestPermissions_NoPendingShareAccount_ReturnsDAppNotFoundFast(t *testing.T) {
+	state := setupTests(t)
+	start := time.Now()
+	permReq := requestPermissionsReq("https://no-pending-perm.test", "", "personal_sign")
+	_, err := state.api.CallRPC(state.ctx, permReq)
+	require.ErrorIs(t, err, commands.ErrDAppNotFound)
+	require.Less(t, time.Since(start), 500*time.Millisecond)
+}


### PR DESCRIPTION
- Fix race between `eth_requestAccounts` and `wallet_requestPermissions`: wait until the dApp row and permissions are committed before releasing the share-account wait (fixes “dApp not found” / “permission not persisted”).
- Fix double-connect-disconnect noise: reject duplicate connect for the same origin where appropriate; fix disconnect error payload type
- Fix infinite dApps connection recursion 
- Partial permissions revocation (fixes Velora.xyz)
- TDD tests (reproducing the issue)

```mermaid
sequenceDiagram
  participant DApp
  participant Go as status-go
  participant DB

  DApp->>Go: eth_requestAccounts
  Go->>Go: begin share-account wait
  par Second call
    DApp->>Go: wallet_requestPermissions
    Go->>Go: wait until share completes
  end
  Note over Go: user approves
  Go->>DB: upsert dApp + insert permissions
  Go->>Go: end wait / release waiters
  Go-->>DApp: permissions OK
```

fixes status-im/status-app#20591