### PR TITLE
fix: remove non-protected shard (64)

### DIFF
--- a/pkg/messaging/layers/transport/filters_manager.go
+++ b/pkg/messaging/layers/transport/filters_manager.go
@@ -154,7 +154,6 @@ func (f *FiltersManager) InitCommunityFilters(communityFiltersToInitialize []Com
 
 		topics := make([]string, 0)
 		topics = append(topics, wakuv2.DefaultShardPubsubTopic())
-		topics = append(topics, wakuv2.DefaultNonProtectedPubsubTopic())
 
 		for _, pubsubTopic := range topics {
 			pk := &cf.PrivKey.PublicKey

--- a/pkg/messaging/types/shard.go
+++ b/pkg/messaging/types/shard.go
@@ -26,7 +26,6 @@ func (s *Shard) PubsubTopic() string {
 
 const MainStatusShardCluster = 16
 const DefaultShardIndex = 32
-const NonProtectedShardIndex = 64
 
 func DefaultShardPubsubTopic() string {
 	return wakuproto.NewStaticShardingPubsubTopic(MainStatusShardCluster, DefaultShardIndex).String()
@@ -37,16 +36,4 @@ func DefaultShard() *Shard {
 		Cluster: MainStatusShardCluster,
 		Index:   DefaultShardIndex,
 	}
-}
-
-func DefaultNonProtectedShard() *Shard {
-	return &Shard{
-		Cluster: MainStatusShardCluster,
-		Index:   NonProtectedShardIndex,
-	}
-}
-
-// TODO this is used only for community control messages, we need to stop using it once migration is done
-func DefaultNonProtectedPubsubTopic() string {
-	return DefaultNonProtectedShard().PubsubTopic()
 }

--- a/pkg/messaging/waku/config.go
+++ b/pkg/messaging/waku/config.go
@@ -111,9 +111,8 @@ func setDefaults(cfg *Config) *Config {
 
 	if cfg.DefaultShardPubsubTopic == "" {
 		cfg.DefaultShardPubsubTopic = DefaultShardPubsubTopic()
-		//For now populating with both used shards, but this can be populated from user subscribed communities etc once community sharding is implemented
+		// This can be populated from user subscribed communities etc once community sharding is implemented
 		cfg.DefaultShardedPubsubTopics = append(cfg.DefaultShardedPubsubTopics, DefaultShardPubsubTopic())
-		cfg.DefaultShardedPubsubTopics = append(cfg.DefaultShardedPubsubTopics, DefaultNonProtectedPubsubTopic())
 	}
 
 	return cfg

--- a/pkg/messaging/waku/shard.go
+++ b/pkg/messaging/waku/shard.go
@@ -18,20 +18,7 @@ func (s *Shard) PubsubTopic() string {
 
 const MainStatusShardCluster = 16
 const DefaultShardIndex = 32
-const NonProtectedShardIndex = 64
 
 func DefaultShardPubsubTopic() string {
 	return wakuproto.NewStaticShardingPubsubTopic(MainStatusShardCluster, DefaultShardIndex).String()
-}
-
-func DefaultNonProtectedShard() *Shard {
-	return &Shard{
-		Cluster: MainStatusShardCluster,
-		Index:   NonProtectedShardIndex,
-	}
-}
-
-// TODO this is used only for community control messages, we need to stop using it once migration is done
-func DefaultNonProtectedPubsubTopic() string {
-	return DefaultNonProtectedShard().PubsubTopic()
 }

--- a/protocol/messenger_communities.go
+++ b/protocol/messenger_communities.go
@@ -353,7 +353,6 @@ func (m *Messenger) handleCommunitiesSubscription(c chan *communities.Subscripti
 					Sender:              community.PrivateKey(),
 					SkipEncryptionLayer: true,
 					MessageType:         protobuf.ApplicationMetadataMessage_COMMUNITY_USER_KICKED,
-					PubsubTopic:         types2.DefaultNonProtectedPubsubTopic(),
 				}
 
 				_, err = m.sender.SendPrivate(context.Background(), pk, rawMessage)
@@ -691,7 +690,6 @@ func (m *Messenger) handleCommunitySharedAddressesRequest(state *ReceivedMessage
 		CommunityID:         community.ID(),
 		SkipEncryptionLayer: true,
 		MessageType:         protobuf.ApplicationMetadataMessage_COMMUNITY_SHARED_ADDRESSES_RESPONSE,
-		PubsubTopic:         types2.DefaultNonProtectedPubsubTopic(),
 		ResendType:          common.ResendTypeRawMessage,
 		ResendMethod:        common.ResendMethodSendPrivate,
 		Recipients:          []*ecdsa.PublicKey{signer},
@@ -1467,7 +1465,6 @@ func (m *Messenger) RequestToJoinCommunity(request *requests.RequestToJoinCommun
 		ResendType:          common.ResendTypeRawMessage,
 		SkipEncryptionLayer: true,
 		MessageType:         protobuf.ApplicationMetadataMessage_COMMUNITY_REQUEST_TO_JOIN,
-		PubsubTopic:         types2.DefaultNonProtectedPubsubTopic(),
 		Priority:            &types2.HighPriority,
 	}
 
@@ -1858,7 +1855,6 @@ func (m *Messenger) CancelRequestToJoinCommunity(ctx context.Context, request *r
 		CommunityID:         community.ID(),
 		SkipEncryptionLayer: true,
 		MessageType:         protobuf.ApplicationMetadataMessage_COMMUNITY_CANCEL_REQUEST_TO_JOIN,
-		PubsubTopic:         types2.DefaultNonProtectedPubsubTopic(),
 		ResendType:          common.ResendTypeRawMessage,
 		Priority:            &types2.HighPriority,
 	}
@@ -2014,7 +2010,6 @@ func (m *Messenger) acceptRequestToJoinCommunity(requestToJoin *communities.Requ
 			CommunityID:         community.ID(),
 			SkipEncryptionLayer: true,
 			MessageType:         protobuf.ApplicationMetadataMessage_COMMUNITY_REQUEST_TO_JOIN_RESPONSE,
-			PubsubTopic:         types2.DefaultNonProtectedPubsubTopic(),
 			ResendType:          common.ResendTypeRawMessage,
 			ResendMethod:        common.ResendMethodSendPrivate,
 			Recipients:          []*ecdsa.PublicKey{pk},
@@ -2463,7 +2458,7 @@ func (m *Messenger) DefaultFilters(o *communities.Community) types2.ChatsToIniti
 	return types2.ChatsToInitialize{
 		{ChatID: cID, PubsubTopic: communityPubsubTopic},
 		{ChatID: memberUpdateChannelID, PubsubTopic: communityPubsubTopic},
-		{ChatID: uncompressedPubKey, PubsubTopic: types2.DefaultNonProtectedPubsubTopic()},
+		{ChatID: uncompressedPubKey, PubsubTopic: communityPubsubTopic},
 	}
 }
 

--- a/protocol/messenger_filter_init.go
+++ b/protocol/messenger_filter_init.go
@@ -21,11 +21,6 @@ func (m *Messenger) InitFilters() error {
 	// Seed the for color generation
 	rand.Seed(time.Now().Unix())
 
-	// Community requests will arrive in this pubsub topic
-	// TODO remove once fully migrated to Global Community Control and Content Topic https://github.com/status-im/status-go/issues/6384
-	if err := m.messaging.SubscribeToPubsubTopic(types.DefaultNonProtectedPubsubTopic()); err != nil {
-		return err
-	}
 	filters, publicKeys, err := m.collectFiltersAndKeys()
 	if err != nil {
 		return err


### PR DESCRIPTION
## What & why

Removes the non-protected shard (`NonProtectedShardIndex = 64`) from status-go.

Community static sharding is obsolete (status-im/status-desktop#19341), and the 128/256 community control/content shards were already dropped in #7404. The non-protected shard (64) was the last special-case shard — used only for community control messages (request to join, kick, shared addresses, etc.).

All community traffic now uses the default shard (32):
- `Community.PubsubTopic()` returns `""`, which `GetPubsubTopic` resolves to `DefaultShardPubsubTopic` (shard 32).
- The node already subscribes to the default shard at startup (`setupRelaySubscriptions`), so the explicit non-protected subscription in `InitFilters` is no longer needed.

Closes the migration tracked in #6384.

## Changes

- Remove `NonProtectedShardIndex`, `DefaultNonProtectedShard`, `DefaultNonProtectedPubsubTopic` from `pkg/messaging/types/shard.go` and `pkg/messaging/waku/shard.go`.
- Drop the non-protected topic from `DefaultShardedPubsubTopics` (waku config) and `InitCommunityFilters` (filters manager).
- Remove the non-protected subscription in `InitFilters`.
- Community control `RawMessage`s and the `DefaultFilters` admin-key filter now fall back to the default shard (empty `PubsubTopic`).

## Notes

Draft — opened for review. Behavioral change: community control messages move from shard 64 to shard 32. Old clients that only listen on shard 64 would not receive them; this is the intended consolidation following the static-sharding removal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)