### PR TITLE
refactor(transport): remove EnvelopesMonitor's internal retry

### DIFF
--- a/pkg/messaging/core_config.go
+++ b/pkg/messaging/core_config.go
@@ -63,7 +63,6 @@ func WithEnvelopeEventsConfig(econf *types2.EnvelopeEventsConfig) Options {
 	return func(c *config) {
 		if econf != nil {
 			c.envelopesMonitorConfig.EnvelopeEventsHandler = econf.EnvelopeEventsHandler
-			c.envelopesMonitorConfig.MaxAttempts = econf.MaxMessageDeliveryAttempts
 			c.envelopesMonitorConfig.AwaitOnlyMailServerConfirmations = econf.MailServerConfirmations
 		}
 	}

--- a/pkg/messaging/layers/transport/envelopes_monitor.go
+++ b/pkg/messaging/layers/transport/envelopes_monitor.go
@@ -1,11 +1,8 @@
 package transport
 
 import (
-	"context"
 	"errors"
-	"math"
 	"sync"
-	"time"
 
 	"go.uber.org/zap"
 
@@ -28,7 +25,6 @@ const (
 
 type EnvelopesMonitorConfig struct {
 	EnvelopeEventsHandler            EnvelopeEventsHandler
-	MaxAttempts                      int
 	AwaitOnlyMailServerConfirmations bool
 	IsMailserver                     func(types.EnodeID) bool
 	Logger                           *zap.Logger
@@ -50,17 +46,10 @@ func NewEnvelopesMonitor(w types.Waku, config EnvelopesMonitorConfig) *Envelopes
 		logger = zap.NewNop()
 	}
 
-	var api types.PublicWakuAPI
-	if w != nil {
-		api = w.PublicWakuAPI()
-	}
-
 	return &EnvelopesMonitor{
 		w:                                w,
-		api:                              api,
 		handler:                          config.EnvelopeEventsHandler,
 		awaitOnlyMailServerConfirmations: config.AwaitOnlyMailServerConfirmations,
-		maxAttempts:                      config.MaxAttempts,
 		isMailserver:                     config.IsMailserver,
 		logger:                           logger.With(zap.Namespace("EnvelopesMonitor")),
 
@@ -76,27 +65,21 @@ func NewEnvelopesMonitor(w types.Waku, config EnvelopesMonitorConfig) *Envelopes
 }
 
 type monitoredEnvelope struct {
-	envelopeHashID  types2.Hash
-	state           EnvelopeState
-	attempts        int
-	message         *types.NewMessage
-	messageIDs      [][]byte
-	lastAttemptTime time.Time
+	envelopeHashID types2.Hash
+	state          EnvelopeState
+	messageIDs     [][]byte
 }
 
 // EnvelopesMonitor is responsible for monitoring waku envelopes state.
 type EnvelopesMonitor struct {
 	gocommon.PauseBroadcaster
 
-	w           types.Waku
-	api         types.PublicWakuAPI
-	handler     EnvelopeEventsHandler
-	maxAttempts int
+	w       types.Waku
+	handler EnvelopeEventsHandler
 
 	mu sync.Mutex
 
 	envelopes             map[types2.Hash]*monitoredEnvelope
-	retryQueue            []*monitoredEnvelope
 	batches               map[types2.Hash]map[types2.Hash]struct{}
 	messageEnvelopeHashes map[string][]types2.Hash
 
@@ -112,16 +95,11 @@ type EnvelopesMonitor struct {
 // Start processing events.
 func (m *EnvelopesMonitor) Start() {
 	m.quit = make(chan struct{})
-	m.wg.Add(2)
-	go func() {
-		defer gocommon.LogOnPanic()
-		m.handleEnvelopeEvents()
-		m.wg.Done()
-	}()
+	m.wg.Add(1)
 	go func() {
 		defer gocommon.LogOnPanic()
 		defer m.wg.Done()
-		m.retryLoop()
+		m.handleEnvelopeEvents()
 	}()
 }
 
@@ -145,15 +123,12 @@ func (m *EnvelopesMonitor) Add(messageIDs [][]byte, envelopeHashes []types2.Hash
 		m.messageEnvelopeHashes[types2.HexBytes(messageID).String()] = envelopeHashes
 	}
 
-	for i, envelopeHash := range envelopeHashes {
+	for _, envelopeHash := range envelopeHashes {
 		if _, ok := m.envelopes[envelopeHash]; !ok {
 			m.envelopes[envelopeHash] = &monitoredEnvelope{
-				envelopeHashID:  envelopeHash,
-				state:           EnvelopePosted,
-				attempts:        1,
-				lastAttemptTime: time.Now(),
-				message:         messages[i],
-				messageIDs:      messageIDs,
+				envelopeHashID: envelopeHash,
+				state:          EnvelopePosted,
+				messageIDs:     messageIDs,
 			}
 		}
 	}
@@ -300,85 +275,22 @@ func (m *EnvelopesMonitor) handleEventEnvelopeExpired(event types.EnvelopeEvent)
 
 // handleEnvelopeFailure is a common code path for processing envelopes failures. not thread safe, lock
 // must be used on a higher level.
+//
+// Transport-level retry was removed (logos-messaging/pm#380): logos-delivery
+// performs retransmission internally. A failed envelope is now reported as
+// expired immediately; the message stays unconfirmed and the app layer (raw
+// message resend) remains the backstop until the Messaging API is integrated.
 func (m *EnvelopesMonitor) handleEnvelopeFailure(hash types2.Hash, err error) {
 	if envelope, ok := m.envelopes[hash]; ok {
 		m.clearMessageState(hash)
 		if envelope.state == EnvelopeSent {
 			return
 		}
-		if envelope.attempts < m.maxAttempts {
-			m.retryQueue = append(m.retryQueue, envelope)
-		} else {
-			m.logger.Debug("envelope expired", zap.String("hash", hash.String()))
-			m.removeFromRetryQueue(hash)
-			if m.handler != nil {
-				m.handler.EnvelopeExpired(envelope.messageIDs, err)
-			}
+		m.logger.Debug("envelope expired", zap.String("hash", hash.String()))
+		if m.handler != nil {
+			m.handler.EnvelopeExpired(envelope.messageIDs, err)
 		}
 	}
-}
-
-func backoffDuration(attempts int) time.Duration {
-	baseDelay := 1 * time.Second
-	maxDelay := 30 * time.Second
-	backoff := baseDelay * time.Duration(math.Pow(2, float64(attempts)))
-	if backoff > maxDelay {
-		backoff = maxDelay
-	}
-	return backoff
-}
-
-// retryLoop handles the retry logic to send envelope in a loop
-func (m *EnvelopesMonitor) retryLoop() {
-	sub := m.Subscribe()
-	defer sub.Unsubscribe()
-	pt := gocommon.NewPausableTicker(gocommon.PausableTickerConfig{
-		Interval: 500 * time.Millisecond,
-		OnTick:   m.retryOnce,
-	}, sub.C())
-	pt.Run(m.quit)
-}
-
-// retryOnce retries once
-func (m *EnvelopesMonitor) retryOnce() {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-
-	for _, envelope := range m.retryQueue {
-		if envelope.attempts < m.maxAttempts {
-			elapsed := time.Since(envelope.lastAttemptTime)
-			if elapsed < backoffDuration(envelope.attempts) {
-				continue
-			}
-
-			m.logger.Debug("retrying to send a message", zap.String("hash", envelope.envelopeHashID.String()), zap.Int("attempt", envelope.attempts+1))
-			hex, err := m.api.Post(context.TODO(), *envelope.message)
-			if err != nil {
-				m.logger.Error("failed to retry sending message", zap.String("hash", envelope.envelopeHashID.String()), zap.Int("attempt", envelope.attempts+1), zap.Error(err))
-				if m.handler != nil {
-					m.handler.EnvelopeExpired(envelope.messageIDs, err)
-				}
-			} else {
-				m.removeFromRetryQueue(envelope.envelopeHashID)
-				envelope.envelopeHashID = types2.BytesToHash(hex)
-			}
-			envelope.state = EnvelopePosted
-			envelope.attempts++
-			envelope.lastAttemptTime = time.Now()
-			m.envelopes[envelope.envelopeHashID] = envelope
-		}
-	}
-}
-
-// removeFromRetryQueue removes the specified envelope from the retry queue
-func (m *EnvelopesMonitor) removeFromRetryQueue(envelopeID types2.Hash) {
-	var newRetryQueue []*monitoredEnvelope
-	for _, envelope := range m.retryQueue {
-		if envelope.envelopeHashID != envelopeID {
-			newRetryQueue = append(newRetryQueue, envelope)
-		}
-	}
-	m.retryQueue = newRetryQueue
 }
 
 func (m *EnvelopesMonitor) handleEventEnvelopeReceived(event types.EnvelopeEvent) {

--- a/pkg/messaging/layers/transport/envelopes_monitor_test.go
+++ b/pkg/messaging/layers/transport/envelopes_monitor_test.go
@@ -1,10 +1,8 @@
 package transport
 
 import (
-	"context"
 	"reflect"
 	"testing"
-	"time"
 
 	"go.uber.org/zap"
 
@@ -54,7 +52,6 @@ func (s *EnvelopesMonitorSuite) SetupTest() {
 		nil,
 		EnvelopesMonitorConfig{
 			EnvelopeEventsHandler:            s.eventsHandlerMock,
-			MaxAttempts:                      6,
 			AwaitOnlyMailServerConfirmations: false,
 			IsMailserver:                     func(types2.EnodeID) bool { return false },
 			Logger:                           zap.NewNop(),
@@ -224,64 +221,4 @@ func (s *EnvelopesMonitorSuite) TestMultipleHashes_EnvelopeExpired() {
 func (s *EnvelopesMonitorSuite) TestMultipleHashes_Failure() {
 	err := s.monitor.Add(testIDs, []types3.Hash{{0x01}, {0x02}}, []*types2.NewMessage{{}})
 	s.Require().Error(err)
-}
-
-func (s *EnvelopesMonitorSuite) TestRetryOnce() {
-	s.monitor.api = &mockWakuAPI{}
-	err := s.monitor.Add(testIDs, testHashes, []*types2.NewMessage{{}})
-	s.Require().NoError(err)
-	envelope := s.monitor.envelopes[testHash]
-	envelope.attempts = 2
-	envelope.lastAttemptTime = time.Now().Add(-20 * time.Second)
-	s.monitor.retryQueue = append(s.monitor.retryQueue, envelope)
-
-	s.monitor.retryOnce()
-
-	s.Require().Equal(3, envelope.attempts)
-	s.Require().Len(s.monitor.retryQueue, 0)
-	s.Require().Equal(envelope.envelopeHashID, s.monitor.envelopes[envelope.envelopeHashID].envelopeHashID)
-}
-
-func (s *EnvelopesMonitorSuite) TestRetryLoopSkipsWhenPaused() {
-	s.monitor.MarkPaused()
-	defer s.monitor.MarkResumed()
-
-	mockAPI := &mockWakuAPI{}
-	s.monitor.api = mockAPI
-	err := s.monitor.Add(testIDs, testHashes, []*types2.NewMessage{{}})
-	s.Require().NoError(err)
-	envelope := s.monitor.envelopes[testHash]
-	envelope.attempts = 2
-	envelope.lastAttemptTime = time.Now().Add(-20 * time.Second)
-	s.monitor.retryQueue = append(s.monitor.retryQueue, envelope)
-
-	s.monitor.quit = make(chan struct{})
-	go s.monitor.retryLoop()
-	time.Sleep(1100 * time.Millisecond)
-	close(s.monitor.quit)
-	time.Sleep(50 * time.Millisecond)
-
-	s.Require().Equal(0, mockAPI.postCalls)
-}
-
-type mockWakuAPI struct {
-	postCalls int
-}
-
-func (m *mockWakuAPI) Post(ctx context.Context, msg types2.NewMessage) ([]byte, error) {
-	m.postCalls++
-	return []byte{0x01}, nil
-}
-
-func (m *mockWakuAPI) AddPrivateKey(ctx context.Context, privateKey types3.HexBytes) (string, error) {
-	return "", nil
-}
-func (m *mockWakuAPI) DeleteKeyPair(ctx context.Context, key string) (bool, error) {
-	return false, nil
-}
-func (m *mockWakuAPI) NewMessageFilter(req types2.Criteria) (string, error) {
-	return "", nil
-}
-func (m *mockWakuAPI) GetFilterMessages(id string) ([]*types2.Message, error) {
-	return nil, nil
 }


### PR DESCRIPTION
Removes only `EnvelopesMonitor`'s internal re-publish retry — `retryQueue` / `retryLoop` / `retryOnce` / `backoffDuration`, the `api` / `maxAttempts` fields, and the per-envelope `attempts` / `message` / `lastAttemptTime` state that existed solely to re-`Post`. logos-delivery retransmits at the transport level (logos-messaging/pm#380), so the status-side transport retry is redundant.

**Kept intentionally — the correlation core:** the `messageID ↔ envelope-hash` map and the segmentation join that fires `EnvelopeSent(messageIDs)` only once *all* of a message's envelopes are sent. This logic survives the Messaging API integration — it just gets re-keyed from envelope hash to `RequestId` (which needs the go-waku → logos-delivery swap), so it stays rather than being deleted and rebuilt.

A failed envelope now reports `EnvelopeExpired` immediately; app-level raw-message resend remains the reliability backstop while go-waku is still the transport. `EnvelopeEventsConfig.MaxMessageDeliveryAttempts` is left unwired. Integration follow-ups (re-key to `RequestId`, wire `MessageSent`/`MessagePropagated`, re-evaluate app resend) tracked in #7511.

status-app PR: https://github.com/status-im/status-app/pull/21133

🤖 Generated with [Claude Code](https://claude.com/claude-code)