### PR TITLE
fix: bring in zerokit and circom-compat-ffi with fixes to fetching from crates.io

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -8,16 +8,17 @@
         ]
       },
       "locked": {
-        "lastModified": 1736521871,
-        "narHash": "sha256-d34XNLg9NGPEOARHW+BIOAWalkHdEUAwsv3mpLZQxds=",
+        "lastModified": 1779967405,
+        "narHash": "sha256-UP0D5UinZj36LoMv07BhjZuZxYABNDHz975fUXGxjKU=",
         "owner": "logos-storage",
         "repo": "circom-compat-ffi",
-        "rev": "8cd4ed44fdafe59d4ec1184420639cae4c4dbab9",
+        "rev": "3cca4e91054a4d2bb5335feb19138362ce0fe417",
         "type": "github"
       },
       "original": {
         "owner": "logos-storage",
         "repo": "circom-compat-ffi",
+        "rev": "3cca4e91054a4d2bb5335feb19138362ce0fe417",
         "type": "github"
       }
     },

--- a/flake.lock
+++ b/flake.lock
@@ -162,18 +162,18 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1762211504,
-        "narHash": "sha256-SbDoBElFYJ4cYebltxlO2lYnz6qOaDAVY6aNJ5bqHDE=",
-        "ref": "refs/heads/master",
-        "rev": "3160d9504d07791f2fc9b610948a6cf9a58ed488",
-        "revCount": 342,
-        "type": "git",
-        "url": "https://github.com/vacp2p/zerokit"
+        "lastModified": 1779969584,
+        "narHash": "sha256-xr45wlSgWn8u6ZmK3gplwCQYDchJoy36hU9LezOEpAA=",
+        "owner": "vacp2p",
+        "repo": "zerokit",
+        "rev": "b1e4e485ad8e7a13b402c0ad2604ef879d927be4",
+        "type": "github"
       },
       "original": {
-        "rev": "3160d9504d07791f2fc9b610948a6cf9a58ed488",
-        "type": "git",
-        "url": "https://github.com/vacp2p/zerokit"
+        "owner": "vacp2p",
+        "repo": "zerokit",
+        "rev": "b1e4e485ad8e7a13b402c0ad2604ef879d927be4",
+        "type": "github"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -19,6 +19,8 @@
     lmn = {
       url = "git+https://github.com/logos-messaging/logos-messaging-nim?submodules=1&rev=cccc8ab6fda0e54752936db0d5c80b02a2c34a3a";
       inputs.nixpkgs.follows = "nixpkgs";
+      # https://github.com/vacp2p/zerokit/commit/b1e4e485ad8e7a13b402c0ad2604ef879d927be4
+      inputs.zerokit.url = "github:vacp2p/zerokit/b1e4e485ad8e7a13b402c0ad2604ef879d927be4";
     };
     logos-storage-nim = {
       url = "git+https://github.com/logos-storage/logos-storage-nim?submodules=1&rev=3c09f008bb5266a669fd19f18368f9e8b861b664";

--- a/flake.nix
+++ b/flake.nix
@@ -23,6 +23,8 @@
     logos-storage-nim = {
       url = "git+https://github.com/logos-storage/logos-storage-nim?submodules=1&rev=3c09f008bb5266a669fd19f18368f9e8b861b664";
       inputs.nixpkgs.follows = "nixpkgs";
+      # https://github.com/logos-storage/circom-compat-ffi/pull/11
+      inputs.circom-compat.url = "github:logos-storage/circom-compat-ffi/3cca4e91054a4d2bb5335feb19138362ce0fe417";
     };
     # We cannot do follows since the nim-unwrapped-2_0 doesn't exist in this nixpkgs version above
     nim-sds.url = "git+https://github.com/logos-messaging/nim-sds?submodules=1&rev=fb8039c5a56086ec7fb3e5e1a5a593bb3756ccb6";


### PR DESCRIPTION
## Summary

status-app PR : https://github.com/status-im/status-app/pull/21059

Related PRs in dependencies:
- https://github.com/vacp2p/zerokit/pull/415
- https://github.com/logos-storage/circom-compat-ffi/pull/11

Else in status-go CI we get this failure : 
```
crate-alloy-rlp>   0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
crate-ark-crypto-primitives>   0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
crate-alloy-rlp> curl: (22) The requested URL returned error: 403
crate-ark-crypto-primitives> curl: (22) The requested URL returned error: 403
crate-ark-ec>   0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
crate-ark-ec> curl: (22) The requested URL returned error: 403
crate-ark-ff>   0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
crate-ark-ff> curl: (22) The requested URL returned error: 403
crate-ark-groth16>   0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
crate-ark-groth16> curl: (22) The requested URL returned error: 403
crate-ark-poly>   0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
crate-ark-poly> curl: (22) The requested URL returned error: 403
crate-ark-snark>   0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
crate-ark-snark> curl: (22) The requested URL returned error: 403
crate-ethers-core>   0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
crate-ark-serialize>   0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
crate-ethers-core> curl: (22) The requested URL returned error: 403
crate-ark-serialize> curl: (22) The requested URL returned error: 403
crate-scale-info>   0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
crate-scale-info> curl: (22) The requested URL returned error: 403
crate-ark-crypto-primitives> error: cannot download crate-ark-crypto-primitives-0.4.0.tar.gz from any mirror
error: Cannot build '/nix/store/lm210ryfadn6vvs361w5p95bnnnhdf1g-crate-ark-crypto-primitives-0.4.0.tar.gz.drv'.
       Reason: builder failed with exit code 1.
       Output paths:
         /nix/store/d4rxr5imz7q8gnpz33abpny8rv7qbryd-crate-ark-crypto-primitives-0.4.0.tar.gz
       Last 17 log lines:
       >
       > trying https://crates.io/api/v1/crates/ark-crypto-primitives/0.4.0/download
       >   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
       >                                  Dload  Upload   Total   Spent    Left  Speed
       >   0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
       > curl: (22) The requested URL returned error: 403
       > Warning: Problem (retrying all errors). Will retry in 1 second. 3 retries left.
       >   0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
       > curl: (22) The requested URL returned error: 403
       > Warning: Problem (retrying all errors). Will retry in 2 seconds. 2 retries
       > Warning: left.
       >   0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
       > curl: (22) The requested URL returned error: 403
       > Warning: Problem (retrying all errors). Will retry in 4 seconds. 1 retry left.
       >   0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
       > curl: (22) The requested URL returned error: 403
       > error: cannot download crate-ark-crypto-primitives-0.4.0.tar.gz from any mirror
       For full logs, run:
         nix log /nix/store/lm210ryfadn6vvs361w5p95bnnnhdf1g-crate-ark-crypto-primitives-0.4.0.tar.gz.drv
error: Cannot build '/nix/store/lqamh3mbnq2w5klyndgdkx7rlyxsrkpk-ark-crypto-primitives-0.4.0.drv'.
       Reason: 1 dependency failed.
       Output paths:
         /nix/store/vlgn4msdjb31i499grnmj3vz6c3f9jh8-ark-crypto-primitives-0.4.0
error: Build failed due to failed dependency
error: Cannot build '/nix/store/c27fnbqrqaagcxn81y04izj1yfg82c25-cargo-vendor-dir.drv'.
       Reason: 1 dependency failed.
       Output paths:
         /nix/store/jfd5p6gl3a1sdc6aqxn720n0qcf91ayh-cargo-vendor-dir
error: Build failed due to failed dependency
error: Cannot build '/nix/store/bn8s4c113hhsvhg46lmazj0p04z45fba-circom-compat-ffi-0.1.0.drv'.
       Reason: 1 dependency failed.
       Output paths:
         /nix/store/7myhxaq2yyqdw74pspmpnsd6ywwiqypg-circom-compat-ffi-0.1.0
error: Build failed due to failed dependency
error: Cannot build '/nix/store/7s1kqgpvb03a4wn970kkkil1kk33wv52-storage-0.1.0-3c09f008.drv'.
       Reason: 1 dependency failed.
       Output paths:
         /nix/store/z1ia4xdcl9dlib0164zm6iia1s80nmah-storage-0.1.0-3c09f008
error: Build failed due to failed dependency
error: Cannot build '/nix/store/5pah3l0yx5hl0wxyvp40xh3x5a7zd2xy-status-go-61245b6e12d3fe29d432e466a12b8feaec391b36.drv'.
       Reason: 1 dependency failed.
       Output paths:
         /nix/store/ackv4j3m28w9rivslvc7nhi8vll28wx9-status-go-61245b6e12d3fe29d432e466a12b8feaec391b36
error: Build failed due to failed dependency
script returned exit code 1
```