### PR TITLE
chore: drop legacy api.status.im eth proxy

### DIFF
--- a/internal/logutils/callog/status_request_log.go
+++ b/internal/logutils/callog/status_request_log.go
@@ -40,8 +40,6 @@ var sensitiveKeys = []string{
 	"openSeaApiKey",
 	"marketDataProxyUser",
 	"marketDataProxyPassword",
-	"statusProxyBlockchainUser",
-	"statusProxyBlockchainPassword",
 	"verifyENSURL",
 	"verifyTransactionURL",
 	"gifs/api-key",

--- a/internal/rpc/client_test.go
+++ b/internal/rpc/client_test.go
@@ -43,9 +43,9 @@ func TestGetClientsUsingCache(t *testing.T) {
 
 	// Define paths for providers
 	paths := []string{
-		"/api.status.im/nodefleet/foo",
-		"/api.status.im/infura/bar",
-		"/api.status.im/infura.io/baz",
+		"/eth-rpc.status.im/nodefleet/foo",
+		"/eth-rpc.status.im/infura/bar",
+		"/eth-rpc.status.im/infura.io/baz",
 	}
 	user, password := gofakeit.Username(), gofakeit.LetterN(5)
 
@@ -72,7 +72,7 @@ func TestGetClientsUsingCache(t *testing.T) {
 				Name:         fmt.Sprintf("Provider%d", i+1),
 				ChainID:      1,
 				URL:          security.NewSensitiveString(baseURL).Append(path),
-				Type:         params.EmbeddedProxyProviderType,
+				Type:         params.EmbeddedEthRpcProxyProviderType,
 				AuthType:     params.BasicAuth,
 				AuthLogin:    security.NewSensitiveString("incorrectUser"),
 				AuthPassword: security.NewSensitiveString("incorrectPwd"), // will be replaced by correct values by OverrideBasicAuth
@@ -92,7 +92,7 @@ func TestGetClientsUsingCache(t *testing.T) {
 
 	networks = networkhelper.OverrideBasicAuth(
 		networks,
-		params.EmbeddedProxyProviderType,
+		params.EmbeddedEthRpcProxyProviderType,
 		true,
 		security.NewSensitiveString(user),
 		security.NewSensitiveString(password))

--- a/internal/rpc/network/db/network_db_test.go
+++ b/internal/rpc/network/db/network_db_test.go
@@ -57,7 +57,7 @@ func DefaultProviders(chainID uint64) []params.RpcProvider {
 			Name:         "Provider2",
 			ChainID:      chainID,
 			URL:          security.NewSensitiveString("https://rpc.provider2.io"),
-			Type:         params.EmbeddedProxyProviderType,
+			Type:         params.EmbeddedEthRpcProxyProviderType,
 			Enabled:      true,
 			AuthType:     params.BasicAuth,
 			AuthLogin:    security.NewSensitiveString("user1"),
@@ -101,7 +101,7 @@ func (s *NetworksPersistenceTestSuite) verifyNetworkDeletion(chainID uint64) {
 func (s *NetworksPersistenceTestSuite) TestAddAndGetNetworkWithProviders() {
 	network := testutil.CreateNetwork(common.OptimismMainnet, "Optimism Mainnet", []params.RpcProvider{
 		testutil.CreateProvider(common.OptimismMainnet, "Provider1", params.UserProviderType, true, security.NewSensitiveString("https://rpc.optimism.io")),
-		testutil.CreateProvider(common.OptimismMainnet, "Provider2", params.EmbeddedProxyProviderType, false, security.NewSensitiveString("https://backup.optimism.io")),
+		testutil.CreateProvider(common.OptimismMainnet, "Provider2", params.EmbeddedEthRpcProxyProviderType, false, security.NewSensitiveString("https://backup.optimism.io")),
 	})
 	s.addAndVerifyNetworks([]*params.Network{network})
 }

--- a/internal/rpc/network/db/rpc_provider_db_test.go
+++ b/internal/rpc/network/db/rpc_provider_db_test.go
@@ -58,7 +58,7 @@ func (s *RpcProviderPersistenceTestSuite) TestGetRpcProvidersByType() {
 		testutil.CreateProvider(common.EthereumMainnet, "UserProvider1", params.UserProviderType, true, security.NewSensitiveString("https://provider1.example.com")),
 		testutil.CreateProvider(common.EthereumMainnet, "EmbeddedDirect1", params.EmbeddedDirectProviderType, false, security.NewSensitiveString("https://provider2.example.com")),
 		testutil.CreateProvider(common.EthereumMainnet, "UserProvider2", params.UserProviderType, false, security.NewSensitiveString("https://provider3.example.com")),
-		testutil.CreateProvider(common.EthereumMainnet, "EmbeddedProxy1", params.EmbeddedProxyProviderType, true, security.NewSensitiveString("https://provider4.example.com")),
+		testutil.CreateProvider(common.EthereumMainnet, "EmbeddedEthRpcProxy1", params.EmbeddedEthRpcProxyProviderType, true, security.NewSensitiveString("https://provider4.example.com")),
 	}
 
 	for _, provider := range providers {
@@ -75,7 +75,7 @@ func (s *RpcProviderPersistenceTestSuite) TestGetRpcProvidersByType() {
 	s.Require().NoError(err)
 	testutil.CompareProvidersList(s.T(), []params.RpcProvider{providers[1]}, embeddedDirectProviders)
 
-	embeddedProxyProviders, err := s.rpcPersistence.GetRpcProvidersByType(common.EthereumMainnet, params.EmbeddedProxyProviderType)
+	embeddedProxyProviders, err := s.rpcPersistence.GetRpcProvidersByType(common.EthereumMainnet, params.EmbeddedEthRpcProxyProviderType)
 	s.Require().NoError(err)
 	testutil.CompareProvidersList(s.T(), []params.RpcProvider{providers[3]}, embeddedProxyProviders)
 }
@@ -132,7 +132,7 @@ func (s *RpcProviderPersistenceTestSuite) TestSetRpcProviders() {
 
 	newProviders := []params.RpcProvider{
 		testutil.CreateProvider(common.EthereumMainnet, "NewProvider1", params.UserProviderType, true, security.NewSensitiveString("https://newprovider1.example.com")),
-		testutil.CreateProvider(common.EthereumMainnet, "NewProvider2", params.EmbeddedProxyProviderType, true, security.NewSensitiveString("https://newprovider2.example.com")),
+		testutil.CreateProvider(common.EthereumMainnet, "NewProvider2", params.EmbeddedEthRpcProxyProviderType, true, security.NewSensitiveString("https://newprovider2.example.com")),
 	}
 
 	err := s.rpcPersistence.SetRpcProviders(common.EthereumMainnet, newProviders)

--- a/internal/rpc/network/db/utils.go
+++ b/internal/rpc/network/db/utils.go
@@ -9,11 +9,10 @@ import (
 )
 
 // Deprecated: fillDeprecatedURLs populates the `original_rpc_url`, `original_fallback_url`, `rpc_url`,
-// `fallback_url`, `defaultRpcUrl`, `defaultFallbackURL`, and `defaultFallbackURL2` fields.
+// and `fallback_url` fields.
 // Keep for backwrad compatibility until it's fully integrated
 func FillDeprecatedURLs(network *params.Network, providers []params.RpcProvider) {
 	var embeddedDirect []params.RpcProvider
-	var embeddedProxy []params.RpcProvider
 	var userProviders []params.RpcProvider
 
 	// Categorize providers
@@ -21,8 +20,6 @@ func FillDeprecatedURLs(network *params.Network, providers []params.RpcProvider)
 		switch provider.Type {
 		case params.EmbeddedDirectProviderType:
 			embeddedDirect = append(embeddedDirect, provider)
-		case params.EmbeddedProxyProviderType:
-			embeddedProxy = append(embeddedProxy, provider)
 		case params.UserProviderType:
 			userProviders = append(userProviders, provider)
 		}
@@ -46,17 +43,6 @@ func FillDeprecatedURLs(network *params.Network, providers []params.RpcProvider)
 		// Default to EmbeddedDirectProviderType providers if no User providers exist
 		network.RPCURL = network.OriginalRPCURL
 		network.FallbackURL = network.OriginalFallbackURL
-	}
-
-	// Set default_*_url fields based on EmbeddedProxyProviderType providers
-	if len(embeddedProxy) > 0 {
-		network.DefaultRPCURL = embeddedProxy[0].GetFullURL().Reveal()
-		if len(embeddedProxy) > 1 {
-			network.DefaultFallbackURL = embeddedProxy[1].GetFullURL().Reveal()
-		}
-		if len(embeddedProxy) > 2 {
-			network.DefaultFallbackURL2 = embeddedProxy[2].GetFullURL().Reveal()
-		}
 	}
 }
 

--- a/internal/rpc/network/network_test.go
+++ b/internal/rpc/network/network_test.go
@@ -236,9 +236,6 @@ func (s *NetworkManagerTestSuite) TestLegacyFieldPopulation() {
 	s.Equal("https://direct2.ethereum.io", network.OriginalFallbackURL)
 	s.Equal("https://user1.ethereum.io", network.RPCURL)
 	s.Equal("https://user2.ethereum.io", network.FallbackURL)
-	s.Empty(network.DefaultRPCURL)
-	s.Empty(network.DefaultFallbackURL)
-	s.Empty(network.DefaultFallbackURL2)
 }
 
 func (s *NetworkManagerTestSuite) TestLegacyFieldPopulationWithoutUserProviders() {
@@ -268,9 +265,6 @@ func (s *NetworkManagerTestSuite) TestLegacyFieldPopulationWithoutUserProviders(
 	s.Empty(network.OriginalFallbackURL)                  // No second EmbeddedDirect provider
 	s.Equal("https://direct1.sepolia.io", network.RPCURL) // Defaults to OriginalRPCURL
 	s.Empty(network.FallbackURL)                          // Defaults to OriginalFallbackURL, which is empty
-	s.Empty(network.DefaultRPCURL)
-	s.Empty(network.DefaultFallbackURL)
-	s.Empty(network.DefaultFallbackURL2)
 }
 
 func (s *NetworkManagerTestSuite) TestUpsertNetwork() {

--- a/internal/rpc/network/network_test.go
+++ b/internal/rpc/network/network_test.go
@@ -117,7 +117,7 @@ func (s *NetworkManagerTestSuite) TestInitNetworksKeepsUserProviders() {
 	// Re-initialize networks
 	initNetworks := []params.Network{
 		*testutil.CreateNetwork(common.EthereumMainnet, "Ethereum Mainnet", []params.RpcProvider{
-			testutil.CreateProvider(common.EthereumMainnet, "Infura Mainnet", params.EmbeddedProxyProviderType, true, security.NewSensitiveString("https://mainnet.infura.io")),
+			testutil.CreateProvider(common.EthereumMainnet, "Infura Mainnet", params.EmbeddedEthRpcProxyProviderType, true, security.NewSensitiveString("https://mainnet.infura.io")),
 		}),
 	}
 	err = s.manager.InitEmbeddedNetworks(initNetworks)
@@ -137,7 +137,7 @@ func (s *NetworkManagerTestSuite) TestInitNetworksDoesNotSaveEmbeddedProviders()
 	// Re-initialize networks
 	initNetworks := []params.Network{
 		*testutil.CreateNetwork(common.EthereumMainnet, "Ethereum Mainnet", []params.RpcProvider{
-			testutil.CreateProvider(common.EthereumMainnet, "Infura Mainnet", params.EmbeddedProxyProviderType, true, security.NewSensitiveString("https://mainnet.infura.io")),
+			testutil.CreateProvider(common.EthereumMainnet, "Infura Mainnet", params.EmbeddedEthRpcProxyProviderType, true, security.NewSensitiveString("https://mainnet.infura.io")),
 		}),
 	}
 	err := s.manager.InitEmbeddedNetworks(initNetworks)
@@ -154,7 +154,7 @@ func (s *NetworkManagerTestSuite) TestInitEmbeddedNetworks() {
 	// Re-initialize networks
 	initNetworks := []params.Network{
 		*testutil.CreateNetwork(common.EthereumMainnet, "Ethereum Mainnet", []params.RpcProvider{
-			testutil.CreateProvider(common.EthereumMainnet, "Infura Mainnet", params.EmbeddedProxyProviderType, true, security.NewSensitiveString("https://mainnet.infura.io")),
+			testutil.CreateProvider(common.EthereumMainnet, "Infura Mainnet", params.EmbeddedEthRpcProxyProviderType, true, security.NewSensitiveString("https://mainnet.infura.io")),
 		}),
 	}
 	expectedProviders := networkhelper.GetEmbeddedProviders(initNetworks[0].RpcProviders)
@@ -211,9 +211,9 @@ func (s *NetworkManagerTestSuite) TestLegacyFieldPopulation() {
 		*testutil.CreateNetwork(common.EthereumMainnet, "Ethereum Mainnet", []params.RpcProvider{
 			testutil.CreateProvider(common.EthereumMainnet, "DirectProvider1", params.EmbeddedDirectProviderType, true, security.NewSensitiveString("https://direct1.ethereum.io")),
 			testutil.CreateProvider(common.EthereumMainnet, "DirectProvider2", params.EmbeddedDirectProviderType, true, security.NewSensitiveString("https://direct2.ethereum.io")),
-			testutil.CreateProvider(common.EthereumMainnet, "ProxyProvider1", params.EmbeddedProxyProviderType, true, security.NewSensitiveString("https://proxy1.ethereum.io")),
-			testutil.CreateProvider(common.EthereumMainnet, "ProxyProvider2", params.EmbeddedProxyProviderType, true, security.NewSensitiveString("https://proxy2.ethereum.io")),
-			testutil.CreateProvider(common.EthereumMainnet, "ProxyProvider3", params.EmbeddedProxyProviderType, true, security.NewSensitiveString("https://proxy3.ethereum.io")),
+			testutil.CreateProvider(common.EthereumMainnet, "ProxyProvider1", params.EmbeddedEthRpcProxyProviderType, true, security.NewSensitiveString("https://proxy1.ethereum.io")),
+			testutil.CreateProvider(common.EthereumMainnet, "ProxyProvider2", params.EmbeddedEthRpcProxyProviderType, true, security.NewSensitiveString("https://proxy2.ethereum.io")),
+			testutil.CreateProvider(common.EthereumMainnet, "ProxyProvider3", params.EmbeddedEthRpcProxyProviderType, true, security.NewSensitiveString("https://proxy3.ethereum.io")),
 			testutil.CreateProvider(common.EthereumMainnet, "UserProvider1", params.UserProviderType, true, security.NewSensitiveString("https://user1.ethereum.io")),
 			testutil.CreateProvider(common.EthereumMainnet, "UserProvider2", params.UserProviderType, true, security.NewSensitiveString("https://user2.ethereum.io")),
 		}),
@@ -236,9 +236,9 @@ func (s *NetworkManagerTestSuite) TestLegacyFieldPopulation() {
 	s.Equal("https://direct2.ethereum.io", network.OriginalFallbackURL)
 	s.Equal("https://user1.ethereum.io", network.RPCURL)
 	s.Equal("https://user2.ethereum.io", network.FallbackURL)
-	s.Equal("https://proxy1.ethereum.io", network.DefaultRPCURL)
-	s.Equal("https://proxy2.ethereum.io", network.DefaultFallbackURL)
-	s.Equal("https://proxy3.ethereum.io", network.DefaultFallbackURL2)
+	s.Empty(network.DefaultRPCURL)
+	s.Empty(network.DefaultFallbackURL)
+	s.Empty(network.DefaultFallbackURL2)
 }
 
 func (s *NetworkManagerTestSuite) TestLegacyFieldPopulationWithoutUserProviders() {
@@ -246,8 +246,8 @@ func (s *NetworkManagerTestSuite) TestLegacyFieldPopulationWithoutUserProviders(
 	initNetworks := []params.Network{
 		*testutil.CreateNetwork(common.EthereumSepolia, "Sepolia Testnet", []params.RpcProvider{
 			testutil.CreateProvider(common.EthereumSepolia, "DirectProvider1", params.EmbeddedDirectProviderType, true, security.NewSensitiveString("https://direct1.sepolia.io")),
-			testutil.CreateProvider(common.EthereumSepolia, "ProxyProvider1", params.EmbeddedProxyProviderType, true, security.NewSensitiveString("https://proxy1.sepolia.io")),
-			testutil.CreateProvider(common.EthereumSepolia, "ProxyProvider2", params.EmbeddedProxyProviderType, true, security.NewSensitiveString("https://proxy2.sepolia.io")),
+			testutil.CreateProvider(common.EthereumSepolia, "ProxyProvider1", params.EmbeddedEthRpcProxyProviderType, true, security.NewSensitiveString("https://proxy1.sepolia.io")),
+			testutil.CreateProvider(common.EthereumSepolia, "ProxyProvider2", params.EmbeddedEthRpcProxyProviderType, true, security.NewSensitiveString("https://proxy2.sepolia.io")),
 		}),
 	}
 
@@ -268,9 +268,9 @@ func (s *NetworkManagerTestSuite) TestLegacyFieldPopulationWithoutUserProviders(
 	s.Empty(network.OriginalFallbackURL)                  // No second EmbeddedDirect provider
 	s.Equal("https://direct1.sepolia.io", network.RPCURL) // Defaults to OriginalRPCURL
 	s.Empty(network.FallbackURL)                          // Defaults to OriginalFallbackURL, which is empty
-	s.Equal("https://proxy1.sepolia.io", network.DefaultRPCURL)
-	s.Equal("https://proxy2.sepolia.io", network.DefaultFallbackURL)
-	s.Empty(network.DefaultFallbackURL2) // No third Proxy provider
+	s.Empty(network.DefaultRPCURL)
+	s.Empty(network.DefaultFallbackURL)
+	s.Empty(network.DefaultFallbackURL2)
 }
 
 func (s *NetworkManagerTestSuite) TestUpsertNetwork() {
@@ -278,7 +278,7 @@ func (s *NetworkManagerTestSuite) TestUpsertNetwork() {
 
 	// Create a new network
 	newNetwork := testutil.CreateNetwork(chainID, "Ethereum Mainnet", []params.RpcProvider{
-		testutil.CreateProvider(chainID, "Infura Mainnet", params.EmbeddedProxyProviderType, true, security.NewSensitiveString("https://mainnet.infura.io")),
+		testutil.CreateProvider(chainID, "Infura Mainnet", params.EmbeddedEthRpcProxyProviderType, true, security.NewSensitiveString("https://mainnet.infura.io")),
 	})
 	// Check that these values are overiden for upserted networks
 	newNetwork.IsActive = true

--- a/internal/rpc/network/testutil/testutil.go
+++ b/internal/rpc/network/testutil/testutil.go
@@ -125,7 +125,7 @@ func MinimalActiveNetworks() []params.Network {
 			CreateProvider(
 				common.EthereumMainnet,
 				"Dummy Provider",
-				params.EmbeddedProxyProviderType,
+				params.EmbeddedEthRpcProxyProviderType,
 				true,
 				security.NewSensitiveString("http://localhost:0"),
 			),

--- a/params/config.go
+++ b/params/config.go
@@ -231,8 +231,6 @@ type WalletConfig struct {
 	CoingeckoDemoAPIKey   security.SensitiveString `json:"CoingeckoDemoAPIKey"`
 	MarketDataProxyConfig MarketDataProxyConfig    `json:"MarketDataProxyConfig"`
 	NftProxyConfig        NftProxyConfig           `json:"NftProxyConfig"`
-	StatusProxyUser       security.SensitiveString `json:"StatusProxyBlockchainUser"`
-	StatusProxyPassword   security.SensitiveString `json:"StatusProxyBlockchainPassword"`
 
 	StatusProxyStageName     string                   `json:"StatusProxyStageName"`
 	EnableMercuryoProvider   bool                     `json:"EnableMercuryoProvider"`

--- a/params/network_config.go
+++ b/params/network_config.go
@@ -22,7 +22,6 @@ const (
 type RpcProviderType string
 
 const (
-	EmbeddedProxyProviderType       RpcProviderType = "embedded-proxy"         // Proxy-based RPC provider
 	EmbeddedEthRpcProxyProviderType RpcProviderType = "embedded-eth-rpc-proxy" // EthRpcProxy-based RPC provider (smart proxy)
 	EmbeddedDirectProviderType      RpcProviderType = "embedded-direct"        // Direct RPC provider
 	UserProviderType                RpcProviderType = "user"                   // User-defined RPC provider
@@ -35,7 +34,7 @@ type RpcProvider struct {
 	Name             string                   `json:"name" validate:"required,min=1"`   // Provider name for identification
 	URL              security.SensitiveString `json:"url" validate:"required,url"`      // Current Provider URL
 	EnableRPSLimiter bool                     `json:"enableRpsLimiter"`                 // Enable RPC rate limiting for this provider
-	Type             RpcProviderType          `json:"type" validate:"required,oneof=embedded-proxy embedded-eth-rpc-proxy embedded-direct user"`
+	Type             RpcProviderType          `json:"type" validate:"required,oneof=embedded-eth-rpc-proxy embedded-direct user"`
 	Enabled          bool                     `json:"enabled"` // Whether the provider is enabled
 	// Authentication
 	AuthType     RpcProviderAuthType      `json:"authType" validate:"required,oneof=no-auth basic-auth token-auth puzzle-auth"` // Type of authentication
@@ -120,10 +119,6 @@ func newRpcProvider(chainID uint64, name string, url security.SensitiveString, e
 
 func NewUserProvider(chainID uint64, name string, url security.SensitiveString, enableRpsLimiter bool) *RpcProvider {
 	return newRpcProvider(chainID, name, url, enableRpsLimiter, UserProviderType)
-}
-
-func NewProxyProvider(chainID uint64, name string, url security.SensitiveString, enableRpsLimiter bool) *RpcProvider {
-	return newRpcProvider(chainID, name, url, enableRpsLimiter, EmbeddedProxyProviderType)
 }
 
 func NewEthRpcProxyProvider(chainID uint64, name string, url security.SensitiveString, enableRpsLimiter bool, usePuzzleAuth bool) *RpcProvider {

--- a/params/network_config.go
+++ b/params/network_config.go
@@ -67,9 +67,6 @@ type Network struct {
 
 	// Deprecated fields (kept for backward compatibility)
 	// FIXME: Removal of deprecated fields in integration PR https://github.com/status-im/status-go/pull/6178
-	DefaultRPCURL       string `json:"defaultRpcUrl" validate:"omitempty,url"`       // Deprecated: proxy rpc url
-	DefaultFallbackURL  string `json:"defaultFallbackURL" validate:"omitempty,url"`  // Deprecated: proxy fallback url
-	DefaultFallbackURL2 string `json:"defaultFallbackURL2" validate:"omitempty,url"` // Deprecated: second proxy fallback url
 	RPCURL              string `json:"rpcUrl" validate:"omitempty,url"`              // Deprecated: direct rpc url
 	OriginalRPCURL      string `json:"originalRpcUrl" validate:"omitempty,url"`      // Deprecated: direct rpc url if user overrides RPCURL
 	FallbackURL         string `json:"fallbackURL" validate:"omitempty,url"`         // Deprecated

--- a/params/networkdefaults/default_networks.go
+++ b/params/networkdefaults/default_networks.go
@@ -13,16 +13,10 @@ import (
 const (
 	// Host suffixes for providers
 	SmartProxyHostSuffix = "eth-rpc.status.im"
-	ProxyHostSuffix      = "api.status.im"
 
 	iconURLPrefix         = "network/"
 	testNetworkIconSuffix = "-test"
 )
-
-// Direct proxy endpoint (1 endpoint per chain/network)
-func proxyUrl(stageName, provider, chainName, networkName string) security.SensitiveString {
-	return security.NewSensitiveStringPrintf("https://%s.%s/%s/%s/%s/", stageName, ProxyHostSuffix, provider, chainName, networkName)
-}
 
 // New eth-rpc-proxy endpoint (provider agnostic)
 func getProxyHost(customUrl, stageName string) string {
@@ -47,7 +41,6 @@ type providerType uint8
 const (
 	providerTypeEthRpcProxy providerType = iota
 	providerTypeEthRpcProxyWithProvider
-	providerTypeProxy
 	providerTypeDirect
 )
 
@@ -59,14 +52,14 @@ type providerSpec struct {
 	// For providerKindDirect
 	directURL security.SensitiveString
 
-	// For providerKindEthRpcProxyWithProvider and providerKindProxy (URL path component)
+	// For providerKindEthRpcProxyWithProvider (URL path component)
 	targetProvider string
 }
 
 type networkSpec struct {
 	chainID uint64
 
-	// Used for status smart-proxy + old proxy URL generation
+	// Used for status smart-proxy URL generation
 	proxyChainName   string
 	proxyNetworkName string
 
@@ -90,7 +83,6 @@ type networkSpec struct {
 // configEnv groups runtime options
 type configEnv struct {
 	ProxyHost          string
-	StageName          string
 	EnableRpcProviders bool
 	UsePuzzleAuth      bool
 }
@@ -107,8 +99,6 @@ func buildRpcProvidersFromSpec(spec networkSpec, env configEnv) []params.RpcProv
 			out = append(out, *params.NewEthRpcProxyProvider(spec.chainID, p.name, smartProxyUrl(env.ProxyHost, spec.proxyChainName, spec.proxyNetworkName), false, env.UsePuzzleAuth))
 		case providerTypeEthRpcProxyWithProvider:
 			out = append(out, *params.NewEthRpcProxyProvider(spec.chainID, p.name, smartProxyUrlWithProvider(env.ProxyHost, spec.proxyChainName, spec.proxyNetworkName, p.targetProvider), false, env.UsePuzzleAuth))
-		case providerTypeProxy:
-			out = append(out, *params.NewProxyProvider(spec.chainID, p.name, proxyUrl(env.StageName, p.targetProvider, spec.proxyChainName, spec.proxyNetworkName), false))
 		case providerTypeDirect:
 			out = append(out, *params.NewDirectProvider(spec.chainID, p.name, p.directURL, p.enableRpsLimiter))
 		}
@@ -142,10 +132,9 @@ func buildNetworkFromSpec(spec networkSpec, env configEnv) params.Network {
 	}
 }
 
-func defaultNetworks(proxyHost, stageName string, thirdpartyServicesEnabled bool, usePuzzleAuth bool) []params.Network {
+func defaultNetworks(proxyHost string, thirdpartyServicesEnabled bool, usePuzzleAuth bool) []params.Network {
 	env := configEnv{
 		ProxyHost:          proxyHost,
-		StageName:          stageName,
 		EnableRpcProviders: thirdpartyServicesEnabled,
 		UsePuzzleAuth:      usePuzzleAuth,
 	}
@@ -172,22 +161,13 @@ func setRPCs(networks []params.Network, walletConfig *requests.WalletSecretsConf
 		walletConfig.EthRpcProxyUser,
 		walletConfig.EthRpcProxyPassword)
 
-	// Apply auth for old proxy
-	hasOldProxyCredentials := !walletConfig.StatusProxyUser.Empty() && !walletConfig.StatusProxyPassword.Empty()
-	networks = networkhelper.OverrideBasicAuth(
-		networks,
-		params.EmbeddedProxyProviderType,
-		hasOldProxyCredentials,
-		walletConfig.StatusProxyUser,
-		walletConfig.StatusProxyPassword)
-
 	return networks
 }
 
 func BuildDefaultNetworks(walletSecretsConfig *requests.WalletSecretsConfig, thirdpartyServicesEnabled bool) []params.Network {
 	proxyHost := getProxyHost(walletSecretsConfig.EthRpcProxyUrl.Reveal(), walletSecretsConfig.StatusProxyStageName)
 	networks := setRPCs(
-		defaultNetworks(proxyHost, walletSecretsConfig.StatusProxyStageName, thirdpartyServicesEnabled, walletSecretsConfig.EthRpcProxyUsePuzzleAuth),
+		defaultNetworks(proxyHost, thirdpartyServicesEnabled, walletSecretsConfig.EthRpcProxyUsePuzzleAuth),
 		walletSecretsConfig,
 	)
 	return networkhelper.WithCommunitiesSupported(networks)

--- a/params/networkdefaults/default_networks_config.go
+++ b/params/networkdefaults/default_networks_config.go
@@ -13,7 +13,6 @@ var defaultNetworkSpecs = []networkSpec{
 		chainName:        "Ethereum",
 		providers: []providerSpec{
 			{providerType: providerTypeEthRpcProxy, name: common.StatusSmartProxy},
-			{providerType: providerTypeProxy, name: common.ProxyInfura, targetProvider: common.Infura},
 			{providerType: providerTypeDirect, name: common.DirectInfura, directURL: security.NewSensitiveString("https://mainnet.infura.io/v3/"), enableRpsLimiter: true},
 			{providerType: providerTypeDirect, name: common.DirectGrove, directURL: security.NewSensitiveString("https://eth.rpc.grove.city/v1/")},
 			{providerType: providerTypeEthRpcProxyWithProvider, name: common.SmartProxyAlchemy, targetProvider: common.Alchemy},
@@ -38,7 +37,6 @@ var defaultNetworkSpecs = []networkSpec{
 		chainName:        "Hoodi",
 		providers: []providerSpec{
 			{providerType: providerTypeEthRpcProxy, name: common.StatusSmartProxy},
-			{providerType: providerTypeProxy, name: common.ProxyInfura, targetProvider: common.Infura},
 			{providerType: providerTypeDirect, name: common.DirectInfura, directURL: security.NewSensitiveString("https://hoodi.infura.io/v3/"), enableRpsLimiter: true},
 			{providerType: providerTypeEthRpcProxyWithProvider, name: common.SmartProxyAlchemy, targetProvider: common.Alchemy},
 		},
@@ -62,7 +60,6 @@ var defaultNetworkSpecs = []networkSpec{
 		chainName:        "Sepolia",
 		providers: []providerSpec{
 			{providerType: providerTypeEthRpcProxy, name: common.StatusSmartProxy},
-			{providerType: providerTypeProxy, name: common.ProxyInfura, targetProvider: common.Infura},
 			{providerType: providerTypeDirect, name: common.DirectInfura, directURL: security.NewSensitiveString("https://sepolia.infura.io/v3/"), enableRpsLimiter: true},
 			{providerType: providerTypeDirect, name: common.DirectGrove, directURL: security.NewSensitiveString("https://eth-sepolia-testnet.rpc.grove.city/v1/")},
 			{providerType: providerTypeEthRpcProxyWithProvider, name: common.SmartProxyAlchemy, targetProvider: common.Alchemy},
@@ -87,7 +84,6 @@ var defaultNetworkSpecs = []networkSpec{
 		chainName:        "Optimism",
 		providers: []providerSpec{
 			{providerType: providerTypeEthRpcProxy, name: common.StatusSmartProxy},
-			{providerType: providerTypeProxy, name: common.ProxyInfura, targetProvider: common.Infura},
 			{providerType: providerTypeDirect, name: common.DirectInfura, directURL: security.NewSensitiveString("https://optimism-mainnet.infura.io/v3/"), enableRpsLimiter: true},
 			{providerType: providerTypeDirect, name: common.DirectGrove, directURL: security.NewSensitiveString("https://optimism.rpc.grove.city/v1/")},
 			{providerType: providerTypeEthRpcProxyWithProvider, name: common.SmartProxyAlchemy, targetProvider: common.Alchemy},
@@ -112,7 +108,6 @@ var defaultNetworkSpecs = []networkSpec{
 		chainName:        "Optimism Sepolia",
 		providers: []providerSpec{
 			{providerType: providerTypeEthRpcProxy, name: common.StatusSmartProxy},
-			{providerType: providerTypeProxy, name: common.ProxyInfura, targetProvider: common.Infura},
 			{providerType: providerTypeDirect, name: common.DirectInfura, directURL: security.NewSensitiveString("https://optimism-sepolia.infura.io/v3/"), enableRpsLimiter: true},
 			{providerType: providerTypeDirect, name: common.DirectGrove, directURL: security.NewSensitiveString("https://optimism-sepolia-testnet.rpc.grove.city/v1/")},
 			{providerType: providerTypeEthRpcProxyWithProvider, name: common.SmartProxyAlchemy, targetProvider: common.Alchemy},
@@ -137,7 +132,6 @@ var defaultNetworkSpecs = []networkSpec{
 		chainName:        "Arbitrum",
 		providers: []providerSpec{
 			{providerType: providerTypeEthRpcProxy, name: common.StatusSmartProxy},
-			{providerType: providerTypeProxy, name: common.ProxyInfura, targetProvider: common.Infura},
 			{providerType: providerTypeDirect, name: common.DirectInfura, directURL: security.NewSensitiveString("https://arbitrum-mainnet.infura.io/v3/"), enableRpsLimiter: true},
 			{providerType: providerTypeDirect, name: common.DirectGrove, directURL: security.NewSensitiveString("https://arbitrum-one.rpc.grove.city/v1/")},
 			{providerType: providerTypeEthRpcProxyWithProvider, name: common.SmartProxyAlchemy, targetProvider: common.Alchemy},
@@ -162,7 +156,6 @@ var defaultNetworkSpecs = []networkSpec{
 		chainName:        "Arbitrum Sepolia",
 		providers: []providerSpec{
 			{providerType: providerTypeEthRpcProxy, name: common.StatusSmartProxy},
-			{providerType: providerTypeProxy, name: common.ProxyInfura, targetProvider: common.Infura},
 			{providerType: providerTypeDirect, name: common.DirectInfura, directURL: security.NewSensitiveString("https://arbitrum-sepolia.infura.io/v3/"), enableRpsLimiter: true},
 			{providerType: providerTypeDirect, name: common.DirectGrove, directURL: security.NewSensitiveString("https://arbitrum-sepolia-testnet.rpc.grove.city/v1/")},
 			{providerType: providerTypeEthRpcProxyWithProvider, name: common.SmartProxyAlchemy, targetProvider: common.Alchemy},
@@ -187,7 +180,6 @@ var defaultNetworkSpecs = []networkSpec{
 		chainName:        "Base",
 		providers: []providerSpec{
 			{providerType: providerTypeEthRpcProxy, name: common.StatusSmartProxy},
-			{providerType: providerTypeProxy, name: common.ProxyInfura, targetProvider: common.Infura},
 			{providerType: providerTypeDirect, name: common.DirectInfura, directURL: security.NewSensitiveString("https://base-mainnet.infura.io/v3/"), enableRpsLimiter: true},
 			{providerType: providerTypeDirect, name: common.DirectGrove, directURL: security.NewSensitiveString("https://base.rpc.grove.city/v1/")},
 			{providerType: providerTypeEthRpcProxyWithProvider, name: common.SmartProxyAlchemy, targetProvider: common.Alchemy},
@@ -212,7 +204,6 @@ var defaultNetworkSpecs = []networkSpec{
 		chainName:        "Base Sepolia",
 		providers: []providerSpec{
 			{providerType: providerTypeEthRpcProxy, name: common.StatusSmartProxy},
-			{providerType: providerTypeProxy, name: common.ProxyInfura, targetProvider: common.Infura},
 			{providerType: providerTypeDirect, name: common.DirectInfura, directURL: security.NewSensitiveString("https://base-sepolia.infura.io/v3/"), enableRpsLimiter: true},
 			{providerType: providerTypeDirect, name: common.DirectGrove, directURL: security.NewSensitiveString("https://base-testnet.rpc.grove.city/v1/")},
 			{providerType: providerTypeEthRpcProxyWithProvider, name: common.SmartProxyAlchemy, targetProvider: common.Alchemy},
@@ -237,7 +228,6 @@ var defaultNetworkSpecs = []networkSpec{
 		chainName:        "Linea",
 		providers: []providerSpec{
 			{providerType: providerTypeEthRpcProxy, name: common.StatusSmartProxy},
-			{providerType: providerTypeProxy, name: common.ProxyInfura, targetProvider: common.Infura},
 			{providerType: providerTypeDirect, name: common.DirectInfura, directURL: security.NewSensitiveString("https://linea-mainnet.infura.io/v3/"), enableRpsLimiter: true},
 			{providerType: providerTypeDirect, name: common.DirectGrove, directURL: security.NewSensitiveString("https://linea.rpc.grove.city/v1/")},
 			{providerType: providerTypeEthRpcProxyWithProvider, name: common.SmartProxyAlchemy, targetProvider: common.Alchemy},
@@ -262,7 +252,6 @@ var defaultNetworkSpecs = []networkSpec{
 		chainName:        "Linea Sepolia",
 		providers: []providerSpec{
 			{providerType: providerTypeEthRpcProxy, name: common.StatusSmartProxy},
-			{providerType: providerTypeProxy, name: common.ProxyInfura, targetProvider: common.Infura},
 			{providerType: providerTypeDirect, name: common.DirectInfura, directURL: security.NewSensitiveString("https://linea-sepolia.infura.io/v3/"), enableRpsLimiter: true},
 			{providerType: providerTypeDirect, name: common.DirectGrove, directURL: security.NewSensitiveString("https://linea-sepolia-testnet.rpc.grove.city/v1/")},
 			{providerType: providerTypeEthRpcProxyWithProvider, name: common.SmartProxyAlchemy, targetProvider: common.Alchemy},
@@ -287,7 +276,6 @@ var defaultNetworkSpecs = []networkSpec{
 		chainName:        "Unichain",
 		providers: []providerSpec{
 			{providerType: providerTypeEthRpcProxy, name: common.StatusSmartProxy},
-			{providerType: providerTypeProxy, name: common.ProxyInfura, targetProvider: common.Infura},
 			{providerType: providerTypeDirect, name: common.DirectInfura, directURL: security.NewSensitiveString("https://unichain-mainnet.infura.io/v3/"), enableRpsLimiter: true},
 			{providerType: providerTypeDirect, name: common.DirectCustom, directURL: security.NewSensitiveString("https://mainnet.unichain.org"), enableRpsLimiter: true},
 			{providerType: providerTypeEthRpcProxyWithProvider, name: common.SmartProxyAlchemy, targetProvider: common.Alchemy},
@@ -312,7 +300,6 @@ var defaultNetworkSpecs = []networkSpec{
 		chainName:        "Unichain Sepolia",
 		providers: []providerSpec{
 			{providerType: providerTypeEthRpcProxy, name: common.StatusSmartProxy},
-			{providerType: providerTypeProxy, name: common.ProxyInfura, targetProvider: common.Infura},
 			{providerType: providerTypeDirect, name: common.DirectInfura, directURL: security.NewSensitiveString("https://unichain-sepolia.infura.io/v3/"), enableRpsLimiter: true},
 			{providerType: providerTypeDirect, name: common.DirectCustom, directURL: security.NewSensitiveString("https://sepolia.unichain.org"), enableRpsLimiter: true},
 			{providerType: providerTypeEthRpcProxyWithProvider, name: common.SmartProxyAlchemy, targetProvider: common.Alchemy},
@@ -481,7 +468,6 @@ var defaultNetworkSpecs = []networkSpec{
 		chainName:        "ZKsync",
 		providers: []providerSpec{
 			{providerType: providerTypeEthRpcProxy, name: common.StatusSmartProxy},
-			{providerType: providerTypeProxy, name: common.ProxyInfura, targetProvider: common.Infura},
 			{providerType: providerTypeDirect, name: common.DirectInfura, directURL: security.NewSensitiveString("https://zksync-mainnet.infura.io/v3/"), enableRpsLimiter: true},
 			{providerType: providerTypeDirect, name: common.DirectCustom, directURL: security.NewSensitiveString("https://mainnet.era.zksync.io"), enableRpsLimiter: true},
 			{providerType: providerTypeEthRpcProxyWithProvider, name: common.SmartProxyAlchemy, targetProvider: common.Alchemy},
@@ -506,7 +492,6 @@ var defaultNetworkSpecs = []networkSpec{
 		chainName:        "ZKsync Sepolia",
 		providers: []providerSpec{
 			{providerType: providerTypeEthRpcProxy, name: common.StatusSmartProxy},
-			{providerType: providerTypeProxy, name: common.ProxyInfura, targetProvider: common.Infura},
 			{providerType: providerTypeDirect, name: common.DirectInfura, directURL: security.NewSensitiveString("https://zksync-sepolia.infura.io/v3/"), enableRpsLimiter: true},
 			{providerType: providerTypeDirect, name: common.DirectCustom, directURL: security.NewSensitiveString("https://sepolia.era.zksync.dev"), enableRpsLimiter: true},
 			{providerType: providerTypeEthRpcProxyWithProvider, name: common.SmartProxyAlchemy, targetProvider: common.Alchemy},
@@ -579,7 +564,6 @@ var defaultNetworkSpecs = []networkSpec{
 		chainName:        "Scroll",
 		providers: []providerSpec{
 			{providerType: providerTypeEthRpcProxy, name: common.StatusSmartProxy},
-			{providerType: providerTypeProxy, name: common.ProxyInfura, targetProvider: common.Infura},
 			{providerType: providerTypeDirect, name: common.DirectInfura, directURL: security.NewSensitiveString("https://scroll-mainnet.infura.io/v3/"), enableRpsLimiter: true},
 			{providerType: providerTypeDirect, name: common.DirectCustom, directURL: security.NewSensitiveString("https://rpc.scroll.io"), enableRpsLimiter: true},
 			{providerType: providerTypeEthRpcProxyWithProvider, name: common.SmartProxyAlchemy, targetProvider: common.Alchemy},
@@ -604,7 +588,6 @@ var defaultNetworkSpecs = []networkSpec{
 		chainName:        "Scroll Sepolia",
 		providers: []providerSpec{
 			{providerType: providerTypeEthRpcProxy, name: common.StatusSmartProxy},
-			{providerType: providerTypeProxy, name: common.ProxyInfura, targetProvider: common.Infura},
 			{providerType: providerTypeDirect, name: common.DirectInfura, directURL: security.NewSensitiveString("https://scroll-sepolia.infura.io/v3/"), enableRpsLimiter: true},
 			{providerType: providerTypeDirect, name: common.DirectCustom, directURL: security.NewSensitiveString("https://sepolia-rpc.scroll.io"), enableRpsLimiter: true},
 			{providerType: providerTypeEthRpcProxyWithProvider, name: common.SmartProxyAlchemy, targetProvider: common.Alchemy},
@@ -629,7 +612,6 @@ var defaultNetworkSpecs = []networkSpec{
 		chainName:        "Blast",
 		providers: []providerSpec{
 			{providerType: providerTypeEthRpcProxy, name: common.StatusSmartProxy},
-			{providerType: providerTypeProxy, name: common.ProxyInfura, targetProvider: common.Infura},
 			{providerType: providerTypeDirect, name: common.DirectInfura, directURL: security.NewSensitiveString("https://blast-mainnet.infura.io/v3/"), enableRpsLimiter: true},
 			{providerType: providerTypeDirect, name: common.DirectCustom, directURL: security.NewSensitiveString("https://rpc.blast.io"), enableRpsLimiter: true},
 			{providerType: providerTypeEthRpcProxyWithProvider, name: common.SmartProxyAlchemy, targetProvider: common.Alchemy},
@@ -654,7 +636,6 @@ var defaultNetworkSpecs = []networkSpec{
 		chainName:        "Blast Sepolia",
 		providers: []providerSpec{
 			{providerType: providerTypeEthRpcProxy, name: common.StatusSmartProxy},
-			{providerType: providerTypeProxy, name: common.ProxyInfura, targetProvider: common.Infura},
 			{providerType: providerTypeDirect, name: common.DirectInfura, directURL: security.NewSensitiveString("https://blast-sepolia.infura.io/v3/"), enableRpsLimiter: true},
 			{providerType: providerTypeDirect, name: common.DirectCustom, directURL: security.NewSensitiveString("https://sepolia.blast.io"), enableRpsLimiter: true},
 			{providerType: providerTypeEthRpcProxyWithProvider, name: common.SmartProxyAlchemy, targetProvider: common.Alchemy},

--- a/params/networkdefaults/default_networks_test.go
+++ b/params/networkdefaults/default_networks_test.go
@@ -64,11 +64,6 @@ func TestBuildDefaultNetworks(t *testing.T) {
 		}
 		require.NoError(t, err)
 
-		// legacy default proxy fields are no longer populated
-		require.Empty(t, n.DefaultRPCURL)
-		require.Empty(t, n.DefaultFallbackURL)
-		require.Empty(t, n.DefaultFallbackURL2)
-
 		// check fallback options
 		if strings.Contains(n.RPCURL, "infura.io") {
 			require.True(t, strings.Contains(n.RPCURL, infuraToken.Reveal()))

--- a/params/networkdefaults/default_networks_test.go
+++ b/params/networkdefaults/default_networks_test.go
@@ -5,12 +5,11 @@ import (
 	"testing"
 
 	"github.com/pkg/errors"
-	"github.com/stretchr/testify/require"
-
 	"github.com/status-im/status-go/params"
 	"github.com/status-im/status-go/pkg/security"
 	"github.com/status-im/status-go/protocol/requests"
 	"github.com/status-im/status-go/services/wallet/common"
+	"github.com/stretchr/testify/require"
 )
 
 func TestBuildDefaultNetworks(t *testing.T) {
@@ -65,16 +64,10 @@ func TestBuildDefaultNetworks(t *testing.T) {
 		}
 		require.NoError(t, err)
 
-		// check default chains
-		if n.DefaultRPCURL != "" {
-			require.True(t, strings.Contains(n.DefaultRPCURL, stageName))
-		}
-		if n.DefaultFallbackURL != "" {
-			require.True(t, strings.Contains(n.DefaultFallbackURL, stageName))
-		}
-		if n.DefaultFallbackURL2 != "" {
-			require.True(t, strings.Contains(actualNetworks[0].DefaultFallbackURL2, stageName))
-		}
+		// legacy default proxy fields are no longer populated
+		require.Empty(t, n.DefaultRPCURL)
+		require.Empty(t, n.DefaultFallbackURL)
+		require.Empty(t, n.DefaultFallbackURL2)
 
 		// check fallback options
 		if strings.Contains(n.RPCURL, "infura.io") {
@@ -82,13 +75,6 @@ func TestBuildDefaultNetworks(t *testing.T) {
 		}
 		if strings.Contains(n.FallbackURL, "grove.city") {
 			require.True(t, strings.Contains(n.FallbackURL, poktToken.Reveal()))
-		}
-
-		// Check proxy providers for stageName
-		for _, provider := range n.RpcProviders {
-			if provider.Type == params.EmbeddedProxyProviderType {
-				require.Contains(t, provider.URL.Reveal(), stageName, "Proxy provider URL should contain stageName")
-			}
 		}
 
 		// Check direct providers for tokens

--- a/params/networkhelper/provider_utils_test.go
+++ b/params/networkhelper/provider_utils_test.go
@@ -27,16 +27,16 @@ func TestMergeProvidersPreserveEnabledAndOrder(t *testing.T) {
 		*params.NewUserProvider(chainID, "UserProvider1", security.NewSensitiveString("https://userprovider1.example.com"), true),
 		*params.NewUserProvider(chainID, "UserProvider2", security.NewSensitiveString("https://userprovider2.example.com"), true),
 		*params.NewDirectProvider(chainID, "EmbeddedProvider1", security.NewSensitiveString("https://embeddedprovider1.example.com"), true),
-		*params.NewProxyProvider(chainID, "EmbeddedProvider2", security.NewSensitiveString("https://embeddedprovider2.example.com"), true),
+		*params.NewEthRpcProxyProvider(chainID, "EmbeddedProvider2", security.NewSensitiveString("https://embeddedprovider2.example.com"), true, false),
 	}
 	currentProviders[1].Enabled = false // UserProvider2 is disabled
 	currentProviders[2].Enabled = false // EmbeddedProvider1 is disabled
 
 	// New providers to merge
 	newProviders := []params.RpcProvider{
-		*params.NewDirectProvider(chainID, "EmbeddedProvider1", security.NewSensitiveString("https://embeddedprovider1-new.example.com"), true), // Should retain Enabled: false
-		*params.NewProxyProvider(chainID, "EmbeddedProvider3", security.NewSensitiveString("https://embeddedprovider3.example.com"), true),      // New embedded provider
-		*params.NewDirectProvider(chainID, "EmbeddedProvider4", security.NewSensitiveString("https://embeddedprovider4.example.com"), true),     // New embedded provider
+		*params.NewDirectProvider(chainID, "EmbeddedProvider1", security.NewSensitiveString("https://embeddedprovider1-new.example.com"), true),         // Should retain Enabled: false
+		*params.NewEthRpcProxyProvider(chainID, "EmbeddedProvider3", security.NewSensitiveString("https://embeddedprovider3.example.com"), true, false), // New embedded provider
+		*params.NewDirectProvider(chainID, "EmbeddedProvider4", security.NewSensitiveString("https://embeddedprovider4.example.com"), true),             // New embedded provider
 	}
 
 	// Call MergeProviders
@@ -62,12 +62,12 @@ func TestOverrideBasicAuth(t *testing.T) {
 	networks := []params.Network{
 		*testutil.CreateNetwork(walletcommon.EthereumMainnet, "Ethereum Mainnet", []params.RpcProvider{
 			*params.NewUserProvider(walletcommon.EthereumMainnet, "Provider1", security.NewSensitiveString("https://userprovider.example.com"), true),
-			*params.NewProxyProvider(walletcommon.EthereumMainnet, "Provider2", security.NewSensitiveString("https://proxyprovider.example.com"), true),
+			*params.NewEthRpcProxyProvider(walletcommon.EthereumMainnet, "Provider2", security.NewSensitiveString("https://ethrpcproxy.example.com"), true, false),
 			*params.NewEthRpcProxyProvider(walletcommon.EthereumMainnet, "Provider3", security.NewSensitiveString("https://ethrpcproxy.example.com"), true, false),
 		}),
 		*testutil.CreateNetwork(walletcommon.OptimismMainnet, "Optimism", []params.RpcProvider{
 			*params.NewDirectProvider(walletcommon.OptimismMainnet, "Provider4", security.NewSensitiveString("https://directprovider.example.com"), true),
-			*params.NewProxyProvider(walletcommon.OptimismMainnet, "Provider5", security.NewSensitiveString("https://proxyprovider2.example.com"), true),
+			*params.NewEthRpcProxyProvider(walletcommon.OptimismMainnet, "Provider5", security.NewSensitiveString("https://ethrpcproxy2.example.com"), true, false),
 			*params.NewEthRpcProxyProvider(walletcommon.OptimismMainnet, "Provider6", security.NewSensitiveString("https://ethrpcproxy2.example.com"), true, false),
 		}),
 	}
@@ -76,37 +76,10 @@ func TestOverrideBasicAuth(t *testing.T) {
 	networks[1].RpcProviders[1].Enabled = false
 	networks[1].RpcProviders[2].Enabled = false
 
-	user := security.NewSensitiveString(gofakeit.Username())
-	password := security.NewSensitiveString(gofakeit.LetterN(5))
-
-	// Test updating EmbeddedProxyProviderType providers
-	updatedNetworks := networkhelper.OverrideBasicAuth(networks, params.EmbeddedProxyProviderType, true, user, password)
-
-	// Verify the networks
-	for i, network := range updatedNetworks {
-		networkCopy := network
-		expectedNetwork := &networks[i]
-		testutil.CompareNetworks(t, expectedNetwork, &networkCopy)
-
-		for j, provider := range networkCopy.RpcProviders {
-			expectedProvider := expectedNetwork.RpcProviders[j]
-			if provider.Type == params.EmbeddedProxyProviderType {
-				assert.True(t, provider.Enabled, "Provider Enabled state should be overridden")
-				assert.Equal(t, user, provider.AuthLogin, "Provider AuthLogin should be overridden")
-				assert.Equal(t, password, provider.AuthPassword, "Provider AuthPassword should be overridden")
-				assert.Equal(t, params.BasicAuth, provider.AuthType, "Provider AuthType should be set to BasicAuth")
-			} else {
-				assert.Equal(t, expectedProvider.Enabled, provider.Enabled, "Provider Enabled state should remain unchanged")
-				assert.Equal(t, expectedProvider.AuthLogin, provider.AuthLogin, "Provider AuthLogin should remain unchanged")
-				assert.Equal(t, expectedProvider.AuthPassword, provider.AuthPassword, "Provider AuthPassword should remain unchanged")
-			}
-		}
-	}
-
 	// Test updating EmbeddedEthRpcProxyProviderType providers
 	user2 := security.NewSensitiveString(gofakeit.Username())
 	password2 := security.NewSensitiveString(gofakeit.LetterN(5))
-	updatedNetworks = networkhelper.OverrideBasicAuth(networks, params.EmbeddedEthRpcProxyProviderType, true, user2, password2)
+	updatedNetworks := networkhelper.OverrideBasicAuth(networks, params.EmbeddedEthRpcProxyProviderType, true, user2, password2)
 
 	// Verify the networks
 	for i, network := range updatedNetworks {

--- a/pkg/backend/defaults.go
+++ b/pkg/backend/defaults.go
@@ -218,12 +218,6 @@ func buildWalletConfig(walletRequest *requests.WalletConfig, request *requests.W
 	if len(walletRequest.CustomTokens) > 0 {
 		walletConfig.CustomTokens = walletRequest.CustomTokens
 	}
-	if !request.StatusProxyUser.Empty() {
-		walletConfig.StatusProxyUser = request.StatusProxyUser
-	}
-	if !request.StatusProxyPassword.Empty() {
-		walletConfig.StatusProxyPassword = request.StatusProxyPassword
-	}
 
 	if !request.EthRpcProxyUrl.Empty() {
 		walletConfig.EthRpcProxyUrl = request.EthRpcProxyUrl

--- a/protocol/requests/create_account.go
+++ b/protocol/requests/create_account.go
@@ -119,8 +119,6 @@ type WalletSecretsConfig struct {
 
 	CoingeckoAPIKey     security.SensitiveString `json:"coingeckoApiKey"`
 	CoingeckoDemoAPIKey security.SensitiveString `json:"coingeckoDemoApiKey"`
-	StatusProxyUser     security.SensitiveString `json:"statusProxyBlockchainUser"`
-	StatusProxyPassword security.SensitiveString `json:"statusProxyBlockchainPassword"`
 
 	EthRpcProxyUrl           security.SensitiveString `json:"ethRpcProxyUrl"`
 	EthRpcProxyUser          security.SensitiveString `json:"ethRpcProxyUser"`

--- a/services/connector/commands/test_helpers.go
+++ b/services/connector/commands/test_helpers.go
@@ -69,10 +69,10 @@ func setupNetworkManager(t *testing.T, db *sql.DB) *network.Manager {
 
 	initNetworks := []params.Network{
 		*network_testutil.CreateNetwork(walletCommon.EthereumMainnet, "Ethereum Mainnet", []params.RpcProvider{
-			network_testutil.CreateProvider(walletCommon.EthereumMainnet, "Infura Mainnet", params.EmbeddedProxyProviderType, true, security.NewSensitiveString("https://mainnet.infura.io")),
+			network_testutil.CreateProvider(walletCommon.EthereumMainnet, "Infura Mainnet", params.EmbeddedEthRpcProxyProviderType, true, security.NewSensitiveString("https://mainnet.infura.io")),
 		}),
 		*network_testutil.CreateNetwork(walletCommon.OptimismMainnet, "Optimism Mainnet", []params.RpcProvider{
-			network_testutil.CreateProvider(walletCommon.OptimismMainnet, "Optimism Mainnet", params.EmbeddedProxyProviderType, true, security.NewSensitiveString("https://mainnet.optimism.io")),
+			network_testutil.CreateProvider(walletCommon.OptimismMainnet, "Optimism Mainnet", params.EmbeddedEthRpcProxyProviderType, true, security.NewSensitiveString("https://mainnet.optimism.io")),
 		}),
 	}
 	require.NoError(t, networkManager.InitEmbeddedNetworks(initNetworks))

--- a/services/connector/test_helpers_test.go
+++ b/services/connector/test_helpers_test.go
@@ -77,10 +77,10 @@ func setupTests(t *testing.T) (state testState) {
 
 	initNetworks := []params.Network{
 		*network_testutil.CreateNetwork(walletCommon.EthereumMainnet, "Ethereum Mainnet", []params.RpcProvider{
-			network_testutil.CreateProvider(walletCommon.EthereumMainnet, "Infura Mainnet", params.EmbeddedProxyProviderType, true, security.NewSensitiveString("https://mainnet.infura.io")),
+			network_testutil.CreateProvider(walletCommon.EthereumMainnet, "Infura Mainnet", params.EmbeddedEthRpcProxyProviderType, true, security.NewSensitiveString("https://mainnet.infura.io")),
 		}),
 		*network_testutil.CreateNetwork(walletCommon.OptimismMainnet, "Optimism Mainnet", []params.RpcProvider{
-			network_testutil.CreateProvider(walletCommon.OptimismMainnet, "Optimism Mainnet", params.EmbeddedProxyProviderType, true, security.NewSensitiveString("https://mainnet.optimism.io")),
+			network_testutil.CreateProvider(walletCommon.OptimismMainnet, "Optimism Mainnet", params.EmbeddedEthRpcProxyProviderType, true, security.NewSensitiveString("https://mainnet.optimism.io")),
 		}),
 	}
 	err = networkManager.InitEmbeddedNetworks(initNetworks)

--- a/services/wallet/api_impl_test.go
+++ b/services/wallet/api_impl_test.go
@@ -60,12 +60,12 @@ func TestAPI_GetAddressDetails(t *testing.T) {
 
 	networks := []params.Network{
 		*testutil.CreateNetwork(chainID, "Ethereum Mainnet", []params.RpcProvider{
-			*params.NewProxyProvider(chainID, "Test Provider", security.NewSensitiveString(serverWith1SecDelay.URL+"/nodefleet/"), false),
+			*params.NewEthRpcProxyProvider(chainID, "Test Provider", security.NewSensitiveString(serverWith1SecDelay.URL+"/nodefleet/"), false, false),
 		},
 		),
 	}
 
-	networks = networkhelper.OverrideBasicAuth(networks, params.EmbeddedProxyProviderType, true, security.NewSensitiveString(gofakeit.Username()), security.NewSensitiveString(gofakeit.LetterN(5)))
+	networks = networkhelper.OverrideBasicAuth(networks, params.EmbeddedEthRpcProxyProviderType, true, security.NewSensitiveString(gofakeit.Username()), security.NewSensitiveString(gofakeit.LetterN(5)))
 	require.NotEmpty(t, networks)
 
 	config := rpc.ClientConfig{

--- a/services/wallet/router/router_test_data.go
+++ b/services/wallet/router/router_test_data.go
@@ -51,7 +51,6 @@ const (
 	stageName = "test"
 
 	// Provider types
-	proxyInfura  = "proxy-infura"
 	directInfura = "direct-infura"
 	directGrove  = "direct-grove"
 )
@@ -103,7 +102,7 @@ var mainnet = params.Network{
 	ChainID:   walletCommon.EthereumMainnet,
 	ChainName: "Ethereum",
 	RpcProviders: []params.RpcProvider{
-		*params.NewProxyProvider(walletCommon.EthereumMainnet, proxyInfura, security.NewSensitiveStringPrintf("https://%s.api.status.im/infura/ethereum/mainnet/", stageName), false),
+		*params.NewEthRpcProxyProvider(walletCommon.EthereumMainnet, "status-smart-proxy", security.NewSensitiveStringPrintf("https://%s.eth-rpc.status.im/ethereum/mainnet/", stageName), false, false),
 		*params.NewDirectProvider(walletCommon.EthereumMainnet, directInfura, security.NewSensitiveString("https://mainnet.infura.io/v3/"), true),
 		*params.NewDirectProvider(walletCommon.EthereumMainnet, directGrove, security.NewSensitiveStringPrintf("https://eth-archival.rpc.grove.city/v1/"), false),
 	},
@@ -127,7 +126,7 @@ var optimism = params.Network{
 	ChainID:   walletCommon.OptimismMainnet,
 	ChainName: "Optimism",
 	RpcProviders: []params.RpcProvider{
-		*params.NewProxyProvider(walletCommon.OptimismMainnet, proxyInfura, security.NewSensitiveStringPrintf("https://%s.api.status.im/infura/optimism/mainnet/", stageName), false),
+		*params.NewEthRpcProxyProvider(walletCommon.OptimismMainnet, "status-smart-proxy", security.NewSensitiveStringPrintf("https://%s.eth-rpc.status.im/optimism/mainnet/", stageName), false, false),
 		*params.NewDirectProvider(walletCommon.OptimismMainnet, directInfura, security.NewSensitiveString("https://optimism-mainnet.infura.io/v3/"), true),
 		*params.NewDirectProvider(walletCommon.OptimismMainnet, directGrove, security.NewSensitiveString("https://optimism.rpc.grove.city/v1/"), false),
 	},
@@ -151,7 +150,7 @@ var arbitrum = params.Network{
 	ChainID:   walletCommon.ArbitrumMainnet,
 	ChainName: "Arbitrum",
 	RpcProviders: []params.RpcProvider{
-		*params.NewProxyProvider(walletCommon.ArbitrumMainnet, proxyInfura, security.NewSensitiveStringPrintf("https://%s.api.status.im/infura/arbitrum/mainnet/", stageName), false),
+		*params.NewEthRpcProxyProvider(walletCommon.ArbitrumMainnet, "status-smart-proxy", security.NewSensitiveStringPrintf("https://%s.eth-rpc.status.im/arbitrum/mainnet/", stageName), false, false),
 		*params.NewDirectProvider(walletCommon.ArbitrumMainnet, directInfura, security.NewSensitiveString("https://arbitrum-mainnet.infura.io/v3/"), true),
 		*params.NewDirectProvider(walletCommon.ArbitrumMainnet, directGrove, security.NewSensitiveString("https://arbitrum-one.rpc.grove.city/v1/"), false),
 	},
@@ -175,7 +174,7 @@ var base = params.Network{
 	ChainID:   walletCommon.BaseMainnet,
 	ChainName: "Base",
 	RpcProviders: []params.RpcProvider{
-		*params.NewProxyProvider(walletCommon.BaseMainnet, proxyInfura, security.NewSensitiveStringPrintf("https://%s.api.status.im/infura/base/mainnet/", stageName), false),
+		*params.NewEthRpcProxyProvider(walletCommon.BaseMainnet, "status-smart-proxy", security.NewSensitiveStringPrintf("https://%s.eth-rpc.status.im/base/mainnet/", stageName), false, false),
 		*params.NewDirectProvider(walletCommon.BaseMainnet, directInfura, security.NewSensitiveString("https://base-mainnet.infura.io/v3/"), true),
 		*params.NewDirectProvider(walletCommon.BaseMainnet, directGrove, security.NewSensitiveString("https://base.rpc.grove.city/v1/"), false),
 	},

--- a/tests-functional/clients/status_backend.py
+++ b/tests-functional/clients/status_backend.py
@@ -241,11 +241,6 @@ class StatusBackend(RpcClient, SignalClient, ApiClient):
         if "STATUS_BUILD_PROXY_USER" not in os.environ:
             return data
 
-        user = os.environ["STATUS_BUILD_PROXY_USER"]
-        password = os.environ["STATUS_BUILD_PROXY_PASSWORD"]
-
-        data["StatusProxyBlockchainUser"] = user
-        data["StatusProxyBlockchainPassword"] = password
         data["StatusProxyEnabled"] = True
         data["StatusProxyStageName"] = "test"
         return data


### PR DESCRIPTION
since api.status.im is shut down
closes https://github.com/status-im/status-go/issues/7477