### PR TITLE
perf: Enrich community members and contacts with visual identity

### DIFF
--- a/internal/accounts-management/common/publickey.go
+++ b/internal/accounts-management/common/publickey.go
@@ -5,10 +5,13 @@ import (
 
 	"github.com/status-im/status-go/internal/accounts-management/types"
 	"github.com/status-im/status-go/pkg/multiformat"
+	identityUtils "github.com/status-im/status-go/protocol/identity"
+	"github.com/status-im/status-go/protocol/identity/alias"
 	"github.com/status-im/status-go/protocol/identity/emojihash"
 )
 
-// GetPublicKeyData processes a public key and returns its compressed form and emoji hash
+// GetPublicKeyData processes a public key and returns its full visual
+// identity: compressed form, emoji hash, alias, and colorId.
 func GetPublicKeyData(publicKey string) (*types.PublicKeyData, error) {
 	if publicKey == "" {
 		return nil, nil
@@ -24,9 +27,21 @@ func GetPublicKeyData(publicKey string) (*types.PublicKeyData, error) {
 		return nil, err
 	}
 
+	aliasName, err := alias.GenerateFromPublicKeyString(publicKey)
+	if err != nil {
+		return nil, err
+	}
+
+	colorID, err := identityUtils.ToColorID(publicKey)
+	if err != nil {
+		return nil, err
+	}
+
 	return &types.PublicKeyData{
 		CompressedKey: compressedKey,
 		EmojiHash:     emojiHash,
+		Alias:         aliasName,
+		ColorID:       colorID,
 	}, nil
 }
 

--- a/internal/accounts-management/common/publickey_test.go
+++ b/internal/accounts-management/common/publickey_test.go
@@ -5,6 +5,11 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
+	"github.com/status-im/status-go/pkg/multiformat"
+	identityUtils "github.com/status-im/status-go/protocol/identity"
+	"github.com/status-im/status-go/protocol/identity/alias"
+	"github.com/status-im/status-go/protocol/identity/emojihash"
 )
 
 func TestGetPublicKeyData(t *testing.T) {
@@ -44,7 +49,86 @@ func TestGetPublicKeyData(t *testing.T) {
 				assert.NotNil(t, data)
 				assert.NotEmpty(t, data.CompressedKey)
 				assert.NotEmpty(t, data.EmojiHash)
+				assert.NotEmpty(t, data.Alias, "alias should be derived for a valid pubkey")
+				assert.GreaterOrEqual(t, data.ColorID, int64(0))
+				assert.LessOrEqual(t, data.ColorID, int64(10))
 			}
+		})
+	}
+}
+
+// TestGetPublicKeyDataDeterministic asserts the pure-function contract: the
+// same pubkey always yields the same identity. Catches accidental state
+// leaks (e.g. introducing a non-thread-safe cache).
+func TestGetPublicKeyDataDeterministic(t *testing.T) {
+	pk := "0x0498593ff6c560f5dad6e947cd9c8aa41d687126fa253eb5d917f1f5911519c570651268c40f818b98ec18b00d2b59e16075a162f1bba6b568b753444b4c5a6a79"
+
+	first, err := GetPublicKeyData(pk)
+	assert.NoError(t, err)
+	assert.NotNil(t, first)
+
+	second, err := GetPublicKeyData(pk)
+	assert.NoError(t, err)
+	assert.NotNil(t, second)
+
+	assert.Equal(t, first.CompressedKey, second.CompressedKey)
+	assert.Equal(t, first.EmojiHash, second.EmojiHash)
+	assert.Equal(t, first.Alias, second.Alias)
+	assert.Equal(t, first.ColorID, second.ColorID)
+}
+
+// TestGetPublicKeyDataGolden is a fixed-input/fixed-output regression test.
+func TestGetPublicKeyDataGolden(t *testing.T) {
+	const pk = "0x04eedbaafd6adf4a9233a13e7b1c3c14461fffeba2e9054b8d456ce5f6ebeafadcbf3dce3716253fbc391277fa5a086b60b283daf61fb5b1f26895f456c2f31ae3"
+
+	pkd, err := GetPublicKeyData(pk)
+	assert.NoError(t, err)
+	assert.NotNil(t, pkd)
+
+	assert.Equal(t, "zQ3shviWSAwB9X9Kz7aZHdUi6yU9S3BEpCsxM94XhFd2k2bWB", pkd.CompressedKey,
+		"compressedKey should match multiformat.SerializeLegacyKey output")
+	assert.Equal(t, "Darkorange Blue Bubblefish", pkd.Alias,
+		"alias should match alias.GenerateFromPublicKeyString output (also asserted in protocol/identity/alias)")
+	assert.Equal(t, int64(9), pkd.ColorID,
+		"colorId should be (pubkey mod 11)")
+	assert.Equal(t, []string{
+		"🛁", "🧎🏿‍♀️", "😱", "👳‍♀️", "🎍",
+		"🕺🏾", "🦸🏼‍♀️", "🕖", "🧏🏻‍♀️", "🤸‍♀️",
+		"🦗", "🚴", "🍄", "👩🏻‍🦰",
+	}, pkd.EmojiHash, "emojiHash should match emojihash.GenerateFor output")
+}
+
+// TestGetPublicKeyDataMatchesPrimitives proves the composition: every field
+// in the result equals what the underlying primitive would produce on its
+// own.
+func TestGetPublicKeyDataMatchesPrimitives(t *testing.T) {
+	pubkeys := []string{
+		"0x0498593ff6c560f5dad6e947cd9c8aa41d687126fa253eb5d917f1f5911519c570651268c40f818b98ec18b00d2b59e16075a162f1bba6b568b753444b4c5a6a79",
+		"0x04eedbaafd6adf4a9233a13e7b1c3c14461fffeba2e9054b8d456ce5f6ebeafadcbf3dce3716253fbc391277fa5a086b60b283daf61fb5b1f26895f456c2f31ae3",
+		"0x04e25da6994ea2dc4ac70727e07eca153ae92bf7609db7befb7ebdceaad348f4fc55bbe90abf9501176301db5aa103fc0eb3bc3750272a26c424a10887db2a7ea8",
+	}
+
+	for _, pk := range pubkeys {
+		t.Run(pk[:10], func(t *testing.T) {
+			pkd, err := GetPublicKeyData(pk)
+			assert.NoError(t, err)
+			assert.NotNil(t, pkd)
+
+			expCompressed, err := multiformat.SerializeLegacyKey(pk)
+			assert.NoError(t, err)
+			assert.Equal(t, expCompressed, pkd.CompressedKey)
+
+			expEmoji, err := emojihash.GenerateFor(pk)
+			assert.NoError(t, err)
+			assert.Equal(t, expEmoji, pkd.EmojiHash)
+
+			expAlias, err := alias.GenerateFromPublicKeyString(pk)
+			assert.NoError(t, err)
+			assert.Equal(t, expAlias, pkd.Alias)
+
+			expColor, err := identityUtils.ToColorID(pk)
+			assert.NoError(t, err)
+			assert.Equal(t, expColor, pkd.ColorID)
 		})
 	}
 }

--- a/internal/accounts-management/types/types.go
+++ b/internal/accounts-management/types/types.go
@@ -7,6 +7,8 @@ import (
 type PublicKeyData struct {
 	CompressedKey string   `json:"compressedKey"`
 	EmojiHash     []string `json:"emojiHash"`
+	Alias         string   `json:"alias"`
+	ColorID       int64    `json:"colorId"`
 }
 
 // SelectedExtKey is a container for the selected (logged in) external account.

--- a/protocol/communities/community.go
+++ b/protocol/communities/community.go
@@ -19,6 +19,8 @@ import (
 	"go.uber.org/zap"
 
 	utils "github.com/status-im/status-go/common"
+	accscommon "github.com/status-im/status-go/internal/accounts-management/common"
+	accstypes "github.com/status-im/status-go/internal/accounts-management/types"
 	"github.com/status-im/status-go/internal/crypto"
 	types "github.com/status-im/status-go/internal/crypto/types"
 	"github.com/status-im/status-go/internal/images"
@@ -31,6 +33,35 @@ import (
 	"github.com/status-im/status-go/protocol/v1"
 	"github.com/status-im/status-go/server"
 )
+
+// enrichedCommunityMember is the JSON-serialization wrapper that combines
+// the protobuf-derived CommunityMember (roles, channel role, last-update
+// clock) with the visual identity derived from the member's public key
+// (alias, colorId, compressedKey, emojiHash)
+type enrichedCommunityMember struct {
+	*protobuf.CommunityMember
+	accstypes.PublicKeyData
+}
+
+// enrichMembersMap wraps every entry of a protobuf members map with the
+// per-pubkey PublicKeyData
+func enrichMembersMap(src map[string]*protobuf.CommunityMember) map[string]*enrichedCommunityMember {
+	if src == nil {
+		return nil
+	}
+	out := make(map[string]*enrichedCommunityMember, len(src))
+	for pubkey, member := range src {
+		if member == nil {
+			continue
+		}
+		entry := &enrichedCommunityMember{CommunityMember: member}
+		if pkd, err := accscommon.GetPublicKeyData(pubkey); err == nil && pkd != nil {
+			entry.PublicKeyData = *pkd
+		}
+		out[pubkey] = entry
+	}
+	return out
+}
 
 const signatureLength = 65
 
@@ -113,22 +144,22 @@ type CommunityAdminSettings struct {
 }
 
 type CommunityChat struct {
-	ID                      string                               `json:"id"`
-	Name                    string                               `json:"name"`
-	Color                   string                               `json:"color"`
-	Emoji                   string                               `json:"emoji"`
-	Description             string                               `json:"description"`
-	Members                 map[string]*protobuf.CommunityMember `json:"members"`
-	Permissions             *protobuf.CommunityPermissions       `json:"permissions"`
-	CanPost                 bool                                 `json:"canPost"`
-	CanView                 bool                                 `json:"canView"`
-	CanPostReactions        bool                                 `json:"canPostReactions"`
-	ViewersCanPostReactions bool                                 `json:"viewersCanPostReactions"`
-	Position                int                                  `json:"position"`
-	CategoryID              string                               `json:"categoryID"`
-	TokenGated              bool                                 `json:"tokenGated"`
-	HideIfPermissionsNotMet bool                                 `json:"hideIfPermissionsNotMet"`
-	MissingEncryptionKey    bool                                 `json:"missingEncryptionKey"`
+	ID                      string                              `json:"id"`
+	Name                    string                              `json:"name"`
+	Color                   string                              `json:"color"`
+	Emoji                   string                              `json:"emoji"`
+	Description             string                              `json:"description"`
+	Members                 map[string]*enrichedCommunityMember `json:"members"`
+	Permissions             *protobuf.CommunityPermissions      `json:"permissions"`
+	CanPost                 bool                                `json:"canPost"`
+	CanView                 bool                                `json:"canView"`
+	CanPostReactions        bool                                `json:"canPostReactions"`
+	ViewersCanPostReactions bool                                `json:"viewersCanPostReactions"`
+	Position                int                                 `json:"position"`
+	CategoryID              string                              `json:"categoryID"`
+	TokenGated              bool                                `json:"tokenGated"`
+	HideIfPermissionsNotMet bool                                `json:"hideIfPermissionsNotMet"`
+	MissingEncryptionKey    bool                                `json:"missingEncryptionKey"`
 }
 
 type CommunityCategory struct {
@@ -216,7 +247,7 @@ func (o *Community) MarshalPublicAPIJSON() ([]byte, error) {
 				Emoji:                   c.Identity.Emoji,
 				Description:             c.Identity.Description,
 				Permissions:             c.Permissions,
-				Members:                 c.Members,
+				Members:                 enrichMembersMap(c.Members),
 				CanPost:                 canPost,
 				CanView:                 canView,
 				CanPostReactions:        canPostReactions,
@@ -288,7 +319,7 @@ func (o *Community) MarshalJSON() ([]byte, error) {
 		Categories                  map[string]CommunityCategory         `json:"categories"`
 		Images                      map[string]Image                     `json:"images"`
 		Permissions                 *protobuf.CommunityPermissions       `json:"permissions"`
-		Members                     map[string]*protobuf.CommunityMember `json:"members"`
+		Members                     map[string]*enrichedCommunityMember  `json:"members"`
 		CanRequestAccess            bool                                 `json:"canRequestAccess"`
 		CanManageUsers              bool                                 `json:"canManageUsers"`              //TODO: we can remove this
 		CanDeleteMessageForEveryone bool                                 `json:"canDeleteMessageForEveryone"` //TODO: we can remove this
@@ -373,13 +404,13 @@ func (o *Community) MarshalJSON() ([]byte, error) {
 			}
 
 			if chat.TokenGated {
-				chat.Members = c.Members
+				chat.Members = enrichMembersMap(c.Members)
 			}
 			communityItem.Chats[id] = chat
 		}
 		communityItem.TokenPermissions = o.tokenPermissions()
 		communityItem.PendingAndBannedMembers = o.PendingAndBannedMembers()
-		communityItem.Members = o.config.CommunityDescription.Members
+		communityItem.Members = enrichMembersMap(o.config.CommunityDescription.Members)
 		communityItem.Permissions = o.config.CommunityDescription.Permissions
 		communityItem.IntroMessage = o.config.CommunityDescription.IntroMessage
 		communityItem.OutroMessage = o.config.CommunityDescription.OutroMessage

--- a/protocol/communities/community_test.go
+++ b/protocol/communities/community_test.go
@@ -11,10 +11,33 @@ import (
 
 	"github.com/stretchr/testify/suite"
 
+	accscommon "github.com/status-im/status-go/internal/accounts-management/common"
 	"github.com/status-im/status-go/internal/crypto"
 	"github.com/status-im/status-go/internal/images"
 	"github.com/status-im/status-go/protocol/protobuf"
 )
+
+// expectedEnrichedMember returns the JSON-shaped representation of an
+// enriched community member (protobuf fields + PublicKeyData) for a given
+// pubkey + roles. Used by TestMarshalJSON to keep the expected wire
+// format aligned with `enrichMembersMap`'s output.
+func expectedEnrichedMember(pubkey string, roles []interface{}) map[string]interface{} {
+	pkd, err := accscommon.GetPublicKeyData(pubkey)
+	if err != nil || pkd == nil {
+		return map[string]interface{}{"roles": roles}
+	}
+	emojiHash := make([]interface{}, 0, len(pkd.EmojiHash))
+	for _, e := range pkd.EmojiHash {
+		emojiHash = append(emojiHash, e)
+	}
+	return map[string]interface{}{
+		"roles":         roles,
+		"alias":         pkd.Alias,
+		"colorId":       float64(pkd.ColorID),
+		"compressedKey": pkd.CompressedKey,
+		"emojiHash":     emojiHash,
+	}
+}
 
 func TestCommunitySuite(t *testing.T) {
 	suite.Run(t, new(CommunitySuite))
@@ -108,6 +131,84 @@ func (s *CommunitySuite) TestHasPermission() {
 	// return false if user is a member and does not have permissions
 	s.Require().False(community.hasRoles(&memberKey.PublicKey, ownerRole()))
 
+}
+
+func (s *CommunitySuite) TestEnrichMembersMap() {
+	// nil input → nil output (renders as JSON `null`, matching legacy
+	// behavior for clients that distinguish null from `{}`).
+	s.Require().Nil(enrichMembersMap(nil))
+
+	// non-nil empty input → non-nil empty output (renders as `{}`).
+	emptyOut := enrichMembersMap(map[string]*protobuf.CommunityMember{})
+	s.Require().NotNil(emptyOut)
+	s.Require().Len(emptyOut, 0)
+
+	// nil entries are skipped — emitting one would produce a row with
+	// only visual-identity fields and no protobuf payload.
+	mixed := map[string]*protobuf.CommunityMember{
+		s.member1Key: {Roles: []protobuf.CommunityMember_Roles{protobuf.CommunityMember_ROLE_OWNER}},
+		s.member2Key: nil,
+		s.member3Key: {Roles: []protobuf.CommunityMember_Roles{protobuf.CommunityMember_ROLE_ADMIN}},
+	}
+	out := enrichMembersMap(mixed)
+	s.Require().Len(out, 2)
+	s.Require().Contains(out, s.member1Key)
+	s.Require().Contains(out, s.member3Key)
+	s.Require().NotContains(out, s.member2Key)
+
+	// Visual identity values must equal what GetPublicKeyData returns
+	// for the same pubkey (which has its own golden + primitive-cross-
+	// validation tests in `accounts-management/common/publickey_test.go`).
+	for pk, entry := range out {
+		s.Require().NotNil(entry.CommunityMember, "member %s missing protobuf payload", pk)
+		expected, err := accscommon.GetPublicKeyData(pk)
+		s.Require().NoError(err)
+		s.Require().NotNil(expected)
+		s.Require().Equal(expected.CompressedKey, entry.CompressedKey, "compressedKey mismatch for %s", pk)
+		s.Require().Equal(expected.EmojiHash, entry.EmojiHash, "emojiHash mismatch for %s", pk)
+		s.Require().Equal(expected.Alias, entry.Alias, "alias mismatch for %s", pk)
+		s.Require().Equal(expected.ColorID, entry.ColorID, "colorId mismatch for %s", pk)
+	}
+
+	// Original protobuf payload must be preserved alongside the
+	// embedded PublicKeyData.
+	s.Require().Equal(
+		protobuf.CommunityMember_ROLE_OWNER,
+		out[s.member1Key].CommunityMember.Roles[0],
+		"protobuf roles must be preserved")
+	s.Require().Equal(
+		protobuf.CommunityMember_ROLE_ADMIN,
+		out[s.member3Key].CommunityMember.Roles[0])
+}
+
+func (s *CommunitySuite) TestMarshalJSONEnrichesMembers() {
+	org := s.buildCommunity(&s.identity.PublicKey)
+
+	bytes, err := json.Marshal(org)
+	s.Require().NoError(err)
+
+	var parsed struct {
+		Members map[string]struct {
+			CompressedKey   string   `json:"compressedKey"`
+			EmojiHash       []string `json:"emojiHash"`
+			Alias           string   `json:"alias"`
+			ColorID         int64    `json:"colorId"`
+			LastUpdateClock uint64   `json:"last_update_clock"`
+		} `json:"members"`
+	}
+	s.Require().NoError(json.Unmarshal(bytes, &parsed))
+	s.Require().Contains(parsed.Members, s.member1Key)
+	s.Require().Contains(parsed.Members, s.member2Key)
+
+	for pk, m := range parsed.Members {
+		expected, err := accscommon.GetPublicKeyData(pk)
+		s.Require().NoError(err)
+		s.Require().NotNil(expected)
+		s.Require().Equal(expected.CompressedKey, m.CompressedKey, "compressedKey mismatch for %s", pk)
+		s.Require().Equal(expected.EmojiHash, m.EmojiHash, "emojiHash mismatch for %s", pk)
+		s.Require().Equal(expected.Alias, m.Alias, "alias mismatch for %s", pk)
+		s.Require().Equal(expected.ColorID, m.ColorID, "colorId mismatch for %s", pk)
+	}
 }
 
 func (s *CommunitySuite) TestCreateChat() {
@@ -1070,6 +1171,7 @@ func (s *CommunitySuite) TestMarshalJSON() {
 	s.Require().NotNil(communityData["chats"])
 
 	expectedChats := map[string]interface{}{}
+	ownerPubkeyHex := crypto.PubkeyToHex(&ownerKey.PublicKey)
 	expectedChat := map[string]interface{}{
 		"canPost":                 true,
 		"canPostReactions":        true,
@@ -1080,9 +1182,7 @@ func (s *CommunitySuite) TestMarshalJSON() {
 		"emoji":                   "",
 		"hideIfPermissionsNotMet": false,
 		"members": map[string]interface{}{
-			crypto.PubkeyToHex(&ownerKey.PublicKey): map[string]interface{}{
-				"roles": []interface{}{float64(1)},
-			},
+			ownerPubkeyHex: expectedEnrichedMember(ownerPubkeyHex, []interface{}{float64(1)}),
 		},
 		"id":                      testChatID1,
 		"name":                    "",

--- a/protocol/contacts/contact_test.go
+++ b/protocol/contacts/contact_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	accscommon "github.com/status-im/status-go/internal/accounts-management/common"
 	"github.com/status-im/status-go/internal/crypto"
 	"github.com/status-im/status-go/protocol/protobuf"
 )
@@ -570,6 +571,22 @@ func TestMarshalContactJSON(t *testing.T) {
 	require.True(t, strings.Contains(string(encodedContact), "primaryName\":\"primary-name"))
 	require.True(t, strings.Contains(string(encodedContact), "secondaryName\":\"secondary-name"))
 	require.True(t, strings.Contains(string(encodedContact), "emojiHash"))
+
+	expected, err := accscommon.GetPublicKeyData(contact.ID)
+	require.NoError(t, err)
+	require.NotNil(t, expected)
+
+	var parsed struct {
+		CompressedKey string   `json:"compressedKey"`
+		EmojiHash     []string `json:"emojiHash"`
+		Alias         string   `json:"alias"`
+		ColorID       int64    `json:"colorId"`
+	}
+	require.NoError(t, json.Unmarshal(encodedContact, &parsed))
+	require.Equal(t, expected.CompressedKey, parsed.CompressedKey)
+	require.Equal(t, expected.EmojiHash, parsed.EmojiHash)
+	require.Equal(t, expected.Alias, parsed.Alias)
+	require.Equal(t, expected.ColorID, parsed.ColorID)
 }
 
 func TestContactContactRequestPropagatedStateReceivedOutOfDateLocalStateOnTheirSide(t *testing.T) {


### PR DESCRIPTION
Cherry-pick https://github.com/status-im/status-go/pull/7430

For each community member and contact Status needs to wire another 4 RPCs to fully resolve the members and contacts. This commit adds the necessary info in the community members and contacts response directly.

Needed for: https://github.com/status-im/status-app/issues/20228

A short summary which serves as a squashed-commit message.

A description to understand introduced changes without reading the code.

Important changes:
- [x] Something worth noting for reviewers.

Closes #
