### PR TITLE
[DO NOT MERGE] feat: migrations phase 2 (v2.39) — send community control on shard 32, advertise version=0

### DIFF
--- a/pkg/messaging/waku/api.go
+++ b/pkg/messaging/waku/api.go
@@ -171,20 +171,26 @@ func (api *PublicWakuAPI) Post(ctx context.Context, req types.NewMessage) ([]byt
 		keyInfo.PubKey = *pubK
 	}
 
-	var version uint32 = 1 // Use wakuv1 encryption
+	// Migration phase 2 to retire the WakuMessage `version` field (status-go#7499):
+	// keep WakuV1-encrypting the payload (encodeVersion=1) but advertise version=0 on
+	// the wire (labelVersion=0). The two must stay decoupled — payload.Encode(0) would
+	// emit plaintext. Receivers since phase 1 (#7500) decode version=0 as WakuV1 when
+	// they hold a key, so an N-1 neighbour still decrypts this.
+	const encodeVersion uint32 = 1 // Use wakuv1 encryption
+	var labelVersion uint32        // = 0, advertised on the wire
 
 	p := new(payload.Payload)
 	p.Data = req.Payload
 	p.Key = keyInfo
 
-	payload, err := p.Encode(version)
+	payload, err := p.Encode(encodeVersion)
 	if err != nil {
 		return nil, err
 	}
 
 	wakuMsg := &pb.WakuMessage{
 		Payload:      payload,
-		Version:      &version,
+		Version:      &labelVersion,
 		ContentTopic: contentTopic.ContentTopic(),
 		Timestamp:    proto.Int64(api.w.timestamp()),
 		Meta:         []byte{}, // TODO: empty for now. Once we use Waku Archive v2, we should deprecate the timestamp and use an ULID here

--- a/protocol/messenger_communities.go
+++ b/protocol/messenger_communities.go
@@ -353,7 +353,7 @@ func (m *Messenger) handleCommunitiesSubscription(c chan *communities.Subscripti
 					Sender:              community.PrivateKey(),
 					SkipEncryptionLayer: true,
 					MessageType:         protobuf.ApplicationMetadataMessage_COMMUNITY_USER_KICKED,
-					PubsubTopic:         types2.DefaultNonProtectedPubsubTopic(),
+					PubsubTopic:         types2.DefaultShardPubsubTopic(),
 				}
 
 				_, err = m.sender.SendPrivate(context.Background(), pk, rawMessage)
@@ -691,7 +691,7 @@ func (m *Messenger) handleCommunitySharedAddressesRequest(state *ReceivedMessage
 		CommunityID:         community.ID(),
 		SkipEncryptionLayer: true,
 		MessageType:         protobuf.ApplicationMetadataMessage_COMMUNITY_SHARED_ADDRESSES_RESPONSE,
-		PubsubTopic:         types2.DefaultNonProtectedPubsubTopic(),
+		PubsubTopic:         types2.DefaultShardPubsubTopic(),
 		ResendType:          common.ResendTypeRawMessage,
 		ResendMethod:        common.ResendMethodSendPrivate,
 		Recipients:          []*ecdsa.PublicKey{signer},
@@ -1467,7 +1467,7 @@ func (m *Messenger) RequestToJoinCommunity(request *requests.RequestToJoinCommun
 		ResendType:          common.ResendTypeRawMessage,
 		SkipEncryptionLayer: true,
 		MessageType:         protobuf.ApplicationMetadataMessage_COMMUNITY_REQUEST_TO_JOIN,
-		PubsubTopic:         types2.DefaultNonProtectedPubsubTopic(),
+		PubsubTopic:         types2.DefaultShardPubsubTopic(),
 		Priority:            &types2.HighPriority,
 	}
 
@@ -1858,7 +1858,7 @@ func (m *Messenger) CancelRequestToJoinCommunity(ctx context.Context, request *r
 		CommunityID:         community.ID(),
 		SkipEncryptionLayer: true,
 		MessageType:         protobuf.ApplicationMetadataMessage_COMMUNITY_CANCEL_REQUEST_TO_JOIN,
-		PubsubTopic:         types2.DefaultNonProtectedPubsubTopic(),
+		PubsubTopic:         types2.DefaultShardPubsubTopic(),
 		ResendType:          common.ResendTypeRawMessage,
 		Priority:            &types2.HighPriority,
 	}
@@ -2014,7 +2014,7 @@ func (m *Messenger) acceptRequestToJoinCommunity(requestToJoin *communities.Requ
 			CommunityID:         community.ID(),
 			SkipEncryptionLayer: true,
 			MessageType:         protobuf.ApplicationMetadataMessage_COMMUNITY_REQUEST_TO_JOIN_RESPONSE,
-			PubsubTopic:         types2.DefaultNonProtectedPubsubTopic(),
+			PubsubTopic:         types2.DefaultShardPubsubTopic(),
 			ResendType:          common.ResendTypeRawMessage,
 			ResendMethod:        common.ResendMethodSendPrivate,
 			Recipients:          []*ecdsa.PublicKey{pk},


### PR DESCRIPTION
## What & why

**Phase 2** of both staged migrations toward the logos-delivery Messaging API, packaged
as the v2.39 release. Builds on the Phase 1 PRs (#7495 shard, #7500 version), which are
combined in this PR's base branch `migration/phase1-combined`.

The whole point of staging is **N±1 interop**: v2.39 must work with both v2.38 (Phase 1) and
v2.40 (Phase 3). This PR makes v2.39 *start sending* on the new shard / new version label while
still receiving everything the previous release emits.

## Migration A — single shard (#7498): send community control on shard 32

Switch the five community-control **send** sites in `protocol/messenger_communities.go`
(request / cancel to join, request-to-join response, user kicked, shared-addresses response)
from `DefaultNonProtectedPubsubTopic()` (64) → `DefaultShardPubsubTopic()` (32).

Listening is **unchanged** — still both 32 and 64 (from Phase 1) — so a v2.38 neighbour, which
already listens on 32 (Phase 1), receives these, and this client still receives a v2.38 peer's
shard-64 traffic.

| Phase | Ver | Listen | Send |
|-|-|-|-|
| 1 | 2.38 | 32, 64 | 64 (#7495) |
| **2** | **2.39** | **32, 64** | **32 ← this PR** |
| 3 | 2.40 | 32 | 32 |

## Migration B — retire WakuMessage `version` field (#7499): advertise version=0

In `pkg/messaging/waku/api.go` `Post`, **decouple** the encode version from the wire label:
the payload stays WakuV1-encrypted (`encodeVersion=1`) but the envelope now advertises
`version=0` (`labelVersion=0`). The two cannot be the same value — `payload.Encode(0)` emits
*plaintext*. Receivers since Phase 1 (#7500) decode `version=0` as WakuV1 when they hold a key,
so a v2.38 neighbour still decrypts this; and this client still decodes a v2.38 peer's
`version=1` messages via go-waku.

| Phase | Ver | Recv v0 | Recv v1 | Send |
|-|-|-|-|-|
| 1 | 2.38 | Decrypt | Decrypt | v1 (#7500) |
| **2** | **2.39** | Decrypt | Decrypt | **v0 ← this PR** |
| 3 | 2.40 | Decrypt | Ignore | v0 |

## Notes
- Draft. Base is `migration/phase1-combined` (= #7495 + #7500) so the diff shows only the
  Phase 2 delta.
- Verified with the cross-version chat compatibility suite (#7497) — see the v2.38↔v2.39 run.
- 2.37 interop is intentionally out of scope (N±1 only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
