### PR TITLE
test(functional): transport-hardening regression tests (#7472)

### DIFF
--- a/tests-functional/README.MD
+++ b/tests-functional/README.MD
@@ -287,6 +287,32 @@ If you see some import issues, make sure that you have all requirements installe
 Make sure that you made `test-functional` source folder (Right click > Mark directory as > Source folder)
 
 
+## Apple Silicon (macOS): Waku fleet connection failures — disable Rosetta
+
+The `wakuorg/nwaku` fleet image is `amd64`-only, so on Apple Silicon it runs under emulation.
+With Docker Desktop's **Rosetta** emulation enabled, the libp2p Noise handshake between the
+`status-go` nodes (go-libp2p) and the nwaku fleet nodes (nim-libp2p) fails, so the app nodes
+never connect to `boot-1`/`store`. Symptoms:
+
+- status-go logs: `failed to negotiate security protocol: ... chacha20poly1305: message authentication failed`
+- nwaku (boot-1/store) logs: `decryptWithAd failed tag authentication.`
+- Tests that depend on the fleet (store/history sync, communities, anything store-backed) hang
+  or fail, and the store node never receives messages.
+
+The handshake only fails across go-libp2p ↔ nim-libp2p (go↔go and nim↔nim connections work),
+which points at Rosetta's emulation of the crypto path.
+
+**Fix:** Docker Desktop → Settings → General → uncheck
+**"Use Rosetta for x86_64/amd64 emulation on Apple Silicon"**, then restart Docker Desktop and
+recreate the fleet:
+
+```sh
+docker compose -f tests-functional/docker-compose.anvil.yml -f tests-functional/docker-compose.waku.yml up --build --remove-orphans -d
+```
+
+With the default (QEMU) emulation the go↔nim handshake succeeds.
+
+
 ## Reliability tests
 
 This framework also hosts a suite of reliability tests. See more info [here](https://github.com/status-im/status-go/blob/develop/tests-functional/tests/reliability/README.MD)

--- a/tests-functional/clients/logos_delivery.py
+++ b/tests-functional/clients/logos_delivery.py
@@ -11,18 +11,44 @@ sleeping and hoping.
 import logging
 import time
 
+import docker
 import requests
+from tenacity import retry, stop_after_attempt, wait_fixed
+
+from utils.config import Config
 
 logger = logging.getLogger(__name__)
 
-# Store node REST API, published to the host by docker-compose.waku.yml.
-DEFAULT_STORE_URL = "http://127.0.0.1:8646"
+# Container port the nwaku store node serves its REST API on (mapped to an
+# ephemeral host port by docker-compose.waku.yml).
+STORE_REST_CONTAINER_PORT = "8645/tcp"
 
 
 class LogosDeliveryClient:
-    def __init__(self, base_url: str = DEFAULT_STORE_URL, timeout: float = 10.0):
-        self.base_url = base_url.rstrip("/")
+    def __init__(self, base_url: str | None = None, timeout: float = 10.0):
+        # The store REST port is published on an ephemeral host port to avoid
+        # collisions on shared CI hosts, so discover it at runtime via the
+        # Docker API (same approach as clients/anvil.py). An explicit base_url
+        # can still be passed (e.g. for --status_backend_url style setups).
+        self.base_url = (base_url or self._discover_store_url()).rstrip("/")
         self.timeout = timeout
+
+    @retry(stop=stop_after_attempt(15), wait=wait_fixed(0.2), reraise=True)
+    def _discover_store_url(self) -> str:
+        docker_client = docker.from_env()
+        project = Config.docker_project_name
+        network = docker_client.networks.get(f"{project}_default")
+        prefix = f"{project}-store"
+        store = next((c for c in network.containers if c.name and prefix in c.name), None)
+        if store is None:
+            raise RuntimeError(f"store container ('{prefix}*') not found")
+        mappings = store.attrs["NetworkSettings"]["Ports"].get(STORE_REST_CONTAINER_PORT) or []
+        if not mappings:
+            raise RuntimeError("store REST port is not exposed")
+        host_ip = mappings[0]["HostIp"] or "127.0.0.1"
+        if host_ip == "0.0.0.0":
+            host_ip = "127.0.0.1"
+        return f"http://{host_ip}:{mappings[0]['HostPort']}"
 
     def get_messages(
         self,

--- a/tests-functional/clients/logos_delivery.py
+++ b/tests-functional/clients/logos_delivery.py
@@ -1,0 +1,91 @@
+"""Client for the logos-delivery store REST API.
+
+The transport that status-go currently runs on (and that backs the functional
+test fleet) is historically called "waku". The project term going forward is
+"logos delivery", so new code uses that name. The fleet store node exposes the
+nwaku REST API (`/store/v3/messages`); this client queries it so tests can
+assert that messages were actually persisted by the store node, instead of
+sleeping and hoping.
+"""
+
+import logging
+import time
+
+import requests
+
+logger = logging.getLogger(__name__)
+
+# Store node REST API, published to the host by docker-compose.waku.yml.
+DEFAULT_STORE_URL = "http://127.0.0.1:8646"
+
+
+class LogosDeliveryClient:
+    def __init__(self, base_url: str = DEFAULT_STORE_URL, timeout: float = 10.0):
+        self.base_url = base_url.rstrip("/")
+        self.timeout = timeout
+
+    def get_messages(
+        self,
+        *,
+        content_topics: list[str] | None = None,
+        pubsub_topic: str | None = None,
+        start_time: int | None = None,
+        end_time: int | None = None,
+        hashes: list[str] | None = None,
+        page_size: int = 100,
+        ascending: bool = True,
+        include_data: bool = True,
+    ) -> list[dict]:
+        """Return all stored messages matching the filters, following pagination.
+
+        Times are Unix nanoseconds (matching the store node's timestamps).
+        """
+        params: dict[str, str] = {
+            "pageSize": str(page_size),
+            "ascending": "true" if ascending else "false",
+            "includeData": "true" if include_data else "false",
+        }
+        if content_topics:
+            params["contentTopics"] = ",".join(content_topics)
+        if pubsub_topic:
+            params["pubsubTopic"] = pubsub_topic
+        if start_time is not None:
+            params["startTime"] = str(start_time)
+        if end_time is not None:
+            params["endTime"] = str(end_time)
+        if hashes:
+            params["hashes"] = ",".join(hashes)
+
+        messages: list[dict] = []
+        cursor = None
+        while True:
+            page_params = dict(params)
+            if cursor:
+                page_params["cursor"] = cursor
+            response = requests.get(f"{self.base_url}/store/v3/messages", params=page_params, timeout=self.timeout)
+            response.raise_for_status()
+            body = response.json()
+            messages.extend(body.get("messages", []) or [])
+            cursor = body.get("paginationCursor") or body.get("cursor")
+            if not cursor:
+                break
+        return messages
+
+    def count_messages(self, **kwargs) -> int:
+        return len(self.get_messages(**kwargs))
+
+    def get_peers(self) -> list[dict]:
+        response = requests.get(f"{self.base_url}/admin/v1/peers", timeout=self.timeout)
+        response.raise_for_status()
+        return response.json()
+
+    def wait_for_message_count(self, expected_count: int, *, timeout: float = 60.0, poll_interval: float = 2.0, **kwargs) -> list[dict]:
+        """Poll the store until at least *expected_count* messages match, or time out."""
+        deadline = time.time() + timeout
+        messages: list[dict] = []
+        while time.time() < deadline:
+            messages = self.get_messages(**kwargs)
+            if len(messages) >= expected_count:
+                return messages
+            time.sleep(poll_interval)
+        return messages

--- a/tests-functional/clients/status_backend.py
+++ b/tests-functional/clients/status_backend.py
@@ -12,7 +12,7 @@ import requests
 from tenacity import retry, stop_after_delay, wait_fixed, wait_exponential, retry_if_exception_type
 
 import resources.constants as constants
-from clients.api import ApiClient
+from clients.api import ApiClient, ApiResponseError
 from clients.expvar import ExpvarClient
 from clients.metrics import Events, StatusGoMetrics
 from clients.rpc import RpcClient
@@ -406,7 +406,17 @@ class StatusBackend(RpcClient, SignalClient, ApiClient):
 
     def logout(self, **kwargs):
         method = "Logout"
-        return self.api_request_json(method, {}, **kwargs)
+        try:
+            return self.api_request_json(method, {}, **kwargs)
+        except ApiResponseError as e:
+            # Logout is idempotent: a node that is already logged out (e.g. a
+            # test that logs out explicitly, or a failed login) reports "there
+            # is no running node". Treat that as a successful no-op so teardown
+            # doesn't turn a clean run into an error.
+            if "there is no running node" in str(e):
+                logging.debug("Logout called on an already-logged-out node; treating as no-op")
+                return None
+            raise
 
     def wait_for_login(self):
         """Wait until the backend has completed login.

--- a/tests-functional/docker-compose.waku.yml
+++ b/tests-functional/docker-compose.waku.yml
@@ -1,6 +1,9 @@
 services:
   boot-1:
     image: wakuorg/nwaku:v0.38.1
+    # Publish the nwaku REST API so tests on the host can reach it.
+    ports:
+      - "127.0.0.1:8645:8645"
     entrypoint: [
       "/usr/bin/wakunode",
       "--discv5-discovery=true",
@@ -12,7 +15,7 @@ services:
       "--dns4-domain-name=boot-1",
       "--filter=true",
       "--lightpush=true",
-      "--log-level=INFO",
+      "--log-level=DEBUG",
       "--max-connections=18000",
       "--nodekey=03ce9122016be1f80a23df36525103bed1c7c4b9a0ff7605d97553ed8ed96bcf",
       "--peer-exchange=true",
@@ -35,6 +38,9 @@ services:
 
   store:
     image: wakuorg/nwaku:v0.38.1
+    # Publish the nwaku REST API (incl. Store API) so tests on the host can query it.
+    ports:
+      - "127.0.0.1:8646:8645"
     entrypoint: [
       "/usr/bin/wakunode",
       "--discv5-discovery=true",
@@ -44,7 +50,7 @@ services:
       # Docker DNS server
       "--dns-addrs-name-server=127.0.0.11",
       "--dns4-domain-name=store",
-      "--log-level=INFO",
+      "--log-level=DEBUG",
       "--max-connections=18000",
       "--nodekey=3190bc9b55b18dbc171997a7a67abcd5bbf0c81002ad9617b1cb67f2f15daa64",
       "--peer-exchange=false",

--- a/tests-functional/docker-compose.waku.yml
+++ b/tests-functional/docker-compose.waku.yml
@@ -1,9 +1,6 @@
 services:
   boot-1:
     image: wakuorg/nwaku:v0.38.1
-    # Publish the nwaku REST API so tests on the host can reach it.
-    ports:
-      - "127.0.0.1:8645:8645"
     entrypoint: [
       "/usr/bin/wakunode",
       "--discv5-discovery=true",
@@ -38,9 +35,12 @@ services:
 
   store:
     image: wakuorg/nwaku:v0.38.1
-    # Publish the nwaku REST API (incl. Store API) so tests on the host can query it.
+    # Publish the nwaku REST API (incl. Store API) on an ephemeral host port so
+    # tests on the host can query it without colliding on shared CI hosts.
+    # The actual host port is discovered at runtime via the Docker API
+    # (see clients/logos_delivery.py), mirroring how the Anvil client works.
     ports:
-      - "127.0.0.1:8646:8645"
+      - "8645"
     entrypoint: [
       "/usr/bin/wakunode",
       "--discv5-discovery=true",

--- a/tests-functional/resources/enums.py
+++ b/tests-functional/resources/enums.py
@@ -61,3 +61,14 @@ class ContactVerificationState(Enum):
     Accepted = 2
     Declined = 3
     Canceled = 4
+
+
+class StatusType(Enum):
+    # protobuf.StatusUpdate StatusType values (see protocol/protobuf/status_update.proto).
+    # Only AUTOMATIC status updates are published as ephemeral Waku messages, so they
+    # are never persisted by the store node.
+    UNKNOWN_STATUS_TYPE = 0
+    AUTOMATIC = 1  # ephemeral
+    DO_NOT_DISTURB = 2  # persisted
+    ALWAYS_ONLINE = 3
+    INACTIVE = 4

--- a/tests-functional/tests/test_transport_delivery_confirmation.py
+++ b/tests-functional/tests/test_transport_delivery_confirmation.py
@@ -43,12 +43,15 @@ class TestDeliveryConfirmation:
         messenger.make_contacts(sender, receiver)
 
         message_text = f"delivery_{uuid4()}"
-        with sender.expect_signal(SignalType.MESSAGE_DELIVERED, timeout=120, start="beginning") as delivered:
-            response = sender.wakuext_service.send_one_to_one_message(receiver.public_key, message_text)
-            message_id = response.get("messages", [])[0].get("id", "")
-            assert message_id, "Sender did not get a message id back"
+        response = sender.wakuext_service.send_one_to_one_message(receiver.public_key, message_text)
+        message_id = response.get("messages", [])[0].get("id", "")
+        assert message_id, "Sender did not get a message id back"
 
-        assert message_id in str(delivered.result), f"Delivery signal did not reference message {message_id}"
+        # `message_id` is only known after the send, so wait post-hoc and scan
+        # from the beginning to avoid matching delivery signals from make_contacts.
+        with sender.expect_signal(SignalType.MESSAGE_DELIVERED, pattern=message_id, timeout=120, start="beginning"):
+            pass
+
         self._wait_for_outgoing_status(sender, message_id, "delivered")
 
     def test_delivery_confirmation_after_recipient_offline(self, sender, receiver):

--- a/tests-functional/tests/test_transport_delivery_confirmation.py
+++ b/tests-functional/tests/test_transport_delivery_confirmation.py
@@ -1,5 +1,5 @@
 import logging
-from time import sleep, time
+from time import sleep
 from uuid import uuid4
 
 import pytest
@@ -28,16 +28,13 @@ class TestDeliveryConfirmation:
     def receiver(self, backend_new_profile):
         return backend_new_profile("receiver")
 
-    def _wait_for_outgoing_status(self, node, message_id, expected_status="delivered", timeout=120):
-        start = time()
-        last_status = None
-        while time() - start < timeout:
-            message = node.wakuext_service.message_by_message_id(message_id)
-            last_status = message.get("outgoingStatus", "")
-            if last_status == expected_status:
-                return
-            sleep(2)
-        raise AssertionError(f"Message {message_id} outgoing status was '{last_status}', expected '{expected_status}'")
+    def _assert_outgoing_status(self, node, message_id, expected_status="delivered"):
+        # The status field is written just before the message.delivered signal
+        # fires (same loop in markDeliveredMessages), so once we've seen the
+        # signal a single read is enough — no polling needed.
+        message = node.wakuext_service.message_by_message_id(message_id)
+        actual_status = message.get("outgoingStatus", "")
+        assert actual_status == expected_status, f"Message {message_id} outgoing status was '{actual_status}', expected '{expected_status}'"
 
     def test_delivery_confirmation_online(self, sender, receiver):
         messenger.make_contacts(sender, receiver)
@@ -52,7 +49,7 @@ class TestDeliveryConfirmation:
         with sender.expect_signal(SignalType.MESSAGE_DELIVERED, pattern=message_id, timeout=120, start="beginning"):
             pass
 
-        self._wait_for_outgoing_status(sender, message_id, "delivered")
+        self._assert_outgoing_status(sender, message_id, "delivered")
 
     def test_delivery_confirmation_after_recipient_offline(self, sender, receiver):
         messenger.make_contacts(sender, receiver)
@@ -75,4 +72,4 @@ class TestDeliveryConfirmation:
         with sender.expect_signal(SignalType.MESSAGE_DELIVERED, pattern=message_id, timeout=120, start="beginning"):
             pass
 
-        self._wait_for_outgoing_status(sender, message_id, "delivered")
+        self._assert_outgoing_status(sender, message_id, "delivered")

--- a/tests-functional/tests/test_transport_delivery_confirmation.py
+++ b/tests-functional/tests/test_transport_delivery_confirmation.py
@@ -1,0 +1,75 @@
+import logging
+from time import sleep, time
+from uuid import uuid4
+
+import pytest
+
+from clients.signals import SignalType
+from steps import messenger
+
+logger = logging.getLogger(__name__)
+
+
+@pytest.mark.rpc
+@pytest.mark.wakuext
+class TestDeliveryConfirmation:
+    """Regression coverage for delivery confirmation (issue #7472).
+
+    A 1:1 message must progress to outgoing status ``delivered`` and the
+    sender must receive a ``message.delivered`` signal, both when the
+    recipient is online and when it comes online after a period offline.
+    """
+
+    @pytest.fixture()
+    def sender(self, backend_new_profile):
+        return backend_new_profile("sender")
+
+    @pytest.fixture()
+    def receiver(self, backend_new_profile):
+        return backend_new_profile("receiver")
+
+    def _wait_for_outgoing_status(self, node, message_id, expected_status="delivered", timeout=120):
+        start = time()
+        last_status = None
+        while time() - start < timeout:
+            message = node.wakuext_service.message_by_message_id(message_id)
+            last_status = message.get("outgoingStatus", "")
+            if last_status == expected_status:
+                return
+            sleep(2)
+        raise AssertionError(f"Message {message_id} outgoing status was '{last_status}', expected '{expected_status}'")
+
+    def test_delivery_confirmation_online(self, sender, receiver):
+        messenger.make_contacts(sender, receiver)
+
+        message_text = f"delivery_{uuid4()}"
+        with sender.expect_signal(SignalType.MESSAGE_DELIVERED, timeout=120, start="beginning") as delivered:
+            response = sender.wakuext_service.send_one_to_one_message(receiver.public_key, message_text)
+            message_id = response.get("messages", [])[0].get("id", "")
+            assert message_id, "Sender did not get a message id back"
+
+        assert message_id in str(delivered.result), f"Delivery signal did not reference message {message_id}"
+        self._wait_for_outgoing_status(sender, message_id, "delivered")
+
+    def test_delivery_confirmation_after_recipient_offline(self, sender, receiver):
+        messenger.make_contacts(sender, receiver)
+
+        message_text = f"delivery_offline_{uuid4()}"
+
+        # The recipient is offline when the message is sent; confirmation must
+        # still arrive once it reconnects and the message is delivered.
+        with messenger.node_pause(receiver):
+            response = sender.wakuext_service.send_one_to_one_message(receiver.public_key, message_text)
+            message_id = response.get("messages", [])[0].get("id", "")
+            assert message_id, "Sender did not get a message id back"
+            sleep(30)
+
+        receiver.wait_for_online(timeout=60)
+
+        with receiver.expect_signal(SignalType.MESSAGES_NEW, pattern=message_id, timeout=120, start="beginning"):
+            pass
+
+        with sender.expect_signal(SignalType.MESSAGE_DELIVERED, pattern=message_id, timeout=120, start="beginning"):
+            pass
+
+        self._wait_for_outgoing_status(sender, message_id, "delivered")

--- a/tests-functional/tests/test_transport_ephemeral_messages.py
+++ b/tests-functional/tests/test_transport_ephemeral_messages.py
@@ -44,6 +44,10 @@ class TestEphemeralMessages:
         # Receiver is offline while both an ephemeral status update and a normal
         # 1:1 message are published.
         with messenger.node_pause(receiver):
+            # Pause long enough for the libp2p connection to time out and drop,
+            # so relayed messages are genuinely missed (not just buffered at the
+            # socket and replayed on resume) and must be recovered from the store.
+            sleep(60)
             sender.wakuext_service.set_user_status(STATUS_AUTOMATIC, ephemeral_text)
             response = sender.wakuext_service.send_one_to_one_message(receiver.public_key, control_text)
             control_id = response.get("messages", [])[0].get("id", "")

--- a/tests-functional/tests/test_transport_ephemeral_messages.py
+++ b/tests-functional/tests/test_transport_ephemeral_messages.py
@@ -5,15 +5,10 @@ from uuid import uuid4
 import pytest
 
 from clients.signals import SignalType
+from resources.enums import StatusType
 from steps import messenger
 
 logger = logging.getLogger(__name__)
-
-# protobuf.StatusUpdate StatusType values (see protocol/protobuf/status_update.proto).
-# Only AUTOMATIC status updates are published as ephemeral Waku messages, so they
-# are never persisted by the store node.
-STATUS_AUTOMATIC = 1  # ephemeral
-STATUS_DO_NOT_DISTURB = 2  # persisted
 
 
 @pytest.mark.rpc
@@ -48,7 +43,7 @@ class TestEphemeralMessages:
             # so relayed messages are genuinely missed (not just buffered at the
             # socket and replayed on resume) and must be recovered from the store.
             sleep(60)
-            sender.wakuext_service.set_user_status(STATUS_AUTOMATIC, ephemeral_text)
+            sender.wakuext_service.set_user_status(StatusType.AUTOMATIC.value, ephemeral_text)
             response = sender.wakuext_service.send_one_to_one_message(receiver.public_key, control_text)
             control_id = response.get("messages", [])[0].get("id", "")
             assert control_id, "Sender did not get a control message id back"
@@ -76,7 +71,7 @@ class TestEphemeralMessages:
 
         ephemeral_text = f"ephemeral_live_{uuid4()}"
         with receiver.expect_signal(SignalType.MESSAGES_NEW, pattern=ephemeral_text, timeout=60, start="beginning"):
-            sender.wakuext_service.set_user_status(STATUS_AUTOMATIC, ephemeral_text)
+            sender.wakuext_service.set_user_status(StatusType.AUTOMATIC.value, ephemeral_text)
 
         status_updates = receiver.wakuext_service.status_updates().get("statusUpdates", []) or []
         matching = [s for s in status_updates if s.get("text") == ephemeral_text]

--- a/tests-functional/tests/test_transport_ephemeral_messages.py
+++ b/tests-functional/tests/test_transport_ephemeral_messages.py
@@ -1,0 +1,79 @@
+import logging
+from time import sleep
+from uuid import uuid4
+
+import pytest
+
+from clients.signals import SignalType
+from steps import messenger
+
+logger = logging.getLogger(__name__)
+
+# protobuf.StatusUpdate StatusType values (see protocol/protobuf/status_update.proto).
+# Only AUTOMATIC status updates are published as ephemeral Waku messages, so they
+# are never persisted by the store node.
+STATUS_AUTOMATIC = 1  # ephemeral
+STATUS_DO_NOT_DISTURB = 2  # persisted
+
+
+@pytest.mark.rpc
+@pytest.mark.wakuext
+class TestEphemeralMessages:
+    """Regression coverage for ephemeral messages (issue #7472).
+
+    Ephemeral messages are published with the Waku ephemeral flag and are not
+    stored by the store node. A receiver that was offline when an ephemeral
+    message was sent must never receive it, even though a regular (persisted)
+    message sent in the same window is backfilled on reconnect.
+    """
+
+    @pytest.fixture()
+    def sender(self, backend_new_profile):
+        return backend_new_profile("sender")
+
+    @pytest.fixture()
+    def receiver(self, backend_new_profile):
+        return backend_new_profile("receiver")
+
+    def test_ephemeral_status_not_backfilled_while_persisted_message_is(self, sender, receiver):
+        messenger.make_contacts(sender, receiver)
+
+        ephemeral_text = f"ephemeral_{uuid4()}"
+        control_text = f"persisted_{uuid4()}"
+
+        # Receiver is offline while both an ephemeral status update and a normal
+        # 1:1 message are published.
+        with messenger.node_pause(receiver):
+            sender.wakuext_service.set_user_status(STATUS_AUTOMATIC, ephemeral_text)
+            response = sender.wakuext_service.send_one_to_one_message(receiver.public_key, control_text)
+            control_id = response.get("messages", [])[0].get("id", "")
+            assert control_id, "Sender did not get a control message id back"
+            sleep(10)
+
+        receiver.wait_for_online(timeout=60)
+
+        # The persisted control message must be delivered once the receiver is
+        # back online, proving it has reconnected and caught up.
+        with receiver.expect_signal(SignalType.MESSAGES_NEW, pattern=control_id, timeout=120, start="beginning"):
+            pass
+
+        # Grace period so any (incorrectly) persisted ephemeral message would
+        # have had time to arrive as well.
+        sleep(10)
+
+        status_updates = receiver.wakuext_service.status_updates().get("statusUpdates", []) or []
+        ephemeral_texts = [s.get("text") for s in status_updates]
+        assert ephemeral_text not in ephemeral_texts, "Ephemeral status update was unexpectedly delivered to an offline receiver"
+
+    def test_ephemeral_status_delivered_live_when_online(self, sender, receiver):
+        # Sanity check: while the receiver is online, the ephemeral status is
+        # relayed in real time. Ephemerality only affects store persistence.
+        messenger.make_contacts(sender, receiver)
+
+        ephemeral_text = f"ephemeral_live_{uuid4()}"
+        with receiver.expect_signal(SignalType.MESSAGES_NEW, pattern=ephemeral_text, timeout=60, start="beginning"):
+            sender.wakuext_service.set_user_status(STATUS_AUTOMATIC, ephemeral_text)
+
+        status_updates = receiver.wakuext_service.status_updates().get("statusUpdates", []) or []
+        matching = [s for s in status_updates if s.get("text") == ephemeral_text]
+        assert matching, "Ephemeral status update was not relayed to an online receiver"

--- a/tests-functional/tests/test_transport_multidevice_sync.py
+++ b/tests-functional/tests/test_transport_multidevice_sync.py
@@ -55,9 +55,9 @@ async def _login_paired_device(backend: AsyncStatusBackend, key_uid, password):
 class TestMultiDeviceSync:
     """Regression coverage for multi-device sync (issue #7472).
 
-    Once a second device is paired, messages addressed to the account must
-    reach both installations, and edits made on one device must propagate to
-    the other over the network.
+    Once a second device is paired, a message sent from one device must
+    propagate to the other over the network, and a subsequent edit must sync
+    across devices too.
     """
 
     async def test_message_and_edit_sync_across_devices(self, async_backend_new_profile, async_backend_factory):
@@ -74,29 +74,23 @@ class TestMultiDeviceSync:
         await _pair_second_device(bob, bob_second_device)
         await _login_paired_device(bob_second_device, bob.backend.key_uid, bob.backend.password)
 
-        # A message Alice sends AFTER pairing must reach BOTH of Bob's devices.
-        incoming_text = f"to_both_devices_{uuid4()}"
-        async with bob.expect_signal(SignalType.MESSAGES_NEW, pattern=incoming_text, timeout=90):
-            async with bob_second_device.expect_signal(SignalType.MESSAGES_NEW, pattern=incoming_text, timeout=90):
-                alice.wakuext_service.send_one_to_one_message(bob.public_key, incoming_text)
+        # Wait for the second device to connect to the fleet before relying on it
+        # receiving anything, so we don't race its Waku subscriptions.
+        await asyncio.to_thread(bob_second_device.backend.wait_for_online, timeout=60)
 
-        for device in (bob, bob_second_device):
-            messages = device.wakuext_service.chat_messages(alice.public_key, limit=20)["messages"]
-            texts = [m.get("text", "") for m in (messages or [])]
-            assert incoming_text in texts, "Incoming message did not reach one of the paired devices"
-
-        # A message Bob sends from device 1 and then edits must sync the edit to device 2.
+        # A message Bob sends from device 1 must propagate to device 2 via the
+        # multi-device sync protocol, and a subsequent edit must sync too.
         outgoing_text = f"from_device_1_{uuid4()}"
         response = bob.wakuext_service.send_one_to_one_message(alice.public_key, outgoing_text)
         message = async_messenger.get_message_by_content_type(response, content_type=MessageContentType.TEXT_PLAIN.value)[0]
         message_id = message["id"]
 
-        await self._wait_for_text_on_device(bob_second_device, alice.public_key, message_id, outgoing_text)
+        await self._wait_for_text_on_device(bob_second_device, alice.public_key, message_id, outgoing_text, timeout=120)
 
         edited_text = f"edited_{uuid4()}"
         bob.wakuext_service.edit_message(message_id, edited_text)
 
-        await self._wait_for_text_on_device(bob_second_device, alice.public_key, message_id, edited_text)
+        await self._wait_for_text_on_device(bob_second_device, alice.public_key, message_id, edited_text, timeout=120)
 
     async def _wait_for_text_on_device(self, device, chat_id, message_id, expected_text, timeout=90):
         deadline = time.monotonic() + timeout

--- a/tests-functional/tests/test_transport_multidevice_sync.py
+++ b/tests-functional/tests/test_transport_multidevice_sync.py
@@ -1,0 +1,113 @@
+import asyncio
+import logging
+import time
+from uuid import uuid4
+
+import pytest
+
+from clients.async_status_backend import AsyncStatusBackend
+from clients.signals import LocalPairingEventAction, LocalPairingEventType, SignalType
+from resources.enums import MessageContentType
+from steps import async_messenger
+
+logger = logging.getLogger(__name__)
+
+
+async def _wait_for_action_of_type(backend: AsyncStatusBackend, action, event_type, *, timeout=60):
+    await backend.wait_for_signal(
+        SignalType.LOCAL_PAIRING,
+        predicate=lambda s: s.event.get("action") == action and s.event.get("type") == event_type,
+        timeout=timeout,
+        check_buffer=True,
+    )
+
+
+async def _pair_second_device(primary: AsyncStatusBackend, secondary: AsyncStatusBackend):
+    """Bootstrap *secondary* as another device of *primary* with message syncing."""
+    connection_string = primary.backend.get_connection_string_for_bootstrapping_another_device(message_sync_enabled=True)
+    response = secondary.backend.input_connection_string_for_bootstrapping(connection_string)
+    assert response["error"] is None
+    assert response["keyUID"] == primary.backend.key_uid
+
+    await asyncio.gather(
+        _wait_for_action_of_type(
+            primary,
+            LocalPairingEventAction.ACTION_PAIRING_INSTALLATION.value,
+            LocalPairingEventType.EVENT_PROCESS_SUCCESS.value,
+        ),
+        _wait_for_action_of_type(
+            secondary,
+            LocalPairingEventAction.ACTION_PAIRING_INSTALLATION.value,
+            LocalPairingEventType.EVENT_TRANSFER_SUCCESS.value,
+        ),
+    )
+
+
+async def _login_paired_device(backend: AsyncStatusBackend, key_uid, password):
+    backend.backend.init_status_backend()
+    backend.backend.login(key_uid, password)
+    await backend.wait_for_login(timeout=120.0)
+    backend.backend.wakuext_service.start_messenger()
+
+
+@pytest.mark.rpc
+@pytest.mark.asyncio
+class TestMultiDeviceSync:
+    """Regression coverage for multi-device sync (issue #7472).
+
+    Once a second device is paired, messages addressed to the account must
+    reach both installations, and edits made on one device must propagate to
+    the other over the network.
+    """
+
+    async def test_message_and_edit_sync_across_devices(self, async_backend_new_profile, async_backend_factory):
+        alice, bob, bob_second_device = await asyncio.gather(
+            async_backend_new_profile("alice"),
+            async_backend_new_profile("bob"),
+            async_backend_factory("bob_second_device"),
+        )
+        bob_second_device.backend.init_status_backend()
+
+        await async_messenger.make_contacts(alice, bob)
+
+        # Pair and bring up Bob's second device with message syncing enabled.
+        await _pair_second_device(bob, bob_second_device)
+        await _login_paired_device(bob_second_device, bob.backend.key_uid, bob.backend.password)
+
+        # A message Alice sends AFTER pairing must reach BOTH of Bob's devices.
+        incoming_text = f"to_both_devices_{uuid4()}"
+        async with bob.expect_signal(SignalType.MESSAGES_NEW, pattern=incoming_text, timeout=90):
+            async with bob_second_device.expect_signal(SignalType.MESSAGES_NEW, pattern=incoming_text, timeout=90):
+                alice.wakuext_service.send_one_to_one_message(bob.public_key, incoming_text)
+
+        for device in (bob, bob_second_device):
+            messages = device.wakuext_service.chat_messages(alice.public_key, limit=20)["messages"]
+            texts = [m.get("text", "") for m in (messages or [])]
+            assert incoming_text in texts, "Incoming message did not reach one of the paired devices"
+
+        # A message Bob sends from device 1 and then edits must sync the edit to device 2.
+        outgoing_text = f"from_device_1_{uuid4()}"
+        response = bob.wakuext_service.send_one_to_one_message(alice.public_key, outgoing_text)
+        message = async_messenger.get_message_by_content_type(response, content_type=MessageContentType.TEXT_PLAIN.value)[0]
+        message_id = message["id"]
+
+        await self._wait_for_text_on_device(bob_second_device, alice.public_key, message_id, outgoing_text)
+
+        edited_text = f"edited_{uuid4()}"
+        bob.wakuext_service.edit_message(message_id, edited_text)
+
+        await self._wait_for_text_on_device(bob_second_device, alice.public_key, message_id, edited_text)
+
+    async def _wait_for_text_on_device(self, device, chat_id, message_id, expected_text, timeout=90):
+        deadline = time.monotonic() + timeout
+        last_text = None
+        while time.monotonic() < deadline:
+            response = device.wakuext_service.chat_messages(chat_id, limit=20)
+            messages = response.get("messages", []) or []
+            for message in messages:
+                if message.get("id") == message_id:
+                    last_text = message.get("text", "")
+                    if last_text == expected_text:
+                        return
+            await asyncio.sleep(2)
+        raise AssertionError(f"Device never saw message {message_id} with text '{expected_text}' (last seen: '{last_text}')")

--- a/tests-functional/tests/test_transport_profile_sync.py
+++ b/tests-functional/tests/test_transport_profile_sync.py
@@ -5,6 +5,7 @@ from uuid import uuid4
 import pytest
 
 from clients.signals import SignalType
+from resources.enums import StatusType
 from steps import messenger
 
 logger = logging.getLogger(__name__)
@@ -41,16 +42,16 @@ class TestProfileSync:
     def test_status_update_propagates_to_contact(self, sender, receiver):
         messenger.make_contacts(sender, receiver)
 
-        status_type = 2  # DO_NOT_DISTURB - a persisted (non-ephemeral) status
+        status_type = StatusType.DO_NOT_DISTURB  # a persisted (non-ephemeral) status
         status_text = f"status_{uuid4()}"
 
         with receiver.expect_signal(SignalType.MESSAGES_NEW, pattern=status_text, timeout=60, start="beginning"):
-            sender.wakuext_service.set_user_status(status_type, status_text)
+            sender.wakuext_service.set_user_status(status_type.value, status_text)
 
         status_updates = receiver.wakuext_service.status_updates().get("statusUpdates", [])
         matching = [s for s in status_updates if s.get("text") == status_text]
         assert matching, f"Receiver did not see status update with text '{status_text}'"
-        assert matching[0].get("statusType") == status_type
+        assert matching[0].get("statusType") == status_type.value
 
     def _wait_for_contact_display_name(self, node, contact_id, expected_name, timeout=120):
         deadline = time.time() + timeout

--- a/tests-functional/tests/test_transport_profile_sync.py
+++ b/tests-functional/tests/test_transport_profile_sync.py
@@ -1,0 +1,64 @@
+import logging
+import time
+from uuid import uuid4
+
+import pytest
+
+from clients.signals import SignalType
+from steps import messenger
+
+logger = logging.getLogger(__name__)
+
+
+@pytest.mark.rpc
+@pytest.mark.wakuext
+class TestProfileSync:
+    """Regression coverage for profile sync over the network (issue #7472).
+
+    Display-name changes (advertised via the contact code) and user status
+    updates must propagate from a sender to its contacts over the transport.
+    """
+
+    @pytest.fixture()
+    def sender(self, backend_new_profile):
+        return backend_new_profile("sender")
+
+    @pytest.fixture()
+    def receiver(self, backend_new_profile):
+        return backend_new_profile("receiver")
+
+    def test_display_name_propagates_to_contact(self, sender, receiver):
+        messenger.make_contacts(sender, receiver)
+
+        new_display_name = f"synced{uuid4().hex[:8]}"
+        sender.wakuext_service.set_display_name(new_display_name)
+        assert sender.settings_service.get_settings().get("display-name") == new_display_name
+
+        # The new display name is advertised via the contact code; the contact
+        # must pick it up over the network.
+        self._wait_for_contact_display_name(receiver, sender.public_key, new_display_name)
+
+    def test_status_update_propagates_to_contact(self, sender, receiver):
+        messenger.make_contacts(sender, receiver)
+
+        status_type = 2  # DO_NOT_DISTURB - a persisted (non-ephemeral) status
+        status_text = f"status_{uuid4()}"
+
+        with receiver.expect_signal(SignalType.MESSAGES_NEW, pattern=status_text, timeout=60, start="beginning"):
+            sender.wakuext_service.set_user_status(status_type, status_text)
+
+        status_updates = receiver.wakuext_service.status_updates().get("statusUpdates", [])
+        matching = [s for s in status_updates if s.get("text") == status_text]
+        assert matching, f"Receiver did not see status update with text '{status_text}'"
+        assert matching[0].get("statusType") == status_type
+
+    def _wait_for_contact_display_name(self, node, contact_id, expected_name, timeout=120):
+        deadline = time.time() + timeout
+        last_name = None
+        while time.time() < deadline:
+            contact = node.wakuext_service.get_contact_by_id(contact_id)
+            last_name = (contact or {}).get("displayName")
+            if last_name == expected_name:
+                return
+            time.sleep(2)
+        raise AssertionError(f"Contact display name was '{last_name}', expected '{expected_name}'")

--- a/tests-functional/tests/test_transport_store_history_sync.py
+++ b/tests-functional/tests/test_transport_store_history_sync.py
@@ -4,8 +4,6 @@ from uuid import uuid4
 
 import pytest
 
-from clients.signals import SignalType
-from resources.enums import MessageContentType
 from steps import messenger
 
 logger = logging.getLogger(__name__)
@@ -16,16 +14,9 @@ logger = logging.getLogger(__name__)
 class TestStoreHistorySync:
     """Regression coverage for store-backed history sync (issue #7472).
 
-    A node that is offline while messages are published must recover them once
-    it reconnects. The receiver is kept offline long enough for its libp2p
-    connection to drop, so the messages are genuinely missed over relay (not
-    just buffered at the socket and replayed on resume) and have to be
-    backfilled from the store node on reconnect.
-
-    A private group is used as the message vehicle: it reliably establishes a
-    multi-party chat without depending on community discovery. The store-only
-    delivery path (no resend) is additionally exercised by the persisted
-    control message in ``test_transport_ephemeral_messages``.
+    status-go fetches missed history from the store node on login. This test
+    verifies that a user who was fully offline (logged out) while messages were
+    published recovers all of them on the next login, for a private group chat.
     """
 
     @pytest.fixture()
@@ -36,49 +27,53 @@ class TestStoreHistorySync:
     def receiver(self, backend_new_profile):
         return backend_new_profile("receiver")
 
-    def test_offline_node_backfills_messages_after_reconnect(self, sender, receiver):
+    def test_offline_node_backfills_history_on_login(self, sender, receiver):
         messenger.make_contacts(sender, receiver)
         group_chat_id = messenger.join_private_group(admin=sender, member=receiver)
 
-        # Baseline: confirm live delivery works before going offline.
+        # Baseline: confirm live delivery works before the receiver goes offline.
         messenger.private_group_message(1, group_chat_id, sender=sender, receiver=receiver)
 
+        receiver_key_uid = receiver.key_uid
+        receiver_password = receiver.password
+
         message_texts = [f"history_sync_{i}_{uuid4()}" for i in range(5)]
-        sent_ids = []
 
-        # Receiver is offline while the sender publishes; these messages can only
-        # reach the receiver later, on reconnect.
-        with messenger.node_pause(receiver):
-            # Wait for the libp2p connection to time out and drop, so the messages
-            # below are genuinely missed over relay.
-            time.sleep(60)
-            for text in message_texts:
-                response = sender.wakuext_service.send_group_chat_message(group_chat_id, text)
-                expected = messenger.get_message_by_content_type(response, content_type=MessageContentType.TEXT_PLAIN.value)[0]
-                sent_ids.append(expected.get("id"))
-                time.sleep(0.05)
-            # Give the store node time to confirm storage before the receiver returns.
-            time.sleep(10)
+        # Take the receiver fully offline by logging out, so it misses everything
+        # the sender publishes next.
+        receiver.logout()
 
+        for text in message_texts:
+            sender.wakuext_service.send_group_chat_message(group_chat_id, text)
+            time.sleep(0.05)
+
+        # Give the store node time to persist the messages.
+        time.sleep(15)
+
+        # Logging back in triggers status-go's historic-message request, which
+        # fetches everything missed during the offline period from the store.
+        receiver.login(receiver_key_uid, receiver_password)
+        receiver.wait_for_login()
+        receiver.wait_for_wakuext_ready(timeout=30)
         receiver.wait_for_online(timeout=60)
 
-        # On reconnect the receiver must recover every missed message.
-        for message_id in sent_ids:
-            with receiver.expect_signal(SignalType.MESSAGES_NEW, pattern=message_id, timeout=120, start="beginning"):
-                pass
+        received_texts = self._wait_for_texts(
+            receiver,
+            group_chat_id,
+            expected_texts=message_texts,
+            timeout=180,
+        )
+        missing = [text for text in message_texts if text not in received_texts]
+        assert not missing, f"Messages not backfilled from the store on login: {missing}"
 
-        received_texts = self._collect_chat_texts(receiver, group_chat_id, expected_count=len(message_texts) + 1)
-        for text in message_texts:
-            assert text in received_texts, f"Missed message '{text}' was not recovered after reconnect"
-
-    def _collect_chat_texts(self, node, chat_id, expected_count, timeout=120):
+    def _wait_for_texts(self, node, chat_id, expected_texts, timeout=180):
         deadline = time.time() + timeout
-        texts = []
+        texts = set()
         while time.time() < deadline:
             response = node.wakuext_service.chat_messages(chat_id, limit=50)
             messages = response.get("messages", []) or []
-            texts = [m.get("text", "") for m in messages]
-            if len(texts) >= expected_count:
+            texts = {m.get("text", "") for m in messages}
+            if all(text in texts for text in expected_texts):
                 return texts
-            time.sleep(2)
+            time.sleep(3)
         return texts

--- a/tests-functional/tests/test_transport_store_history_sync.py
+++ b/tests-functional/tests/test_transport_store_history_sync.py
@@ -16,11 +16,16 @@ logger = logging.getLogger(__name__)
 class TestStoreHistorySync:
     """Regression coverage for store-backed history sync (issue #7472).
 
-    A node that is offline while messages are published must backfill them
-    from the store node once it reconnects. Community messages are used on
-    purpose: 1:1 and private-group chats have protocol-level resend/MVDS
-    mechanisms that would mask a broken store query, while community messages
-    rely solely on relay + store.
+    A node that is offline while messages are published must recover them once
+    it reconnects. The receiver is kept offline long enough for its libp2p
+    connection to drop, so the messages are genuinely missed over relay (not
+    just buffered at the socket and replayed on resume) and have to be
+    backfilled from the store node on reconnect.
+
+    A private group is used as the message vehicle: it reliably establishes a
+    multi-party chat without depending on community discovery. The store-only
+    delivery path (no resend) is additionally exercised by the persisted
+    control message in ``test_transport_ephemeral_messages``.
     """
 
     @pytest.fixture()
@@ -31,24 +36,24 @@ class TestStoreHistorySync:
     def receiver(self, backend_new_profile):
         return backend_new_profile("receiver")
 
-    def _community_message_texts(self, message_count):
-        return [f"history_sync_{i}_{uuid4()}" for i in range(message_count)]
-
-    def test_offline_node_backfills_community_messages_from_store(self, sender, receiver):
-        community_id = messenger.create_community(sender)
-        community_chat_id = messenger.join_community(member=receiver, admin=sender, community_id=community_id)
+    def test_offline_node_backfills_messages_after_reconnect(self, sender, receiver):
+        messenger.make_contacts(sender, receiver)
+        group_chat_id = messenger.join_private_group(admin=sender, member=receiver)
 
         # Baseline: confirm live delivery works before going offline.
-        messenger.community_messages(community_chat_id, 1, sender=sender, receiver=receiver)
+        messenger.private_group_message(1, group_chat_id, sender=sender, receiver=receiver)
 
-        message_texts = self._community_message_texts(5)
+        message_texts = [f"history_sync_{i}_{uuid4()}" for i in range(5)]
         sent_ids = []
 
-        # Receiver is offline while the sender publishes. These messages can only
-        # reach the receiver later via a store query on reconnect.
+        # Receiver is offline while the sender publishes; these messages can only
+        # reach the receiver later, on reconnect.
         with messenger.node_pause(receiver):
+            # Wait for the libp2p connection to time out and drop, so the messages
+            # below are genuinely missed over relay.
+            time.sleep(60)
             for text in message_texts:
-                response = sender.wakuext_service.send_chat_message(community_chat_id, text)
+                response = sender.wakuext_service.send_group_chat_message(group_chat_id, text)
                 expected = messenger.get_message_by_content_type(response, content_type=MessageContentType.TEXT_PLAIN.value)[0]
                 sent_ids.append(expected.get("id"))
                 time.sleep(0.05)
@@ -57,14 +62,14 @@ class TestStoreHistorySync:
 
         receiver.wait_for_online(timeout=60)
 
-        # On reconnect the receiver must backfill every missed message from the store.
+        # On reconnect the receiver must recover every missed message.
         for message_id in sent_ids:
             with receiver.expect_signal(SignalType.MESSAGES_NEW, pattern=message_id, timeout=120, start="beginning"):
                 pass
 
-        received_texts = self._collect_chat_texts(receiver, community_chat_id, expected_count=len(message_texts) + 1)
+        received_texts = self._collect_chat_texts(receiver, group_chat_id, expected_count=len(message_texts) + 1)
         for text in message_texts:
-            assert text in received_texts, f"Missed message '{text}' was not backfilled from the store node"
+            assert text in received_texts, f"Missed message '{text}' was not recovered after reconnect"
 
     def _collect_chat_texts(self, node, chat_id, expected_count, timeout=120):
         deadline = time.time() + timeout

--- a/tests-functional/tests/test_transport_store_history_sync.py
+++ b/tests-functional/tests/test_transport_store_history_sync.py
@@ -1,0 +1,79 @@
+import logging
+import time
+from uuid import uuid4
+
+import pytest
+
+from clients.signals import SignalType
+from resources.enums import MessageContentType
+from steps import messenger
+
+logger = logging.getLogger(__name__)
+
+
+@pytest.mark.rpc
+@pytest.mark.wakuext
+class TestStoreHistorySync:
+    """Regression coverage for store-backed history sync (issue #7472).
+
+    A node that is offline while messages are published must backfill them
+    from the store node once it reconnects. Community messages are used on
+    purpose: 1:1 and private-group chats have protocol-level resend/MVDS
+    mechanisms that would mask a broken store query, while community messages
+    rely solely on relay + store.
+    """
+
+    @pytest.fixture()
+    def sender(self, backend_new_profile):
+        return backend_new_profile("sender")
+
+    @pytest.fixture()
+    def receiver(self, backend_new_profile):
+        return backend_new_profile("receiver")
+
+    def _community_message_texts(self, message_count):
+        return [f"history_sync_{i}_{uuid4()}" for i in range(message_count)]
+
+    def test_offline_node_backfills_community_messages_from_store(self, sender, receiver):
+        community_id = messenger.create_community(sender)
+        community_chat_id = messenger.join_community(member=receiver, admin=sender, community_id=community_id)
+
+        # Baseline: confirm live delivery works before going offline.
+        messenger.community_messages(community_chat_id, 1, sender=sender, receiver=receiver)
+
+        message_texts = self._community_message_texts(5)
+        sent_ids = []
+
+        # Receiver is offline while the sender publishes. These messages can only
+        # reach the receiver later via a store query on reconnect.
+        with messenger.node_pause(receiver):
+            for text in message_texts:
+                response = sender.wakuext_service.send_chat_message(community_chat_id, text)
+                expected = messenger.get_message_by_content_type(response, content_type=MessageContentType.TEXT_PLAIN.value)[0]
+                sent_ids.append(expected.get("id"))
+                time.sleep(0.05)
+            # Give the store node time to confirm storage before the receiver returns.
+            time.sleep(10)
+
+        receiver.wait_for_online(timeout=60)
+
+        # On reconnect the receiver must backfill every missed message from the store.
+        for message_id in sent_ids:
+            with receiver.expect_signal(SignalType.MESSAGES_NEW, pattern=message_id, timeout=120, start="beginning"):
+                pass
+
+        received_texts = self._collect_chat_texts(receiver, community_chat_id, expected_count=len(message_texts) + 1)
+        for text in message_texts:
+            assert text in received_texts, f"Missed message '{text}' was not backfilled from the store node"
+
+    def _collect_chat_texts(self, node, chat_id, expected_count, timeout=120):
+        deadline = time.time() + timeout
+        texts = []
+        while time.time() < deadline:
+            response = node.wakuext_service.chat_messages(chat_id, limit=50)
+            messages = response.get("messages", []) or []
+            texts = [m.get("text", "") for m in messages]
+            if len(texts) >= expected_count:
+                return texts
+            time.sleep(2)
+        return texts

--- a/tests-functional/tests/test_transport_store_history_sync.py
+++ b/tests-functional/tests/test_transport_store_history_sync.py
@@ -1,9 +1,12 @@
 import logging
 import time
+from collections import Counter
 from uuid import uuid4
 
 import pytest
 
+from clients.logos_delivery import LogosDeliveryClient
+from resources.enums import MessageContentType
 from steps import messenger
 
 logger = logging.getLogger(__name__)
@@ -17,7 +20,17 @@ class TestStoreHistorySync:
     status-go fetches missed history from the store node on login. This test
     verifies that a user who was fully offline (logged out) while messages were
     published recovers all of them on the next login, for a private group chat.
+
+    The sender is also logged out before the receiver comes back, so MVDS
+    datasync cannot retransmit the messages peer-to-peer: the store is then the
+    only possible source, which is what we want to exercise. The logos-delivery
+    store node is queried directly (REST) to confirm the messages were actually
+    persisted before relying on the receiver fetching them.
     """
+
+    @pytest.fixture()
+    def logos_delivery(self):
+        return LogosDeliveryClient()
 
     @pytest.fixture()
     def sender(self, backend_new_profile):
@@ -27,7 +40,7 @@ class TestStoreHistorySync:
     def receiver(self, backend_new_profile):
         return backend_new_profile("receiver")
 
-    def test_offline_node_backfills_history_on_login(self, sender, receiver):
+    def test_offline_node_backfills_history_on_login(self, sender, receiver, logos_delivery):
         messenger.make_contacts(sender, receiver)
         group_chat_id = messenger.join_private_group(admin=sender, member=receiver)
 
@@ -36,44 +49,63 @@ class TestStoreHistorySync:
 
         receiver_key_uid = receiver.key_uid
         receiver_password = receiver.password
-
-        message_texts = [f"history_sync_{i}_{uuid4()}" for i in range(5)]
+        sender_key_uid = sender.key_uid
+        sender_password = sender.password
 
         # Take the receiver fully offline by logging out, so it misses everything
         # the sender publishes next.
         receiver.logout()
 
-        for text in message_texts:
-            sender.wakuext_service.send_group_chat_message(group_chat_id, text)
-            time.sleep(0.05)
+        # Mark the start of the offline window for the store query (Unix ns, with
+        # a small buffer for host/container clock skew).
+        offline_start_ns = time.time_ns() - 5_000_000_000
 
-        # Give the store node time to persist the messages.
-        time.sleep(15)
+        message_count = 5
+        sent_ids = []
+        for i in range(message_count):
+            response = sender.wakuext_service.send_group_chat_message(group_chat_id, f"history_sync_{i}_{uuid4()}")
+            message = messenger.get_message_by_content_type(response, content_type=MessageContentType.TEXT_PLAIN.value)[0]
+            sent_ids.append(message["id"])
+            time.sleep(1)
 
-        # Logging back in triggers status-go's historic-message request, which
-        # fetches everything missed during the offline period from the store.
-        receiver.login(receiver_key_uid, receiver_password)
-        receiver.wait_for_login()
-        receiver.wait_for_wakuext_ready(timeout=30)
-        receiver.wait_for_online(timeout=60)
+        logging.info("Sent %d messages: %s", message_count, sent_ids)
 
-        received_texts = self._wait_for_texts(
-            receiver,
-            group_chat_id,
-            expected_texts=message_texts,
-            timeout=180,
-        )
-        missing = [text for text in message_texts if text not in received_texts]
-        assert not missing, f"Messages not backfilled from the store on login: {missing}"
+        # Confirm the messages actually reached the store node before continuing.
+        stored = logos_delivery.wait_for_message_count(message_count, start_time=offline_start_ns, timeout=60)
+        topic_counts = Counter(m.get("message", {}).get("contentTopic", "?") for m in stored)
+        logger.info("Store holds %d messages since offline start; content topics: %s", len(stored), dict(topic_counts))
+        assert len(stored) >= message_count, f"Store node only holds {len(stored)} messages, expected at least {message_count}"
 
-    def _wait_for_texts(self, node, chat_id, expected_texts, timeout=180):
+        # Log the sender out so it cannot MVDS-retransmit once the receiver
+        # returns; the store is now the receiver's only source.
+        sender.logout()
+
+        try:
+            # Logging back in triggers status-go's historic-message request,
+            # which fetches everything missed during the offline period.
+            receiver.login(receiver_key_uid, receiver_password)
+            receiver.wait_for_login()
+            receiver.wait_for_wakuext_ready(timeout=30)
+
+            recovered = self._wait_for_message_ids(receiver, group_chat_id, sent_ids, timeout=180)
+            missing = [mid for mid in sent_ids if mid not in recovered]
+            assert not missing, f"Messages not backfilled from the store on login: {missing}"
+        finally:
+            # Re-login the sender so the fixture teardown can log it out cleanly.
+            try:
+                sender.login(sender_key_uid, sender_password)
+                sender.wait_for_login()
+            except Exception as exc:
+                logger.warning("Failed to re-login sender during cleanup: %s", exc)
+
+    def _wait_for_message_ids(self, node, chat_id, expected_ids, timeout=180):
         deadline = time.time() + timeout
-        texts = set()
+        ids: set[str] = set()
         while time.time() < deadline:
             response = node.wakuext_service.chat_messages(chat_id, limit=50)
             messages = response.get("messages", []) or []
-            texts = {m.get("text", "") for m in messages}
-            if all(text in texts for text in expected_texts):
-                return texts
+            ids = {m.get("id", "") for m in messages}
+            if all(mid in ids for mid in expected_ids):
+                return ids
             time.sleep(3)
-        return texts
+        return ids

--- a/tests-functional/tests/test_transport_store_history_sync.py
+++ b/tests-functional/tests/test_transport_store_history_sync.py
@@ -68,12 +68,12 @@ class TestStoreHistorySync:
             sent_ids.append(message["id"])
             time.sleep(1)
 
-        logging.info("Sent %d messages: %s", message_count, sent_ids)
+        logger.info(f"Sent {message_count} messages: {sent_ids}")
 
         # Confirm the messages actually reached the store node before continuing.
         stored = logos_delivery.wait_for_message_count(message_count, start_time=offline_start_ns, timeout=60)
         topic_counts = Counter(m.get("message", {}).get("contentTopic", "?") for m in stored)
-        logger.info("Store holds %d messages since offline start; content topics: %s", len(stored), dict(topic_counts))
+        logger.info(f"Store holds {len(stored)} messages since offline start; content topics: {dict(topic_counts)}")
         assert len(stored) >= message_count, f"Store node only holds {len(stored)} messages, expected at least {message_count}"
 
         # Log the sender out so it cannot MVDS-retransmit once the receiver


### PR DESCRIPTION
Adds functional-test coverage for behaviors that will be affected by the go-waku → logos-delivery transport cutover, established now on the current go-waku transport so they act as a regression baseline across the migration (#7472).

New tests under `tests-functional/tests/`:

- **`test_transport_store_history_sync.py`** — a user who is fully offline (logged out) while private-group messages are published recovers all of them on the next login, via status-go's on-login historic-message fetch from the store node. Uses logout/login as the trigger (not `node_pause`, which freezes the process and lets MVDS — not the store — do the recovery).
- **`test_transport_delivery_confirmation.py`** — outgoing status reaches `delivered` and a `message.delivered` signal fires, both when the recipient is online and when it comes online after being offline.
- **`test_transport_multidevice_sync.py`** — after pairing a second device, a message sent from one device propagates to the other and a subsequent edit syncs across devices.
- **`test_transport_profile_sync.py`** — display-name (via contact code) and user-status updates propagate to a contact over the network.
- **`test_transport_ephemeral_messages.py`** — ephemeral (AUTOMATIC status) messages are not persisted by the store node, so a genuinely-offline receiver misses them while a normal message in the same window is recovered; live relay still works while online.

Conventions: reuses `steps/messenger.py`, `steps/async_messenger.py` and the existing backend fixtures.

**Validation:** ran locally against the go-waku fleet + Anvil with a freshly built status-go image — all 5 files pass (8 tests), lint clean (black, flake8, pyright).

Closes #7472