### PR TITLE
fix: Process contact code advertisment in the push client

### DIFF
--- a/protocol/messenger_handler.go
+++ b/protocol/messenger_handler.go
@@ -2701,6 +2701,14 @@ func (m *Messenger) HandleGroupChatInvitation(ctx context.Context, state *Receiv
 }
 
 func (m *Messenger) HandleContactCodeAdvertisement(ctx context.Context, state *ReceivedMessageState, cca *protobuf.ContactCodeAdvertisement, statusMessage *common.StatusMessage) error {
+	publicKey := state.CurrentMessageState.PublicKey
+
+	if m.pushNotificationClient != nil {
+		if err := m.pushNotificationClient.HandleContactCodeAdvertisement(publicKey, cca); err != nil {
+			m.logger.Warn("failed to handle ContactCodeAdvertisement push notification info", zap.Error(err))
+		}
+	}
+
 	if cca.ChatIdentity == nil {
 		return nil
 	}

--- a/protocol/push_notification_test.go
+++ b/protocol/push_notification_test.go
@@ -692,6 +692,74 @@ func (s *MessengerPushNotificationSuite) TestContactCode() {
 
 }
 
+// TestContactCodeAdvertisementStoresPushInfoViaHandler is a regression test for the bug
+// where Messenger.HandleContactCodeAdvertisement stopped forwarding the advertisement to
+// the push notification client (the forwarding was dropped in the "generate handlers"
+// refactor). The push info carried in a contact code is the channel light clients rely on
+// to learn a contact's push registration — the live query response is ephemeral and is
+// routinely missed by light clients — so the handler MUST forward it. Unlike TestContactCode
+// (which calls the push client method directly and so never exercised this wiring), this
+// test drives the messenger handler and asserts the recipient's push info is stored.
+func (s *MessengerPushNotificationSuite) TestContactCodeAdvertisementStoresPushInfoViaHandler() {
+	bob1 := s.m
+	messenger, _ := s.newPushNotificationServer()
+	alice := s.newMessenger()
+
+	s.Require().NoError(alice.EnableSendingPushNotifications())
+
+	// Register bob1 with the push notification server so its contact code carries push info.
+	err := bob1.AddPushNotificationsServer(context.Background(), &messenger.identity.PublicKey, pushnotificationclient.ServerTypeCustom)
+	s.Require().NoError(err)
+
+	err = bob1.RegisterForPushNotifications(context.Background(), bob1DeviceToken, testAPNTopic, protobuf.PushNotificationRegistration_APN_TOKEN)
+	s.Require().NoError(err)
+
+	err = testutils2.RetryWithBackOff(func() error {
+		if _, err := messenger.RetrieveAll(); err != nil {
+			return err
+		}
+		if _, err := bob1.RetrieveAll(); err != nil {
+			return err
+		}
+		registered, err := bob1.RegisteredForPushNotifications()
+		if err != nil {
+			return err
+		}
+		if !registered {
+			return errors.New("not registered")
+		}
+		return nil
+	})
+	s.Require().NoError(err)
+
+	contactCodeAdvertisement, err := bob1.buildContactCodeAdvertisement()
+	s.Require().NoError(err)
+	s.Require().NotNil(contactCodeAdvertisement)
+	s.Require().NotEmpty(contactCodeAdvertisement.PushNotificationInfo)
+	// The common case for periodic push-info re-advertisements has no chat identity attached;
+	// this is precisely the shape the buggy handler dropped (it bailed when ChatIdentity == nil).
+	s.Require().Nil(contactCodeAdvertisement.ChatIdentity)
+
+	// alice has never interacted with bob1, so it must not yet have bob1's push info.
+	infoBefore, err := alice.pushNotificationClient.GetPushNotificationInfo(&bob1.identity.PublicKey, nil)
+	s.Require().NoError(err)
+	s.Require().Empty(infoBefore)
+
+	// Drive the messenger handler (the wiring under test) rather than the push client directly.
+	state := &ReceivedMessageState{
+		CurrentMessageState: &CurrentMessageState{
+			PublicKey: &bob1.identity.PublicKey,
+		},
+	}
+	s.Require().NoError(alice.HandleContactCodeAdvertisement(context.Background(), state, contactCodeAdvertisement, nil))
+
+	// The handler must have forwarded the advertisement to the push client, which stores
+	// bob1's push registration so a subsequent send can dispatch a notification.
+	infoAfter, err := alice.pushNotificationClient.GetPushNotificationInfo(&bob1.identity.PublicKey, nil)
+	s.Require().NoError(err)
+	s.Require().NotEmpty(infoAfter, "messenger handler must forward contact-code push info to the push notification client")
+}
+
 func (s *MessengerPushNotificationSuite) TestReceivePushNotificationMention() {
 	bob := s.m
 	messenger, _ := s.newPushNotificationServer()

--- a/protocol/pushnotificationserver/gorush.go
+++ b/protocol/pushnotificationserver/gorush.go
@@ -12,22 +12,30 @@ import (
 	"github.com/status-im/status-go/protocol/protobuf"
 )
 
-const defaultNewMessageNotificationText = "You have a new message"
-const defaultMentionNotificationText = "Someone mentioned you"
+const defaultNewMessageNotificationText = "New message in Messenger"
+const defaultMentionNotificationText = "New mention or reply in Communities"
 const defaultRequestToJoinCommunityNotificationText = "Someone requested to join a community you are an admin of"
+
+const deepLinkChats = "status-app://chats"       // plain messages -> messenger
+const deepLinkActivityCenter = "status-app://ac" // mentions, community requests, etc. -> activity center
 
 type GoRushRequestData struct {
 	EncryptedMessage string `json:"encryptedMessage"`
 	ChatID           string `json:"chatId"`
 	PublicKey        string `json:"publicKey"`
+	DeepLink         string `json:"deepLink,omitempty"`
 }
 
 type GoRushRequestNotification struct {
-	Tokens   []string           `json:"tokens"`
-	Platform uint               `json:"platform"`
-	Message  string             `json:"message"`
-	Topic    string             `json:"topic"`
-	Data     *GoRushRequestData `json:"data"`
+	Tokens           []string           `json:"tokens"`
+	Platform         uint               `json:"platform"`
+	Message          string             `json:"message"`
+	Topic            string             `json:"topic"`
+	ContentAvailable bool               `json:"content_available,omitempty"`
+	Sound            string             `json:"sound,omitempty"`
+	Priority         string             `json:"priority,omitempty"`
+	PushType         string             `json:"push_type,omitempty"`
+	Data             *GoRushRequestData `json:"data"`
 }
 
 type GoRushRequest struct {
@@ -62,16 +70,33 @@ func PushNotificationRegistrationToGoRushRequest(requestAndRegistrations []*Requ
 		} else {
 			text = defaultMentionNotificationText
 		}
+		isAPN := registration.TokenType == protobuf.PushNotificationRegistration_APN_TOKEN
+		var sound, priority, pushType, deepLink string
+		if isAPN {
+			sound = "default"
+			priority = "high"
+			pushType = "alert"
+			if request.Type == protobuf.PushNotification_MESSAGE {
+				deepLink = deepLinkChats
+			} else {
+				deepLink = deepLinkActivityCenter
+			}
+		}
 		goRushRequests.Notifications = append(goRushRequests.Notifications,
 			&GoRushRequestNotification{
-				Tokens:   []string{registration.DeviceToken},
-				Platform: tokenTypeToGoRushPlatform(registration.TokenType),
-				Message:  text,
-				Topic:    registration.ApnTopic,
+				Tokens:           []string{registration.DeviceToken},
+				Platform:         tokenTypeToGoRushPlatform(registration.TokenType),
+				Message:          text,
+				Topic:            registration.ApnTopic,
+				ContentAvailable: isAPN,
+				Sound:            sound,
+				Priority:         priority,
+				PushType:         pushType,
 				Data: &GoRushRequestData{
 					EncryptedMessage: types.EncodeHex(request.Message),
 					ChatID:           types.EncodeHex(request.ChatId),
 					PublicKey:        types.EncodeHex(request.PublicKey),
+					DeepLink:         deepLink,
 				},
 			})
 	}

--- a/protocol/pushnotificationserver/gorush_test.go
+++ b/protocol/pushnotificationserver/gorush_test.go
@@ -74,13 +74,18 @@ func TestPushNotificationRegistrationToGoRushRequest(t *testing.T) {
 	expectedRequests := &GoRushRequest{
 		Notifications: []*GoRushRequestNotification{
 			{
-				Tokens:   []string{token1},
-				Platform: platform1,
-				Message:  defaultNewMessageNotificationText,
+				Tokens:           []string{token1},
+				Platform:         platform1,
+				Message:          defaultNewMessageNotificationText,
+				ContentAvailable: true,
+				Sound:            "default",
+				Priority:         "high",
+				PushType:         "alert",
 				Data: &GoRushRequestData{
 					EncryptedMessage: hexMessage1,
 					ChatID:           types.EncodeHex(chatID),
 					PublicKey:        types.EncodeHex(publicKey1),
+					DeepLink:         deepLinkChats,
 				},
 			},
 			{
@@ -107,4 +112,59 @@ func TestPushNotificationRegistrationToGoRushRequest(t *testing.T) {
 	}
 	actualRequests := PushNotificationRegistrationToGoRushRequest(requestAndRegistrations)
 	require.Equal(t, expectedRequests, actualRequests)
+}
+
+func TestGoRushRequestMakesAPNAlertWithSound(t *testing.T) {
+	req := PushNotificationRegistrationToGoRushRequest([]*RequestAndRegistration{{
+		Request: &protobuf.PushNotification{Type: protobuf.PushNotification_MESSAGE},
+		Registration: &protobuf.PushNotificationRegistration{
+			TokenType:   protobuf.PushNotificationRegistration_APN_TOKEN,
+			DeviceToken: "tok",
+			ApnTopic:    "im.status.ethereum",
+		},
+	}})
+	n := req.Notifications[0]
+	require.Equal(t, "default", n.Sound)
+	require.Equal(t, "high", n.Priority)
+	require.Equal(t, "alert", n.PushType)
+	require.True(t, n.ContentAvailable)
+}
+
+func TestGoRushRequestFirebaseUnaffected(t *testing.T) {
+	req := PushNotificationRegistrationToGoRushRequest([]*RequestAndRegistration{{
+		Request: &protobuf.PushNotification{Type: protobuf.PushNotification_MESSAGE},
+		Registration: &protobuf.PushNotificationRegistration{
+			TokenType:   protobuf.PushNotificationRegistration_FIREBASE_TOKEN,
+			DeviceToken: "tok",
+		},
+	}})
+	n := req.Notifications[0]
+	require.Empty(t, n.Sound)
+	require.Empty(t, n.PushType)
+	require.Empty(t, n.Data.DeepLink)
+}
+
+func TestGoRushRequestDeepLinkByType(t *testing.T) {
+	cases := []struct {
+		name     string
+		pushType protobuf.PushNotification_PushNotificationType
+		expected string
+	}{
+		{"message", protobuf.PushNotification_MESSAGE, deepLinkChats},
+		{"mention", protobuf.PushNotification_MENTION, deepLinkActivityCenter},
+		{"community request", protobuf.PushNotification_REQUEST_TO_JOIN_COMMUNITY, deepLinkActivityCenter},
+		{"unknown", protobuf.PushNotification_UNKNOWN_PUSH_NOTIFICATION_TYPE, deepLinkActivityCenter},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := PushNotificationRegistrationToGoRushRequest([]*RequestAndRegistration{{
+				Request: &protobuf.PushNotification{Type: tc.pushType},
+				Registration: &protobuf.PushNotificationRegistration{
+					TokenType:   protobuf.PushNotificationRegistration_APN_TOKEN,
+					DeviceToken: "tok",
+				},
+			}})
+			require.Equal(t, tc.expected, req.Notifications[0].Data.DeepLink)
+		})
+	}
 }


### PR DESCRIPTION
Process the contact code advertisment with the push client

status PR https://github.com/status-im/status-app/pull/21009