### PR TITLE
feat(wallet): skip TANGYUAN and POSI tokens on BSCMainnet

### DIFF
--- a/services/wallet/common/const.go
+++ b/services/wallet/common/const.go
@@ -414,5 +414,7 @@ func SkippedTokenKeys() []string {
 	return []string{
 		types.TokenKey(OptimismMainnet, common.HexToAddress("0xDeadDeAddeAddEAddeadDEaDDEAdDeaDDeAD0000")),
 		types.TokenKey(OptimismSepolia, common.HexToAddress("0xDeadDeAddeAddEAddeadDEaDDEAdDeaDDeAD0000")),
+		types.TokenKey(BSCMainnet, common.HexToAddress("0x683e9dcf085e5efcc7925858aace94d4b8882024")), // TANGYUAN
+		types.TokenKey(BSCMainnet, common.HexToAddress("0x5ca42204cdaa70d5c773946e69de942b85ca6706")), // POSI
 	}
 }

--- a/services/wallet/token/token_test.go
+++ b/services/wallet/token/token_test.go
@@ -347,7 +347,11 @@ func Test_tokensListsValidity(t *testing.T) {
 					break
 				}
 			}
-			require.Equal(t, 1, numOfOccurrences)
+			if slices.Contains(walletcommon.SkippedTokenKeys(), token.Key()) {
+				require.Equal(t, 0, numOfOccurrences, "token %s is in skipped token keys", token.Key())
+				continue
+			}
+			require.Equal(t, 1, numOfOccurrences, "token %s appears %d times in allTokens", token.Key(), numOfOccurrences)
 		}
 	}
 }


### PR DESCRIPTION
Added token keys for TANGYUAN and POSI to the SkippedTokenKeys list.

Closes https://github.com/status-im/status-app/issues/20860