### PR TITLE
test: align push notification test with new default message text

### DIFF
--- a/tests-functional/tests/test_push_notification_server.py
+++ b/tests-functional/tests/test_push_notification_server.py
@@ -10,7 +10,7 @@ from steps import messenger
 from utils import keys
 
 APN_TOPIC = "im.status.ethereum"
-DEFAULT_PUSH_MESSAGE = "You have a new message"
+DEFAULT_PUSH_MESSAGE = "New message in Messenger"
 
 
 @pytest.fixture


### PR DESCRIPTION
Fixes #7501.

#7459 changed the default 1:1 push message from `"You have a new message"` to `"New message in Messenger"`, but `TestPushNotificationServer` still asserted the old string and failed on this branch. Updates the test's expected message to match.

`develop` needs no change: #7459 isn't there yet, so its server constant and the test still agree on the old string. This update should ride along when #7459 is forward-ported.