### PR TITLE
fix(wallet-connect): advertise wallet_switchEthereumChain

### DIFF
--- a/services/connector/commands/switch_ethereum_chain_test.go
+++ b/services/connector/commands/switch_ethereum_chain_test.go
@@ -2,10 +2,12 @@ package commands
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/status-im/status-go/internal/crypto/types"
 	walletCommon "github.com/status-im/status-go/services/wallet/common"
@@ -49,7 +51,9 @@ func TestFailToSwitchEthereumChainWithUnsupportedChainId(t *testing.T) {
 	assert.NoError(t, err)
 
 	_, err = state.cmd.Execute(state.ctx, request)
-	assert.Equal(t, ErrUnsupportedNetwork, err)
+	require.Error(t, err)
+	require.True(t, errors.Is(err, ErrUnsupportedNetwork),
+		"unknown chain error must still satisfy errors.Is(ErrUnsupportedNetwork) for backward compatibility, got %v", err)
 }
 
 func TestSwitchEthereumChainSuccess(t *testing.T) {

--- a/services/connector/commands/test_helpers.go
+++ b/services/connector/commands/test_helpers.go
@@ -59,6 +59,24 @@ type testState struct {
 	mockCtrl        *gomock.Controller
 	ethClientGetter *mock_chainutils.MockEthClientGetter
 	feeManager      *mock_chainutils.MockFeeManager
+	networkManager  *network.Manager
+}
+
+func setupNetworkManager(t *testing.T, db *sql.DB) *network.Manager {
+	t.Helper()
+	networkManager := network.NewManager(db, nil)
+	require.NotNil(t, networkManager)
+
+	initNetworks := []params.Network{
+		*network_testutil.CreateNetwork(walletCommon.EthereumMainnet, "Ethereum Mainnet", []params.RpcProvider{
+			network_testutil.CreateProvider(walletCommon.EthereumMainnet, "Infura Mainnet", params.EmbeddedProxyProviderType, true, security.NewSensitiveString("https://mainnet.infura.io")),
+		}),
+		*network_testutil.CreateNetwork(walletCommon.OptimismMainnet, "Optimism Mainnet", []params.RpcProvider{
+			network_testutil.CreateProvider(walletCommon.OptimismMainnet, "Optimism Mainnet", params.EmbeddedProxyProviderType, true, security.NewSensitiveString("https://mainnet.optimism.io")),
+		}),
+	}
+	require.NoError(t, networkManager.InitEmbeddedNetworks(initNetworks))
+	return networkManager
 }
 
 func setupCommand(t *testing.T, method string) (state testState, close func()) {
@@ -71,19 +89,7 @@ func setupCommand(t *testing.T, method string) (state testState, close func()) {
 	state.db, closeDb = createDB(t)
 	state.walletDb, closeWalletDb = createWalletDB(t)
 
-	networkManager := network.NewManager(state.db, nil)
-	require.NotNil(t, networkManager)
-
-	initNetworks := []params.Network{
-		*network_testutil.CreateNetwork(walletCommon.EthereumMainnet, "Ethereum Mainnet", []params.RpcProvider{
-			network_testutil.CreateProvider(walletCommon.EthereumMainnet, "Infura Mainnet", params.EmbeddedProxyProviderType, true, security.NewSensitiveString("https://mainnet.infura.io")),
-		}),
-		*network_testutil.CreateNetwork(walletCommon.OptimismMainnet, "Optimism Mainnet", []params.RpcProvider{
-			network_testutil.CreateProvider(walletCommon.OptimismMainnet, "Optimism Mainnet", params.EmbeddedProxyProviderType, true, security.NewSensitiveString("https://mainnet.optimism.io")),
-		}),
-	}
-	err := networkManager.InitEmbeddedNetworks(initNetworks)
-	require.NoError(t, err)
+	state.networkManager = setupNetworkManager(t, state.db)
 
 	state.handler = NewClientSideHandler(state.db, nil)
 
@@ -99,10 +105,10 @@ func setupCommand(t *testing.T, method string) (state testState, close func()) {
 	case Method_EthRequestAccounts:
 		state.cmd = NewRequestAccountsCommand(state.walletDb, state.handler)
 	case Method_EthChainId:
-		defaultChainIDGetter := chainutils.NewNetworkManagerAdapter(networkManager)
+		defaultChainIDGetter := chainutils.NewNetworkManagerAdapter(state.networkManager)
 		state.cmd = NewChainIDCommand(state.walletDb, defaultChainIDGetter)
 	case "net_version":
-		defaultChainIDGetter := chainutils.NewNetworkManagerAdapter(networkManager)
+		defaultChainIDGetter := chainutils.NewNetworkManagerAdapter(state.networkManager)
 		state.cmd = NewNetVersionCommand(state.walletDb, defaultChainIDGetter)
 	case Method_PersonalSign:
 		state.cmd = NewSignCommand(state.walletDb, state.handler)
@@ -115,7 +121,7 @@ func setupCommand(t *testing.T, method string) (state testState, close func()) {
 	case Method_RevokePermissions:
 		state.cmd = NewRevokePermissionsCommand(state.walletDb, wcSessionDisconnector)
 	case Method_SwitchEthereumChain:
-		state.cmd = NewSwitchEthereumChainCommand(state.walletDb, networkManager)
+		state.cmd = NewSwitchEthereumChainCommand(state.walletDb, state.networkManager)
 	}
 
 	return state, func() {

--- a/services/connector/walletconnect/helpers.go
+++ b/services/connector/walletconnect/helpers.go
@@ -106,8 +106,14 @@ func BuildNamespaces(meta SessionMetadata, proposal *ProposalParams) (map[string
 		eipAccounts[i] = fmt.Sprintf("eip155:%d:%s", cid, meta.Account)
 	}
 
-	// Extract methods and events from proposal
-	methods := []string{"personal_sign", "eth_signTypedData", "eth_signTypedData_v4", "eth_sendTransaction"}
+	// Default methods Status supports for WalletConnect dapps.
+	methods := []string{
+		"personal_sign",
+		"eth_signTypedData",
+		"eth_signTypedData_v4",
+		"eth_sendTransaction",
+		"wallet_switchEthereumChain",
+	}
 	events := []string{"accountsChanged", "chainChanged"}
 
 	if reqEip, hasEip := proposal.RequiredNamespaces["eip155"]; hasEip {

--- a/services/connector/walletconnect/helpers_test.go
+++ b/services/connector/walletconnect/helpers_test.go
@@ -26,13 +26,14 @@ func TestBuildNamespaces_DefaultMethodsAndEvents(t *testing.T) {
 	require.Contains(t, ns.Methods, "personal_sign")
 	require.Contains(t, ns.Methods, "eth_signTypedData")
 	require.Contains(t, ns.Methods, "eth_signTypedData_v4")
+	require.Contains(t, ns.Methods, "wallet_switchEthereumChain")
 	require.Contains(t, ns.Events, "accountsChanged")
 	require.Contains(t, ns.Events, "chainChanged")
 	require.Contains(t, chains, "eip155:1")
 	require.Contains(t, accounts, "eip155:1:"+meta.Account)
 }
 
-func TestBuildNamespaces_OverridesMethodsFromRequiredNamespaces(t *testing.T) {
+func TestBuildNamespaces_OverwritesWithRequiredMethodsWhenNonEmpty(t *testing.T) {
 	meta := SessionMetadata{
 		Account: "0xabc",
 		ChainID: 1,
@@ -50,8 +51,9 @@ func TestBuildNamespaces_OverridesMethodsFromRequiredNamespaces(t *testing.T) {
 	namespaces, _, _ := BuildNamespaces(meta, proposal)
 
 	ns := namespaces["eip155"]
-	require.Equal(t, []string{"custom_method_a", "custom_method_b"}, ns.Methods)
-	require.Equal(t, []string{"custom_event"}, ns.Events)
+
+	require.ElementsMatch(t, []string{"custom_method_a", "custom_method_b"}, ns.Methods)
+	require.ElementsMatch(t, []string{"custom_event"}, ns.Events)
 }
 
 func TestBuildNamespaces_EmptyRequiredMethodsKeepsDefaults(t *testing.T) {


### PR DESCRIPTION
* add missing `wallet_switchEthereumChain` to the list of exposed methods for wallet connect. 
* fixes wc + playground.li.fi

refs status-im/status-app#20591