### PR TITLE
fix(protocol): respect contact request notification setting

### DIFF
--- a/internal/protocol/local_notification_settings_test.go
+++ b/internal/protocol/local_notification_settings_test.go
@@ -9,6 +9,8 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	"github.com/status-im/status-go/internal/crypto"
+	"github.com/status-im/status-go/internal/crypto/types"
+	"github.com/status-im/status-go/internal/protocol/requests"
 	"github.com/status-im/status-go/internal/testutils"
 )
 
@@ -164,6 +166,70 @@ func (s *LocalNotificationSettingsSuite) TestGroupChatsTurnOff() {
 
 	s.Require().NotEmpty(bobResponse.Messages())
 	s.Require().Empty(bobResponse.Notifications(), "GroupChats=TurnOff should produce no local notifications")
+}
+
+// TestContactRequestsTurnOff_OneToOneContactRequest verifies that one-to-one
+// pending contact requests obey the dedicated ContactRequests setting instead
+// of falling through to the generic one-to-one chat notification setting.
+func (s *LocalNotificationSettingsSuite) TestContactRequestsTurnOff_OneToOneContactRequest() {
+	bob := s.m
+	alice := s.newMessenger()
+
+	s.Require().NoError(bob.settings.SetContactRequests(notifValueTurnOff))
+	s.Require().NoError(bob.settings.SetOneToOneChats(notifValueSendAlerts))
+
+	request := &requests.SendContactRequest{
+		ID:      types.EncodeHex(crypto.FromECDSAPub(&bob.identity.PublicKey)),
+		Message: "hello!",
+	}
+	_, err := alice.SendContactRequest(context.Background(), request)
+	s.Require().NoError(err)
+
+	response, err := WaitOnMessengerResponse(
+		bob,
+		func(r *MessengerResponse) bool {
+			return len(r.Messages()) >= 2 && len(r.ActivityCenterNotifications()) == 1
+		},
+		"contact request not received",
+	)
+	s.Require().NoError(err)
+	s.Require().NotNil(response)
+
+	s.Require().NotEmpty(response.Messages())
+	s.Require().NotEmpty(response.ActivityCenterNotifications())
+	s.Require().Empty(response.Notifications(), "ContactRequests=TurnOff should suppress 1:1 contact request local notifications")
+}
+
+// TestContactRequestsSendAlerts_OneToOneContactRequest verifies that enabling
+// ContactRequests keeps the existing one-to-one contact request alert behavior,
+// even when ordinary one-to-one chat messages are muted separately.
+func (s *LocalNotificationSettingsSuite) TestContactRequestsSendAlerts_OneToOneContactRequest() {
+	bob := s.m
+	alice := s.newMessenger()
+
+	s.Require().NoError(bob.settings.SetContactRequests(notifValueSendAlerts))
+	s.Require().NoError(bob.settings.SetOneToOneChats(notifValueTurnOff))
+
+	request := &requests.SendContactRequest{
+		ID:      types.EncodeHex(crypto.FromECDSAPub(&bob.identity.PublicKey)),
+		Message: "hello!",
+	}
+	_, err := alice.SendContactRequest(context.Background(), request)
+	s.Require().NoError(err)
+
+	response, err := WaitOnMessengerResponse(
+		bob,
+		func(r *MessengerResponse) bool {
+			return len(r.Messages()) >= 2 && len(r.ActivityCenterNotifications()) == 1
+		},
+		"contact request not received",
+	)
+	s.Require().NoError(err)
+	s.Require().NotNil(response)
+
+	s.Require().NotEmpty(response.Messages())
+	s.Require().NotEmpty(response.ActivityCenterNotifications())
+	s.Require().NotEmpty(response.Notifications(), "ContactRequests=SendAlerts should allow 1:1 contact request local notifications")
 }
 
 // TestContactRequestsTurnOff_GroupInvite verifies that when ContactRequests is TurnOff,

--- a/internal/protocol/local_notifications.go
+++ b/internal/protocol/local_notifications.go
@@ -151,6 +151,7 @@ type NotificationSettingsProvider interface {
 	GetGlobalMentions() (string, error)
 	GetAllMessages() (string, error)
 	GetMessagePreview() (int, error)
+	GetContactRequests() (string, error)
 	HasExemption(id string) (bool, error)
 	GetExMuteAllMessages(id string) (bool, error)
 	GetExPersonalMentions(id string) (string, error)
@@ -210,6 +211,14 @@ func showMessageNotification(settings NotificationSettingsProvider, publicKey ec
 
 	// 2. One-to-one chats
 	if chat.OneToOne() {
+		if message.ContactRequestState == common.ContactRequestStatePending {
+			val, err := settings.GetContactRequests()
+			if err == nil && !isNotificationAllowed(val) {
+				return false
+			}
+			return true
+		}
+
 		val, err := settings.GetOneToOneChats()
 		if err == nil && !isNotificationAllowed(val) {
 			return false

--- a/internal/protocol/local_notifications_test.go
+++ b/internal/protocol/local_notifications_test.go
@@ -22,6 +22,7 @@ type mockNotificationSettings struct {
 	personalMentions   string
 	globalMentions     string
 	allMessages        string
+	contactRequests    string
 	messagePreview     int
 	hasExemption       bool
 	exMuteAllMessages  bool
@@ -35,8 +36,11 @@ func (m *mockNotificationSettings) GetGroupChats() (string, error)    { return m
 func (m *mockNotificationSettings) GetPersonalMentions() (string, error) {
 	return m.personalMentions, nil
 }
-func (m *mockNotificationSettings) GetGlobalMentions() (string, error)   { return m.globalMentions, nil }
-func (m *mockNotificationSettings) GetAllMessages() (string, error)      { return m.allMessages, nil }
+func (m *mockNotificationSettings) GetGlobalMentions() (string, error) { return m.globalMentions, nil }
+func (m *mockNotificationSettings) GetAllMessages() (string, error)    { return m.allMessages, nil }
+func (m *mockNotificationSettings) GetContactRequests() (string, error) {
+	return m.contactRequests, nil
+}
 func (m *mockNotificationSettings) GetMessagePreview() (int, error)      { return m.messagePreview, nil }
 func (m *mockNotificationSettings) HasExemption(id string) (bool, error) { return m.hasExemption, nil }
 func (m *mockNotificationSettings) GetExMuteAllMessages(id string) (bool, error) {
@@ -349,6 +353,34 @@ func TestShowMessageNotification_Exemptions(t *testing.T) {
 			globalMentions:   notifValueTurnOff,
 			hasExemption:     true,
 			exGlobalMentions: notifValueSendAlerts,
+		}
+		got := showMessageNotification(settings, key.PublicKey, msg, chat, nil)
+		require.True(t, got)
+	})
+}
+
+func TestShowMessageNotification_OneToOneContactRequestsUseContactRequestSetting(t *testing.T) {
+	key, _ := crypto.GenerateKey()
+	pkHex := types.EncodeHex(crypto.FromECDSAPub(&key.PublicKey))
+	chat := &Chat{ID: pkHex, ChatType: ChatTypeOneToOne, Active: true}
+	msg := common.NewMessage()
+	msg.ID, msg.ChatId, msg.Text, msg.From = "m1", chat.ID, "hello!", "0xabc"
+	msg.MessageType = protobuf.MessageType_ONE_TO_ONE
+	msg.ContactRequestState = common.ContactRequestStatePending
+
+	t.Run("contact requests off suppresses even when one-to-one chats are on", func(t *testing.T) {
+		settings := &mockNotificationSettings{
+			oneToOneChats:   notifValueSendAlerts,
+			contactRequests: notifValueTurnOff,
+		}
+		got := showMessageNotification(settings, key.PublicKey, msg, chat, nil)
+		require.False(t, got)
+	})
+
+	t.Run("contact requests on allows even when one-to-one chats are off", func(t *testing.T) {
+		settings := &mockNotificationSettings{
+			oneToOneChats:   notifValueTurnOff,
+			contactRequests: notifValueSendAlerts,
 		}
 		got := showMessageNotification(settings, key.PublicKey, msg, chat, nil)
 		require.True(t, got)


### PR DESCRIPTION
## Summary
- Route pending one-to-one contact request local notifications through the dedicated `ContactRequests` notification setting.
- Keep ordinary one-to-one message notifications controlled by `OneToOneChats`.
- Add unit and messenger-level coverage for `ContactRequests=TurnOff` and `ContactRequests=SendAlerts` on one-to-one contact requests.

## Why
`ContactRequests` already controls contact-request-style notifications for group invites/community requests. Pending one-to-one contact requests still fell through the generic one-to-one chat notification branch, so disabling contact request notifications could still allow a local notification for this contact request path.

## Testing
- `git diff --check origin/develop...HEAD`
- conflict marker scan on changed files
- Not run: `go test ./protocol -run 'Test(LocalNotificationSettingsSuite|ShowMessageNotification)' -count=1` because the local environment has no Go toolchain (`go: command not found`).
