### PR TITLE
fix(protocol): guard connection state access

### DIFF
--- a/internal/protocol/messenger.go
+++ b/internal/protocol/messenger.go
@@ -159,6 +159,7 @@ type Messenger struct {
 	ratchetNotFoundDelay time.Duration
 
 	connectionState       connection.State
+	connectionStateMu     sync.RWMutex
 	contractMaker         *contracts.ContractMaker
 	verificationDatabase  *verification.Persistence
 	savedAddressesManager *wallet.SavedAddressesManager

--- a/internal/protocol/messenger_connection_state_test.go
+++ b/internal/protocol/messenger_connection_state_test.go
@@ -1,0 +1,29 @@
+package protocol
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/status-im/status-go/internal/connection"
+)
+
+func TestMessengerConnectionStateAccessorsAreConcurrentSafe(t *testing.T) {
+	m := &Messenger{}
+
+	var wg sync.WaitGroup
+	for i := 0; i < 100; i++ {
+		wg.Add(2)
+
+		go func(i int) {
+			defer wg.Done()
+			m.setConnectionState(connection.State{Expensive: i%2 == 0})
+		}(i)
+
+		go func() {
+			defer wg.Done()
+			_ = m.isConnectionExpensive()
+		}()
+	}
+
+	wg.Wait()
+}

--- a/internal/protocol/messenger_mailserver.go
+++ b/internal/protocol/messenger_mailserver.go
@@ -692,7 +692,7 @@ func (m *Messenger) calculateGapForChat(chat *Chat, from uint32) (*common.Messag
 }
 
 func (m *Messenger) canSyncWithStoreNodes() (bool, error) {
-	if m.connectionState.IsExpensive() {
+	if m.isConnectionExpensive() {
 		return m.settings.CanSyncOnMobileNetwork()
 	}
 	return true, nil
@@ -700,7 +700,21 @@ func (m *Messenger) canSyncWithStoreNodes() (bool, error) {
 
 func (m *Messenger) ConnectionChanged(state connection.State) {
 	m.messaging.ConnectionChanged(state)
+	m.setConnectionState(state)
+}
+
+func (m *Messenger) setConnectionState(state connection.State) {
+	m.connectionStateMu.Lock()
+	defer m.connectionStateMu.Unlock()
+
 	m.connectionState = state
+}
+
+func (m *Messenger) isConnectionExpensive() bool {
+	m.connectionStateMu.RLock()
+	defer m.connectionStateMu.RUnlock()
+
+	return m.connectionState.IsExpensive()
 }
 
 // processMailserverBatch queries the store for a single batch, applying the


### PR DESCRIPTION
## Summary

- protect `Messenger.connectionState` with a small RW mutex and route mailserver sync gating through accessor helpers
- protect `messaging.Core.connectionState` while preserving the offline/online reliability transition behavior
- add a focused concurrent accessor regression for the messenger connection-state helpers

Follow-up to #7350, which restored the mobile `ConnectionChange` propagation chain.

## Why

`ConnectionChanged` can run while mailserver sync checks read the current connection state to decide whether expensive networks should be allowed. The restored state cache was read and written directly, which leaves the new connection-state path race-prone under concurrent network changes and store-node sync checks.

## Validation

- `git diff --check origin/develop...HEAD`
- changed-file conflict marker scan: no matches in this PR's changed files
- `go test` not run locally because this environment does not have the Go toolchain installed (`go: command not found`)
