### PR TITLE
feat(connector): ephemeral dApp records

### DIFF
--- a/services/connector/api.go
+++ b/services/connector/api.go
@@ -193,7 +193,11 @@ func (api *API) GetPermittedDAppsList() ([]persistence.DApp, error) {
 }
 
 // DeleteEphemeralDApps removes persisted connector rows for ephemeral (incognito) sessions.
-func (api *API) DeleteEphemeralDApps() error {
+// Untrusted callers (e.g. browser WebSocket) cannot invoke this.
+func (api *API) DeleteEphemeralDApps(ctx context.Context) error {
+	if IsUntrustedConnection(ctx) {
+		return ErrNotAllowedForUntrustedConnection
+	}
 	return persistence.DeleteEphemeralDApps(api.s.db)
 }
 

--- a/services/connector/api.go
+++ b/services/connector/api.go
@@ -192,6 +192,11 @@ func (api *API) GetPermittedDAppsList() ([]persistence.DApp, error) {
 	return persistence.SelectAllDApps(api.s.db)
 }
 
+// DeleteEphemeralDApps removes persisted connector rows for ephemeral (incognito) sessions.
+func (api *API) DeleteEphemeralDApps() error {
+	return persistence.DeleteEphemeralDApps(api.s.db)
+}
+
 func (api *API) RequestAccountsAccepted(args commands.RequestAccountsAcceptedArgs) error {
 	return api.c.RequestAccountsAccepted(args)
 }

--- a/services/connector/api_test.go
+++ b/services/connector/api_test.go
@@ -210,14 +210,15 @@ func TestDeleteEphemeralDApps(t *testing.T) {
 		URL:           "https://ephemeral-dapp.com",
 		Name:          "Ephemeral",
 		IconURL:       "",
-		ClientID:      "status-desktop/dapp-browser#ephemeral",
+		ClientID:      "status-desktop/dapp-browser" + persistence.EphemeralClientIDSuffix,
 		SharedAccount: types2.HexToAddress("0x2222"),
 		ChainID:       0x1,
 	}
 	require.NoError(t, persistence.UpsertDApp(state.walletDb, &normal))
 	require.NoError(t, persistence.UpsertDApp(state.walletDb, &ephemeral))
 
-	require.NoError(t, state.api.DeleteEphemeralDApps())
+	ctx := WithConnectionType(context.Background(), ConnectionTypeTrusted)
+	require.NoError(t, state.api.DeleteEphemeralDApps(ctx))
 
 	gotNormal, err := persistence.SelectDApp(state.walletDb, normal.URL, normal.ClientID)
 	require.NoError(t, err)
@@ -226,6 +227,15 @@ func TestDeleteEphemeralDApps(t *testing.T) {
 	gotEphemeral, err := persistence.SelectDApp(state.walletDb, ephemeral.URL, ephemeral.ClientID)
 	require.NoError(t, err)
 	require.Nil(t, gotEphemeral)
+}
+
+func TestDeleteEphemeralDApps_UntrustedConnection(t *testing.T) {
+	state := setupTests(t)
+
+	ctx := WithConnectionType(context.Background(), ConnectionTypeUntrusted)
+	err := state.api.DeleteEphemeralDApps(ctx)
+	require.Error(t, err)
+	require.Equal(t, ErrNotAllowedForUntrustedConnection, err)
 }
 
 func TestGetWCActiveSessions(t *testing.T) {

--- a/services/connector/api_test.go
+++ b/services/connector/api_test.go
@@ -195,6 +195,39 @@ func TestGetPermittedDAppsList(t *testing.T) {
 	require.Empty(t, dapps)
 }
 
+func TestDeleteEphemeralDApps(t *testing.T) {
+	state := setupTests(t)
+
+	normal := persistence.DApp{
+		URL:           "https://normal-dapp.com",
+		Name:          "Normal",
+		IconURL:       "",
+		ClientID:      "status-desktop/dapp-browser",
+		SharedAccount: types2.HexToAddress("0x1111"),
+		ChainID:       0x1,
+	}
+	ephemeral := persistence.DApp{
+		URL:           "https://ephemeral-dapp.com",
+		Name:          "Ephemeral",
+		IconURL:       "",
+		ClientID:      "status-desktop/dapp-browser#ephemeral",
+		SharedAccount: types2.HexToAddress("0x2222"),
+		ChainID:       0x1,
+	}
+	require.NoError(t, persistence.UpsertDApp(state.walletDb, &normal))
+	require.NoError(t, persistence.UpsertDApp(state.walletDb, &ephemeral))
+
+	require.NoError(t, state.api.DeleteEphemeralDApps())
+
+	gotNormal, err := persistence.SelectDApp(state.walletDb, normal.URL, normal.ClientID)
+	require.NoError(t, err)
+	require.NotNil(t, gotNormal)
+
+	gotEphemeral, err := persistence.SelectDApp(state.walletDb, ephemeral.URL, ephemeral.ClientID)
+	require.NoError(t, err)
+	require.Nil(t, gotEphemeral)
+}
+
 func TestGetWCActiveSessions(t *testing.T) {
 	state := setupTests(t)
 

--- a/services/connector/commands/request_accounts_test.go
+++ b/services/connector/commands/request_accounts_test.go
@@ -136,7 +136,7 @@ func TestRequestAccounts_EphemeralDoesNotReuseNormalSession(t *testing.T) {
 	t.Cleanup(close)
 
 	normalClientID := "status-desktop/dapp-browser"
-	ephemeralClientID := "status-desktop/dapp-browser#ephemeral"
+	ephemeralClientID := "status-desktop/dapp-browser" + persistence.EphemeralClientIDSuffix
 
 	origin := "https://some-dapp.com"
 	normalAccount := types.Address{0xAA}

--- a/services/connector/commands/request_accounts_test.go
+++ b/services/connector/commands/request_accounts_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/status-im/status-go/internal/crypto/types"
 	persistence "github.com/status-im/status-go/services/connector/database"
@@ -125,6 +126,68 @@ func TestRequestAccountsRejected(t *testing.T) {
 
 	_, err = state.cmd.Execute(state.ctx, request)
 	assert.Equal(t, ErrRequestAccountsRejectedByUser, err)
+}
+
+// TestRequestAccounts_EphemeralDoesNotReuseNormalSession verifies that an
+// ephemeral (incognito) clientID never silently reuses a permission that was
+// granted to the normal-session clientID for the same dApp origin.
+func TestRequestAccounts_EphemeralDoesNotReuseNormalSession(t *testing.T) {
+	state, close := setupCommand(t, Method_EthRequestAccounts)
+	t.Cleanup(close)
+
+	normalClientID := "status-desktop/dapp-browser"
+	ephemeralClientID := "status-desktop/dapp-browser#ephemeral"
+
+	origin := "https://some-dapp.com"
+	normalAccount := types.Address{0xAA}
+	ephemeralAccount := types.Address{0xBB}
+
+	// Pre-populate a normal-session dApp + eth_accounts permission.
+	normalDApp := &persistence.DApp{
+		URL: origin, Name: "SomeDApp", IconURL: "",
+		ClientID: normalClientID, SharedAccount: normalAccount, ChainID: 1,
+	}
+	require.NoError(t, persistence.UpsertDApp(state.walletDb, normalDApp))
+	require.NoError(t, persistence.InsertPermission(state.walletDb, origin, normalClientID, Method_EthAccounts, []persistence.Caveat{}, 1))
+
+	// Now call eth_requestAccounts with the ephemeral clientID for the same origin.
+	// This MUST NOT silently reuse the normal-session permission — it must trigger the share UI.
+	sharePromptInvoked := false
+	signal.SetMobileSignalHandler(signal.MobileSignalHandler(func(s []byte) {
+		var evt EventType
+		require.NoError(t, json.Unmarshal(s, &evt))
+		if evt.Type == signal.EventConnectorSendRequestAccounts {
+			sharePromptInvoked = true
+			var ev signal.ConnectorSendRequestAccountsSignal
+			require.NoError(t, json.Unmarshal(evt.Event, &ev))
+			// Simulate user approving with the ephemeral account.
+			require.NoError(t, state.handler.RequestAccountsAccepted(RequestAccountsAcceptedArgs{
+				RequestID: ev.RequestID,
+				Account:   ephemeralAccount,
+				ChainID:   1,
+			}))
+		}
+	}))
+	t.Cleanup(signal.ResetMobileSignalHandler)
+
+	ephemeralDApp := signal.ConnectorDApp{
+		URL: origin, Name: "SomeDApp", IconURL: "", ClientID: ephemeralClientID,
+	}
+	request, err := ConstructRPCRequest(Method_EthRequestAccounts, []interface{}{}, &ephemeralDApp)
+	require.NoError(t, err)
+
+	response, err := state.cmd.Execute(state.ctx, request)
+	require.NoError(t, err)
+	require.True(t, sharePromptInvoked, "share prompt must fire for ephemeral clientID even when normal session has permission")
+
+	// The returned account must be the ephemeral one, not the normal-session one.
+	require.Equal(t, FormatAccountAddressToResponse(ephemeralAccount), response)
+
+	// Normal-session dApp must be completely untouched.
+	got, err := persistence.SelectDApp(state.walletDb, origin, normalClientID)
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	require.Equal(t, normalAccount, got.SharedAccount)
 }
 
 func TestRequestAccountsWithExistingDApp(t *testing.T) {

--- a/services/connector/database/persistence.go
+++ b/services/connector/database/persistence.go
@@ -8,13 +8,21 @@ import (
 	"github.com/status-im/status-go/internal/crypto/types"
 )
 
-const deleteEphemeralDAppsQuery = "DELETE FROM connector_dapps WHERE client_id LIKE '%#ephemeral%'"
+// EphemeralClientIDSuffix marks connector sessions that must not persist across runs.
+const EphemeralClientIDSuffix = "#ephemeral"
 
-// DeleteEphemeralDApps removes connector_dapps rows whose clientID contains
-// the "#ephemeral" marker (e.g. "status-desktop/dapp-browser#ephemeral").
+const deleteEphemeralDAppsQuery = "DELETE FROM connector_dapps WHERE client_id LIKE '%' || ?"
+
+// IsEphemeralClientID reports whether clientID uses the ephemeral suffix convention.
+func IsEphemeralClientID(id string) bool {
+	return strings.HasSuffix(id, EphemeralClientIDSuffix)
+}
+
+// DeleteEphemeralDApps removes connector_dapps rows whose clientID ends with
+// EphemeralClientIDSuffix (e.g. "status-desktop/dapp-browser#ephemeral").
 // Linked connector_permissions rows are removed via FK ON DELETE CASCADE.
 func DeleteEphemeralDApps(db *sql.DB) error {
-	_, err := db.Exec(deleteEphemeralDAppsQuery)
+	_, err := db.Exec(deleteEphemeralDAppsQuery, EphemeralClientIDSuffix)
 	return err
 }
 

--- a/services/connector/database/persistence.go
+++ b/services/connector/database/persistence.go
@@ -8,6 +8,16 @@ import (
 	"github.com/status-im/status-go/internal/crypto/types"
 )
 
+const deleteEphemeralDAppsQuery = "DELETE FROM connector_dapps WHERE client_id LIKE '%#ephemeral%'"
+
+// DeleteEphemeralDApps removes connector_dapps rows whose clientID contains
+// the "#ephemeral" marker (e.g. "status-desktop/dapp-browser#ephemeral").
+// Linked connector_permissions rows are removed via FK ON DELETE CASCADE.
+func DeleteEphemeralDApps(db *sql.DB) error {
+	_, err := db.Exec(deleteEphemeralDAppsQuery)
+	return err
+}
+
 func NormalizeURL(url string) string {
 	return strings.TrimRight(url, "/")
 }

--- a/services/connector/database/persistence_test.go
+++ b/services/connector/database/persistence_test.go
@@ -591,9 +591,9 @@ func TestDeleteWCSession(t *testing.T) {
 }
 
 // TestDeleteEphemeralDApps verifies that DeleteEphemeralDApps removes only
-// rows whose clientID contains the "#ephemeral" marker, cascades to their
+// rows whose clientID ends with the "#ephemeral" suffix, cascades to their
 // permissions via the FK, and leaves all other rows (normal sessions,
-// WalletConnect, non-ephemeral uuid suffixes) untouched.
+// WalletConnect, longer suffixes) untouched.
 func TestDeleteEphemeralDApps(t *testing.T) {
 	db, close := setupTestDB(t)
 	defer close()
@@ -604,7 +604,12 @@ func TestDeleteEphemeralDApps(t *testing.T) {
 	}
 	ephemeral := DApp{
 		URL: "https://dapp.com", Name: "Ephemeral", IconURL: "",
-		ClientID: "status-desktop/dapp-browser#ephemeral", SharedAccount: types.HexToAddress("0x2222"), ChainID: 0x1,
+		ClientID: "status-desktop/dapp-browser" + EphemeralClientIDSuffix, SharedAccount: types.HexToAddress("0x2222"), ChainID: 0x1,
+	}
+	require.True(t, IsEphemeralClientID(ephemeral.ClientID))
+	notQuiteEphemeral := DApp{
+		URL: "https://almost.com", Name: "Almost", IconURL: "",
+		ClientID: "status-desktop/dapp-browser#ephemeral-extra", SharedAccount: types.HexToAddress("0x5555"), ChainID: 0x1,
 	}
 	wcDApp := DApp{
 		URL: "https://wc-dapp.com", Name: "WC", IconURL: "",
@@ -612,6 +617,7 @@ func TestDeleteEphemeralDApps(t *testing.T) {
 	}
 	require.NoError(t, UpsertDApp(db, &normal))
 	require.NoError(t, UpsertDApp(db, &ephemeral))
+	require.NoError(t, UpsertDApp(db, &notQuiteEphemeral))
 	require.NoError(t, UpsertDApp(db, &wcDApp))
 	require.NoError(t, InsertPermission(db, ephemeral.URL, ephemeral.ClientID, "eth_accounts", []Caveat{}, 1))
 
@@ -634,6 +640,11 @@ func TestDeleteEphemeralDApps(t *testing.T) {
 
 	// WalletConnect row intact.
 	got, err = SelectDApp(db, wcDApp.URL, wcDApp.ClientID)
+	require.NoError(t, err)
+	require.NotNil(t, got)
+
+	// Longer suffix than "#ephemeral" must remain.
+	got, err = SelectDApp(db, notQuiteEphemeral.URL, notQuiteEphemeral.ClientID)
 	require.NoError(t, err)
 	require.NotNil(t, got)
 }

--- a/services/connector/database/persistence_test.go
+++ b/services/connector/database/persistence_test.go
@@ -590,6 +590,54 @@ func TestDeleteWCSession(t *testing.T) {
 	require.Nil(t, session)
 }
 
+// TestDeleteEphemeralDApps verifies that DeleteEphemeralDApps removes only
+// rows whose clientID contains the "#ephemeral" marker, cascades to their
+// permissions via the FK, and leaves all other rows (normal sessions,
+// WalletConnect, non-ephemeral uuid suffixes) untouched.
+func TestDeleteEphemeralDApps(t *testing.T) {
+	db, close := setupTestDB(t)
+	defer close()
+
+	normal := DApp{
+		URL: "https://dapp.com", Name: "Normal", IconURL: "",
+		ClientID: "status-desktop/dapp-browser", SharedAccount: types.HexToAddress("0x1111"), ChainID: 0x1,
+	}
+	ephemeral := DApp{
+		URL: "https://dapp.com", Name: "Ephemeral", IconURL: "",
+		ClientID: "status-desktop/dapp-browser#ephemeral", SharedAccount: types.HexToAddress("0x2222"), ChainID: 0x1,
+	}
+	wcDApp := DApp{
+		URL: "https://wc-dapp.com", Name: "WC", IconURL: "",
+		ClientID: WCClientID, SharedAccount: types.HexToAddress("0x3333"), ChainID: 0x1,
+	}
+	require.NoError(t, UpsertDApp(db, &normal))
+	require.NoError(t, UpsertDApp(db, &ephemeral))
+	require.NoError(t, UpsertDApp(db, &wcDApp))
+	require.NoError(t, InsertPermission(db, ephemeral.URL, ephemeral.ClientID, "eth_accounts", []Caveat{}, 1))
+
+	require.NoError(t, DeleteEphemeralDApps(db))
+
+	// Ephemeral row gone.
+	got, err := SelectDApp(db, ephemeral.URL, ephemeral.ClientID)
+	require.NoError(t, err)
+	require.Nil(t, got)
+
+	// Permissions cascaded.
+	perms, err := SelectPermissions(db, ephemeral.URL, ephemeral.ClientID)
+	require.NoError(t, err)
+	require.Empty(t, perms)
+
+	// Normal row intact.
+	got, err = SelectDApp(db, normal.URL, normal.ClientID)
+	require.NoError(t, err)
+	require.NotNil(t, got)
+
+	// WalletConnect row intact.
+	got, err = SelectDApp(db, wcDApp.URL, wcDApp.ClientID)
+	require.NoError(t, err)
+	require.NotNil(t, got)
+}
+
 func TestDeleteWCSessionIdempotent(t *testing.T) {
 	db, close := setupTestDB(t)
 	defer close()

--- a/services/connector/service.go
+++ b/services/connector/service.go
@@ -16,6 +16,7 @@ import (
 	"github.com/status-im/status-go/common"
 	"github.com/status-im/status-go/internal/rpc/network"
 	"github.com/status-im/status-go/services/connector/chainutils"
+	persistence "github.com/status-im/status-go/services/connector/database"
 )
 
 const serviceName = "connector"
@@ -72,6 +73,12 @@ func (s *Service) Start() error {
 	if s.started {
 		return nil
 	}
+
+	// Purge any ephemeral dApp rows left over from a previous (possibly crashed) run.
+	if err := persistence.DeleteEphemeralDApps(s.db); err != nil {
+		s.logger.Warn("failed to delete ephemeral dapps on start", zap.Error(err))
+	}
+
 	// Create an RPC server
 	s.rpcServer = gethrpc.NewServer()
 
@@ -131,6 +138,11 @@ func (s *Service) Stop() error {
 func (s *Service) stopLocked() error {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
 	defer cancel()
+
+	// Purge ephemeral dApp rows on graceful shutdown so they never persist across runs.
+	if err := persistence.DeleteEphemeralDApps(s.db); err != nil {
+		s.logger.Warn("failed to delete ephemeral dapps on stop", zap.Error(err))
+	}
 
 	if s.api != nil && s.api.wcClient != nil {
 		if err := s.api.wcClient.Close(); err != nil {

--- a/services/connector/service.go
+++ b/services/connector/service.go
@@ -60,11 +60,12 @@ type Service struct {
 
 	config *Config
 
-	rpcServer *gethrpc.Server
-	wsServer  *http.Server
-	mu        sync.Mutex
-	paused    bool
-	started   bool
+	rpcServer          *gethrpc.Server
+	wsServer           *http.Server
+	mu                 sync.Mutex
+	paused             bool
+	started            bool
+	purgeEphemeralOnce sync.Once
 }
 
 func (s *Service) Start() error {
@@ -74,10 +75,11 @@ func (s *Service) Start() error {
 		return nil
 	}
 
-	// Purge any ephemeral dApp rows left over from a previous (possibly crashed) run.
-	if err := persistence.DeleteEphemeralDApps(s.db); err != nil {
-		s.logger.Warn("failed to delete ephemeral dapps on start", zap.Error(err))
-	}
+	s.purgeEphemeralOnce.Do(func() {
+		if err := persistence.DeleteEphemeralDApps(s.db); err != nil {
+			s.logger.Warn("failed to delete ephemeral dapps on first start", zap.Error(err))
+		}
+	})
 
 	// Create an RPC server
 	s.rpcServer = gethrpc.NewServer()
@@ -132,17 +134,16 @@ func (s *Service) Start() error {
 func (s *Service) Stop() error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	return s.stopLocked()
+	err := s.stopLocked()
+	if err2 := persistence.DeleteEphemeralDApps(s.db); err2 != nil {
+		s.logger.Warn("failed to delete ephemeral dapps on stop", zap.Error(err2))
+	}
+	return err
 }
 
 func (s *Service) stopLocked() error {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
 	defer cancel()
-
-	// Purge ephemeral dApp rows on graceful shutdown so they never persist across runs.
-	if err := persistence.DeleteEphemeralDApps(s.db); err != nil {
-		s.logger.Warn("failed to delete ephemeral dapps on stop", zap.Error(err))
-	}
 
 	if s.api != nil && s.api.wcClient != nil {
 		if err := s.api.wcClient.Close(); err != nil {

--- a/services/connector/service_test.go
+++ b/services/connector/service_test.go
@@ -8,7 +8,28 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	types2 "github.com/status-im/status-go/internal/crypto/types"
+	persistence "github.com/status-im/status-go/services/connector/database"
 )
+
+func TestService_StopClearsEphemeralDApps(t *testing.T) {
+	state := setupTests(t)
+
+	require.NoError(t, state.service.Start())
+
+	// Insert ephemeral row after Start (simulates a fresh incognito session).
+	require.NoError(t, persistence.UpsertDApp(state.walletDb, &persistence.DApp{
+		URL: "https://incognito-dapp2.com", Name: "Incognito DApp 2", IconURL: "",
+		ClientID: "status-desktop/dapp-browser#ephemeral", SharedAccount: types2.Address{}, ChainID: 0x1,
+	}))
+
+	require.NoError(t, state.service.Stop())
+
+	got, err := persistence.SelectDApp(state.walletDb, "https://incognito-dapp2.com", "status-desktop/dapp-browser#ephemeral")
+	require.NoError(t, err)
+	require.Nil(t, got, "ephemeral dApp must be removed on service Stop")
+}
 
 func TestNewService(t *testing.T) {
 	state := setupTests(t)

--- a/services/connector/service_test.go
+++ b/services/connector/service_test.go
@@ -13,7 +13,28 @@ import (
 	persistence "github.com/status-im/status-go/services/connector/database"
 )
 
-func TestService_StopClearsEphemeralDApps(t *testing.T) {
+func ephemeralBrowserClientID() string {
+	return "status-desktop/dapp-browser" + persistence.EphemeralClientIDSuffix
+}
+
+func TestService_StartPurgesStaleEphemeralDAppsOnce(t *testing.T) {
+	state := setupTests(t)
+
+	require.NoError(t, persistence.UpsertDApp(state.walletDb, &persistence.DApp{
+		URL: "https://stale.com", Name: "Stale", IconURL: "",
+		ClientID:      ephemeralBrowserClientID(),
+		SharedAccount: types2.Address{}, ChainID: 0x1,
+	}))
+
+	require.NoError(t, state.service.Start())
+	require.NoError(t, state.service.Stop())
+
+	got, err := persistence.SelectDApp(state.walletDb, "https://stale.com", ephemeralBrowserClientID())
+	require.NoError(t, err)
+	require.Nil(t, got, "stale ephemeral row must be purged on first Start")
+}
+
+func TestService_StopPurgesEphemeralDApps(t *testing.T) {
 	state := setupTests(t)
 
 	require.NoError(t, state.service.Start())
@@ -21,12 +42,13 @@ func TestService_StopClearsEphemeralDApps(t *testing.T) {
 	// Insert ephemeral row after Start (simulates a fresh incognito session).
 	require.NoError(t, persistence.UpsertDApp(state.walletDb, &persistence.DApp{
 		URL: "https://incognito-dapp2.com", Name: "Incognito DApp 2", IconURL: "",
-		ClientID: "status-desktop/dapp-browser#ephemeral", SharedAccount: types2.Address{}, ChainID: 0x1,
+		ClientID:      ephemeralBrowserClientID(),
+		SharedAccount: types2.Address{}, ChainID: 0x1,
 	}))
 
 	require.NoError(t, state.service.Stop())
 
-	got, err := persistence.SelectDApp(state.walletDb, "https://incognito-dapp2.com", "status-desktop/dapp-browser#ephemeral")
+	got, err := persistence.SelectDApp(state.walletDb, "https://incognito-dapp2.com", ephemeralBrowserClientID())
 	require.NoError(t, err)
 	require.Nil(t, got, "ephemeral dApp must be removed on service Stop")
 }
@@ -107,6 +129,33 @@ func TestService_PauseResumeBackground(t *testing.T) {
 
 	err = state.service.Stop()
 	require.NoError(t, err)
+}
+
+func TestService_PauseResumePreservesEphemeralDApps(t *testing.T) {
+	state := setupTests(t)
+	state.service.config.WSEnabled = false
+
+	t.Cleanup(func() { _ = state.service.Stop() })
+
+	require.NoError(t, state.service.Start())
+
+	require.NoError(t, persistence.UpsertDApp(state.walletDb, &persistence.DApp{
+		URL: "https://pause-incognito.com", Name: "Pause Test", IconURL: "",
+		ClientID:      ephemeralBrowserClientID(),
+		SharedAccount: types2.Address{}, ChainID: 0x1,
+	}))
+
+	require.NoError(t, state.service.Pause())
+
+	got, err := persistence.SelectDApp(state.walletDb, "https://pause-incognito.com", ephemeralBrowserClientID())
+	require.NoError(t, err)
+	require.NotNil(t, got, "ephemeral dApp must survive Pause")
+
+	require.NoError(t, state.service.Resume())
+
+	got, err = persistence.SelectDApp(state.walletDb, "https://pause-incognito.com", ephemeralBrowserClientID())
+	require.NoError(t, err)
+	require.NotNil(t, got, "ephemeral dApp must survive Resume")
 }
 
 // freeLocalTCPPort reserves an ephemeral TCP port on loopback for the test process.


### PR DESCRIPTION
Adds support for marking connector dApp records as ephemeral (incognito) and cleaning them up automatically.

* `persistence.DeleteEphemeralDApps(db)` — deletes rows from connector_dapps where client_id `LIKE '%#ephemeral%'`
* `Start/Stop` purge ephemeral rows


https://github.com/user-attachments/assets/df898196-3a30-4174-a8de-f9a48189185f


required for https://github.com/status-im/status-app/pull/20808
refs https://github.com/status-im/status-app/issues/20676
