### PR TITLE
fix: puzzle-auth providers should not depend on the presence/absence of basic-auth credentials

### DIFF
--- a/params/networkhelper/provider_utils.go
+++ b/params/networkhelper/provider_utils.go
@@ -103,10 +103,11 @@ func OverrideBasicAuth(networks []params.Network, providerType params.RpcProvide
 		for j := range network.RpcProviders {
 			provider := &network.RpcProviders[j]
 			if provider.Type == providerType {
-				provider.Enabled = enabled
 				if provider.AuthType == params.PuzzleAuth {
+					// Puzzle-auth providers don't depend on basic-auth credentials, must not be touched
 					continue
 				}
+				provider.Enabled = enabled
 				provider.AuthType = params.BasicAuth
 				provider.AuthLogin = user
 				provider.AuthPassword = password

--- a/params/networkhelper/provider_utils_test.go
+++ b/params/networkhelper/provider_utils_test.go
@@ -130,28 +130,55 @@ func TestOverrideBasicAuth(t *testing.T) {
 	}
 }
 
-func TestOverrideBasicAuth_PuzzleSkipsCredsRespectsEnabled(t *testing.T) {
+func TestOverrideBasicAuth_PuzzleProvidersLeftUntouched(t *testing.T) {
 	ethPuzzle := *params.NewEthRpcProxyProvider(walletcommon.EthereumMainnet, "SmartPuzzle",
 		security.NewSensitiveString("https://eth.example.com/ethereum/mainnet/"), false, true)
 	require.Equal(t, params.PuzzleAuth, ethPuzzle.AuthType)
+	require.True(t, ethPuzzle.Enabled)
+
+	ethNoPuzzleAuth := *params.NewEthRpcProxyProvider(walletcommon.EthereumMainnet, "NoPuzzleAuth",
+		security.NewSensitiveString("https://eth.example.com/ethereum/mainnet/"), false, false)
+	require.Equal(t, params.NoAuth, ethNoPuzzleAuth.AuthType)
+	require.True(t, ethNoPuzzleAuth.AuthLogin.Empty())
+	require.True(t, ethNoPuzzleAuth.AuthPassword.Empty())
+	require.True(t, ethNoPuzzleAuth.Enabled)
 
 	networks := []params.Network{
-		*testutil.CreateNetwork(walletcommon.EthereumMainnet, "Ethereum", []params.RpcProvider{ethPuzzle}),
+		*testutil.CreateNetwork(walletcommon.EthereumMainnet, "Ethereum", []params.RpcProvider{ethPuzzle, ethNoPuzzleAuth}),
 	}
 	user := security.NewSensitiveString("u")
 	pass := security.NewSensitiveString("p")
+
 	updated := networkhelper.OverrideBasicAuth(networks, params.EmbeddedEthRpcProxyProviderType, true, user, pass)
 	require.Len(t, updated, 1)
-	p := updated[0].RpcProviders[0]
-	require.Equal(t, params.PuzzleAuth, p.AuthType)
-	require.True(t, p.Enabled)
-	require.True(t, p.AuthLogin.Empty())
-	require.True(t, p.AuthPassword.Empty())
+	for _, p := range updated[0].RpcProviders {
+		if p.AuthType == params.PuzzleAuth {
+			require.Equal(t, params.PuzzleAuth, p.AuthType)
+			require.True(t, p.Enabled) // puzzle provider stays enabled
+			require.True(t, p.AuthLogin.Empty())
+			require.True(t, p.AuthPassword.Empty())
+		} else {
+			require.Equal(t, params.BasicAuth, p.AuthType)
+			require.True(t, p.Enabled) // basic auth provider is enabled
+			require.False(t, p.AuthLogin.Empty())
+			require.False(t, p.AuthPassword.Empty())
+		}
+	}
 
 	disabled := networkhelper.OverrideBasicAuth(networks, params.EmbeddedEthRpcProxyProviderType, false, user, pass)
-	p2 := disabled[0].RpcProviders[0]
-	require.Equal(t, params.PuzzleAuth, p2.AuthType)
-	require.False(t, p2.Enabled)
+	for _, p := range disabled[0].RpcProviders {
+		if p.AuthType == params.PuzzleAuth {
+			require.Equal(t, params.PuzzleAuth, p.AuthType)
+			require.True(t, p.Enabled) // puzzle provider stays enabled
+			require.True(t, p.AuthLogin.Empty())
+			require.True(t, p.AuthPassword.Empty())
+		} else {
+			require.Equal(t, params.BasicAuth, p.AuthType)
+			require.False(t, p.Enabled) // direct provider is disabled
+			require.False(t, p.AuthLogin.Empty())
+			require.False(t, p.AuthPassword.Empty())
+		}
+	}
 }
 
 func TestOverrideDirectProvidersAuth(t *testing.T) {

--- a/services/wallet/activityfetcher/service.go
+++ b/services/wallet/activityfetcher/service.go
@@ -20,6 +20,7 @@ import (
 	"github.com/status-im/status-go/services/accounts/accountsevent"
 	ac "github.com/status-im/status-go/services/wallet/activity/common"
 	"github.com/status-im/status-go/services/wallet/common"
+	"github.com/status-im/status-go/services/wallet/multistandardbalance"
 	"github.com/status-im/status-go/services/wallet/pendingtxtracker"
 	"github.com/status-im/status-go/services/wallet/walletevent"
 )
@@ -29,7 +30,8 @@ const (
 )
 
 const (
-	EventActivityFetchComplete walletevent.EventType = "wallet-activity-fetch-complete"
+	EventActivityFetchComplete        walletevent.EventType = "wallet-activity-fetch-complete"
+	EventActivityNewTransfersDetected walletevent.EventType = "wallet-activity-new-transfers-detected"
 )
 
 type fetcherID struct {
@@ -43,10 +45,11 @@ type Service struct {
 	accountsGetter         accounts.AccountsStorage
 	ethClientGetter        rpc.EthClientGetter
 
-	networksPublisher *pubsub.Publisher
-	accountsPublisher *pubsub.Publisher
-	eventFeed         *event.Feed
-	checkRefetchCh    chan bool
+	networksPublisher             *pubsub.Publisher
+	accountsPublisher             *pubsub.Publisher
+	multistandardBalancePublisher *pubsub.Publisher
+	eventFeed                     *event.Feed
+	checkRefetchCh                chan bool
 
 	cancelFnMap      map[fetcherID]context.CancelFunc
 	cancelFnMapMutex sync.RWMutex
@@ -65,22 +68,24 @@ func NewService(
 	accountsPublisher *pubsub.Publisher,
 	ethClientGetter rpc.EthClientGetter,
 	eventFeed *event.Feed,
+	multistandardBalancePublisher *pubsub.Publisher,
 ) *Service {
 	logger := logutils.ZapLogger().Named("ActivityFetcher")
 
 	service := &Service{
-		activityFetcherManager: activityFetcherManager,
-		networksGetter:         networksGetter,
-		accountsGetter:         accountsGetter,
-		ethClientGetter:        ethClientGetter,
-		networksPublisher:      networksGetter.GetPublisher(),
-		accountsPublisher:      accountsPublisher,
-		eventFeed:              eventFeed,
-		checkRefetchCh:         make(chan bool),
-		cancelFnMap:            make(map[fetcherID]context.CancelFunc),
-		targetedFetchCh:        make(chan []fetcherID),
-		logger:                 logger,
-		ch:                     make(chan walletevent.Event, 100),
+		activityFetcherManager:        activityFetcherManager,
+		networksGetter:                networksGetter,
+		accountsGetter:                accountsGetter,
+		ethClientGetter:               ethClientGetter,
+		networksPublisher:             networksGetter.GetPublisher(),
+		accountsPublisher:             accountsPublisher,
+		multistandardBalancePublisher: multistandardBalancePublisher,
+		eventFeed:                     eventFeed,
+		checkRefetchCh:                make(chan bool),
+		cancelFnMap:                   make(map[fetcherID]context.CancelFunc),
+		targetedFetchCh:               make(chan []fetcherID),
+		logger:                        logger,
+		ch:                            make(chan walletevent.Event, 100),
 	}
 
 	return service
@@ -197,6 +202,41 @@ func (s *Service) startAccountWatcher() {
 	}()
 }
 
+// startBalanceChangeWatcher subscribes to multistandardbalance fetch-finished events and triggers activity fetch
+func (s *Service) startBalanceChangeWatcher() {
+	if s.multistandardBalancePublisher == nil {
+		return
+	}
+
+	ch, unsub := pubsub.Subscribe[multistandardbalance.EventBalanceFetchFinished](s.multistandardBalancePublisher, 10)
+	go func() {
+		defer gocommon.LogOnPanic()
+		defer unsub()
+		for {
+			select {
+			case <-s.stopCh:
+				return
+			case event, ok := <-ch:
+				if !ok {
+					return
+				}
+				if !event.BalanceChanged {
+					continue
+				}
+				if !s.activityFetcherManager.IsChainSupported(event.Key.ChainID) {
+					continue
+				}
+				ids := []fetcherID{{account: event.Key.Account, chainID: event.Key.ChainID}}
+				select {
+				case s.targetedFetchCh <- ids:
+				case <-s.stopCh:
+					return
+				}
+			}
+		}
+	}()
+}
+
 func (s *Service) Start(ctx context.Context) {
 	s.logger.Info("Starting activity fetcher")
 	s.stopCh = make(chan struct{})
@@ -204,6 +244,7 @@ func (s *Service) Start(ctx context.Context) {
 	s.startNetworkWatcher()
 	s.startAccountWatcher()
 	s.startTransactionWatcher()
+	s.startBalanceChangeWatcher()
 
 	go func() {
 		defer gocommon.LogOnPanic()
@@ -544,11 +585,26 @@ func (s *Service) fetchActivity(ctx context.Context, chainID uint64, account get
 		return
 	}
 
-	_, err = s.activityFetcherManager.FetchActivity(ctx, chainID, account, currentBlock)
+	container, err := s.activityFetcherManager.FetchActivity(ctx, chainID, account, currentBlock)
 	if err != nil {
 		s.logger.Error("Failed to fetch activity", zap.Error(err))
 		return
 	}
+	if len(container.Items) > 0 {
+		// at least one new transfer for detected, so trigger a balance refresh
+		s.emitNewTransfersDetected(chainID, account, len(container.Items))
+	}
+}
+
+func (s *Service) emitNewTransfersDetected(chainID uint64, account gethcommon.Address, count int) {
+	if s.eventFeed == nil {
+		return
+	}
+	s.eventFeed.Send(walletevent.Event{
+		Type:     EventActivityNewTransfersDetected,
+		ChainID:  chainID,
+		Accounts: []gethcommon.Address{account},
+	})
 }
 
 func (s *Service) RefetchTxHistory() error {

--- a/services/wallet/service.go
+++ b/services/wallet/service.go
@@ -325,7 +325,7 @@ func NewService(
 	alchemyFetcherClient := activityfetcher_alchemy.NewClient(alchemyEthClientGetter)
 	alchemyFetcherManager := alchemymanager.NewManager(alchemyFetcherClient, alchemyFetcherDb)
 	activityFetcherManager := activityfetcher.NewManager(alchemyFetcherManager)
-	activityFetcherService := activityfetcher.NewService(activityFetcherManager, rpcClient.GetNetworkManager(), accountsDB, accountsPublisher, rpcClient, feed)
+	activityFetcherService := activityfetcher.NewService(activityFetcherManager, rpcClient.GetNetworkManager(), accountsDB, accountsPublisher, rpcClient, feed, multistandardBalanceController.GetPublisher())
 
 	return &Service{
 		db:                             db,


### PR DESCRIPTION
If the same network has puzzle-auth and basic-auth providers an incorrect enable flag might be used if there is no ethrpc/status proxy credentials set.