### PR TITLE
fix(waku): Avoid peer reconnection storm

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -102,7 +102,7 @@ require (
 	github.com/schollz/peerdiscovery v1.7.0
 	github.com/status-im/extkeys v1.4.0
 	github.com/status-im/go-wallet-sdk v0.0.0-20260428172609-d99313975e5c
-	github.com/waku-org/go-waku v0.10.2-0.20260421101052-de84ba47f9b0
+	github.com/waku-org/go-waku v0.10.2-0.20260518064454-d6d39395ac48
 	github.com/waku-org/sds-go-bindings v0.0.0-20251222164514-d5b47a911904
 	github.com/wk8/go-ordered-map/v2 v2.1.7
 	go.uber.org/atomic v1.11.0

--- a/go.sum
+++ b/go.sum
@@ -2416,8 +2416,8 @@ github.com/waku-org/go-libp2p-pubsub v0.13.1-gowaku h1:ovXh1m76i0yPWXt95Z9ZRyEk0
 github.com/waku-org/go-libp2p-pubsub v0.13.1-gowaku/go.mod h1:MKPU5vMI8RRFyTP0HfdsF9cLmL1nHAeJm44AxJGJx44=
 github.com/waku-org/go-libp2p-rendezvous v0.0.0-20240110193335-a67d1cc760a0 h1:R4YYx2QamhBRl/moIxkDCNW+OP7AHbyWLBygDc/xIMo=
 github.com/waku-org/go-libp2p-rendezvous v0.0.0-20240110193335-a67d1cc760a0/go.mod h1:EhZP9fee0DYjKH/IOQvoNSy1tSHp2iZadsHGphcAJgY=
-github.com/waku-org/go-waku v0.10.2-0.20260421101052-de84ba47f9b0 h1:AXjJAIyEUQWJIjCGU+ZGSbat6lI1Gcrl0cD/vEVOFkQ=
-github.com/waku-org/go-waku v0.10.2-0.20260421101052-de84ba47f9b0/go.mod h1:PDs4hlPbONeMQGsNyfArZV4R2Js1Zy5oqLBfw2VU278=
+github.com/waku-org/go-waku v0.10.2-0.20260518064454-d6d39395ac48 h1:a00GguapTGSRIN9ocw93WsrMOTD07TJ1iqCashttNwA=
+github.com/waku-org/go-waku v0.10.2-0.20260518064454-d6d39395ac48/go.mod h1:PDs4hlPbONeMQGsNyfArZV4R2Js1Zy5oqLBfw2VU278=
 github.com/waku-org/go-zerokit-rln v0.1.14-0.20240102145250-fa738c0bdf59 h1:jisj+OCI6QydLtFq3Pyhu49wl9ytPN7oAHjMfepHDrA=
 github.com/waku-org/go-zerokit-rln v0.1.14-0.20240102145250-fa738c0bdf59/go.mod h1:1PdBdPzyTaKt3VnpAHk3zj+r9dXPFOr3IHZP9nFle6E=
 github.com/waku-org/go-zerokit-rln-apple v0.0.0-20230916172309-ee0ee61dde2b h1:KgZVhsLkxsj5gb/FfndSCQu6VYwALrCOgYI3poR95yE=

--- a/nix/pkgs/status-go/library/default.nix
+++ b/nix/pkgs/status-go/library/default.nix
@@ -11,7 +11,7 @@ let
 in pkgs.buildGoModule {
   pname = "status-go";
   src = builtins.path { path = ./../../../..; name = "status-go-library"; };
-  vendorHash = "sha256-IIuv1pePG8LO+qXL7STLbxxHepS2BGHCO5ORNjG37kk=";
+  vendorHash = "sha256-itcTnM/Jm4shXuW38g6YlgNyLAHFs0CBlysqDwh4xXk=";
 
   inherit meta version;
 

--- a/pkg/messaging/layers/reliability/datasync/datasync.go
+++ b/pkg/messaging/layers/reliability/datasync/datasync.go
@@ -18,10 +18,7 @@ type DataSync struct {
 	*datasyncnode.Node
 	// NodeTransport is the implementation of the datasync transport interface.
 	*NodeTransport
-	logger *zap.Logger
-	// sendingEnabled gates whether Unwrap feeds received messages into the node
-	// for acknowledgement. Read on the inbound-message goroutine, written by
-	// reliability.SetPaused on the lifecycle goroutine — hence atomic.
+	logger         *zap.Logger
 	sendingEnabled atomic.Bool
 }
 
@@ -56,12 +53,6 @@ func (d *DataSync) Stop() {
 	d.Node.Stop()
 }
 
-// SetSendingEnabled toggles whether Unwrap feeds received datasync messages into
-// the node for acknowledgement. It is flipped to false around a node recreate
-// (see reliability.SetPaused) so Unwrap short-circuits instead of pushing
-// packets onto a transport whose consumer goroutine has exited — AddPacket is
-// non-blocking and buffered, so it wouldn't hang, but those packets would be
-// silently dropped during the recreate window.
 func (d *DataSync) SetSendingEnabled(v bool) {
 	d.sendingEnabled.Store(v)
 }

--- a/pkg/messaging/layers/reliability/datasync/transport.go
+++ b/pkg/messaging/layers/reliability/datasync/transport.go
@@ -17,10 +17,6 @@ const backoffInterval = 60
 
 var errNotInitialized = errors.New("datasync transport not initialized")
 
-// DatasyncTicker is the mvds outbound-loop interval while running. The loop is
-// idled while the host is backgrounded by reliability.SetPaused, which stops the
-// mvds node and recreates it with a much larger tick — see
-// pkg/messaging/layers/reliability/reliability.go.
 const DatasyncTicker = 300 * time.Millisecond
 
 func currentOffsetToSecond() uint64 {
@@ -52,11 +48,6 @@ func (t *NodeTransport) Init(dispatch func(state.PeerID, *protobuf.Payload) erro
 	t.logger = logger
 }
 
-// AddPacket hands an inbound datasync packet to the node's watch loop. The send is
-// non-blocking: if the node isn't currently consuming (e.g. mid-Stop during a pause/resume
-// node recreate, see reliability.SetPaused), the packet is dropped rather than blocking the
-// caller's goroutine forever — the sender re-acks on retransmit, so this is recoverable
-// (mirrors NodeTransport.Send, which also swallows errors for the same reason).
 func (t *NodeTransport) AddPacket(p transport.Packet) {
 	select {
 	case t.packets <- p:

--- a/pkg/messaging/layers/reliability/reliability.go
+++ b/pkg/messaging/layers/reliability/reliability.go
@@ -21,14 +21,7 @@ import (
 )
 
 // pausedDuration is the tick interval handed to the mvds node while the host is
-// backgrounded. We don't modify the mvds package: the interval is the `duration`
-// argument to Node.Start, so we stop the node and recreate it with a different
-// one. 5 minutes is rare enough that the SoC deep-sleeps essentially the whole
-// interval (battery-wise indistinguishable from never ticking) yet still lets
-// the outbound loop drain its in-memory ack buffer (mvds `payloads`) every 5
-// minutes — so acks owed for messages received while backgrounded go out within
-// ~5 min instead of waiting for the next foreground, and a queued message that
-// ages past its SendEpoch dispatches on the first tick after resume.
+// backgrounded and service paused
 const pausedDuration = 5 * time.Minute
 
 var errNotStarted = errors.New("reliability layer not started")
@@ -139,17 +132,7 @@ func (r *Reliability) mvdsDispatch(receiver mvdsstate.PeerID, payload *mvdsproto
 // loop by stopping the data-sync node and recreating it with a different tick
 // interval (pausedDuration vs DatasyncTicker). While paused the loop's outbound
 // work runs only every pausedDuration; inbound processing and peer-status
-// handling keep running. Safe to call before Start (the state is recorded and
-// applied when Start runs).
-//
-// Caveat: messages queued via WrapAndQueueMessageForDispatch while paused are
-// persisted to SQLite but not transmitted until either the next pausedDuration
-// tick or the next Resume (whichever comes first) — callers that must send
-// promptly while backgrounded (e.g. the Android notification quick-reply) should
-// Resume("messaging") first. Acks owed for messages received while paused live
-// in the mvds node's in-memory `payloads` buffer; the pausedDuration tick drains
-// them, but the resume-recreate drops whatever accumulated since the last tick
-// (senders re-ack on retransmit, so no message loss — only delayed "delivered").
+// handling keep running.
 func (r *Reliability) SetPaused(paused bool) error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
@@ -162,11 +145,7 @@ func (r *Reliability) SetPaused(paused bool) error {
 		return nil // not started yet; Start will pick the right interval
 	}
 	start := time.Now()
-	// Stop accepting inbound packets into the (about-to-be-stopped) node: with
-	// AddPacket non-blocking on a buffered channel, an in-flight Unwrap wouldn't
-	// hang here — but once the node's Watch goroutine exits the packets it pushed
-	// would be silently dropped. Short-circuit Unwrap so we don't decode and
-	// then discard packets during the recreate window.
+	// Stop accepting inbound packets into the (about-to-be-stopped) node
 	old.SetSendingEnabled(false)
 	old.Stop()
 	stopDur := time.Since(start)
@@ -176,10 +155,6 @@ func (r *Reliability) SetPaused(paused bool) error {
 	}
 	buildStart := time.Now()
 	if err := r.buildNode(duration); err != nil {
-		// The old node is already stopped; don't leave the atomic pointer aimed
-		// at a corpse. Started() now reports false and Unwrap/WrapAndQueue return
-		// errNotStarted; the next Reliability.Start (e.g. on a connection change)
-		// will rebuild.
 		r.datasync.Store(nil)
 		r.logger.Error("reliability SetPaused: rebuild failed; data-sync node is down until next Start", zap.Error(err))
 		return err

--- a/pkg/messaging/waku/gowaku.go
+++ b/pkg/messaging/waku/gowaku.go
@@ -175,7 +175,15 @@ type Waku struct {
 	connStatusSubscriptions map[string]*types.ConnStatusSubscription
 	connStatusMu            sync.Mutex
 	onlineChecker           *onlinechecker.DefaultOnlineChecker
-	state                   connection.State
+	// stateMu guards state and stateInitialized. ConnectionChanged is invoked
+	// from the OS/mobile path while checkForConnectionChanges and
+	// handleNetworkChangeFromApp run on the internal poller goroutine, so all
+	// three accesses must be synchronized.
+	stateMu sync.RWMutex
+	state   connection.State
+	// stateInitialized distinguishes "no ConnectionChange received yet" from
+	// "ConnectionChange received with Offline=false"
+	stateInitialized bool
 
 	StorenodeCycle   *history.StorenodeCycle
 	HistoryRetriever *history.HistoryRetriever
@@ -516,6 +524,25 @@ func (w *Waku) discoverAndConnectPeers() {
 	}
 }
 
+// dnsDiscoveryBackoff returns the wait duration before the next DNS discovery
+// retry attempt. attempt is the number of failures so far (0 = sentinel
+// meaning "no retry, no wait"; 1 = first failure just happened, wait 1s
+// before retry; 2 = second failure, 2s; etc). Exponential, capped at 60s.
+// Capped attempt at 30 to avoid shift overflow.
+func dnsDiscoveryBackoff(attempt int) time.Duration {
+	if attempt < 1 {
+		return 0
+	}
+	if attempt > 30 {
+		attempt = 30
+	}
+	backoff := 500 * time.Millisecond * time.Duration(1<<attempt)
+	if backoff > 60*time.Second {
+		return 60 * time.Second
+	}
+	return backoff
+}
+
 func (w *Waku) discoverAndConnect(address string) {
 	fnApply := func(d dnsdisc.DiscoveredNode, wg *sync.WaitGroup) {
 		defer wg.Done()
@@ -526,10 +553,32 @@ func (w *Waku) discoverAndConnect(address string) {
 
 	go func() {
 		defer gocommon.LogOnPanic()
-		if err := w.dnsDiscover(w.ctx, address, fnApply, false); err != nil {
+		// Retry on failure with exponential backoff: at cold start on Android,
+		// the device DNS resolver isn't always ready when statusgo starts and
+		// the enrtree:// lookup hits ::1:53 with "connection refused". Without
+		// retry the node stays on whatever DNS-cached store peers it has until
+		// the next real network event (e.g. airplane toggle) calls
+		// discoverAndConnectPeers again. The loop terminates on success or
+		// context cancellation (statusgo shutdown).
+		for attempt := 1; ; attempt++ {
+			err := w.dnsDiscover(w.ctx, address, fnApply, false)
+			if err == nil {
+				return
+			}
+			if w.ctx.Err() != nil {
+				return
+			}
 			w.logger.Error("dns discovery failed",
 				zap.String("dnsDiscURL", address),
+				zap.Int("attempt", attempt),
 				zap.Error(err))
+			t := time.NewTimer(dnsDiscoveryBackoff(attempt))
+			select {
+			case <-t.C:
+			case <-w.ctx.Done():
+				t.Stop()
+				return
+			}
 		}
 	}()
 }
@@ -1277,10 +1326,18 @@ func (w *Waku) checkForConnectionChanges() {
 		w.onPeerStats(latestConnStatus)
 	}
 
-	w.ConnectionChanged(connection.State{
-		Type:    w.state.Type, //setting state type as previous one since there won't be a change here
+	// Build the proposed next state. checkForConnectionChanges never originates
+	// a Type change (the comment below acknowledges this), and it has no OS
+	// visibility to learn about Expensive — both flow through the explicit
+	// mobile.ConnectionChange path.
+	prevState, _ := w.snapshotState()
+	next := connection.State{
+		Type:    prevState.Type, //setting state type as previous one since there won't be a change here
 		Offline: !latestConnStatus.IsOnline,
-	})
+	}
+	if w.shouldFireConnectionChanged(next) {
+		w.ConnectionChanged(next)
+	}
 }
 
 func (w *Waku) reportPeerMetrics() {
@@ -1684,10 +1741,23 @@ func (w *Waku) StopDiscV5() error {
 	return nil
 }
 
+// isNetworkSwitchEvent reports whether next represents a genuine wifi <-> cellular
+// switch (while remaining online) that warrants tearing down peers
+func isNetworkSwitchEvent(prev, next connection.State, prevInitialized bool) bool {
+	if !prevInitialized {
+		return false
+	}
+	if prev.Offline || next.Offline {
+		return false
+	}
+	return prev.Type != next.Type
+}
+
 func (w *Waku) handleNetworkChangeFromApp(state connection.State) {
+	prevState, prevInitialized := w.snapshotState()
 	//If connection state is reported by something other than peerCount becoming 0 e.g from mobile app, disconnect all peers
 	if (state.Offline && len(w.node.Host().Network().Peers()) > 0) ||
-		(w.state.Type != state.Type && !w.state.Offline && !state.Offline) { // network switched between wifi and cellular
+		isNetworkSwitchEvent(prevState, state, prevInitialized) {
 		w.logger.Info("connection switched or offline detected via mobile, disconnecting all peers")
 		w.node.DisconnectAllPeers()
 		if w.cfg.LightClient {
@@ -1702,6 +1772,25 @@ func (w *Waku) isGoingOnline(state connection.State) bool {
 
 func (w *Waku) isGoingOffline(state connection.State) bool {
 	return state.Offline && w.onlineChecker.IsOnline()
+}
+
+// shouldFireConnectionChanged reports whether next represents a change in
+// connectivity. The first observation (no state recorded yet) always fires so
+// downstream consumers like the LightClient FilterManager get initialized.
+func (w *Waku) shouldFireConnectionChanged(next connection.State) bool {
+	prev, prevInitialized := w.snapshotState()
+	if !prevInitialized {
+		return true
+	}
+	return prev.Offline != next.Offline || prev.Type != next.Type
+}
+
+// snapshotState returns a copy of the current connection state and the
+// initialization flag under the stateMu read lock
+func (w *Waku) snapshotState() (connection.State, bool) {
+	w.stateMu.RLock()
+	defer w.stateMu.RUnlock()
+	return w.state, w.stateInitialized
 }
 
 func (w *Waku) ConnectionChanged(state connection.State) {
@@ -1735,7 +1824,10 @@ func (w *Waku) ConnectionChanged(state connection.State) {
 	}
 	// update state
 	w.onlineChecker.SetOnline(isOnline)
+	w.stateMu.Lock()
 	w.state = state
+	w.stateInitialized = true
+	w.stateMu.Unlock()
 }
 
 // seedBootnodesForDiscV5 tries to fetch bootnodes

--- a/pkg/messaging/waku/gowaku_storm_test.go
+++ b/pkg/messaging/waku/gowaku_storm_test.go
@@ -1,0 +1,245 @@
+package wakuv2
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/status-im/status-go/internal/connection"
+)
+
+// TestShouldFireConnectionChanged validates the idempotency guard that
+// suppresses no-op ConnectionChanged calls from checkForConnectionChanges.
+//
+// Without this guard, every libp2p peer event triggers a full filter
+// resubscription cascade in lightClient mode (gowaku.go:1280 -> ConnectionChanged
+// -> filterManager.OnConnectionStatusChange -> resubscribeAllSubscriptions ->
+// per-peer libp2p dials). The dial completions emit fresh peer events that
+// loop back into the trigger — a self-amplifying loop that accumulates
+// thousands of orphan goroutines and pins statusgo at >2 cores of CPU.
+//
+// The guard fires on the very first observation (so downstream consumers like
+// the LightClient FilterManager get initialized even when peers connect before
+// the first poll) and thereafter only on a real change in Offline or Type.
+// Expensive is intentionally excluded because checkForConnectionChanges has
+// no OS visibility to learn about metered-connection changes — those flow in
+// through the explicit mobile.ConnectionChange path.
+func TestShouldFireConnectionChanged(t *testing.T) {
+	wifi := connection.NewType("wifi")
+	cellular := connection.NewType("cellular")
+	unknown := connection.NewType("")
+
+	cases := []struct {
+		name            string
+		prev            connection.State
+		next            connection.State
+		prevInitialized bool
+		expect          bool
+	}{
+		{
+			name:            "first observation, peers already online — fires (FilterManager init)",
+			prev:            connection.State{}, // zero-value
+			next:            connection.State{Offline: false, Type: unknown},
+			prevInitialized: false,
+			expect:          true,
+		},
+		{
+			name:            "first observation, no peers yet — fires",
+			prev:            connection.State{},
+			next:            connection.State{Offline: true, Type: unknown},
+			prevInitialized: false,
+			expect:          true,
+		},
+		{
+			name:            "no change — online wifi stays online wifi",
+			prev:            connection.State{Offline: false, Type: wifi},
+			next:            connection.State{Offline: false, Type: wifi},
+			prevInitialized: true,
+			expect:          false,
+		},
+		{
+			name:            "offline → online",
+			prev:            connection.State{Offline: true, Type: unknown},
+			next:            connection.State{Offline: false, Type: unknown},
+			prevInitialized: true,
+			expect:          true,
+		},
+		{
+			name:            "online → offline",
+			prev:            connection.State{Offline: false, Type: wifi},
+			next:            connection.State{Offline: true, Type: wifi},
+			prevInitialized: true,
+			expect:          true,
+		},
+		{
+			name:            "type wifi → cellular (network switch)",
+			prev:            connection.State{Offline: false, Type: wifi},
+			next:            connection.State{Offline: false, Type: cellular},
+			prevInitialized: true,
+			expect:          true,
+		},
+		{
+			name:            "type cellular → wifi (network switch)",
+			prev:            connection.State{Offline: false, Type: cellular},
+			next:            connection.State{Offline: false, Type: wifi},
+			prevInitialized: true,
+			expect:          true,
+		},
+		{
+			name:            "no change — both offline same type",
+			prev:            connection.State{Offline: true, Type: unknown},
+			next:            connection.State{Offline: true, Type: unknown},
+			prevInitialized: true,
+			expect:          false,
+		},
+		{
+			name:            "expensive flag toggled in isolation — ignored",
+			prev:            connection.State{Offline: false, Type: wifi, Expensive: false},
+			next:            connection.State{Offline: false, Type: wifi, Expensive: true},
+			prevInitialized: true,
+			expect:          false,
+		},
+		{
+			name:            "expensive AND online state change — fires",
+			prev:            connection.State{Offline: true, Type: wifi, Expensive: true},
+			next:            connection.State{Offline: false, Type: wifi, Expensive: false},
+			prevInitialized: true,
+			expect:          true,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			w, err := New(nil, nil, nil, nil, nil, nil)
+			require.NoError(t, err)
+			if tc.prevInitialized {
+				w.stateMu.Lock()
+				w.state = tc.prev
+				w.stateInitialized = true
+				w.stateMu.Unlock()
+			}
+			require.Equal(t, tc.expect, w.shouldFireConnectionChanged(tc.next))
+		})
+	}
+}
+
+// TestIsNetworkSwitchEvent guards the predicate that gates the
+// DisconnectAllPeers branch in handleNetworkChangeFromApp. Pre-fix, the
+// switch branch fired on the very first ConnectionChange after Waku
+// construction because w.state.Type starts at zero-value connectionUnknown,
+// and the first observation (e.g. wifi) compared as "type changed while
+// online" — so the bootstrap peers that just connected were torn down,
+// stranding the node on the 6 DNS-bootstrap peers until the next real
+// network event (airplane toggle) gave the discv5 DHT enough time to fill.
+//
+// The fix is to distinguish "state not yet set" from "state observed with
+// Offline=false": the first call has no prior state to compare against, so
+// a Type difference vs the zero value is NOT a switch event.
+func TestIsNetworkSwitchEvent(t *testing.T) {
+	wifi := connection.NewType("wifi")
+	cellular := connection.NewType("cellular")
+	unknown := connection.NewType("")
+
+	cases := []struct {
+		name            string
+		prev            connection.State
+		next            connection.State
+		prevInitialized bool
+		expect          bool
+	}{
+		{
+			name:            "cold start: not initialized + first online state — NOT a switch",
+			prev:            connection.State{}, // zero-value: Offline=false, Type=unknown
+			next:            connection.State{Offline: false, Type: wifi},
+			prevInitialized: false,
+			expect:          false,
+		},
+		{
+			name:            "cold start: not initialized + first offline state — NOT a switch",
+			prev:            connection.State{},
+			next:            connection.State{Offline: true, Type: unknown},
+			prevInitialized: false,
+			expect:          false,
+		},
+		{
+			name:            "real switch: wifi to cellular while online — IS a switch",
+			prev:            connection.State{Offline: false, Type: wifi},
+			next:            connection.State{Offline: false, Type: cellular},
+			prevInitialized: true,
+			expect:          true,
+		},
+		{
+			name:            "real switch: cellular to wifi while online — IS a switch",
+			prev:            connection.State{Offline: false, Type: cellular},
+			next:            connection.State{Offline: false, Type: wifi},
+			prevInitialized: true,
+			expect:          true,
+		},
+		{
+			name:            "no change: same type online — NOT a switch",
+			prev:            connection.State{Offline: false, Type: wifi},
+			next:            connection.State{Offline: false, Type: wifi},
+			prevInitialized: true,
+			expect:          false,
+		},
+		{
+			name:            "going offline (prev online, next offline) — NOT a switch (handled by offline branch)",
+			prev:            connection.State{Offline: false, Type: wifi},
+			next:            connection.State{Offline: true, Type: wifi},
+			prevInitialized: true,
+			expect:          false,
+		},
+		{
+			name:            "coming online (prev offline, next online) — NOT a switch (handled by online transition)",
+			prev:            connection.State{Offline: true, Type: wifi},
+			next:            connection.State{Offline: false, Type: wifi},
+			prevInitialized: true,
+			expect:          false,
+		},
+		{
+			name:            "coming online with type change — NOT a switch (going-online edge owns this)",
+			prev:            connection.State{Offline: true, Type: wifi},
+			next:            connection.State{Offline: false, Type: cellular},
+			prevInitialized: true,
+			expect:          false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.expect, isNetworkSwitchEvent(tc.prev, tc.next, tc.prevInitialized))
+		})
+	}
+}
+
+// TestDnsDiscoveryBackoff guards the exponential backoff schedule used to
+// retry enrtree:// DNS bootstrap discovery when it fails at cold start
+// (commonly: Android's DNS resolver isn't wired up yet, so the lookup goes
+// to ::1:53 and returns "connection refused"). Pre-fix, the failure was
+// logged once and the bootstrap was abandoned — the node stayed on the 6
+// DNS-cached store peers until a real network event triggered a retry.
+//
+// The schedule: 0 (no initial wait), then 1s, 2s, 4s, 8s, 16s, 32s,
+// capped at 60s thereafter. Capped at attempt 30 to avoid shift overflow.
+func TestDnsDiscoveryBackoff(t *testing.T) {
+	cases := []struct {
+		attempt int
+		expect  time.Duration
+	}{
+		{attempt: 0, expect: 0}, // sentinel: no wait
+		{attempt: 1, expect: 1 * time.Second},
+		{attempt: 2, expect: 2 * time.Second},
+		{attempt: 3, expect: 4 * time.Second},
+		{attempt: 4, expect: 8 * time.Second},
+		{attempt: 5, expect: 16 * time.Second},
+		{attempt: 6, expect: 32 * time.Second},
+		{attempt: 7, expect: 60 * time.Second},    // cap kicks in
+		{attempt: 50, expect: 60 * time.Second},   // stays at cap
+		{attempt: 1000, expect: 60 * time.Second}, // overflow-safe
+	}
+	for _, tc := range cases {
+		t.Run(fmt.Sprintf("attempt=%d", tc.attempt), func(t *testing.T) {
+			require.Equal(t, tc.expect, dnsDiscoveryBackoff(tc.attempt))
+		})
+	}
+}


### PR DESCRIPTION

This commit is fixing 2 issues in waku:
1. Unnecesary disconnect/reconnects. The disconnect/reconnect storm creates deadlocks and crashes in gowaku (rootcause handled upstream https://github.com/logos-messaging/logos-delivery-go/pull/1302)
2. dns failure at startup will silently give up - no retries. Fixing an issue where if the dns lookup is briefly interrupted by connection changes it will retry with an exponential backfire.

- filter connection changes and forward the signal only when a change happened
- dnsDiscovery: retry on failure with exponential backoff

Iterates https://github.com/status-im/status-app/issues/20587
