### PR TITLE
feat(preferences): storage for settings

### DIFF
--- a/internal/db/appdatabase/migrations/sql/1779444743_create_preferences.up.sql
+++ b/internal/db/appdatabase/migrations/sql/1779444743_create_preferences.up.sql
@@ -1,0 +1,7 @@
+CREATE TABLE IF NOT EXISTS preferences (
+    category   TEXT    NOT NULL,
+    key        TEXT    NOT NULL,
+    value      TEXT    NOT NULL,
+    updated_at INTEGER NOT NULL,
+    PRIMARY KEY (category, key)
+) WITHOUT ROWID;

--- a/pkg/backend/node/get_status_node.go
+++ b/pkg/backend/node/get_status_node.go
@@ -48,6 +48,7 @@ import (
 	"github.com/status-im/status-go/services/newsfeed"
 	"github.com/status-im/status-go/services/permissions"
 	"github.com/status-im/status-go/services/personal"
+	"github.com/status-im/status-go/services/preferences"
 	"github.com/status-im/status-go/services/rpcstats"
 	"github.com/status-im/status-go/services/sharedurls"
 	"github.com/status-im/status-go/services/stickers"
@@ -122,6 +123,7 @@ type StatusNode struct {
 	appGeneralSrvc         *appgeneral.Service
 	ethSrvc                *eth.Service
 	newsfeedSrvc           *newsfeed.Service
+	preferencesSrvc        *preferences.Service
 	sharedUrlsSrvc         *sharedurls.Service
 	linkPreviewSrvc        *linkpreview.Service
 
@@ -513,6 +515,7 @@ func (n *StatusNode) Stop() error {
 	n.pendingTracker = nil
 	n.appGeneralSrvc = nil
 	n.newsfeedSrvc = nil
+	n.preferencesSrvc = nil
 
 	n.logger.Debug("status node stopped")
 	return errors.Join(errs...)

--- a/pkg/backend/node/status_node_services.go
+++ b/pkg/backend/node/status_node_services.go
@@ -33,6 +33,7 @@ import (
 	localnotifications "github.com/status-im/status-go/services/local-notifications"
 	"github.com/status-im/status-go/services/permissions"
 	"github.com/status-im/status-go/services/personal"
+	"github.com/status-im/status-go/services/preferences"
 	"github.com/status-im/status-go/services/rpcstats"
 	"github.com/status-im/status-go/services/stickers"
 	"github.com/status-im/status-go/services/updates"
@@ -82,6 +83,7 @@ func (b *StatusNode) initServices(config *params.NodeConfig, mediaServer *server
 	services = appendIf(b.appDB != nil && b.multiaccountsDB != nil, services, b.accountsService(accDB, mediaServer))
 	services = appendIf(config.BrowsersConfig.Enabled, services, b.browsersService())
 	services = appendIf(config.PermissionsConfig.Enabled, services, b.permissionsService())
+	services = appendIf(b.appDB != nil, services, b.preferencesService())
 	services = appendIf(config.ConnectorConfig.Enabled, services, b.connectorService())
 	services = append(services, b.gifService(accDB))
 	services = append(services, b.ChatService(accDB))
@@ -290,6 +292,13 @@ func (b *StatusNode) permissionsService() *permissions.Service {
 		b.permissionsSrvc = permissions.NewService(permissions.NewDB(b.appDB))
 	}
 	return b.permissionsSrvc
+}
+
+func (b *StatusNode) preferencesService() *preferences.Service {
+	if b.preferencesSrvc == nil {
+		b.preferencesSrvc = preferences.NewService(b.appDB)
+	}
+	return b.preferencesSrvc
 }
 
 func (b *StatusNode) appgeneralService() *appgeneral.Service {

--- a/services/preferences/api.go
+++ b/services/preferences/api.go
@@ -1,0 +1,74 @@
+package preferences
+
+import (
+	"context"
+)
+
+type GetResult struct {
+	Value string `json:"value"`
+	Found bool   `json:"found"`
+}
+
+type CountResult struct {
+	Removed int `json:"removed"`
+}
+
+type API struct {
+	store PreferenceStore
+}
+
+func NewAPI(store PreferenceStore) *API {
+	return &API{store: store}
+}
+
+func (api *API) Get(_ context.Context, category, key string) (GetResult, error) {
+	value, found, err := api.store.Get(category, key)
+	if err != nil {
+		return GetResult{}, err
+	}
+	return GetResult{Value: value, Found: found}, nil
+}
+
+func (api *API) GetAll(_ context.Context, category string) (map[string]string, error) {
+	return api.store.GetAll(category)
+}
+
+func (api *API) ListKeys(_ context.Context, category string) ([]string, error) {
+	return api.store.ListKeys(category)
+}
+
+func (api *API) ListCategories(_ context.Context) ([]string, error) {
+	return api.store.ListCategories()
+}
+
+func (api *API) Set(_ context.Context, category, key, value string) error {
+	return api.store.Set(category, key, value)
+}
+
+func (api *API) SetMany(_ context.Context, category string, kvs map[string]string) error {
+	return api.store.SetMany(category, kvs)
+}
+
+func (api *API) Delete(_ context.Context, category, key string) error {
+	return api.store.Delete(category, key)
+}
+
+func (api *API) DeleteCategory(_ context.Context, category string) (CountResult, error) {
+	removed, err := api.store.DeleteCategory(category)
+	if err != nil {
+		return CountResult{}, err
+	}
+	return CountResult{Removed: removed}, nil
+}
+
+func (api *API) PurgeUnknown(_ context.Context, category string, validKeys []string) (CountResult, error) {
+	removed, err := api.store.PurgeUnknown(category, validKeys)
+	if err != nil {
+		return CountResult{}, err
+	}
+	return CountResult{Removed: removed}, nil
+}
+
+func (api *API) LoadAndPurgeUnknown(_ context.Context, category string, validKeys []string) (map[string]string, error) {
+	return api.store.LoadAndPurgeUnknown(category, validKeys)
+}

--- a/services/preferences/interfaces.go
+++ b/services/preferences/interfaces.go
@@ -1,0 +1,17 @@
+package preferences
+
+//go:generate go tool mockgen -package=mock_preferences -source=interfaces.go -destination=mock/interfaces.go
+
+// PreferenceStore is the persistence seam for per-account opaque preferences.
+type PreferenceStore interface {
+	Set(category, key, value string) error
+	SetMany(category string, kvs map[string]string) error
+	Get(category, key string) (value string, found bool, err error)
+	GetAll(category string) (map[string]string, error)
+	ListCategories() ([]string, error)
+	ListKeys(category string) ([]string, error)
+	Delete(category, key string) error
+	DeleteCategory(category string) (removed int, err error)
+	PurgeUnknown(category string, validKeys []string) (removed int, err error)
+	LoadAndPurgeUnknown(category string, validKeys []string) (values map[string]string, err error)
+}

--- a/services/preferences/persistence.go
+++ b/services/preferences/persistence.go
@@ -1,0 +1,303 @@
+package preferences
+
+import (
+	"database/sql"
+	"errors"
+	"fmt"
+	"time"
+
+	sq "github.com/Masterminds/squirrel"
+)
+
+var (
+	errEmptyCategory  = errors.New("category must not be empty")
+	errEmptyKey       = errors.New("key must not be empty")
+	errEmptyValidKeys = errors.New("validKeys must not be empty; use DeleteCategory to remove all keys in a category")
+)
+
+type sqlExecer interface {
+	Exec(query string, args ...any) (sql.Result, error)
+}
+
+// Store is the SQLite adapter for PreferenceStore.
+type Store struct {
+	db *sql.DB
+}
+
+func NewStore(db *sql.DB) *Store {
+	return &Store{db: db}
+}
+
+func validateCategory(category string) error {
+	if category == "" {
+		return errEmptyCategory
+	}
+	return nil
+}
+
+func validateCategoryKey(category, key string) error {
+	if err := validateCategory(category); err != nil {
+		return err
+	}
+	if key == "" {
+		return errEmptyKey
+	}
+	return nil
+}
+
+func upsert(exec sqlExecer, category, key, value string, updatedAt int64) error {
+	query, args, err := sq.Insert("preferences").
+		Columns("category", "key", "value", "updated_at").
+		Values(category, key, value, updatedAt).
+		Suffix(`ON CONFLICT (category, key) DO UPDATE SET
+			value = excluded.value,
+			updated_at = excluded.updated_at`).
+		ToSql()
+	if err != nil {
+		return fmt.Errorf("build upsert query: %w", err)
+	}
+
+	_, err = exec.Exec(query, args...)
+	if err != nil {
+		return fmt.Errorf("upsert preference: %w", err)
+	}
+	return nil
+}
+
+func (s *Store) Set(category, key, value string) error {
+	if err := validateCategoryKey(category, key); err != nil {
+		return err
+	}
+	return upsert(s.db, category, key, value, time.Now().UnixMilli())
+}
+
+func (s *Store) SetMany(category string, kvs map[string]string) (err error) {
+	if err = validateCategory(category); err != nil {
+		return err
+	}
+	if len(kvs) == 0 {
+		return nil
+	}
+
+	var tx *sql.Tx
+	tx, err = s.db.Begin()
+	if err != nil {
+		return fmt.Errorf("begin transaction: %w", err)
+	}
+	defer func() {
+		if err == nil {
+			err = tx.Commit()
+			return
+		}
+		_ = tx.Rollback()
+	}()
+
+	now := time.Now().UnixMilli()
+	for key, value := range kvs {
+		if key == "" {
+			return errEmptyKey
+		}
+		if err = upsert(tx, category, key, value, now); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (s *Store) Get(category, key string) (value string, found bool, err error) {
+	if err := validateCategoryKey(category, key); err != nil {
+		return "", false, err
+	}
+
+	query, args, err := sq.Select("value").
+		From("preferences").
+		Where(sq.Eq{"category": category, "key": key}).
+		ToSql()
+	if err != nil {
+		return "", false, fmt.Errorf("build get query: %w", err)
+	}
+
+	err = s.db.QueryRow(query, args...).Scan(&value)
+	if errors.Is(err, sql.ErrNoRows) {
+		return "", false, nil
+	}
+	if err != nil {
+		return "", false, fmt.Errorf("get preference: %w", err)
+	}
+	return value, true, nil
+}
+
+func (s *Store) GetAll(category string) (map[string]string, error) {
+	if err := validateCategory(category); err != nil {
+		return nil, err
+	}
+
+	query, args, err := sq.Select("key", "value").
+		From("preferences").
+		Where(sq.Eq{"category": category}).
+		ToSql()
+	if err != nil {
+		return nil, fmt.Errorf("build getall query: %w", err)
+	}
+
+	rows, err := s.db.Query(query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("getall preferences: %w", err)
+	}
+	defer rows.Close()
+
+	result := make(map[string]string)
+	for rows.Next() {
+		var key, value string
+		if err := rows.Scan(&key, &value); err != nil {
+			return nil, fmt.Errorf("scan preference row: %w", err)
+		}
+		result[key] = value
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate preferences: %w", err)
+	}
+	return result, nil
+}
+
+func (s *Store) ListCategories() ([]string, error) {
+	query, args, err := sq.Select("DISTINCT category").
+		From("preferences").
+		OrderBy("category").
+		ToSql()
+	if err != nil {
+		return nil, fmt.Errorf("build list categories query: %w", err)
+	}
+
+	rows, err := s.db.Query(query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("list preference categories: %w", err)
+	}
+	defer rows.Close()
+
+	var categories []string
+	for rows.Next() {
+		var category string
+		if err := rows.Scan(&category); err != nil {
+			return nil, fmt.Errorf("scan preference category: %w", err)
+		}
+		categories = append(categories, category)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate preference categories: %w", err)
+	}
+	return categories, nil
+}
+
+func (s *Store) ListKeys(category string) ([]string, error) {
+	if err := validateCategory(category); err != nil {
+		return nil, err
+	}
+
+	query, args, err := sq.Select("key").
+		From("preferences").
+		Where(sq.Eq{"category": category}).
+		OrderBy("key").
+		ToSql()
+	if err != nil {
+		return nil, fmt.Errorf("build listkeys query: %w", err)
+	}
+
+	rows, err := s.db.Query(query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("list preference keys: %w", err)
+	}
+	defer rows.Close()
+
+	var keys []string
+	for rows.Next() {
+		var key string
+		if err := rows.Scan(&key); err != nil {
+			return nil, fmt.Errorf("scan preference key: %w", err)
+		}
+		keys = append(keys, key)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate preference keys: %w", err)
+	}
+	return keys, nil
+}
+
+func (s *Store) Delete(category, key string) error {
+	if err := validateCategoryKey(category, key); err != nil {
+		return err
+	}
+
+	query, args, err := sq.Delete("preferences").
+		Where(sq.Eq{"category": category, "key": key}).
+		ToSql()
+	if err != nil {
+		return fmt.Errorf("build delete query: %w", err)
+	}
+
+	_, err = s.db.Exec(query, args...)
+	if err != nil {
+		return fmt.Errorf("delete preference: %w", err)
+	}
+	return nil
+}
+
+func (s *Store) DeleteCategory(category string) (int, error) {
+	if err := validateCategory(category); err != nil {
+		return 0, err
+	}
+
+	query, args, err := sq.Delete("preferences").
+		Where(sq.Eq{"category": category}).
+		ToSql()
+	if err != nil {
+		return 0, fmt.Errorf("build delete category query: %w", err)
+	}
+
+	result, err := s.db.Exec(query, args...)
+	if err != nil {
+		return 0, fmt.Errorf("delete category: %w", err)
+	}
+
+	removed, err := result.RowsAffected()
+	if err != nil {
+		return 0, fmt.Errorf("delete category rows affected: %w", err)
+	}
+	return int(removed), nil
+}
+
+func (s *Store) PurgeUnknown(category string, validKeys []string) (int, error) {
+	if err := validateCategory(category); err != nil {
+		return 0, err
+	}
+	if len(validKeys) == 0 {
+		return 0, errEmptyValidKeys
+	}
+
+	query, args, err := sq.Delete("preferences").
+		Where(sq.Eq{"category": category}).
+		Where(sq.NotEq{"key": validKeys}).
+		ToSql()
+	if err != nil {
+		return 0, fmt.Errorf("build purge query: %w", err)
+	}
+
+	result, err := s.db.Exec(query, args...)
+	if err != nil {
+		return 0, fmt.Errorf("purge unknown preferences: %w", err)
+	}
+
+	removed, err := result.RowsAffected()
+	if err != nil {
+		return 0, fmt.Errorf("purge rows affected: %w", err)
+	}
+	return int(removed), nil
+}
+
+func (s *Store) LoadAndPurgeUnknown(category string, validKeys []string) (map[string]string, error) {
+	if _, err := s.PurgeUnknown(category, validKeys); err != nil {
+		return nil, err
+	}
+	return s.GetAll(category)
+}

--- a/services/preferences/rpc_test.go
+++ b/services/preferences/rpc_test.go
@@ -1,0 +1,70 @@
+package preferences
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/rpc"
+	"github.com/stretchr/testify/require"
+
+	rpc2 "github.com/status-im/status-go/pkg/backend/node/rpc"
+)
+
+func TestPreferencesRPCMethods(t *testing.T) {
+	store := setupTestStore(t)
+	api := NewAPI(store)
+
+	server := rpc.NewServer()
+	require.NoError(t, server.RegisterName("preferences", api))
+
+	call := func(method string, params string) string {
+		t.Helper()
+		input := `{"jsonrpc":"2.0","id":1,"method":"` + method + `","params":` + params + `}`
+		codec := rpc2.NewSingleRequestCodec(input)
+		server.ServeCodec(codec.GethCodec(), 0)
+		return codec.Output()
+	}
+
+	category := "BrowserSettings_test"
+	require.NotContains(t, call("preferences_getAll", `["`+category+`"]`), `"error"`)
+	out := call("preferences_set", `["`+category+`","restoreOpenTabs","true"]`)
+	t.Log("set:", out)
+	require.NotContains(t, out, `"error"`)
+
+	all, err := api.GetAll(context.Background(), category)
+	require.NoError(t, err)
+	require.Equal(t, "true", all["restoreOpenTabs"])
+}
+
+func TestPreferencesListCategoriesRPC(t *testing.T) {
+	store := setupTestStore(t)
+	api := NewAPI(store)
+
+	server := rpc.NewServer()
+	require.NoError(t, server.RegisterName("preferences", api))
+
+	call := func(method string, params string) string {
+		t.Helper()
+		input := `{"jsonrpc":"2.0","id":1,"method":"` + method + `","params":` + params + `}`
+		codec := rpc2.NewSingleRequestCodec(input)
+		server.ServeCodec(codec.GethCodec(), 0)
+		return codec.Output()
+	}
+
+	require.NoError(t, store.Set("chat", "a", "1"))
+	require.NoError(t, store.Set("wallet", "b", "2"))
+
+	out := call("preferences_listCategories", `[]`)
+	require.NotContains(t, out, `"error"`)
+
+	var resp struct {
+		Result []string `json:"result"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(out), &resp))
+	require.Equal(t, []string{"chat", "wallet"}, resp.Result)
+
+	categories, err := api.ListCategories(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, resp.Result, categories)
+}

--- a/services/preferences/service.go
+++ b/services/preferences/service.go
@@ -1,0 +1,39 @@
+package preferences
+
+import (
+	"database/sql"
+
+	"github.com/ethereum/go-ethereum/rpc"
+)
+
+type Service struct {
+	store PreferenceStore
+}
+
+func NewService(db *sql.DB) *Service {
+	return NewServiceWithStore(NewStore(db))
+}
+
+func NewServiceWithStore(store PreferenceStore) *Service {
+	return &Service{
+		store: store,
+	}
+}
+
+func (s *Service) Start() error {
+	return nil
+}
+
+func (s *Service) Stop() error {
+	return nil
+}
+
+func (s *Service) APIs() []rpc.API {
+	return []rpc.API{
+		{
+			Namespace: "preferences",
+			Version:   "0.1.0",
+			Service:   NewAPI(s.store),
+		},
+	}
+}

--- a/services/preferences/service_test.go
+++ b/services/preferences/service_test.go
@@ -1,0 +1,235 @@
+package preferences
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+
+	mock_preferences "github.com/status-im/status-go/services/preferences/mock"
+)
+
+func setupTestAPI(t *testing.T) (*API, *mock_preferences.MockPreferenceStore) {
+	t.Helper()
+	ctrl := gomock.NewController(t)
+	store := mock_preferences.NewMockPreferenceStore(ctrl)
+	svc := NewServiceWithStore(store)
+	api, ok := svc.APIs()[0].Service.(*API)
+	require.True(t, ok)
+	return api, store
+}
+
+func setupTestAPIWithStore(t *testing.T) (*API, *Store) {
+	t.Helper()
+	store := setupTestStore(t)
+	svc := NewServiceWithStore(store)
+	api, ok := svc.APIs()[0].Service.(*API)
+	require.True(t, ok)
+	require.Equal(t, "preferences", svc.APIs()[0].Namespace)
+	return api, store
+}
+
+func TestAPIMock(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("GetStoreError", func(t *testing.T) {
+		api, store := setupTestAPI(t)
+		storeErr := errors.New("store failure")
+		store.EXPECT().Get("chat", "key").Return("", false, storeErr)
+		result, err := api.Get(ctx, "chat", "key")
+		require.ErrorIs(t, err, storeErr)
+		require.False(t, result.Found)
+	})
+
+	t.Run("DeleteCategoryStoreError", func(t *testing.T) {
+		api, store := setupTestAPI(t)
+		storeErr := errors.New("delete category failed")
+		store.EXPECT().DeleteCategory("chat").Return(0, storeErr)
+		result, err := api.DeleteCategory(ctx, "chat")
+		require.ErrorIs(t, err, storeErr)
+		require.Zero(t, result.Removed)
+	})
+
+	t.Run("SetDelegatesToStore", func(t *testing.T) {
+		api, store := setupTestAPI(t)
+		store.EXPECT().Set("chat", "theme", "dark").Return(nil)
+		require.NoError(t, api.Set(ctx, "chat", "theme", "dark"))
+	})
+
+	t.Run("LoadAndPurgeUnknownDelegatesToStore", func(t *testing.T) {
+		api, store := setupTestAPI(t)
+		expected := map[string]string{"keep": "1"}
+		store.EXPECT().LoadAndPurgeUnknown("chat", []string{"keep"}).Return(expected, nil)
+		got, err := api.LoadAndPurgeUnknown(ctx, "chat", []string{"keep"})
+		require.NoError(t, err)
+		require.Equal(t, expected, got)
+	})
+
+	t.Run("LoadAndPurgeUnknownStoreError", func(t *testing.T) {
+		api, store := setupTestAPI(t)
+		storeErr := errors.New("load and purge failed")
+		store.EXPECT().LoadAndPurgeUnknown("chat", []string{"keep"}).Return(nil, storeErr)
+		got, err := api.LoadAndPurgeUnknown(ctx, "chat", []string{"keep"})
+		require.ErrorIs(t, err, storeErr)
+		require.Nil(t, got)
+	})
+}
+
+func TestBrowserOwnerE2E(t *testing.T) {
+	t.Run("FullSessionLifecycle", func(t *testing.T) {
+		store := setupTestStore(t)
+		category := browserCategory(testBrowserAccountPubKey)
+
+		all := browserOwnerInit(t, store, category)
+		require.Empty(t, all)
+
+		require.NoError(t, store.SetMany(category, map[string]string{
+			browserKeyRestoreOpenTabs:   "true",
+			browserKeyOpenTabs:          sampleOpenTabsTwoTabJSON,
+			browserKeyActiveTabIndex:    "1",
+			browserSnapshotKey("tab-1"): sampleSnapshotData,
+			browserSnapshotKey("tab-2"): sampleSnapshotData,
+		}))
+
+		all = browserOwnerInit(t, store, category)
+		require.Len(t, all, 5)
+
+		oneTab := `[{"uuid":"tab-1","url":"https://a.example","title":"A","icon":""}]`
+		require.NoError(t, store.Set(category, browserKeyOpenTabs, oneTab))
+
+		all = browserOwnerInit(t, store, category)
+		require.Contains(t, all, browserSnapshotKey("tab-1"))
+		require.NotContains(t, all, browserSnapshotKey("tab-2"))
+	})
+
+	t.Run("PurgesLegacyMonolithicSnapshotKey", func(t *testing.T) {
+		store := setupTestStore(t)
+		category := browserCategory(testBrowserAccountPubKey)
+		require.NoError(t, store.SetMany(category, map[string]string{
+			browserKeyOpenTabs:       sampleOpenTabsOneTabJSON,
+			"tabLatestSnapshots":     `{"tab-1":"data:image/png;base64,old"}`,
+			browserKeyActiveTabIndex: "0",
+		}))
+		all := browserOwnerInit(t, store, category)
+		require.NotContains(t, all, "tabLatestSnapshots")
+	})
+
+	t.Run("APIPurgeOrphanSnapshot", func(t *testing.T) {
+		api, store := setupTestAPIWithStore(t)
+		ctx := context.Background()
+		category := browserCategory(testBrowserAccountPubKey)
+
+		require.NoError(t, store.SetMany(category, map[string]string{
+			browserKeyOpenTabs:          sampleOpenTabsTwoTabJSON,
+			browserSnapshotKey("tab-1"): sampleSnapshotData,
+			browserSnapshotKey("tab-2"): sampleSnapshotData,
+		}))
+		oneTab := `[{"uuid":"tab-1","url":"https://a.example","title":"A","icon":""}]`
+		require.NoError(t, store.Set(category, browserKeyOpenTabs, oneTab))
+
+		validKeys, err := browserValidKeys(oneTab)
+		require.NoError(t, err)
+		result, err := api.PurgeUnknown(ctx, category, validKeys)
+		require.NoError(t, err)
+		require.Equal(t, 1, result.Removed)
+
+		got, err := api.Get(ctx, category, browserSnapshotKey("tab-2"))
+		require.NoError(t, err)
+		require.False(t, got.Found)
+		got, err = api.Get(ctx, category, browserSnapshotKey("tab-1"))
+		require.NoError(t, err)
+		require.True(t, got.Found)
+	})
+}
+
+func TestAPIE2E(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("GetFound", func(t *testing.T) {
+		api, store := setupTestAPIWithStore(t)
+		require.NoError(t, store.Set("chat", "theme", "dark"))
+		result, err := api.Get(ctx, "chat", "theme")
+		require.NoError(t, err)
+		require.True(t, result.Found)
+		require.Equal(t, "dark", result.Value)
+	})
+
+	t.Run("GetNotFound", func(t *testing.T) {
+		api, _ := setupTestAPIWithStore(t)
+		result, err := api.Get(ctx, "chat", "missing")
+		require.NoError(t, err)
+		require.False(t, result.Found)
+	})
+
+	t.Run("SetMany", func(t *testing.T) {
+		api, _ := setupTestAPIWithStore(t)
+		kvs := map[string]string{"width": "800", "height": "600"}
+		require.NoError(t, api.SetMany(ctx, "chat", kvs))
+		all, err := api.GetAll(ctx, "chat")
+		require.NoError(t, err)
+		require.Equal(t, kvs, all)
+	})
+
+	t.Run("ListCategories", func(t *testing.T) {
+		api, store := setupTestAPIWithStore(t)
+		require.NoError(t, store.Set("chat", "a", "1"))
+		require.NoError(t, store.Set("wallet", "b", "2"))
+		categories, err := api.ListCategories(ctx)
+		require.NoError(t, err)
+		require.Equal(t, []string{"chat", "wallet"}, categories)
+	})
+
+	t.Run("DeleteCategory", func(t *testing.T) {
+		api, store := setupTestAPIWithStore(t)
+		require.NoError(t, store.Set("chat", "a", "1"))
+		require.NoError(t, store.Set("chat", "b", "2"))
+		result, err := api.DeleteCategory(ctx, "chat")
+		require.NoError(t, err)
+		require.Equal(t, 2, result.Removed)
+	})
+
+	t.Run("PurgeUnknown", func(t *testing.T) {
+		api, store := setupTestAPIWithStore(t)
+		require.NoError(t, store.Set("chat", "keep", "1"))
+		require.NoError(t, store.Set("chat", "drop", "2"))
+		result, err := api.PurgeUnknown(ctx, "chat", []string{"keep"})
+		require.NoError(t, err)
+		require.Equal(t, 1, result.Removed)
+	})
+
+	t.Run("PurgeUnknownEmptyValidKeysRejected", func(t *testing.T) {
+		api, _ := setupTestAPIWithStore(t)
+		_, err := api.PurgeUnknown(ctx, "chat", nil)
+		require.ErrorIs(t, err, errEmptyValidKeys)
+	})
+
+	t.Run("LoadAndPurgeUnknown", func(t *testing.T) {
+		api, store := setupTestAPIWithStore(t)
+		require.NoError(t, store.Set("chat", "keep", "1"))
+		require.NoError(t, store.Set("chat", "drop", "2"))
+		values, err := api.LoadAndPurgeUnknown(ctx, "chat", []string{"keep"})
+		require.NoError(t, err)
+		require.Equal(t, map[string]string{"keep": "1"}, values)
+		all, err := api.GetAll(ctx, "chat")
+		require.NoError(t, err)
+		require.Equal(t, map[string]string{"keep": "1"}, all)
+	})
+
+	t.Run("LoadAndPurgeUnknownEmptyCategoryRejected", func(t *testing.T) {
+		api, _ := setupTestAPIWithStore(t)
+		_, err := api.LoadAndPurgeUnknown(ctx, "", []string{"keep"})
+		require.ErrorIs(t, err, errEmptyCategory)
+	})
+
+	t.Run("LoadAndPurgeUnknownEmptyValidKeysRejected", func(t *testing.T) {
+		api, store := setupTestAPIWithStore(t)
+		require.NoError(t, store.Set("chat", "a", "1"))
+		_, err := api.LoadAndPurgeUnknown(ctx, "chat", nil)
+		require.ErrorIs(t, err, errEmptyValidKeys)
+		all, err := api.GetAll(ctx, "chat")
+		require.NoError(t, err)
+		require.Equal(t, map[string]string{"a": "1"}, all)
+	})
+}

--- a/services/preferences/store_test.go
+++ b/services/preferences/store_test.go
@@ -1,0 +1,328 @@
+package preferences
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/status-im/status-go/internal/db/appdatabase"
+	"github.com/status-im/status-go/internal/testutils"
+)
+
+const testBrowserAccountPubKey = "0xdeadbeef"
+
+const browserSnapshotKeyPrefix = "snapshot/"
+
+const (
+	browserKeyRestoreOpenTabs = "restoreOpenTabs"
+	browserKeyOpenTabs        = "openTabs"
+	browserKeyCurrentTabIndex = "currentTabIndex"
+	browserKeyActiveTabIndex  = "activeTabIndex"
+)
+
+const (
+	sampleOpenTabsOneTabJSON = `[{"uuid":"tab-1","url":"https://status.app","title":"Status","icon":""}]`
+	sampleOpenTabsTwoTabJSON = `[{"uuid":"tab-1","url":"https://a.example","title":"A","icon":""},{"uuid":"tab-2","url":"https://b.example","title":"B","icon":""}]`
+	sampleSnapshotData       = "data:image/png;base64,abc"
+)
+
+type browserTab struct {
+	UUID  string `json:"uuid"`
+	URL   string `json:"url"`
+	Title string `json:"title"`
+	Icon  string `json:"icon"`
+}
+
+func browserCategory(accountPubKey string) string {
+	return "BrowserSettings_" + accountPubKey
+}
+
+func browserSnapshotKey(tabUUID string) string {
+	return browserSnapshotKeyPrefix + tabUUID
+}
+
+func browserValidKeys(openTabsJSON string) ([]string, error) {
+	keys := []string{
+		browserKeyRestoreOpenTabs,
+		browserKeyOpenTabs,
+		browserKeyActiveTabIndex,
+	}
+	if openTabsJSON == "" {
+		return keys, nil
+	}
+	var tabs []browserTab
+	if err := json.Unmarshal([]byte(openTabsJSON), &tabs); err != nil {
+		return nil, err
+	}
+	for _, tab := range tabs {
+		if tab.UUID != "" {
+			keys = append(keys, browserSnapshotKeyPrefix+tab.UUID)
+		}
+	}
+	return keys, nil
+}
+
+func browserOwnerInit(t *testing.T, store *Store, category string) map[string]string {
+	t.Helper()
+	all, err := store.GetAll(category)
+	require.NoError(t, err)
+	validKeys, err := browserValidKeys(all[browserKeyOpenTabs])
+	require.NoError(t, err)
+	_, err = store.PurgeUnknown(category, validKeys)
+	require.NoError(t, err)
+	all, err = store.GetAll(category)
+	require.NoError(t, err)
+	return all
+}
+
+func setupTestStore(t *testing.T) *Store {
+	t.Helper()
+
+	db, err := testutils.SetupTestMemorySQLDB(appdatabase.DbInitializer{})
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, db.Close())
+	})
+
+	return NewStore(db)
+}
+
+func TestStore(t *testing.T) {
+	t.Run("SetGet", func(t *testing.T) {
+		store := setupTestStore(t)
+		require.NoError(t, store.Set("chat", "lastChannel", `{"id":"general"}`))
+		value, found, err := store.Get("chat", "lastChannel")
+		require.NoError(t, err)
+		require.True(t, found)
+		require.Equal(t, `{"id":"general"}`, value)
+	})
+
+	t.Run("GetNotFound", func(t *testing.T) {
+		store := setupTestStore(t)
+		value, found, err := store.Get("chat", "missing")
+		require.NoError(t, err)
+		require.False(t, found)
+		require.Empty(t, value)
+	})
+
+	t.Run("SetUpdatesExistingValue", func(t *testing.T) {
+		store := setupTestStore(t)
+		require.NoError(t, store.Set("chat", "theme", "dark"))
+		require.NoError(t, store.Set("chat", "theme", "light"))
+		value, found, err := store.Get("chat", "theme")
+		require.NoError(t, err)
+		require.True(t, found)
+		require.Equal(t, "light", value)
+	})
+
+	t.Run("GetAll", func(t *testing.T) {
+		store := setupTestStore(t)
+		require.NoError(t, store.Set("chat", "a", "1"))
+		require.NoError(t, store.Set("chat", "b", "2"))
+		require.NoError(t, store.Set("wallet", "c", "3"))
+		all, err := store.GetAll("chat")
+		require.NoError(t, err)
+		require.Equal(t, map[string]string{"a": "1", "b": "2"}, all)
+	})
+
+	t.Run("ListKeys", func(t *testing.T) {
+		store := setupTestStore(t)
+		require.NoError(t, store.Set("chat", "b", "2"))
+		require.NoError(t, store.Set("chat", "a", "1"))
+		keys, err := store.ListKeys("chat")
+		require.NoError(t, err)
+		require.Equal(t, []string{"a", "b"}, keys)
+	})
+
+	t.Run("ListCategoriesEmpty", func(t *testing.T) {
+		store := setupTestStore(t)
+		categories, err := store.ListCategories()
+		require.NoError(t, err)
+		require.Empty(t, categories)
+	})
+
+	t.Run("ListCategoriesDistinct", func(t *testing.T) {
+		store := setupTestStore(t)
+		require.NoError(t, store.Set("chat", "a", "1"))
+		require.NoError(t, store.Set("chat", "b", "2"))
+		require.NoError(t, store.Set("wallet", "c", "3"))
+		categories, err := store.ListCategories()
+		require.NoError(t, err)
+		require.Equal(t, []string{"chat", "wallet"}, categories)
+	})
+
+	t.Run("SetMany", func(t *testing.T) {
+		store := setupTestStore(t)
+		err := store.SetMany("chat", map[string]string{"width": "800", "height": "600"})
+		require.NoError(t, err)
+		all, err := store.GetAll("chat")
+		require.NoError(t, err)
+		require.Equal(t, map[string]string{"width": "800", "height": "600"}, all)
+	})
+
+	t.Run("Delete", func(t *testing.T) {
+		store := setupTestStore(t)
+		require.NoError(t, store.Set("chat", "temp", "value"))
+		require.NoError(t, store.Delete("chat", "temp"))
+		_, found, err := store.Get("chat", "temp")
+		require.NoError(t, err)
+		require.False(t, found)
+	})
+
+	t.Run("DeleteCategory", func(t *testing.T) {
+		store := setupTestStore(t)
+		require.NoError(t, store.Set("chat", "a", "1"))
+		require.NoError(t, store.Set("chat", "b", "2"))
+		require.NoError(t, store.Set("wallet", "c", "3"))
+		removed, err := store.DeleteCategory("chat")
+		require.NoError(t, err)
+		require.Equal(t, 2, removed)
+		all, err := store.GetAll("wallet")
+		require.NoError(t, err)
+		require.Equal(t, map[string]string{"c": "3"}, all)
+	})
+
+	t.Run("PurgeUnknown", func(t *testing.T) {
+		store := setupTestStore(t)
+		require.NoError(t, store.Set("chat", "keep", "1"))
+		require.NoError(t, store.Set("chat", "drop", "2"))
+		require.NoError(t, store.Set("chat", "also-drop", "3"))
+		removed, err := store.PurgeUnknown("chat", []string{"keep"})
+		require.NoError(t, err)
+		require.Equal(t, 2, removed)
+		all, err := store.GetAll("chat")
+		require.NoError(t, err)
+		require.Equal(t, map[string]string{"keep": "1"}, all)
+	})
+
+	t.Run("PurgeUnknownEmptyWhitelistRejected", func(t *testing.T) {
+		store := setupTestStore(t)
+		require.NoError(t, store.Set("chat", "a", "1"))
+		_, err := store.PurgeUnknown("chat", nil)
+		require.ErrorIs(t, err, errEmptyValidKeys)
+		all, err := store.GetAll("chat")
+		require.NoError(t, err)
+		require.Equal(t, map[string]string{"a": "1"}, all)
+	})
+
+	t.Run("LoadAndPurgeUnknown", func(t *testing.T) {
+		store := setupTestStore(t)
+		require.NoError(t, store.Set("chat", "keep", "1"))
+		require.NoError(t, store.Set("chat", "drop", "2"))
+		require.NoError(t, store.Set("chat", "also-drop", "3"))
+		values, err := store.LoadAndPurgeUnknown("chat", []string{"keep"})
+		require.NoError(t, err)
+		require.Equal(t, map[string]string{"keep": "1"}, values)
+		all, err := store.GetAll("chat")
+		require.NoError(t, err)
+		require.Equal(t, map[string]string{"keep": "1"}, all)
+	})
+
+	t.Run("LoadAndPurgeUnknownEmptyCategory", func(t *testing.T) {
+		store := setupTestStore(t)
+		_, err := store.LoadAndPurgeUnknown("", []string{"keep"})
+		require.ErrorIs(t, err, errEmptyCategory)
+	})
+
+	t.Run("LoadAndPurgeUnknownEmptyValidKeysRejected", func(t *testing.T) {
+		store := setupTestStore(t)
+		require.NoError(t, store.Set("chat", "a", "1"))
+		_, err := store.LoadAndPurgeUnknown("chat", nil)
+		require.ErrorIs(t, err, errEmptyValidKeys)
+		all, err := store.GetAll("chat")
+		require.NoError(t, err)
+		require.Equal(t, map[string]string{"a": "1"}, all)
+	})
+
+	t.Run("ValidationErrors", func(t *testing.T) {
+		store := setupTestStore(t)
+		_, _, err := store.Get("", "key")
+		require.ErrorIs(t, err, errEmptyCategory)
+		_, _, err = store.Get("chat", "")
+		require.ErrorIs(t, err, errEmptyKey)
+		require.ErrorIs(t, store.Set("chat", "", "value"), errEmptyKey)
+	})
+}
+
+func TestBrowserOwner(t *testing.T) {
+	t.Run("PersistOpenTabsAndDynamicSnapshots", func(t *testing.T) {
+		store := setupTestStore(t)
+		category := browserCategory(testBrowserAccountPubKey)
+		require.NoError(t, store.SetMany(category, map[string]string{
+			browserKeyRestoreOpenTabs:   "true",
+			browserKeyOpenTabs:          sampleOpenTabsOneTabJSON,
+			browserSnapshotKey("tab-1"): sampleSnapshotData,
+			browserKeyActiveTabIndex:    "0",
+		}))
+		all, err := store.GetAll(category)
+		require.NoError(t, err)
+		require.JSONEq(t, sampleOpenTabsOneTabJSON, all[browserKeyOpenTabs])
+		require.Equal(t, sampleSnapshotData, all[browserSnapshotKey("tab-1")])
+	})
+
+	t.Run("PurgeRemovesRenamedCurrentTabIndex", func(t *testing.T) {
+		store := setupTestStore(t)
+		category := browserCategory(testBrowserAccountPubKey)
+		require.NoError(t, store.SetMany(category, map[string]string{
+			browserKeyRestoreOpenTabs: "true",
+			browserKeyOpenTabs:        sampleOpenTabsOneTabJSON,
+			browserKeyCurrentTabIndex: "2",
+		}))
+		all := browserOwnerInit(t, store, category)
+		require.NotContains(t, all, browserKeyCurrentTabIndex)
+		require.NoError(t, store.Set(category, browserKeyActiveTabIndex, "0"))
+	})
+
+	t.Run("PurgeKeepsSnapshotsListedInOpenTabs", func(t *testing.T) {
+		store := setupTestStore(t)
+		category := browserCategory(testBrowserAccountPubKey)
+		require.NoError(t, store.SetMany(category, map[string]string{
+			browserKeyOpenTabs:          sampleOpenTabsTwoTabJSON,
+			browserSnapshotKey("tab-1"): sampleSnapshotData,
+			browserSnapshotKey("tab-2"): sampleSnapshotData,
+			browserKeyCurrentTabIndex:   "1",
+		}))
+		all := browserOwnerInit(t, store, category)
+		require.Contains(t, all, browserSnapshotKey("tab-1"))
+		require.Contains(t, all, browserSnapshotKey("tab-2"))
+		require.NotContains(t, all, browserKeyCurrentTabIndex)
+	})
+
+	t.Run("PurgeDoesNotMigrateRenamedValue", func(t *testing.T) {
+		store := setupTestStore(t)
+		category := browserCategory(testBrowserAccountPubKey)
+		require.NoError(t, store.Set(category, browserKeyCurrentTabIndex, "7"))
+		all := browserOwnerInit(t, store, category)
+		require.NotContains(t, all, browserKeyCurrentTabIndex)
+		require.NotContains(t, all, browserKeyActiveTabIndex)
+	})
+
+	t.Run("FreshStartNoLegacyImport", func(t *testing.T) {
+		store := setupTestStore(t)
+		category := browserCategory(testBrowserAccountPubKey)
+		all := browserOwnerInit(t, store, category)
+		require.Empty(t, all)
+	})
+
+	t.Run("ValidKeysIncludesSnapshotPerTabUUID", func(t *testing.T) {
+		keys, err := browserValidKeys(sampleOpenTabsTwoTabJSON)
+		require.NoError(t, err)
+		require.Contains(t, keys, browserSnapshotKey("tab-1"))
+		require.Contains(t, keys, browserSnapshotKey("tab-2"))
+	})
+
+	t.Run("IsolatedPerAccountCategory", func(t *testing.T) {
+		store := setupTestStore(t)
+		catA := browserCategory("0xaaa")
+		catB := browserCategory("0xbbb")
+		require.NoError(t, store.Set(catA, browserKeyOpenTabs, `[{"uuid":"a","url":"https://a.example"}]`))
+		require.NoError(t, store.Set(catB, browserKeyOpenTabs, `[{"uuid":"b","url":"https://b.example"}]`))
+		allA, err := store.GetAll(catA)
+		require.NoError(t, err)
+		allB, err := store.GetAll(catB)
+		require.NoError(t, err)
+		require.Contains(t, allA[browserKeyOpenTabs], "a.example")
+		require.Contains(t, allB[browserKeyOpenTabs], "b.example")
+	})
+}


### PR DESCRIPTION
* Local preferences backend.
* It should be used instead of plain text(INI) storage for Qml `Settings`
* It will be used to store opened tabs and snapshots
* Should NOT synced between devices 

refs status-im/status-app#20922
status-app pr: https://github.com/status-im/status-app/pull/21015