### PR TITLE
fix(wc): reconnect broken connections

### DIFF
--- a/services/connector/api.go
+++ b/services/connector/api.go
@@ -7,13 +7,10 @@ import (
 	"fmt"
 	"time"
 
-	"go.uber.org/zap"
-
 	"github.com/status-im/status-go/services/connector/chainutils"
 	"github.com/status-im/status-go/services/connector/commands"
 	persistence "github.com/status-im/status-go/services/connector/database"
 	"github.com/status-im/status-go/services/connector/walletconnect"
-	"github.com/status-im/status-go/signal"
 )
 
 var (
@@ -27,7 +24,6 @@ type API struct {
 	s                          *Service
 	r                          *CommandRegistry
 	c                          *commands.ClientSideHandler
-	wcClient                   *walletconnect.Client
 	changeAccountCommand       *commands.ChangeAccountCommand
 	pairWCCommand              *commands.PairWCCommand
 	wcSessionDisconnector      commands.WCSessionDisconnector
@@ -41,50 +37,11 @@ type API struct {
 func NewAPI(s *Service) *API {
 	r := NewCommandRegistry()
 
-	wcClient, err := walletconnect.NewClient(s.config.ProjectID)
-	if err != nil {
-		s.logger.Error("failed to create WalletConnect client", zap.Error(err))
-	}
+	getWC := func() *walletconnect.Client { return s.GetClient() }
 
-	if wcClient != nil {
-		activeSessions, err := persistence.SelectActiveWCSessions(s.db, time.Now().Unix())
-		if err != nil {
-			s.logger.Error("failed to load active WC sessions", zap.Error(err))
-		} else if len(activeSessions) > 0 {
-			restoredSessions := make([]walletconnect.RestoredSession, 0, len(activeSessions))
-			for _, session := range activeSessions {
-				restoredSessions = append(restoredSessions, walletconnect.RestoredSession{
-					Topic:  session.Topic,
-					SymKey: session.SymKey,
-				})
-			}
-			wcClient.RestoreSessions(restoredSessions)
-			s.logger.Info("restored WalletConnect sessions", zap.Int("count", len(restoredSessions)))
-			if err := wcClient.ConnectAndResubscribe(); err != nil {
-				s.logger.Warn("failed to connect relay for restored WC sessions", zap.Error(err))
-			}
-		}
-	}
+	wcSessionDisconnector := commands.NewWCSessionDisconnector(s.db, getWC)
 
-	wcSessionDisconnector := commands.NewWCSessionDisconnector(s.db, wcClient)
-
-	if wcClient != nil {
-		wcClient.SetSessionDeleteHandler(func(topic string) {
-			s.logger.Info("received wc_sessionDelete", zap.String("topic", topic))
-			session, err := persistence.SelectWCSession(s.db, topic)
-			dappURL := ""
-			if err == nil && session != nil {
-				dappURL = session.DAppURL
-			}
-			if err := wcSessionDisconnector.DisconnectSession(context.Background(), topic); err != nil {
-				s.logger.Error("failed to disconnect WC session", zap.String("topic", topic), zap.Error(err))
-			} else {
-				s.logger.Info("WC session disconnected", zap.String("topic", topic), zap.String("dappURL", dappURL))
-			}
-			signal.SendWCSessionDelete(topic, dappURL)
-		})
-	}
-	c := commands.NewClientSideHandler(s.db, wcClient)
+	c := commands.NewClientSideHandler(s.db, getWC)
 
 	// Transactions and signing
 	r.Register("eth_sendTransaction", commands.NewSendTransactionCommand(s.db, s.ethClientGetter, s.feeManager, c))
@@ -117,15 +74,14 @@ func NewAPI(s *Service) *API {
 		s:                          s,
 		r:                          r,
 		c:                          c,
-		wcClient:                   wcClient,
 		changeAccountCommand:       changeAccountCommand,
-		pairWCCommand:              commands.NewPairWCCommand(wcClient),
+		pairWCCommand:              commands.NewPairWCCommand(getWC),
 		wcSessionDisconnector:      wcSessionDisconnector,
 		getWCActiveSessionsCommand: commands.NewGetWCActiveSessionsCommand(s.db),
-		approveWCSessionCommand:    commands.NewApproveWCSessionCommand(s.db, wcClient),
-		rejectWCSessionCommand:     commands.NewRejectWCSessionCommand(wcClient),
-		approveWCSessionRequestCmd: commands.NewApproveWCSessionRequestCommand(wcClient),
-		rejectWCSessionRequestCmd:  commands.NewRejectWCSessionRequestCommand(wcClient),
+		approveWCSessionCommand:    commands.NewApproveWCSessionCommand(s.db, getWC),
+		rejectWCSessionCommand:     commands.NewRejectWCSessionCommand(getWC),
+		approveWCSessionRequestCmd: commands.NewApproveWCSessionRequestCommand(getWC),
+		rejectWCSessionRequestCmd:  commands.NewRejectWCSessionRequestCommand(getWC),
 	}
 }
 
@@ -261,7 +217,8 @@ func (api *API) RejectWCSessionRequest(ctx context.Context, topic, requestIDStr 
 }
 
 func (api *API) UpdateWCSessionChains(ctx context.Context, topic string, account string, chains []uint64) error {
-	if api.wcClient == nil {
+	wcClient := api.s.GetClient()
+	if wcClient == nil {
 		return fmt.Errorf("WalletConnect client not initialized")
 	}
 
@@ -313,7 +270,7 @@ func (api *API) UpdateWCSessionChains(ctx context.Context, topic string, account
 	namespaces, _, _ := walletconnect.BuildNamespaces(meta, proposal)
 
 	// Send session update to dApp
-	if err := api.wcClient.SendSessionUpdate(topic, namespaces); err != nil {
+	if err := wcClient.SendSessionUpdate(topic, namespaces); err != nil {
 		return fmt.Errorf("failed to send session update: %w", err)
 	}
 
@@ -333,7 +290,8 @@ func (api *API) UpdateWCSessionChains(ctx context.Context, topic string, account
 
 // EmitWCSessionEvent sends a wc_sessionEvent to the dapp (e.g., chainChanged, accountsChanged, connect, disconnect).
 func (api *API) EmitWCSessionEvent(ctx context.Context, topic, name, dataJSON, chainID string) error {
-	if api.wcClient == nil {
+	wcClient := api.s.GetClient()
+	if wcClient == nil {
 		return fmt.Errorf("WalletConnect client not initialized")
 	}
 
@@ -349,5 +307,5 @@ func (api *API) EmitWCSessionEvent(ctx context.Context, topic, name, dataJSON, c
 		Data: data,
 	}
 
-	return api.wcClient.SendSessionEvent(topic, event, chainID)
+	return wcClient.SendSessionEvent(topic, event, chainID)
 }

--- a/services/connector/api.go
+++ b/services/connector/api.go
@@ -219,7 +219,7 @@ func (api *API) RejectWCSessionRequest(ctx context.Context, topic, requestIDStr 
 func (api *API) UpdateWCSessionChains(ctx context.Context, topic string, account string, chains []uint64) error {
 	wcClient := api.s.GetClient()
 	if wcClient == nil {
-		return fmt.Errorf("WalletConnect client not initialized")
+		return commands.ErrWCClientNotInitialized
 	}
 
 	if len(chains) == 0 {
@@ -292,7 +292,7 @@ func (api *API) UpdateWCSessionChains(ctx context.Context, topic string, account
 func (api *API) EmitWCSessionEvent(ctx context.Context, topic, name, dataJSON, chainID string) error {
 	wcClient := api.s.GetClient()
 	if wcClient == nil {
-		return fmt.Errorf("WalletConnect client not initialized")
+		return commands.ErrWCClientNotInitialized
 	}
 
 	var data interface{}

--- a/services/connector/api_test.go
+++ b/services/connector/api_test.go
@@ -418,7 +418,7 @@ func TestPairWalletConnect_InvalidURI(t *testing.T) {
 
 func TestUpdateWCSessionChains_NilClient(t *testing.T) {
 	state := setupTests(t)
-	state.api.wcClient = nil
+	state.service.wcClient.Store(nil)
 
 	err := state.api.UpdateWCSessionChains(state.ctx, "some-topic", "0x1234", []uint64{1})
 	require.Error(t, err)
@@ -427,7 +427,7 @@ func TestUpdateWCSessionChains_NilClient(t *testing.T) {
 
 func TestEmitWCSessionEvent_NilClient(t *testing.T) {
 	state := setupTests(t)
-	state.api.wcClient = nil
+	state.service.wcClient.Store(nil)
 
 	err := state.api.EmitWCSessionEvent(state.ctx, "some-topic", "accountsChanged", "", "eip155:1")
 	require.Error(t, err)
@@ -458,6 +458,6 @@ func TestNewAPI_WithRestoredSessions(t *testing.T) {
 		&Config{},
 	)
 
-	api := NewAPI(service)
-	require.NotNil(t, api)
+	require.NotNil(t, service.api)
+	require.NotNil(t, service.GetClient())
 }

--- a/services/connector/api_test.go
+++ b/services/connector/api_test.go
@@ -422,7 +422,7 @@ func TestUpdateWCSessionChains_NilClient(t *testing.T) {
 
 	err := state.api.UpdateWCSessionChains(state.ctx, "some-topic", "0x1234", []uint64{1})
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "WalletConnect client not initialized")
+	require.ErrorIs(t, err, commands.ErrWCClientNotInitialized)
 }
 
 func TestEmitWCSessionEvent_NilClient(t *testing.T) {
@@ -431,7 +431,7 @@ func TestEmitWCSessionEvent_NilClient(t *testing.T) {
 
 	err := state.api.EmitWCSessionEvent(state.ctx, "some-topic", "accountsChanged", "", "eip155:1")
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "WalletConnect client not initialized")
+	require.ErrorIs(t, err, commands.ErrWCClientNotInitialized)
 }
 
 func TestNewAPI_WithRestoredSessions(t *testing.T) {

--- a/services/connector/commands/client_handler.go
+++ b/services/connector/commands/client_handler.go
@@ -13,7 +13,6 @@ import (
 
 	types2 "github.com/status-im/status-go/internal/crypto/types"
 	persistence "github.com/status-im/status-go/services/connector/database"
-	"github.com/status-im/status-go/services/connector/walletconnect"
 	"github.com/status-im/status-go/services/wallet/wallettypes"
 	"github.com/status-im/status-go/signal"
 )
@@ -61,10 +60,10 @@ type ClientSideHandler struct {
 	sharePending   map[sharePendingKey]chan struct{}
 }
 
-func NewClientSideHandler(db *sql.DB, wcClient *walletconnect.Client) *ClientSideHandler {
+func NewClientSideHandler(db *sql.DB, getClient WCClientGetter) *ClientSideHandler {
 	return &ClientSideHandler{
 		Db:                    db,
-		wcSessionDisconnector: NewWCSessionDisconnector(db, wcClient),
+		wcSessionDisconnector: NewWCSessionDisconnector(db, getClient),
 		responseChannel:       make(chan Message, 1),
 		isRequestRunning:      0,
 		sharePending:          make(map[sharePendingKey]chan struct{}),

--- a/services/connector/commands/interfaces.go
+++ b/services/connector/commands/interfaces.go
@@ -1,8 +1,15 @@
 package commands
 
-import "context"
+import (
+	"context"
+
+	"github.com/status-im/status-go/services/connector/walletconnect"
+)
 
 //go:generate go tool mockgen -source=interfaces.go -destination=mock/interfaces.go -package=mock_commands
+
+// WCClientGetter returns the live WalletConnect client, or nil if not initialized.
+type WCClientGetter func() *walletconnect.Client
 
 // WCSessionDisconnector handles disconnecting WalletConnect sessions
 type WCSessionDisconnector interface {

--- a/services/connector/commands/walletconnect.go
+++ b/services/connector/commands/walletconnect.go
@@ -12,6 +12,19 @@ import (
 	"github.com/status-im/status-go/services/connector/walletconnect"
 )
 
+var errWCClientNotInitialized = fmt.Errorf("WalletConnect client not initialized")
+
+func (g WCClientGetter) resolve() (*walletconnect.Client, error) {
+	if g == nil {
+		return nil, errWCClientNotInitialized
+	}
+	c := g()
+	if c == nil {
+		return nil, errWCClientNotInitialized
+	}
+	return c, nil
+}
+
 type wcSessionDisconnector struct {
 	db        *sql.DB
 	getClient WCClientGetter
@@ -40,13 +53,11 @@ func (d *wcSessionDisconnector) DisconnectSession(ctx context.Context, topic str
 		_ = persistence.DeleteWCSession(d.db, topic)
 	}
 
-	if d.getClient != nil {
-		if client := d.getClient(); client != nil {
-			go func(ctx context.Context, topic string, client *walletconnect.Client) {
-				defer common.LogOnPanic()
-				_ = client.SendSessionDelete(ctx, topic)
-			}(ctx, topic, client)
-		}
+	if client, err := d.getClient.resolve(); err == nil {
+		go func(ctx context.Context, topic string, client *walletconnect.Client) {
+			defer common.LogOnPanic()
+			_ = client.SendSessionDelete(ctx, topic)
+		}(ctx, topic, client)
 	}
 	return nil
 }
@@ -62,12 +73,9 @@ func NewPairWCCommand(getClient WCClientGetter) *PairWCCommand {
 }
 
 func (c *PairWCCommand) Execute(ctx context.Context, uri string) error {
-	var client *walletconnect.Client
-	if c.getClient != nil {
-		client = c.getClient()
-	}
-	if client == nil {
-		return fmt.Errorf("WalletConnect client not initialized")
+	client, err := c.getClient.resolve()
+	if err != nil {
+		return err
 	}
 	return client.Pair(ctx, uri)
 }
@@ -103,12 +111,9 @@ func (c *ApproveWCSessionCommand) Execute(ctx context.Context, proposalID, accou
 		return "", fmt.Errorf("invalid account address: %s", account)
 	}
 
-	var client *walletconnect.Client
-	if c.getClient != nil {
-		client = c.getClient()
-	}
-	if client == nil {
-		return "", fmt.Errorf("WalletConnect client not initialized")
+	client, err := c.getClient.resolve()
+	if err != nil {
+		return "", err
 	}
 
 	if len(supportedChains) == 0 {
@@ -167,12 +172,9 @@ func NewRejectWCSessionCommand(getClient WCClientGetter) *RejectWCSessionCommand
 }
 
 func (c *RejectWCSessionCommand) Execute(ctx context.Context, proposalID string) error {
-	var client *walletconnect.Client
-	if c.getClient != nil {
-		client = c.getClient()
-	}
-	if client == nil {
-		return fmt.Errorf("WalletConnect client not initialized")
+	client, err := c.getClient.resolve()
+	if err != nil {
+		return err
 	}
 	return client.RejectSession(proposalID)
 }
@@ -188,12 +190,9 @@ func NewApproveWCSessionRequestCommand(getClient WCClientGetter) *ApproveWCSessi
 }
 
 func (c *ApproveWCSessionRequestCommand) Execute(ctx context.Context, topic, requestIDStr, signature string) error {
-	var client *walletconnect.Client
-	if c.getClient != nil {
-		client = c.getClient()
-	}
-	if client == nil {
-		return fmt.Errorf("WalletConnect client not initialized")
+	client, err := c.getClient.resolve()
+	if err != nil {
+		return err
 	}
 	var requestID int64
 	if _, err := fmt.Sscanf(requestIDStr, "%d", &requestID); err != nil {
@@ -213,12 +212,9 @@ func NewRejectWCSessionRequestCommand(getClient WCClientGetter) *RejectWCSession
 }
 
 func (c *RejectWCSessionRequestCommand) Execute(ctx context.Context, topic, requestIDStr string, code int, message string) error {
-	var client *walletconnect.Client
-	if c.getClient != nil {
-		client = c.getClient()
-	}
-	if client == nil {
-		return fmt.Errorf("WalletConnect client not initialized")
+	client, err := c.getClient.resolve()
+	if err != nil {
+		return err
 	}
 	var requestID int64
 	if _, err := fmt.Sscanf(requestIDStr, "%d", &requestID); err != nil {

--- a/services/connector/commands/walletconnect.go
+++ b/services/connector/commands/walletconnect.go
@@ -3,6 +3,7 @@ package commands
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"time"
 
@@ -12,15 +13,15 @@ import (
 	"github.com/status-im/status-go/services/connector/walletconnect"
 )
 
-var errWCClientNotInitialized = fmt.Errorf("WalletConnect client not initialized")
+var ErrWCClientNotInitialized = errors.New("WalletConnect client not initialized")
 
 func (g WCClientGetter) resolve() (*walletconnect.Client, error) {
 	if g == nil {
-		return nil, errWCClientNotInitialized
+		return nil, ErrWCClientNotInitialized
 	}
 	c := g()
 	if c == nil {
-		return nil, errWCClientNotInitialized
+		return nil, ErrWCClientNotInitialized
 	}
 	return c, nil
 }

--- a/services/connector/commands/walletconnect.go
+++ b/services/connector/commands/walletconnect.go
@@ -13,15 +13,15 @@ import (
 )
 
 type wcSessionDisconnector struct {
-	db       *sql.DB
-	wcClient *walletconnect.Client
+	db        *sql.DB
+	getClient WCClientGetter
 }
 
 // NewWCSessionDisconnector creates a new WCSessionDisconnector
-func NewWCSessionDisconnector(db *sql.DB, wcClient *walletconnect.Client) WCSessionDisconnector {
+func NewWCSessionDisconnector(db *sql.DB, getClient WCClientGetter) WCSessionDisconnector {
 	return &wcSessionDisconnector{
-		db:       db,
-		wcClient: wcClient,
+		db:        db,
+		getClient: getClient,
 	}
 }
 
@@ -40,27 +40,36 @@ func (d *wcSessionDisconnector) DisconnectSession(ctx context.Context, topic str
 		_ = persistence.DeleteWCSession(d.db, topic)
 	}
 
-	if d.wcClient != nil {
-		go func(ctx context.Context, topic string) {
-			defer common.LogOnPanic()
-			_ = d.wcClient.SendSessionDelete(ctx, topic)
-		}(ctx, topic)
+	if d.getClient != nil {
+		if client := d.getClient(); client != nil {
+			go func(ctx context.Context, topic string, client *walletconnect.Client) {
+				defer common.LogOnPanic()
+				_ = client.SendSessionDelete(ctx, topic)
+			}(ctx, topic, client)
+		}
 	}
 	return nil
 }
 
 type PairWCCommand struct {
-	wcClient *walletconnect.Client
+	getClient WCClientGetter
 }
 
-func NewPairWCCommand(wcClient *walletconnect.Client) *PairWCCommand {
+func NewPairWCCommand(getClient WCClientGetter) *PairWCCommand {
 	return &PairWCCommand{
-		wcClient: wcClient,
+		getClient: getClient,
 	}
 }
 
 func (c *PairWCCommand) Execute(ctx context.Context, uri string) error {
-	return c.wcClient.Pair(ctx, uri)
+	var client *walletconnect.Client
+	if c.getClient != nil {
+		client = c.getClient()
+	}
+	if client == nil {
+		return fmt.Errorf("WalletConnect client not initialized")
+	}
+	return client.Pair(ctx, uri)
 }
 
 type GetWCActiveSessionsCommand struct {
@@ -78,14 +87,14 @@ func (c *GetWCActiveSessionsCommand) Execute(ctx context.Context, validAtTimesta
 }
 
 type ApproveWCSessionCommand struct {
-	db       *sql.DB
-	wcClient *walletconnect.Client
+	db        *sql.DB
+	getClient WCClientGetter
 }
 
-func NewApproveWCSessionCommand(db *sql.DB, wcClient *walletconnect.Client) *ApproveWCSessionCommand {
+func NewApproveWCSessionCommand(db *sql.DB, getClient WCClientGetter) *ApproveWCSessionCommand {
 	return &ApproveWCSessionCommand{
-		db:       db,
-		wcClient: wcClient,
+		db:        db,
+		getClient: getClient,
 	}
 }
 
@@ -94,7 +103,11 @@ func (c *ApproveWCSessionCommand) Execute(ctx context.Context, proposalID, accou
 		return "", fmt.Errorf("invalid account address: %s", account)
 	}
 
-	if c.wcClient == nil {
+	var client *walletconnect.Client
+	if c.getClient != nil {
+		client = c.getClient()
+	}
+	if client == nil {
 		return "", fmt.Errorf("WalletConnect client not initialized")
 	}
 
@@ -118,7 +131,7 @@ func (c *ApproveWCSessionCommand) Execute(ctx context.Context, proposalID, accou
 		ExpirySec: 0,
 	}
 
-	result, err := c.wcClient.ApproveSession(ctx, proposalID, meta)
+	result, err := client.ApproveSession(ctx, proposalID, meta)
 	if err != nil {
 		return "", fmt.Errorf("approve session: %w", err)
 	}
@@ -144,60 +157,72 @@ func (c *ApproveWCSessionCommand) Execute(ctx context.Context, proposalID, accou
 }
 
 type RejectWCSessionCommand struct {
-	wcClient *walletconnect.Client
+	getClient WCClientGetter
 }
 
-func NewRejectWCSessionCommand(wcClient *walletconnect.Client) *RejectWCSessionCommand {
+func NewRejectWCSessionCommand(getClient WCClientGetter) *RejectWCSessionCommand {
 	return &RejectWCSessionCommand{
-		wcClient: wcClient,
+		getClient: getClient,
 	}
 }
 
 func (c *RejectWCSessionCommand) Execute(ctx context.Context, proposalID string) error {
-	if c.wcClient == nil {
+	var client *walletconnect.Client
+	if c.getClient != nil {
+		client = c.getClient()
+	}
+	if client == nil {
 		return fmt.Errorf("WalletConnect client not initialized")
 	}
-	return c.wcClient.RejectSession(proposalID)
+	return client.RejectSession(proposalID)
 }
 
 type ApproveWCSessionRequestCommand struct {
-	wcClient *walletconnect.Client
+	getClient WCClientGetter
 }
 
-func NewApproveWCSessionRequestCommand(wcClient *walletconnect.Client) *ApproveWCSessionRequestCommand {
+func NewApproveWCSessionRequestCommand(getClient WCClientGetter) *ApproveWCSessionRequestCommand {
 	return &ApproveWCSessionRequestCommand{
-		wcClient: wcClient,
+		getClient: getClient,
 	}
 }
 
 func (c *ApproveWCSessionRequestCommand) Execute(ctx context.Context, topic, requestIDStr, signature string) error {
-	if c.wcClient == nil {
+	var client *walletconnect.Client
+	if c.getClient != nil {
+		client = c.getClient()
+	}
+	if client == nil {
 		return fmt.Errorf("WalletConnect client not initialized")
 	}
 	var requestID int64
 	if _, err := fmt.Sscanf(requestIDStr, "%d", &requestID); err != nil {
 		return fmt.Errorf("invalid request ID: %w", err)
 	}
-	return c.wcClient.RespondToWCSessionRequest(topic, requestID, signature)
+	return client.RespondToWCSessionRequest(topic, requestID, signature)
 }
 
 type RejectWCSessionRequestCommand struct {
-	wcClient *walletconnect.Client
+	getClient WCClientGetter
 }
 
-func NewRejectWCSessionRequestCommand(wcClient *walletconnect.Client) *RejectWCSessionRequestCommand {
+func NewRejectWCSessionRequestCommand(getClient WCClientGetter) *RejectWCSessionRequestCommand {
 	return &RejectWCSessionRequestCommand{
-		wcClient: wcClient,
+		getClient: getClient,
 	}
 }
 
 func (c *RejectWCSessionRequestCommand) Execute(ctx context.Context, topic, requestIDStr string, code int, message string) error {
-	if c.wcClient == nil {
+	var client *walletconnect.Client
+	if c.getClient != nil {
+		client = c.getClient()
+	}
+	if client == nil {
 		return fmt.Errorf("WalletConnect client not initialized")
 	}
 	var requestID int64
 	if _, err := fmt.Sscanf(requestIDStr, "%d", &requestID); err != nil {
 		return fmt.Errorf("invalid request ID: %w", err)
 	}
-	return c.wcClient.RejectWCSessionRequest(topic, requestID, code, message)
+	return client.RejectWCSessionRequest(topic, requestID, code, message)
 }

--- a/services/connector/commands/walletconnect_test.go
+++ b/services/connector/commands/walletconnect_test.go
@@ -71,7 +71,7 @@ func TestApproveWCSessionCommand_EmptyChains(t *testing.T) {
 	client, err := walletconnect.NewClient("test")
 	require.NoError(t, err)
 
-	cmd := NewApproveWCSessionCommand(db, client)
+	cmd := NewApproveWCSessionCommand(db, func() *walletconnect.Client { return client })
 	_, err = cmd.Execute(context.Background(), "proposal1", "0x1234567890abcdef1234567890abcdef12345678", "https://dapp.com", "DApp", "", []uint64{})
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "supportedChains must not be empty")
@@ -94,7 +94,7 @@ func TestApproveWCSessionCommand_ProposalNotFound(t *testing.T) {
 	client, err := walletconnect.NewClient("test")
 	require.NoError(t, err)
 
-	cmd := NewApproveWCSessionCommand(db, client)
+	cmd := NewApproveWCSessionCommand(db, func() *walletconnect.Client { return client })
 	_, err = cmd.Execute(context.Background(), "non-existent-proposal", "0x1234567890abcdef1234567890abcdef12345678", "https://dapp.com", "DApp", "", []uint64{1})
 	require.Error(t, err)
 	require.ErrorIs(t, err, walletconnect.ErrProposalNotFound)
@@ -113,7 +113,7 @@ func TestRejectWCSessionCommand_ProposalNotFound(t *testing.T) {
 	client, err := walletconnect.NewClient("test")
 	require.NoError(t, err)
 
-	cmd := NewRejectWCSessionCommand(client)
+	cmd := NewRejectWCSessionCommand(func() *walletconnect.Client { return client })
 	err = cmd.Execute(context.Background(), "non-existent-proposal")
 	require.Error(t, err)
 	require.ErrorIs(t, err, walletconnect.ErrProposalNotFound)
@@ -132,7 +132,7 @@ func TestApproveWCSessionRequestCommand_InvalidRequestID(t *testing.T) {
 	client, err := walletconnect.NewClient("test")
 	require.NoError(t, err)
 
-	cmd := NewApproveWCSessionRequestCommand(client)
+	cmd := NewApproveWCSessionRequestCommand(func() *walletconnect.Client { return client })
 	err = cmd.Execute(context.Background(), "topic", "not-a-number", "0xsignature")
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "invalid request ID")
@@ -142,7 +142,7 @@ func TestApproveWCSessionRequestCommand_SessionNotFound(t *testing.T) {
 	client, err := walletconnect.NewClient("test")
 	require.NoError(t, err)
 
-	cmd := NewApproveWCSessionRequestCommand(client)
+	cmd := NewApproveWCSessionRequestCommand(func() *walletconnect.Client { return client })
 	err = cmd.Execute(context.Background(), "non-existent-topic", "12345", "0xsignature")
 	require.Error(t, err)
 	require.ErrorIs(t, err, walletconnect.ErrSessionNotFound)
@@ -161,7 +161,7 @@ func TestRejectWCSessionRequestCommand_InvalidRequestID(t *testing.T) {
 	client, err := walletconnect.NewClient("test")
 	require.NoError(t, err)
 
-	cmd := NewRejectWCSessionRequestCommand(client)
+	cmd := NewRejectWCSessionRequestCommand(func() *walletconnect.Client { return client })
 	err = cmd.Execute(context.Background(), "topic", "not-a-number", 4001, "User rejected")
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "invalid request ID")
@@ -171,7 +171,7 @@ func TestRejectWCSessionRequestCommand_SessionNotFound(t *testing.T) {
 	client, err := walletconnect.NewClient("test")
 	require.NoError(t, err)
 
-	cmd := NewRejectWCSessionRequestCommand(client)
+	cmd := NewRejectWCSessionRequestCommand(func() *walletconnect.Client { return client })
 	err = cmd.Execute(context.Background(), "non-existent-topic", "12345", 4001, "User rejected")
 	require.Error(t, err)
 	require.ErrorIs(t, err, walletconnect.ErrSessionNotFound)
@@ -183,7 +183,7 @@ func TestPairWCCommand_InvalidURI(t *testing.T) {
 	client, err := walletconnect.NewClient("test")
 	require.NoError(t, err)
 
-	cmd := NewPairWCCommand(client)
+	cmd := NewPairWCCommand(func() *walletconnect.Client { return client })
 	// An invalid URI that fails ParseURI before any network access
 	err = cmd.Execute(context.Background(), "not-a-valid-wc-uri")
 	require.Error(t, err)

--- a/services/connector/commands/walletconnect_test.go
+++ b/services/connector/commands/walletconnect_test.go
@@ -84,7 +84,7 @@ func TestApproveWCSessionCommand_NilClient(t *testing.T) {
 	cmd := NewApproveWCSessionCommand(db, nil)
 	_, err := cmd.Execute(context.Background(), "proposal1", "0x1234567890abcdef1234567890abcdef12345678", "https://dapp.com", "DApp", "", []uint64{1})
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "WalletConnect client not initialized")
+	require.ErrorIs(t, err, ErrWCClientNotInitialized)
 }
 
 func TestApproveWCSessionCommand_ProposalNotFound(t *testing.T) {
@@ -106,7 +106,7 @@ func TestRejectWCSessionCommand_NilClient(t *testing.T) {
 	cmd := NewRejectWCSessionCommand(nil)
 	err := cmd.Execute(context.Background(), "proposal1")
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "WalletConnect client not initialized")
+	require.ErrorIs(t, err, ErrWCClientNotInitialized)
 }
 
 func TestRejectWCSessionCommand_ProposalNotFound(t *testing.T) {
@@ -125,7 +125,7 @@ func TestApproveWCSessionRequestCommand_NilClient(t *testing.T) {
 	cmd := NewApproveWCSessionRequestCommand(nil)
 	err := cmd.Execute(context.Background(), "topic", "12345", "0xsignature")
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "WalletConnect client not initialized")
+	require.ErrorIs(t, err, ErrWCClientNotInitialized)
 }
 
 func TestApproveWCSessionRequestCommand_InvalidRequestID(t *testing.T) {
@@ -154,7 +154,7 @@ func TestRejectWCSessionRequestCommand_NilClient(t *testing.T) {
 	cmd := NewRejectWCSessionRequestCommand(nil)
 	err := cmd.Execute(context.Background(), "topic", "12345", 4001, "User rejected")
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "WalletConnect client not initialized")
+	require.ErrorIs(t, err, ErrWCClientNotInitialized)
 }
 
 func TestRejectWCSessionRequestCommand_InvalidRequestID(t *testing.T) {

--- a/services/connector/service.go
+++ b/services/connector/service.go
@@ -78,6 +78,29 @@ func (s *Service) GetClient() *walletconnect.Client {
 	return s.wcClient.Load()
 }
 
+func (s *Service) restoreActiveWCSessions(wcClient *walletconnect.Client) {
+	activeSessions, err := persistence.SelectActiveWCSessions(s.db, time.Now().Unix())
+	if err != nil {
+		s.logger.Error("failed to load active WC sessions", zap.Error(err))
+		return
+	}
+	if len(activeSessions) == 0 {
+		return
+	}
+	restored := make([]walletconnect.RestoredSession, 0, len(activeSessions))
+	for _, session := range activeSessions {
+		restored = append(restored, walletconnect.RestoredSession{
+			Topic:  session.Topic,
+			SymKey: session.SymKey,
+		})
+	}
+	wcClient.RestoreSessions(restored)
+	s.logger.Info("restored WalletConnect sessions", zap.Int("count", len(restored)))
+	if err := wcClient.ConnectAndResubscribe(); err != nil {
+		s.logger.Warn("failed to connect relay for restored WC sessions", zap.Error(err))
+	}
+}
+
 // initWCClient creates wcClient when nil. Safe to call without holding s.mu (uses atomic.Pointer).
 func (s *Service) initWCClient() {
 	if s.wcClient.Load() != nil {
@@ -93,23 +116,7 @@ func (s *Service) initWCClient() {
 		return
 	}
 
-	activeSessions, err := persistence.SelectActiveWCSessions(s.db, time.Now().Unix())
-	if err != nil {
-		s.logger.Error("failed to load active WC sessions", zap.Error(err))
-	} else if len(activeSessions) > 0 {
-		restoredSessions := make([]walletconnect.RestoredSession, 0, len(activeSessions))
-		for _, session := range activeSessions {
-			restoredSessions = append(restoredSessions, walletconnect.RestoredSession{
-				Topic:  session.Topic,
-				SymKey: session.SymKey,
-			})
-		}
-		wcClient.RestoreSessions(restoredSessions)
-		s.logger.Info("restored WalletConnect sessions", zap.Int("count", len(restoredSessions)))
-		if err := wcClient.ConnectAndResubscribe(); err != nil {
-			s.logger.Warn("failed to connect relay for restored WC sessions", zap.Error(err))
-		}
-	}
+	s.restoreActiveWCSessions(wcClient)
 
 	wcClient.SetSessionDeleteHandler(func(topic string) {
 		s.logger.Info("received wc_sessionDelete", zap.String("topic", topic))

--- a/services/connector/service.go
+++ b/services/connector/service.go
@@ -81,6 +81,10 @@ func (s *Service) Start() error {
 		}
 	})
 
+	if s.api == nil {
+		s.api = NewAPI(s)
+	}
+
 	// Create an RPC server
 	s.rpcServer = gethrpc.NewServer()
 
@@ -150,6 +154,7 @@ func (s *Service) stopLocked() error {
 			s.logger.Error("failed to close WalletConnect client", zap.Error(err))
 		}
 	}
+	s.api = nil
 
 	if s.wsServer == nil {
 		s.started = false

--- a/services/connector/service.go
+++ b/services/connector/service.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net/http"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"go.uber.org/zap"
@@ -17,6 +18,8 @@ import (
 	"github.com/status-im/status-go/internal/rpc/network"
 	"github.com/status-im/status-go/services/connector/chainutils"
 	persistence "github.com/status-im/status-go/services/connector/database"
+	"github.com/status-im/status-go/services/connector/walletconnect"
+	"github.com/status-im/status-go/signal"
 )
 
 const serviceName = "connector"
@@ -44,6 +47,7 @@ func NewService(
 		config:          config,
 	}
 	s.api = NewAPI(s)
+	s.initWCClient()
 	return s
 }
 
@@ -66,9 +70,70 @@ type Service struct {
 	paused             bool
 	started            bool
 	purgeEphemeralOnce sync.Once
+
+	wcClient atomic.Pointer[walletconnect.Client] // owned by Service; recreated after Pause/Resume or Stop
+}
+
+func (s *Service) GetClient() *walletconnect.Client {
+	return s.wcClient.Load()
+}
+
+// initWCClient creates wcClient when nil. Safe to call without holding s.mu (uses atomic.Pointer).
+func (s *Service) initWCClient() {
+	if s.wcClient.Load() != nil {
+		return
+	}
+
+	wcClient, err := walletconnect.NewClient(s.config.ProjectID)
+	if err != nil {
+		s.logger.Error("failed to create WalletConnect client", zap.Error(err))
+		return
+	}
+	if wcClient == nil {
+		return
+	}
+
+	activeSessions, err := persistence.SelectActiveWCSessions(s.db, time.Now().Unix())
+	if err != nil {
+		s.logger.Error("failed to load active WC sessions", zap.Error(err))
+	} else if len(activeSessions) > 0 {
+		restoredSessions := make([]walletconnect.RestoredSession, 0, len(activeSessions))
+		for _, session := range activeSessions {
+			restoredSessions = append(restoredSessions, walletconnect.RestoredSession{
+				Topic:  session.Topic,
+				SymKey: session.SymKey,
+			})
+		}
+		wcClient.RestoreSessions(restoredSessions)
+		s.logger.Info("restored WalletConnect sessions", zap.Int("count", len(restoredSessions)))
+		if err := wcClient.ConnectAndResubscribe(); err != nil {
+			s.logger.Warn("failed to connect relay for restored WC sessions", zap.Error(err))
+		}
+	}
+
+	wcClient.SetSessionDeleteHandler(func(topic string) {
+		s.logger.Info("received wc_sessionDelete", zap.String("topic", topic))
+		session, err := persistence.SelectWCSession(s.db, topic)
+		dappURL := ""
+		if err == nil && session != nil {
+			dappURL = session.DAppURL
+		}
+		if err := s.api.wcSessionDisconnector.DisconnectSession(context.Background(), topic); err != nil {
+			s.logger.Error("failed to disconnect WC session", zap.String("topic", topic), zap.Error(err))
+		} else {
+			s.logger.Info("WC session disconnected", zap.String("topic", topic), zap.String("dappURL", dappURL))
+		}
+		signal.SendWCSessionDelete(topic, dappURL)
+	})
+
+	if !s.wcClient.CompareAndSwap(nil, wcClient) {
+		_ = wcClient.Close()
+	}
 }
 
 func (s *Service) Start() error {
+	s.initWCClient()
+
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if s.started {
@@ -80,10 +145,6 @@ func (s *Service) Start() error {
 			s.logger.Warn("failed to delete ephemeral dapps on first start", zap.Error(err))
 		}
 	})
-
-	if s.api == nil {
-		s.api = NewAPI(s)
-	}
 
 	// Create an RPC server
 	s.rpcServer = gethrpc.NewServer()
@@ -149,12 +210,11 @@ func (s *Service) stopLocked() error {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
 	defer cancel()
 
-	if s.api != nil && s.api.wcClient != nil {
-		if err := s.api.wcClient.Close(); err != nil {
+	if c := s.wcClient.Swap(nil); c != nil {
+		if err := c.Close(); err != nil {
 			s.logger.Error("failed to close WalletConnect client", zap.Error(err))
 		}
 	}
-	s.api = nil
 
 	if s.wsServer == nil {
 		s.started = false

--- a/services/connector/service_pausable.go
+++ b/services/connector/service_pausable.go
@@ -26,6 +26,7 @@ func (s *Service) Resume() error {
 	s.paused = false
 	s.started = false
 	s.mu.Unlock()
+	s.initWCClient()
 	return s.Start()
 }
 

--- a/services/connector/service_test.go
+++ b/services/connector/service_test.go
@@ -89,36 +89,33 @@ func TestService_Stop(t *testing.T) {
 	assert.NoError(t, err)
 }
 
-func TestService_StopStart_RecreatesWalletConnectClient(t *testing.T) {
-	state := setupTests(t)
-
-	require.NoError(t, state.service.Start())
-	initial := state.service.api.wcClient
-	require.NotNil(t, initial)
-
-	require.NoError(t, state.service.Stop())
-	require.NoError(t, state.service.Start())
-
-	require.NotNil(t, state.service.api)
-	require.NotNil(t, state.service.api.wcClient)
-	require.NotSame(t, initial, state.service.api.wcClient,
-		"wcClient must be recreated after Stop/Start to avoid relay disconnect requested")
-}
-
-func TestService_PauseResume_RecreatesWalletConnectClient(t *testing.T) {
+func TestService_APIPointerStableAcrossPauseResume(t *testing.T) {
 	state := setupTests(t)
 	state.service.config.WSEnabled = false
 
 	require.NoError(t, state.service.Start())
-	initial := state.service.api.wcClient
-	require.NotNil(t, initial)
-
+	apiBefore := state.service.APIs()[0].Service
 	require.NoError(t, state.service.Pause())
 	require.NoError(t, state.service.Resume())
+	apiAfter := state.service.APIs()[0].Service
+	require.Same(t, apiBefore, apiAfter)
+	require.NoError(t, state.service.Stop())
+}
 
-	require.NotNil(t, state.service.api)
-	require.NotNil(t, state.service.api.wcClient)
-	require.NotSame(t, initial, state.service.api.wcClient)
+func TestService_ProviderReturnsFreshClientAfterPauseResume(t *testing.T) {
+	state := setupTests(t)
+	state.service.config.WSEnabled = false
+
+	require.NoError(t, state.service.Start())
+	c1 := state.service.GetClient()
+	require.NotNil(t, c1)
+	require.NoError(t, state.service.Pause())
+	require.Nil(t, state.service.GetClient())
+	require.NoError(t, state.service.Resume())
+	c2 := state.service.GetClient()
+	require.NotNil(t, c2)
+	require.NotSame(t, c1, c2)
+	require.NoError(t, state.service.Stop())
 }
 
 func TestService_APIs(t *testing.T) {

--- a/services/connector/service_test.go
+++ b/services/connector/service_test.go
@@ -89,6 +89,38 @@ func TestService_Stop(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+func TestService_StopStart_RecreatesWalletConnectClient(t *testing.T) {
+	state := setupTests(t)
+
+	require.NoError(t, state.service.Start())
+	initial := state.service.api.wcClient
+	require.NotNil(t, initial)
+
+	require.NoError(t, state.service.Stop())
+	require.NoError(t, state.service.Start())
+
+	require.NotNil(t, state.service.api)
+	require.NotNil(t, state.service.api.wcClient)
+	require.NotSame(t, initial, state.service.api.wcClient,
+		"wcClient must be recreated after Stop/Start to avoid relay disconnect requested")
+}
+
+func TestService_PauseResume_RecreatesWalletConnectClient(t *testing.T) {
+	state := setupTests(t)
+	state.service.config.WSEnabled = false
+
+	require.NoError(t, state.service.Start())
+	initial := state.service.api.wcClient
+	require.NotNil(t, initial)
+
+	require.NoError(t, state.service.Pause())
+	require.NoError(t, state.service.Resume())
+
+	require.NotNil(t, state.service.api)
+	require.NotNil(t, state.service.api.wcClient)
+	require.NotSame(t, initial, state.service.api.wcClient)
+}
+
 func TestService_APIs(t *testing.T) {
 	state := setupTests(t)
 

--- a/services/connector/test_helpers_test.go
+++ b/services/connector/test_helpers_test.go
@@ -98,7 +98,7 @@ func setupTests(t *testing.T) (state testState) {
 		&Config{},
 	)
 
-	state.api = NewAPI(state.service)
+	state.api = state.service.api
 
 	return state
 }

--- a/services/connector/walletconnect/relay.go
+++ b/services/connector/walletconnect/relay.go
@@ -120,6 +120,7 @@ type RelayClient struct {
 	writeMu      sync.Mutex // serializes writes (gorilla/websocket requires it)
 	reconnectMu  sync.Mutex // serializes reconnect attempts
 	readLoopOnce sync.Once  // starts readLoop at most once per RelayClient lifetime
+	closeOnce    sync.Once  // closes r.done at most once (Close idempotent)
 }
 
 // NewRelayClient creates a new relay client.
@@ -279,12 +280,14 @@ func (r *RelayClient) Close() error {
 	r.conn = nil
 	r.mu.Unlock()
 
-	if conn == nil {
-		return nil
-	}
+	r.closeOnce.Do(func() {
+		close(r.done)
+	})
 
-	close(r.done)
-	err := conn.Close()
+	var err error
+	if conn != nil {
+		err = conn.Close()
+	}
 	r.wg.Wait()
 	return err
 }
@@ -405,14 +408,21 @@ func (r *RelayClient) call(method string, params any) (json.RawMessage, error) {
 			return nil, fmt.Errorf("reconnect: %w", err)
 		}
 		conn = r.getConn()
+		if conn == nil {
+			return nil, fmt.Errorf("connection lost immediately after reconnect")
+		}
 	}
 
 	if err := r.writeMessage(conn, body); err != nil {
 		r.markBroken(conn)
 		if err2 := r.ensureConnected(); err2 != nil {
-			return nil, fmt.Errorf("write: %w", err)
+			return nil, fmt.Errorf("write failed: %v; reconnect failed: %w", err, err2)
 		}
-		if err := r.writeMessage(r.getConn(), body); err != nil {
+		newConn := r.getConn()
+		if newConn == nil {
+			return nil, fmt.Errorf("write failed: %v; connection lost after reconnect", err)
+		}
+		if err := r.writeMessage(newConn, body); err != nil {
 			return nil, fmt.Errorf("write: %w", err)
 		}
 	}
@@ -535,6 +545,16 @@ func (r *RelayClient) reconnect() error {
 		}
 
 		r.mu.Lock()
+		if r.disconnectRequested {
+			r.mu.Unlock()
+			_ = conn.Close()
+			return fmt.Errorf("disconnect requested during reconnect")
+		}
+		if r.conn != nil {
+			r.mu.Unlock()
+			_ = conn.Close()
+			return nil
+		}
 		r.conn = conn
 		handler := r.reconnectedHandler
 		r.mu.Unlock()

--- a/services/connector/walletconnect/relay.go
+++ b/services/connector/walletconnect/relay.go
@@ -114,6 +114,7 @@ type RelayClient struct {
 	auth                *Auth
 	done                chan struct{}  // signals shutdown
 	disconnectRequested bool           // true if Close() was called intentionally
+	connectedOnce       bool           // true after first successful Connect(); avoids cold-start dial from call()
 	wg                  sync.WaitGroup // tracks active goroutines
 
 	writeMu      sync.Mutex // serializes writes (gorilla/websocket requires it)
@@ -258,6 +259,7 @@ func (r *RelayClient) Connect() error {
 		return nil
 	}
 	r.conn = conn
+	r.connectedOnce = true
 	r.mu.Unlock()
 
 	r.startHeartbeat(conn)
@@ -393,6 +395,12 @@ func (r *RelayClient) call(method string, params any) (json.RawMessage, error) {
 
 	conn := r.getConn()
 	if conn == nil {
+		r.mu.Lock()
+		everConnected := r.connectedOnce
+		r.mu.Unlock()
+		if !everConnected {
+			return nil, fmt.Errorf("not connected")
+		}
 		if err := r.ensureConnected(); err != nil {
 			return nil, fmt.Errorf("reconnect: %w", err)
 		}

--- a/services/connector/walletconnect/relay.go
+++ b/services/connector/walletconnect/relay.go
@@ -169,6 +169,28 @@ func (r *RelayClient) ensureConnected() error {
 	return r.reconnect()
 }
 
+// acquireConn returns a live conn. It reconnects if a previous Connect() succeeded;
+// returns "not connected" if Connect() was never called.
+func (r *RelayClient) acquireConn() (*websocket.Conn, error) {
+	if conn := r.getConn(); conn != nil {
+		return conn, nil
+	}
+	r.mu.Lock()
+	everConnected := r.connectedOnce
+	r.mu.Unlock()
+	if !everConnected {
+		return nil, fmt.Errorf("not connected")
+	}
+	if err := r.ensureConnected(); err != nil {
+		return nil, fmt.Errorf("reconnect: %w", err)
+	}
+	conn := r.getConn()
+	if conn == nil {
+		return nil, fmt.Errorf("connection lost after reconnect")
+	}
+	return conn, nil
+}
+
 // dialRelay opens a new WebSocket to r.url with auth query parameters.
 func (r *RelayClient) dialRelay() (*websocket.Conn, error) {
 	jwt, err := r.auth.GenerateJWT(r.url)
@@ -396,33 +418,18 @@ func (r *RelayClient) call(method string, params any) (json.RawMessage, error) {
 		return nil, err
 	}
 
-	conn := r.getConn()
-	if conn == nil {
-		r.mu.Lock()
-		everConnected := r.connectedOnce
-		r.mu.Unlock()
-		if !everConnected {
-			return nil, fmt.Errorf("not connected")
-		}
-		if err := r.ensureConnected(); err != nil {
-			return nil, fmt.Errorf("reconnect: %w", err)
-		}
-		conn = r.getConn()
-		if conn == nil {
-			return nil, fmt.Errorf("connection lost immediately after reconnect")
-		}
+	conn, err := r.acquireConn()
+	if err != nil {
+		return nil, err
 	}
 
-	if err := r.writeMessage(conn, body); err != nil {
+	if werr := r.writeMessage(conn, body); werr != nil {
 		r.markBroken(conn)
-		if err2 := r.ensureConnected(); err2 != nil {
-			return nil, fmt.Errorf("write failed: %v; reconnect failed: %w", err, err2)
+		conn, err = r.acquireConn()
+		if err != nil {
+			return nil, fmt.Errorf("write %v; %w", werr, err)
 		}
-		newConn := r.getConn()
-		if newConn == nil {
-			return nil, fmt.Errorf("write failed: %v; connection lost after reconnect", err)
-		}
-		if err := r.writeMessage(newConn, body); err != nil {
+		if err := r.writeMessage(conn, body); err != nil {
 			return nil, fmt.Errorf("write: %w", err)
 		}
 	}
@@ -496,20 +503,21 @@ func (r *RelayClient) readLoop() {
 			continue
 		}
 
-		if resp.idString() == "" {
+		id := resp.idString()
+		if id == "" {
 			r.logger.Debug("ignoring relay message with empty ID")
 			continue
 		}
 
 		r.mu.Lock()
-		if ch, ok := r.pending[resp.idString()]; ok {
+		if ch, ok := r.pending[id]; ok {
 			select {
 			case ch <- &resp:
 			default:
 			}
 		} else {
 			r.logger.Debug("received response for unknown request ID",
-				zap.String("id", resp.idString()))
+				zap.String("id", id))
 		}
 		r.mu.Unlock()
 	}

--- a/services/connector/walletconnect/relay.go
+++ b/services/connector/walletconnect/relay.go
@@ -235,7 +235,7 @@ func (r *RelayClient) startHeartbeat(conn *websocket.Conn) {
 			case <-ticker.C:
 				r.writeMu.Lock()
 				c := r.getConn()
-				if c != conn || c == nil {
+				if c != conn {
 					r.writeMu.Unlock()
 					return
 				}

--- a/services/connector/walletconnect/relay.go
+++ b/services/connector/walletconnect/relay.go
@@ -23,6 +23,13 @@ const (
 	defaultMessageTag = 1000
 )
 
+// Tunable intervals for tests (defaults match production behavior).
+var (
+	relayWriteDeadline = 10 * time.Second
+	relayReadDeadline  = 60 * time.Second
+	relayPingInterval  = 30 * time.Second
+)
+
 // truncate safely truncates a string to a maximum length, adding "..." if truncated.
 func truncate(s string, maxLen int) string {
 	if len(s) <= maxLen {
@@ -108,6 +115,10 @@ type RelayClient struct {
 	done                chan struct{}  // signals shutdown
 	disconnectRequested bool           // true if Close() was called intentionally
 	wg                  sync.WaitGroup // tracks active goroutines
+
+	writeMu      sync.Mutex // serializes writes (gorilla/websocket requires it)
+	reconnectMu  sync.Mutex // serializes reconnect attempts
+	readLoopOnce sync.Once  // starts readLoop at most once per RelayClient lifetime
 }
 
 // NewRelayClient creates a new relay client.
@@ -127,23 +138,45 @@ func NewRelayClient(projectID string) (*RelayClient, error) {
 	}, nil
 }
 
-// Connect establishes WebSocket connection to the relay server.
-func (r *RelayClient) Connect() error {
+func (r *RelayClient) getConn() *websocket.Conn {
 	r.mu.Lock()
 	defer r.mu.Unlock()
+	return r.conn
+}
 
-	if r.conn != nil {
+// markBroken closes conn only if it is still the active connection and clears r.conn.
+func (r *RelayClient) markBroken(conn *websocket.Conn) {
+	if conn == nil {
+		return
+	}
+	r.mu.Lock()
+	if r.conn == conn {
+		_ = r.conn.Close()
+		r.conn = nil
+	}
+	r.mu.Unlock()
+}
+
+// ensureConnected reconnects when r.conn is nil; concurrent callers serialize and share the result.
+func (r *RelayClient) ensureConnected() error {
+	r.reconnectMu.Lock()
+	defer r.reconnectMu.Unlock()
+	if r.getConn() != nil {
 		return nil
 	}
+	return r.reconnect()
+}
 
+// dialRelay opens a new WebSocket to r.url with auth query parameters.
+func (r *RelayClient) dialRelay() (*websocket.Conn, error) {
 	jwt, err := r.auth.GenerateJWT(r.url)
 	if err != nil {
-		return fmt.Errorf("generate auth jwt: %w", err)
+		return nil, fmt.Errorf("generate auth jwt: %w", err)
 	}
 
 	u, err := url.Parse(r.url)
 	if err != nil {
-		return fmt.Errorf("parse relay url: %w", err)
+		return nil, fmt.Errorf("parse relay url: %w", err)
 	}
 	q := u.Query()
 	q.Set("auth", jwt)
@@ -152,37 +185,105 @@ func (r *RelayClient) Connect() error {
 
 	conn, _, err := websocket.DefaultDialer.Dial(u.String(), nil)
 	if err != nil {
-		return fmt.Errorf("dial relay: %w", err)
+		return nil, fmt.Errorf("dial relay: %w", err)
 	}
-	r.conn = conn
+	return conn, nil
+}
+
+// startHeartbeat launches a ping goroutine for conn. The goroutine exits automatically
+// when conn is replaced (c != conn check) or when r.done is closed.
+func (r *RelayClient) startHeartbeat(conn *websocket.Conn) {
+	_ = conn.SetReadDeadline(time.Now().Add(relayReadDeadline))
+	conn.SetPongHandler(func(string) error {
+		return conn.SetReadDeadline(time.Now().Add(relayReadDeadline))
+	})
 
 	r.wg.Add(1)
-	go r.readLoop()
+	go func() {
+		defer common.LogOnPanic()
+		defer r.wg.Done()
+		ticker := time.NewTicker(relayPingInterval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-r.done:
+				return
+			case <-ticker.C:
+				r.writeMu.Lock()
+				c := r.getConn()
+				if c != conn || c == nil {
+					r.writeMu.Unlock()
+					return
+				}
+				_ = c.SetWriteDeadline(time.Now().Add(relayWriteDeadline))
+				err := c.WriteMessage(websocket.PingMessage, nil)
+				r.writeMu.Unlock()
+				if err != nil {
+					r.markBroken(c)
+					return
+				}
+			}
+		}
+	}()
+}
+
+// writeMessage sends a text frame under writeMu with a write deadline.
+func (r *RelayClient) writeMessage(conn *websocket.Conn, data []byte) error {
+	r.writeMu.Lock()
+	defer r.writeMu.Unlock()
+	_ = conn.SetWriteDeadline(time.Now().Add(relayWriteDeadline))
+	return conn.WriteMessage(websocket.TextMessage, data)
+}
+
+// Connect establishes WebSocket connection to the relay server.
+func (r *RelayClient) Connect() error {
+	if r.getConn() != nil {
+		return nil
+	}
+
+	conn, err := r.dialRelay()
+	if err != nil {
+		return err
+	}
+
+	r.mu.Lock()
+	switch {
+	case r.disconnectRequested:
+		r.mu.Unlock()
+		_ = conn.Close()
+		return fmt.Errorf("disconnect requested")
+	case r.conn != nil:
+		r.mu.Unlock()
+		_ = conn.Close()
+		return nil
+	}
+	r.conn = conn
+	r.mu.Unlock()
+
+	r.startHeartbeat(conn)
+
+	r.readLoopOnce.Do(func() {
+		r.wg.Add(1)
+		go r.readLoop()
+	})
 	return nil
 }
 
 // Close gracefully shuts down the WebSocket connection and waits for goroutines to finish.
 func (r *RelayClient) Close() error {
 	r.mu.Lock()
-	if r.conn == nil {
-		r.disconnectRequested = true
-		r.mu.Unlock()
-		return nil
-	}
+	r.disconnectRequested = true
 	conn := r.conn
 	r.conn = nil
-	r.disconnectRequested = true
 	r.mu.Unlock()
 
-	// Signal shutdown
+	if conn == nil {
+		return nil
+	}
+
 	close(r.done)
-
-	// Close websocket
 	err := conn.Close()
-
-	// Wait for readLoop to finish
 	r.wg.Wait()
-
 	return err
 }
 
@@ -265,7 +366,6 @@ func (r *RelayClient) SetReconnectedHandler(handler ReconnectedHandler) {
 }
 
 func (r *RelayClient) call(method string, params any) (json.RawMessage, error) {
-	// Generate WalletConnect-compliant numeric ID with 19 digits of entropy
 	id := payloadID()
 	idStr := fmt.Sprintf("%d", id)
 
@@ -291,15 +391,22 @@ func (r *RelayClient) call(method string, params any) (json.RawMessage, error) {
 		return nil, err
 	}
 
-	r.mu.Lock()
-	conn := r.conn
-	r.mu.Unlock()
+	conn := r.getConn()
 	if conn == nil {
-		return nil, fmt.Errorf("not connected")
+		if err := r.ensureConnected(); err != nil {
+			return nil, fmt.Errorf("reconnect: %w", err)
+		}
+		conn = r.getConn()
 	}
 
-	if err := conn.WriteMessage(websocket.TextMessage, body); err != nil {
-		return nil, fmt.Errorf("write: %w", err)
+	if err := r.writeMessage(conn, body); err != nil {
+		r.markBroken(conn)
+		if err2 := r.ensureConnected(); err2 != nil {
+			return nil, fmt.Errorf("write: %w", err)
+		}
+		if err := r.writeMessage(r.getConn(), body); err != nil {
+			return nil, fmt.Errorf("write: %w", err)
+		}
 	}
 
 	select {
@@ -341,15 +448,10 @@ func (r *RelayClient) readLoop() {
 				return
 			}
 
-			r.mu.Lock()
-			if r.conn != nil {
-				r.conn.Close()
-				r.conn = nil
-			}
-			r.mu.Unlock()
+			r.markBroken(conn)
 
 			r.logger.Info("attempting to reconnect to relay")
-			if reconnectErr := r.reconnect(); reconnectErr != nil {
+			if reconnectErr := r.ensureConnected(); reconnectErr != nil {
 				r.logger.Error("failed to reconnect, exiting readLoop", zap.Error(reconnectErr))
 				return
 			}
@@ -417,24 +519,7 @@ func (r *RelayClient) reconnect() error {
 			return fmt.Errorf("disconnect requested during reconnect")
 		}
 
-		jwt, err := r.auth.GenerateJWT(r.url)
-		if err != nil {
-			r.logger.Debug("failed to generate JWT for reconnect", zap.Error(err))
-			backoff = min(backoff*2, maxBackoff)
-			continue
-		}
-
-		u, err := url.Parse(r.url)
-		if err != nil {
-			r.logger.Error("failed to parse relay URL", zap.Error(err))
-			return fmt.Errorf("parse relay url: %w", err)
-		}
-		q := u.Query()
-		q.Set("auth", jwt)
-		q.Set("projectId", r.projectID)
-		u.RawQuery = q.Encode()
-
-		conn, _, err := websocket.DefaultDialer.Dial(u.String(), nil)
+		conn, err := r.dialRelay()
 		if err != nil {
 			r.logger.Debug("failed to dial relay", zap.Error(err), zap.Int("attempt", attempt))
 			backoff = min(backoff*2, maxBackoff)
@@ -443,13 +528,15 @@ func (r *RelayClient) reconnect() error {
 
 		r.mu.Lock()
 		r.conn = conn
-		reconnectedHandler := r.reconnectedHandler
+		handler := r.reconnectedHandler
 		r.mu.Unlock()
+
+		r.startHeartbeat(conn)
 
 		r.logger.Info("successfully reconnected to relay")
 
-		if reconnectedHandler != nil {
-			reconnectedHandler()
+		if handler != nil {
+			handler()
 		}
 
 		return nil

--- a/services/connector/walletconnect/relay_reconnect_test.go
+++ b/services/connector/walletconnect/relay_reconnect_test.go
@@ -1,137 +1,17 @@
 package walletconnect
 
 import (
-	"encoding/json"
 	"fmt"
-	"net/http"
-	"net/http/httptest"
-	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
 
-	"github.com/gorilla/websocket"
 	"github.com/stretchr/testify/require"
 )
 
-// fakeRelay is an in-process WalletConnect IRN-like WebSocket server for reconnect tests.
-type fakeRelay struct {
-	Server *httptest.Server
-
-	mu          sync.Mutex
-	currentConn *websocket.Conn
-
-	accepted      int32
-	forceDropAt   int32 // after N-th accepted connection, close immediately after upgrade
-	echoSubscribe bool
-	silentOnPing  bool
-}
-
-func newFakeRelay(t *testing.T, forceDropAt int32, echoSubscribe, silentOnPing bool) *fakeRelay {
-	t.Helper()
-	fr := &fakeRelay{
-		forceDropAt:   forceDropAt,
-		echoSubscribe: echoSubscribe,
-		silentOnPing:  silentOnPing,
-	}
-	upgrader := websocket.Upgrader{CheckOrigin: func(*http.Request) bool { return true }}
-
-	mux := http.NewServeMux()
-	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
-		conn, err := upgrader.Upgrade(w, r, nil)
-		if err != nil {
-			return
-		}
-		n := atomic.AddInt32(&fr.accepted, 1)
-		if fr.forceDropAt > 0 && n == fr.forceDropAt {
-			_ = conn.Close()
-			return
-		}
-		if fr.silentOnPing {
-			conn.SetPingHandler(func(string) error { return nil })
-		}
-		fr.mu.Lock()
-		fr.currentConn = conn
-		fr.mu.Unlock()
-		defer func() {
-			fr.mu.Lock()
-			if fr.currentConn == conn {
-				fr.currentConn = nil
-			}
-			fr.mu.Unlock()
-		}()
-
-		for {
-			mt, message, err := conn.ReadMessage()
-			if err != nil {
-				return
-			}
-			_ = mt
-			if !fr.echoSubscribe {
-				continue
-			}
-			var reqMsg struct {
-				ID     json.RawMessage `json:"id"`
-				Method string          `json:"method"`
-			}
-			if err := json.Unmarshal(message, &reqMsg); err != nil {
-				continue
-			}
-			if reqMsg.Method != "irn_subscribe" {
-				continue
-			}
-			resp := fmt.Sprintf(`{"jsonrpc":"2.0","id":%s,"result":"sub-id"}`, string(reqMsg.ID))
-			_ = conn.SetWriteDeadline(time.Now().Add(5 * time.Second))
-			if err := conn.WriteMessage(websocket.TextMessage, []byte(resp)); err != nil {
-				return
-			}
-		}
-	})
-	fr.Server = httptest.NewServer(mux)
-	t.Cleanup(fr.Server.Close)
-	return fr
-}
-
-func (fr *fakeRelay) wsURL() string {
-	u := fr.Server.URL
-	u = strings.Replace(u, "http://", "ws://", 1)
-	u = strings.Replace(u, "https://", "wss://", 1)
-	return u
-}
-
-func (fr *fakeRelay) DropNow() {
-	fr.mu.Lock()
-	c := fr.currentConn
-	fr.mu.Unlock()
-	if c != nil {
-		_ = c.Close()
-	}
-}
-
-func newTestRelayClient(t *testing.T, fr *fakeRelay) *RelayClient {
-	t.Helper()
-	r, err := NewRelayClient("test")
-	require.NoError(t, err)
-	r.url = fr.wsURL()
-	return r
-}
-
-func TestCall_RetriesOnBrokenWrite(t *testing.T) {
-	fr := newFakeRelay(t, 1, true, false)
-	r := newTestRelayClient(t, fr)
-
-	require.NoError(t, r.Connect())
-	// Let readLoop observe EOF after forceDrop before Subscribe races a buffered write on a dead conn.
-	time.Sleep(50 * time.Millisecond)
-	_, err := r.Subscribe("topic-a")
-	require.NoError(t, err)
-	require.EqualValues(t, 2, atomic.LoadInt32(&fr.accepted))
-	_ = r.Close()
-}
-
 func TestCall_SingleFlightReconnect(t *testing.T) {
-	fr := newFakeRelay(t, 0, true, false)
+	fr := newFakeRelay(t, fakeRelayOpts{echoSubscribe: true})
 	r := newTestRelayClient(t, fr)
 
 	require.NoError(t, r.Connect())
@@ -170,7 +50,7 @@ func TestHeartbeat_DetectsDeadConnection(t *testing.T) {
 		relayWriteDeadline, relayReadDeadline, relayPingInterval = oldW, oldR, oldP
 	}()
 
-	fr := newFakeRelay(t, 0, true, true)
+	fr := newFakeRelay(t, fakeRelayOpts{echoSubscribe: true, silentOnPing: true})
 	r := newTestRelayClient(t, fr)
 
 	reconnected := make(chan struct{}, 8)
@@ -188,28 +68,12 @@ func TestHeartbeat_DetectsDeadConnection(t *testing.T) {
 	_ = r.Close()
 }
 
-func TestReadLoop_UsesSingleFlight(t *testing.T) {
-	fr := newFakeRelay(t, 0, true, false)
-	r := newTestRelayClient(t, fr)
-
-	require.NoError(t, r.Connect())
-	require.EqualValues(t, 1, atomic.LoadInt32(&fr.accepted))
-
-	fr.DropNow()
-	time.Sleep(50 * time.Millisecond)
-
-	_, err := r.Subscribe("t1")
-	require.NoError(t, err)
-	require.EqualValues(t, 2, atomic.LoadInt32(&fr.accepted))
-	_ = r.Close()
-}
-
 func TestClose_StopsHeartbeat(t *testing.T) {
 	oldP := relayPingInterval
 	relayPingInterval = 50 * time.Millisecond
 	defer func() { relayPingInterval = oldP }()
 
-	fr := newFakeRelay(t, 0, true, false)
+	fr := newFakeRelay(t, fakeRelayOpts{echoSubscribe: true})
 	r := newTestRelayClient(t, fr)
 
 	require.NoError(t, r.Connect())
@@ -228,7 +92,7 @@ func TestClose_StopsHeartbeat(t *testing.T) {
 }
 
 func TestConnect_IsIdempotentWhenLive(t *testing.T) {
-	fr := newFakeRelay(t, 0, true, false)
+	fr := newFakeRelay(t, fakeRelayOpts{echoSubscribe: true})
 	r := newTestRelayClient(t, fr)
 
 	require.NoError(t, r.Connect())

--- a/services/connector/walletconnect/relay_reconnect_test.go
+++ b/services/connector/walletconnect/relay_reconnect_test.go
@@ -1,0 +1,230 @@
+package walletconnect
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/gorilla/websocket"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeRelay is an in-process WalletConnect IRN-like WebSocket server for reconnect tests.
+type fakeRelay struct {
+	Server *httptest.Server
+
+	mu          sync.Mutex
+	currentConn *websocket.Conn
+
+	accepted      int32
+	forceDropAt   int32 // after N-th accepted connection, close immediately after upgrade
+	echoSubscribe bool
+	silentOnPing  bool
+}
+
+func newFakeRelay(t *testing.T, forceDropAt int32, echoSubscribe, silentOnPing bool) *fakeRelay {
+	t.Helper()
+	fr := &fakeRelay{
+		forceDropAt:   forceDropAt,
+		echoSubscribe: echoSubscribe,
+		silentOnPing:  silentOnPing,
+	}
+	upgrader := websocket.Upgrader{CheckOrigin: func(*http.Request) bool { return true }}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			return
+		}
+		n := atomic.AddInt32(&fr.accepted, 1)
+		if fr.forceDropAt > 0 && n == fr.forceDropAt {
+			_ = conn.Close()
+			return
+		}
+		if fr.silentOnPing {
+			conn.SetPingHandler(func(string) error { return nil })
+		}
+		fr.mu.Lock()
+		fr.currentConn = conn
+		fr.mu.Unlock()
+		defer func() {
+			fr.mu.Lock()
+			if fr.currentConn == conn {
+				fr.currentConn = nil
+			}
+			fr.mu.Unlock()
+		}()
+
+		for {
+			mt, message, err := conn.ReadMessage()
+			if err != nil {
+				return
+			}
+			_ = mt
+			if !fr.echoSubscribe {
+				continue
+			}
+			var reqMsg struct {
+				ID     json.RawMessage `json:"id"`
+				Method string          `json:"method"`
+			}
+			if err := json.Unmarshal(message, &reqMsg); err != nil {
+				continue
+			}
+			if reqMsg.Method != "irn_subscribe" {
+				continue
+			}
+			resp := fmt.Sprintf(`{"jsonrpc":"2.0","id":%s,"result":"sub-id"}`, string(reqMsg.ID))
+			_ = conn.SetWriteDeadline(time.Now().Add(5 * time.Second))
+			if err := conn.WriteMessage(websocket.TextMessage, []byte(resp)); err != nil {
+				return
+			}
+		}
+	})
+	fr.Server = httptest.NewServer(mux)
+	t.Cleanup(fr.Server.Close)
+	return fr
+}
+
+func (fr *fakeRelay) wsURL() string {
+	u := fr.Server.URL
+	u = strings.Replace(u, "http://", "ws://", 1)
+	u = strings.Replace(u, "https://", "wss://", 1)
+	return u
+}
+
+func (fr *fakeRelay) DropNow() {
+	fr.mu.Lock()
+	c := fr.currentConn
+	fr.mu.Unlock()
+	if c != nil {
+		_ = c.Close()
+	}
+}
+
+func newTestRelayClient(t *testing.T, fr *fakeRelay) *RelayClient {
+	t.Helper()
+	r, err := NewRelayClient("test")
+	require.NoError(t, err)
+	r.url = fr.wsURL()
+	return r
+}
+
+func TestCall_RetriesOnBrokenWrite(t *testing.T) {
+	fr := newFakeRelay(t, 1, true, false)
+	r := newTestRelayClient(t, fr)
+
+	require.NoError(t, r.Connect())
+	_, err := r.Subscribe("topic-a")
+	require.NoError(t, err)
+	require.EqualValues(t, 2, atomic.LoadInt32(&fr.accepted))
+	_ = r.Close()
+}
+
+func TestCall_SingleFlightReconnect(t *testing.T) {
+	fr := newFakeRelay(t, 0, true, false)
+	r := newTestRelayClient(t, fr)
+
+	require.NoError(t, r.Connect())
+	require.EqualValues(t, 1, atomic.LoadInt32(&fr.accepted))
+
+	fr.DropNow()
+	// Give readLoop a moment to clear conn before hammering Subscribe.
+	time.Sleep(50 * time.Millisecond)
+
+	var wg sync.WaitGroup
+	for i := 0; i < 5; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			_, _ = r.Subscribe(fmt.Sprintf("t-%d", i))
+		}(i)
+	}
+	wg.Wait()
+
+	require.EqualValues(t, 2, atomic.LoadInt32(&fr.accepted))
+	_ = r.Close()
+}
+
+func TestHeartbeat_DetectsDeadConnection(t *testing.T) {
+	oldW, oldR, oldP := relayWriteDeadline, relayReadDeadline, relayPingInterval
+	relayWriteDeadline = 2 * time.Second
+	relayReadDeadline = 500 * time.Millisecond
+	relayPingInterval = 200 * time.Millisecond
+	defer func() {
+		relayWriteDeadline, relayReadDeadline, relayPingInterval = oldW, oldR, oldP
+	}()
+
+	fr := newFakeRelay(t, 0, true, true)
+	r := newTestRelayClient(t, fr)
+
+	reconnected := make(chan struct{}, 8)
+	r.SetReconnectedHandler(func() {
+		reconnected <- struct{}{}
+	})
+
+	require.NoError(t, r.Connect())
+
+	select {
+	case <-reconnected:
+	case <-time.After(3 * time.Second):
+		t.Fatal("expected reconnect after dead heartbeat / read deadline")
+	}
+	_ = r.Close()
+}
+
+func TestReadLoop_UsesSingleFlight(t *testing.T) {
+	fr := newFakeRelay(t, 0, true, false)
+	r := newTestRelayClient(t, fr)
+
+	require.NoError(t, r.Connect())
+	require.EqualValues(t, 1, atomic.LoadInt32(&fr.accepted))
+
+	fr.DropNow()
+	time.Sleep(50 * time.Millisecond)
+
+	_, err := r.Subscribe("t1")
+	require.NoError(t, err)
+	require.EqualValues(t, 2, atomic.LoadInt32(&fr.accepted))
+	_ = r.Close()
+}
+
+func TestClose_StopsHeartbeat(t *testing.T) {
+	oldP := relayPingInterval
+	relayPingInterval = 50 * time.Millisecond
+	defer func() { relayPingInterval = oldP }()
+
+	fr := newFakeRelay(t, 0, true, false)
+	r := newTestRelayClient(t, fr)
+
+	require.NoError(t, r.Connect())
+
+	done := make(chan struct{})
+	go func() {
+		_ = r.Close()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(1 * time.Second):
+		t.Fatal("Close hung — heartbeat/readLoop did not finish")
+	}
+}
+
+func TestConnect_IsIdempotentWhenLive(t *testing.T) {
+	fr := newFakeRelay(t, 0, true, false)
+	r := newTestRelayClient(t, fr)
+
+	require.NoError(t, r.Connect())
+	require.NoError(t, r.Connect())
+	require.EqualValues(t, 1, atomic.LoadInt32(&fr.accepted))
+	_ = r.Close()
+}

--- a/services/connector/walletconnect/relay_reconnect_test.go
+++ b/services/connector/walletconnect/relay_reconnect_test.go
@@ -142,14 +142,20 @@ func TestCall_SingleFlightReconnect(t *testing.T) {
 	time.Sleep(50 * time.Millisecond)
 
 	var wg sync.WaitGroup
+	errs := make(chan error, 5)
 	for i := 0; i < 5; i++ {
 		wg.Add(1)
 		go func(i int) {
 			defer wg.Done()
-			_, _ = r.Subscribe(fmt.Sprintf("t-%d", i))
+			_, err := r.Subscribe(fmt.Sprintf("t-%d", i))
+			errs <- err
 		}(i)
 	}
 	wg.Wait()
+	close(errs)
+	for err := range errs {
+		require.NoError(t, err)
+	}
 
 	require.EqualValues(t, 2, atomic.LoadInt32(&fr.accepted))
 	_ = r.Close()

--- a/services/connector/walletconnect/relay_reconnect_test.go
+++ b/services/connector/walletconnect/relay_reconnect_test.go
@@ -122,6 +122,8 @@ func TestCall_RetriesOnBrokenWrite(t *testing.T) {
 	r := newTestRelayClient(t, fr)
 
 	require.NoError(t, r.Connect())
+	// Let readLoop observe EOF after forceDrop before Subscribe races a buffered write on a dead conn.
+	time.Sleep(50 * time.Millisecond)
 	_, err := r.Subscribe("topic-a")
 	require.NoError(t, err)
 	require.EqualValues(t, 2, atomic.LoadInt32(&fr.accepted))

--- a/services/connector/walletconnect/relay_reconnect_test.go
+++ b/services/connector/walletconnect/relay_reconnect_test.go
@@ -3,7 +3,6 @@ package walletconnect
 import (
 	"fmt"
 	"sync"
-	"sync/atomic"
 	"testing"
 	"time"
 
@@ -15,7 +14,7 @@ func TestCall_SingleFlightReconnect(t *testing.T) {
 	r := newTestRelayClient(t, fr)
 
 	require.NoError(t, r.Connect())
-	require.EqualValues(t, 1, atomic.LoadInt32(&fr.accepted))
+	waitAccepted(t, fr, 1)
 
 	fr.DropNow()
 	// Give readLoop a moment to clear conn before hammering Subscribe.
@@ -37,7 +36,7 @@ func TestCall_SingleFlightReconnect(t *testing.T) {
 		require.NoError(t, err)
 	}
 
-	require.EqualValues(t, 2, atomic.LoadInt32(&fr.accepted))
+	waitAccepted(t, fr, 2)
 	_ = r.Close()
 }
 
@@ -97,6 +96,6 @@ func TestConnect_IsIdempotentWhenLive(t *testing.T) {
 
 	require.NoError(t, r.Connect())
 	require.NoError(t, r.Connect())
-	require.EqualValues(t, 1, atomic.LoadInt32(&fr.accepted))
+	waitAccepted(t, fr, 1)
 	_ = r.Close()
 }

--- a/services/connector/walletconnect/relay_test.go
+++ b/services/connector/walletconnect/relay_test.go
@@ -3,11 +3,37 @@ package walletconnect
 import (
 	"encoding/json"
 	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
+	"github.com/gorilla/websocket"
 	"github.com/stretchr/testify/require"
 )
+
+// newRelayTestWSServer starts a minimal echo-style relay endpoint for RelayClient dial tests.
+func newRelayTestWSServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	upgrader := websocket.Upgrader{
+		CheckOrigin: func(r *http.Request) bool { return true },
+	}
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := upgrader.Upgrade(w, r, nil)
+		require.NoError(t, err)
+		defer conn.Close()
+		for {
+			if _, _, err := conn.ReadMessage(); err != nil {
+				return
+			}
+		}
+	}))
+}
+
+func relayTestWSURL(server *httptest.Server) string {
+	return "ws" + strings.TrimPrefix(server.URL, "http")
+}
 
 func TestTruncate(t *testing.T) {
 	tests := []struct {
@@ -249,4 +275,38 @@ func TestRelayClient_DisconnectRequested(t *testing.T) {
 	client.mu.Unlock()
 
 	require.True(t, requested)
+}
+
+func TestRelayClient_ConnectAfterClose_ReturnsDisconnectRequested(t *testing.T) {
+	server := newRelayTestWSServer(t)
+	defer server.Close()
+
+	client, err := NewRelayClient("test")
+	require.NoError(t, err)
+	client.url = relayTestWSURL(server)
+
+	require.NoError(t, client.Connect())
+	require.NoError(t, client.Close())
+
+	err = client.Connect()
+	require.Error(t, err)
+	require.ErrorContains(t, err, "disconnect requested")
+}
+
+func TestRelayClient_FreshInstance_ConnectsCleanly(t *testing.T) {
+	server := newRelayTestWSServer(t)
+	defer server.Close()
+	wsURL := relayTestWSURL(server)
+
+	a, err := NewRelayClient("test")
+	require.NoError(t, err)
+	a.url = wsURL
+	require.NoError(t, a.Connect())
+	require.NoError(t, a.Close())
+
+	b, err := NewRelayClient("test")
+	require.NoError(t, err)
+	b.url = wsURL
+	require.NoError(t, b.Connect())
+	require.NoError(t, b.Close())
 }

--- a/services/connector/walletconnect/relay_test.go
+++ b/services/connector/walletconnect/relay_test.go
@@ -2,41 +2,11 @@ package walletconnect
 
 import (
 	"encoding/json"
-	"fmt"
-	"net/http"
-	"net/http/httptest"
-	"strings"
 	"testing"
 	"time"
 
-	"github.com/gorilla/websocket"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
-
-// newRelayTestWSServer starts a minimal echo-style relay endpoint for RelayClient dial tests.
-func newRelayTestWSServer(t *testing.T) *httptest.Server {
-	t.Helper()
-	upgrader := websocket.Upgrader{
-		CheckOrigin: func(r *http.Request) bool { return true },
-	}
-	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		conn, err := upgrader.Upgrade(w, r, nil)
-		if !assert.NoError(t, err) {
-			return
-		}
-		defer conn.Close()
-		for {
-			if _, _, err := conn.ReadMessage(); err != nil {
-				return
-			}
-		}
-	}))
-}
-
-func relayTestWSURL(server *httptest.Server) string {
-	return "ws" + strings.TrimPrefix(server.URL, "http")
-}
 
 func TestTruncate(t *testing.T) {
 	tests := []struct {
@@ -62,119 +32,37 @@ func TestTruncate(t *testing.T) {
 }
 
 func TestPayloadID(t *testing.T) {
-	id1 := payloadID()
-	id2 := payloadID()
-
-	require.NotEqual(t, id1, id2)
-	require.Greater(t, id1, int64(0))
-	require.Greater(t, id2, int64(0))
-
-	require.Greater(t, id1, int64(1000000000000000))
-}
-
-func TestPayloadID_Format(t *testing.T) {
-	id := payloadID()
-	idStr := fmt.Sprintf("%d", id)
-	require.GreaterOrEqual(t, len(idStr), 19)
-}
-
-func TestJSONRPCRequest_Marshal(t *testing.T) {
-	req := jsonRPCRequest{
-		JSONRPC: "2.0",
-		ID:      int64(123456),
-		Method:  "test_method",
-		Params:  map[string]string{"key": "value"},
-	}
-
-	data, err := json.Marshal(req)
-	require.NoError(t, err)
-
-	var decoded map[string]interface{}
-	err = json.Unmarshal(data, &decoded)
-	require.NoError(t, err)
-	require.Equal(t, "2.0", decoded["jsonrpc"])
-	require.Equal(t, float64(123456), decoded["id"])
-	require.Equal(t, "test_method", decoded["method"])
-}
-
-func TestJSONRPCResponse_Unmarshal(t *testing.T) {
-	data := []byte(`{"jsonrpc":"2.0","id":"abc123","result":"test"}`)
-
-	var resp jsonRPCResponse
-	err := json.Unmarshal(data, &resp)
-	require.NoError(t, err)
-	require.Equal(t, "2.0", resp.JSONRPC)
-	require.Equal(t, "abc123", resp.idString())
-	require.Equal(t, json.RawMessage(`"test"`), resp.Result)
-}
-
-func TestJSONRPCResponse_UnmarshalError(t *testing.T) {
-	data := []byte(`{"jsonrpc":"2.0","id":999,"error":{"code":5000,"message":"failed"}}`)
-
-	var resp jsonRPCResponse
-	err := json.Unmarshal(data, &resp)
-	require.NoError(t, err)
-	require.Equal(t, "999", resp.idString())
-	require.NotNil(t, resp.Error)
-	require.Equal(t, 5000, resp.Error.Code)
-	require.Equal(t, "failed", resp.Error.Message)
-}
-
-func TestJSONRPCNotification_Unmarshal(t *testing.T) {
-	data := []byte(`{
-		"jsonrpc":"2.0",
-		"method":"irn_subscription",
-		"params":{
-			"id":"sub123",
-			"data":{
-				"topic":"topic1",
-				"message":"msg1",
-				"publishedAt":1234567890,
-				"tag":1100
-			}
+	const total = 250
+	seen := make(map[int64]struct{}, total)
+	for i := 0; i < total; i++ {
+		if i > 0 && i%50 == 0 {
+			time.Sleep(1 * time.Millisecond)
 		}
-	}`)
-
-	var notif jsonRPCNotification
-	err := json.Unmarshal(data, &notif)
-	require.NoError(t, err)
-	require.Equal(t, "2.0", notif.JSONRPC)
-	require.Equal(t, "irn_subscription", notif.Method)
-	require.Equal(t, "sub123", notif.Params.ID)
-	require.Equal(t, "topic1", notif.Params.Data.Topic)
-	require.Equal(t, "msg1", notif.Params.Data.Message)
-	require.Equal(t, int64(1234567890), notif.Params.Data.PublishedAt)
-	require.Equal(t, 1100, notif.Params.Data.Tag)
-}
-
-func TestNewRelayClient(t *testing.T) {
-	client, err := NewRelayClient("test-project")
-	require.NoError(t, err)
-	require.NotNil(t, client)
-	require.Equal(t, relayURL, client.url)
-	require.Equal(t, "test-project", client.projectID)
-	require.NotNil(t, client.auth)
-	require.NotNil(t, client.pending)
-	require.NotNil(t, client.logger)
-}
-
-func TestRelayClient_SetMessageHandler(t *testing.T) {
-	client, _ := NewRelayClient("test")
-
-	called := false
-	handler := func(topic, message string, tag int) {
-		called = true
+		id := payloadID()
+		// 19-digit ids: id >= 10^18 also guarantees the timestamp*10^6 base layout.
+		require.GreaterOrEqual(t, id, int64(1_000_000_000_000_000_000))
+		_, dup := seen[id]
+		require.False(t, dup, "duplicate id: %d", id)
+		seen[id] = struct{}{}
 	}
+}
 
-	client.SetMessageHandler(handler)
-
-	client.mu.Lock()
-	h := client.messageHandler
-	client.mu.Unlock()
-
-	require.NotNil(t, h)
-	h("topic", "msg", 1)
-	require.True(t, called)
+func TestJSONRPCResponse_idString(t *testing.T) {
+	cases := []struct {
+		name, raw, want string
+	}{
+		{"quoted string", `"abc123"`, "abc123"},
+		{"numeric id", `999`, "999"},
+		{"empty", ``, ""},
+		{"single char", `"x"`, "x"},
+		{"only quotes", `""`, ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			r := jsonRPCResponse{ID: json.RawMessage(tc.raw)}
+			require.Equal(t, tc.want, r.idString())
+		})
+	}
 }
 
 func TestRelayClient_Close_NotConnected(t *testing.T) {
@@ -184,132 +72,26 @@ func TestRelayClient_Close_NotConnected(t *testing.T) {
 	require.NoError(t, err)
 }
 
-func TestRelayMessage_Unmarshal(t *testing.T) {
-	data := []byte(`{
-		"topic":"test-topic",
-		"message":"test-message",
-		"publishedAt":1234567890,
-		"tag":1100
-	}`)
-
-	var msg RelayMessage
-	err := json.Unmarshal(data, &msg)
-	require.NoError(t, err)
-	require.Equal(t, "test-topic", msg.Topic)
-	require.Equal(t, "test-message", msg.Message)
-	require.Equal(t, int64(1234567890), msg.PublishedAt)
-	require.Equal(t, 1100, msg.Tag)
-}
-
-func TestConstants(t *testing.T) {
-	require.Equal(t, "wss://relay.walletconnect.com", relayURL)
-	require.Equal(t, 86400, defaultTTL)
-	require.Equal(t, 1000, defaultMessageTag)
-}
-
-func TestIRNSubscriptionParams_Unmarshal(t *testing.T) {
-	data := []byte(`{
-		"id":"sub-id-123",
-		"data":{
-			"topic":"my-topic",
-			"message":"my-message",
-			"publishedAt":9999999,
-			"tag":1108
-		}
-	}`)
-
-	var params irnSubscriptionParams
-	err := json.Unmarshal(data, &params)
-	require.NoError(t, err)
-	require.Equal(t, "sub-id-123", params.ID)
-	require.Equal(t, "my-topic", params.Data.Topic)
-	require.Equal(t, "my-message", params.Data.Message)
-	require.Equal(t, int64(9999999), params.Data.PublishedAt)
-	require.Equal(t, 1108, params.Data.Tag)
-}
-
-func TestPayloadID_UniqueAcrossCalls(t *testing.T) {
-	// sleeping 1ms guarantees that batches land in different milliseconds to reduce collisions
-	const batchSize = 50
-	const batches = 5
-
-	seen := make(map[int64]bool, batchSize*batches)
-	for b := 0; b < batches; b++ {
-		if b > 0 {
-			time.Sleep(1 * time.Millisecond)
-		}
-		for i := 0; i < batchSize; i++ {
-			id := payloadID()
-			require.False(t, seen[id], "duplicate ID generated")
-			seen[id] = true
-		}
-	}
-}
-
-func TestRelayClient_SetReconnectedHandler(t *testing.T) {
-	client, _ := NewRelayClient("test")
-
-	called := false
-	handler := func() {
-		called = true
-	}
-
-	client.SetReconnectedHandler(handler)
-
-	client.mu.Lock()
-	h := client.reconnectedHandler
-	client.mu.Unlock()
-
-	require.NotNil(t, h)
-	h()
-	require.True(t, called)
-}
-
-func TestRelayClient_DisconnectRequested(t *testing.T) {
-	client, _ := NewRelayClient("test")
-
-	require.False(t, client.disconnectRequested)
-
-	err := client.Close()
-	require.NoError(t, err)
-
-	client.mu.Lock()
-	requested := client.disconnectRequested
-	client.mu.Unlock()
-
-	require.True(t, requested)
-}
-
 func TestRelayClient_ConnectAfterClose_ReturnsDisconnectRequested(t *testing.T) {
-	server := newRelayTestWSServer(t)
-	defer server.Close()
-
-	client, err := NewRelayClient("test")
-	require.NoError(t, err)
-	client.url = relayTestWSURL(server)
+	fr := newFakeRelay(t, fakeRelayOpts{})
+	client := newTestRelayClient(t, fr)
 
 	require.NoError(t, client.Connect())
 	require.NoError(t, client.Close())
 
-	err = client.Connect()
+	err := client.Connect()
 	require.Error(t, err)
 	require.ErrorContains(t, err, "disconnect requested")
 }
 
 func TestRelayClient_FreshInstance_ConnectsCleanly(t *testing.T) {
-	server := newRelayTestWSServer(t)
-	defer server.Close()
-	wsURL := relayTestWSURL(server)
+	fr := newFakeRelay(t, fakeRelayOpts{})
 
-	a, err := NewRelayClient("test")
-	require.NoError(t, err)
-	a.url = wsURL
+	a := newTestRelayClient(t, fr)
 	require.NoError(t, a.Connect())
 	require.NoError(t, a.Close())
 
-	b, err := NewRelayClient("test")
-	require.NoError(t, err)
-	b.url = wsURL
+	b := newTestRelayClient(t, fr)
 	require.NoError(t, b.Connect())
 	require.NoError(t, b.Close())
 }

--- a/services/connector/walletconnect/relay_test.go
+++ b/services/connector/walletconnect/relay_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/gorilla/websocket"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -21,7 +22,9 @@ func newRelayTestWSServer(t *testing.T) *httptest.Server {
 	}
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		conn, err := upgrader.Upgrade(w, r, nil)
-		require.NoError(t, err)
+		if !assert.NoError(t, err) {
+			return
+		}
 		defer conn.Close()
 		for {
 			if _, _, err := conn.ReadMessage(); err != nil {

--- a/services/connector/walletconnect/relay_test_helpers_test.go
+++ b/services/connector/walletconnect/relay_test_helpers_test.go
@@ -1,0 +1,118 @@
+package walletconnect
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/gorilla/websocket"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeRelayOpts configures the in-process WalletConnect IRN-like WebSocket server.
+type fakeRelayOpts struct {
+	forceDropAt   int32 // >0: close the N-th accepted connection immediately after upgrade
+	echoSubscribe bool  // reply to irn_subscribe with a fake "sub-id"
+	silentOnPing  bool  // do not respond to ping (used by heartbeat tests)
+}
+
+// fakeRelay is an in-process WalletConnect IRN-like WebSocket server for relay tests.
+type fakeRelay struct {
+	Server *httptest.Server
+	opts   fakeRelayOpts
+
+	mu          sync.Mutex
+	currentConn *websocket.Conn
+
+	accepted int32
+}
+
+func newFakeRelay(t *testing.T, opts fakeRelayOpts) *fakeRelay {
+	t.Helper()
+	fr := &fakeRelay{opts: opts}
+	upgrader := websocket.Upgrader{CheckOrigin: func(*http.Request) bool { return true }}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			return
+		}
+		n := atomic.AddInt32(&fr.accepted, 1)
+		if fr.opts.forceDropAt > 0 && n == fr.opts.forceDropAt {
+			_ = conn.Close()
+			return
+		}
+		if fr.opts.silentOnPing {
+			conn.SetPingHandler(func(string) error { return nil })
+		}
+		fr.mu.Lock()
+		fr.currentConn = conn
+		fr.mu.Unlock()
+		defer func() {
+			fr.mu.Lock()
+			if fr.currentConn == conn {
+				fr.currentConn = nil
+			}
+			fr.mu.Unlock()
+		}()
+
+		for {
+			_, message, err := conn.ReadMessage()
+			if err != nil {
+				return
+			}
+			if !fr.opts.echoSubscribe {
+				continue
+			}
+			var reqMsg struct {
+				ID     json.RawMessage `json:"id"`
+				Method string          `json:"method"`
+			}
+			if err := json.Unmarshal(message, &reqMsg); err != nil {
+				continue
+			}
+			if reqMsg.Method != "irn_subscribe" {
+				continue
+			}
+			resp := fmt.Sprintf(`{"jsonrpc":"2.0","id":%s,"result":"sub-id"}`, string(reqMsg.ID))
+			_ = conn.SetWriteDeadline(time.Now().Add(5 * time.Second))
+			if err := conn.WriteMessage(websocket.TextMessage, []byte(resp)); err != nil {
+				return
+			}
+		}
+	})
+	fr.Server = httptest.NewServer(mux)
+	t.Cleanup(fr.Server.Close)
+	return fr
+}
+
+func (fr *fakeRelay) wsURL() string {
+	u := fr.Server.URL
+	u = strings.Replace(u, "http://", "ws://", 1)
+	u = strings.Replace(u, "https://", "wss://", 1)
+	return u
+}
+
+func (fr *fakeRelay) DropNow() {
+	fr.mu.Lock()
+	c := fr.currentConn
+	fr.mu.Unlock()
+	if c != nil {
+		_ = c.Close()
+	}
+}
+
+func newTestRelayClient(t *testing.T, fr *fakeRelay) *RelayClient {
+	t.Helper()
+	r, err := NewRelayClient("test")
+	require.NoError(t, err)
+	r.url = fr.wsURL()
+	return r
+}

--- a/services/connector/walletconnect/relay_test_helpers_test.go
+++ b/services/connector/walletconnect/relay_test_helpers_test.go
@@ -109,6 +109,16 @@ func (fr *fakeRelay) DropNow() {
 	}
 }
 
+// waitAccepted waits until fr.accepted reaches want. The client may return from
+// websocket.Dial before the httptest handler goroutine runs AddInt32 after Upgrade,
+// so a plain assert right after Connect() can flake on slow CI.
+func waitAccepted(t *testing.T, fr *fakeRelay, want int32) {
+	t.Helper()
+	require.Eventually(t, func() bool {
+		return atomic.LoadInt32(&fr.accepted) == want
+	}, 2*time.Second, 5*time.Millisecond, "expected fake relay accepted count %d", want)
+}
+
 func newTestRelayClient(t *testing.T, fr *fakeRelay) *RelayClient {
 	t.Helper()
 	r, err := NewRelayClient("test")


### PR DESCRIPTION
the WalletConnect relay client could fail with `subscribe: write: ... broken pipe` whenever the underlying WebSocket had been silently killed by timeouts. 

* fix parallel dials: `ensureConnected()` is shared by `call()`, `readLoop` and heartbeat
* call() now uses SetWriteDeadline under a mutex
* WebSocket heartbeat detects dead sockets instead 


refs status-im/status-app#20767
refs https://github.com/status-im/status-app/pull/20809