### PR TITLE
feat(messaging): decode incoming version=0 payloads as WakuV1

### DIFF
--- a/pkg/messaging/waku/common/filter_test.go
+++ b/pkg/messaging/waku/common/filter_test.go
@@ -152,6 +152,46 @@ func TestInstallIdenticalFilters(t *testing.T) {
 	require.NotNil(t, msg)
 }
 
+// TestOpenVersionZeroDecodesAsV1 covers the status-go#7499 migration: an
+// incoming message whose payload is WakuV1-encrypted but whose envelope is
+// labeled version=0 must still be decrypted (treated the same as version=1),
+// and the original envelope must be left untouched.
+func TestOpenVersionZeroDecodesAsV1(t *testing.T) {
+	filter, err := generateFilter(t, true)
+	require.NoError(t, err)
+
+	data := make([]byte, 20)
+	_, err = crand.Read(data) // nolint: gosec
+	require.NoError(t, err)
+
+	p := &payload.Payload{
+		Data: data,
+		Key:  &payload.KeyInfo{Kind: payload.Symmetric, SymKey: filter.KeySym},
+	}
+	encoded, err := p.Encode(1) // WakuV1 encryption
+	require.NoError(t, err)
+
+	// Label the envelope version=0 while the payload stays v1-encrypted.
+	var versionZero uint32
+	msg := &pb.WakuMessage{
+		Payload:      encoded,
+		Version:      &versionZero,
+		ContentTopic: maps.Keys(filter.ContentTopics)[0].ContentTopic(),
+		Timestamp:    proto.Int64(time.Now().UnixNano()),
+		Meta:         []byte{},
+	}
+	envelope := protocol.NewEnvelope(msg, time.Now().UnixNano(), filter.PubsubTopic)
+	received := NewReceivedMessage(envelope, "test")
+	received.SymKeyHash = crypto.Keccak256Hash(filter.KeySym)
+
+	opened := received.Open(filter)
+	require.NotNil(t, opened, "version=0 message should be decoded as WakuV1")
+	require.Equal(t, data, opened.Data)
+
+	// We clone before overriding, so the original envelope keeps version=0.
+	require.Equal(t, uint32(0), received.Envelope.Message().GetVersion())
+}
+
 func TestInstallFilterWithSymAndAsymKeys(t *testing.T) {
 	filters := NewFilters(testShard, createLogger(t))
 	filter1, _ := generateFilter(t, true)

--- a/pkg/messaging/waku/common/message.go
+++ b/pkg/messaging/waku/common/message.go
@@ -6,8 +6,10 @@ import (
 	"time"
 
 	"go.uber.org/zap"
+	"google.golang.org/protobuf/proto"
 
 	"github.com/waku-org/go-waku/waku/v2/payload"
+	"github.com/waku-org/go-waku/waku/v2/protocol/pb"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
@@ -175,7 +177,23 @@ func (msg *ReceivedMessage) Open(watcher *Filter) (result *ReceivedMessage) {
 		msg.SymKeyHash = crypto.Keccak256Hash(watcher.KeySym)
 	}
 
-	raw, err := payload.DecodePayload(msg.Envelope.Message(), keyInfo)
+	wakuMsg := msg.Envelope.Message()
+
+	// Migration to retire the WakuMessage `version` field (status-go#7499):
+	// always decode incoming payloads as WakuV1-encrypted, treating version=0
+	// the same as version=1. status-go only ever emits version=1, so a
+	// version=0 envelope is never genuine plaintext; once later releases start
+	// publishing version=0 with v1-encoded payloads, they must still decrypt
+	// here. We clone before overriding so the original envelope (hash, storage)
+	// is untouched, and only force this when the filter has a decryption key —
+	// keyless filters keep the legacy "return payload as-is" behaviour.
+	if wakuMsg.GetVersion() == 0 && (keyInfo.Kind == payload.Symmetric || keyInfo.Kind == payload.Asymmetric) {
+		wakuMsg = proto.Clone(wakuMsg).(*pb.WakuMessage)
+		forcedVersion := uint32(1)
+		wakuMsg.Version = &forcedVersion
+	}
+
+	raw, err := payload.DecodePayload(wakuMsg, keyInfo)
 
 	if err != nil {
 		logutils.ZapLogger().Error("failed to decode message", zap.Error(err))


### PR DESCRIPTION
Phase 1 of retiring the WakuMessage `version` field (#7499) — receive side only, for v2.38.

## What

On receive, decode incoming `version=0` envelopes as WakuV1-encrypted, exactly like `version=1`, whenever the matching filter has a decryption key.

## Why

To adopt the logos-delivery Messaging API (which publishes `version=0`) without a wire-format break, every release must interoperate with N±1. Teaching receivers to accept `version=0`-as-encrypted **before** any sender emits it is the prerequisite: a later release can then publish `version=0` with v1-encoded payloads and its N-1 neighbour still decrypts.

Safe because status-go only ever emits `version=1` (verified: the sole version-setting site, `waku/api.go`, hardcodes `1`; `NewMessage` has no version field), so there is no genuine plaintext-v0 traffic this could misread.

## Notes

- This does **not** drop WakuV1 encoding/encryption — payloads stay encrypted; only the receiver's interpretation of the `version` label changes.
- The envelope is cloned before the version is overridden, so its hash/storage are untouched.
- Keyless filters keep the legacy "return payload as-is" behaviour.
- Does not depend on #7484 (codec relocation, develop only); this branch still uses go-waku's `payload` codec.

Draft: opening for review of the approach on the release branch.
