### PR TITLE
feat: listen for community control messages on the default shard (32)

### DIFF
--- a/protocol/messenger_communities.go
+++ b/protocol/messenger_communities.go
@@ -2464,6 +2464,10 @@ func (m *Messenger) DefaultFilters(o *communities.Community) types2.ChatsToIniti
 		{ChatID: cID, PubsubTopic: communityPubsubTopic},
 		{ChatID: memberUpdateChannelID, PubsubTopic: communityPubsubTopic},
 		{ChatID: uncompressedPubKey, PubsubTopic: types2.DefaultNonProtectedPubsubTopic()},
+		// Migration phase 1 (#7498): also listen for community control messages on
+		// the default shard, so that when publishing moves off the non-protected
+		// shard (phase 2) clients already receive them. Sending is unchanged here.
+		{ChatID: uncompressedPubKey, PubsubTopic: types2.DefaultShardPubsubTopic()},
 	}
 }
 


### PR DESCRIPTION
Iterates:
- https://github.com/status-im/status-go/issues/7498

## What & why

**Phase 1** of migrating community control traffic onto a single pubsub topic — the default shard (**32**) — and dropping the non-protected shard (**64**). Tracking issue: #7498.

Clients start **listening** for community control on shard 32 in addition to shard 64, so that when publishing later moves to shard 32 (Phase 2), they already receive it. We can't move publishing first: deployed clients filter-subscribe to community control content topics on a fixed `(shard, content-topic)` pair (filter delivery is keyed on the exact pair), so they must learn to listen on 32 before anything is published there.

## Change

`DefaultFilters` now also registers the community broadcast topic on the default shard:

```go
{ChatID: uncompressedPubKey, PubsubTopic: types2.DefaultShardPubsubTopic()},
```

**Sending is unchanged** (still shard 64). Other receive paths already cover shard 32 — member personal topics default to shard 32, and control-node admin filters (`InitCommunityFilters`) cover both 32 and 64 — so this is the only receive change needed.

Purely additive (one extra filter); no existing path is altered.

## Next phases (see #7498)

- **Phase 2:** switch publishing to shard 32; keep listening on 64.
- **Phase 3:** drop shard-64 listening; remove `NonProtectedShardIndex` and related code.

## Notes

- Draft.
- Builds locally except for an unrelated `libsds.h` cgo dependency missing in my environment; gopls type-checks the change cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)