### PR TITLE
[DO NOT MERGE] feat: migrations phase 3 (v2.40) — drop the non-protected shard (64)

### DIFF
--- a/pkg/messaging/layers/transport/filters_manager.go
+++ b/pkg/messaging/layers/transport/filters_manager.go
@@ -154,7 +154,6 @@ func (f *FiltersManager) InitCommunityFilters(communityFiltersToInitialize []Com
 
 		topics := make([]string, 0)
 		topics = append(topics, wakuv2.DefaultShardPubsubTopic())
-		topics = append(topics, wakuv2.DefaultNonProtectedPubsubTopic())
 
 		for _, pubsubTopic := range topics {
 			pk := &cf.PrivKey.PublicKey

--- a/pkg/messaging/types/shard.go
+++ b/pkg/messaging/types/shard.go
@@ -26,7 +26,6 @@ func (s *Shard) PubsubTopic() string {
 
 const MainStatusShardCluster = 16
 const DefaultShardIndex = 32
-const NonProtectedShardIndex = 64
 
 func DefaultShardPubsubTopic() string {
 	return wakuproto.NewStaticShardingPubsubTopic(MainStatusShardCluster, DefaultShardIndex).String()
@@ -37,16 +36,4 @@ func DefaultShard() *Shard {
 		Cluster: MainStatusShardCluster,
 		Index:   DefaultShardIndex,
 	}
-}
-
-func DefaultNonProtectedShard() *Shard {
-	return &Shard{
-		Cluster: MainStatusShardCluster,
-		Index:   NonProtectedShardIndex,
-	}
-}
-
-// TODO this is used only for community control messages, we need to stop using it once migration is done
-func DefaultNonProtectedPubsubTopic() string {
-	return DefaultNonProtectedShard().PubsubTopic()
 }

--- a/pkg/messaging/waku/config.go
+++ b/pkg/messaging/waku/config.go
@@ -111,9 +111,8 @@ func setDefaults(cfg *Config) *Config {
 
 	if cfg.DefaultShardPubsubTopic == "" {
 		cfg.DefaultShardPubsubTopic = DefaultShardPubsubTopic()
-		//For now populating with both used shards, but this can be populated from user subscribed communities etc once community sharding is implemented
+		// Migration phase 3 (#7498): only the default shard remains; the non-protected shard was dropped.
 		cfg.DefaultShardedPubsubTopics = append(cfg.DefaultShardedPubsubTopics, DefaultShardPubsubTopic())
-		cfg.DefaultShardedPubsubTopics = append(cfg.DefaultShardedPubsubTopics, DefaultNonProtectedPubsubTopic())
 	}
 
 	return cfg

--- a/pkg/messaging/waku/shard.go
+++ b/pkg/messaging/waku/shard.go
@@ -18,20 +18,7 @@ func (s *Shard) PubsubTopic() string {
 
 const MainStatusShardCluster = 16
 const DefaultShardIndex = 32
-const NonProtectedShardIndex = 64
 
 func DefaultShardPubsubTopic() string {
 	return wakuproto.NewStaticShardingPubsubTopic(MainStatusShardCluster, DefaultShardIndex).String()
-}
-
-func DefaultNonProtectedShard() *Shard {
-	return &Shard{
-		Cluster: MainStatusShardCluster,
-		Index:   NonProtectedShardIndex,
-	}
-}
-
-// TODO this is used only for community control messages, we need to stop using it once migration is done
-func DefaultNonProtectedPubsubTopic() string {
-	return DefaultNonProtectedShard().PubsubTopic()
 }

--- a/protocol/messenger_communities.go
+++ b/protocol/messenger_communities.go
@@ -2463,10 +2463,8 @@ func (m *Messenger) DefaultFilters(o *communities.Community) types2.ChatsToIniti
 	return types2.ChatsToInitialize{
 		{ChatID: cID, PubsubTopic: communityPubsubTopic},
 		{ChatID: memberUpdateChannelID, PubsubTopic: communityPubsubTopic},
-		{ChatID: uncompressedPubKey, PubsubTopic: types2.DefaultNonProtectedPubsubTopic()},
-		// Migration phase 1 (#7498): also listen for community control messages on
-		// the default shard, so that when publishing moves off the non-protected
-		// shard (phase 2) clients already receive them. Sending is unchanged here.
+		// Migration phase 3 (#7498): community control is sent and received on the
+		// default shard (32); the non-protected shard (64) listener has been dropped.
 		{ChatID: uncompressedPubKey, PubsubTopic: types2.DefaultShardPubsubTopic()},
 	}
 }

--- a/protocol/messenger_filter_init.go
+++ b/protocol/messenger_filter_init.go
@@ -21,11 +21,8 @@ func (m *Messenger) InitFilters() error {
 	// Seed the for color generation
 	rand.Seed(time.Now().Unix())
 
-	// Community requests will arrive in this pubsub topic
-	// TODO remove once fully migrated to Global Community Control and Content Topic https://github.com/status-im/status-go/issues/6384
-	if err := m.messaging.SubscribeToPubsubTopic(types.DefaultNonProtectedPubsubTopic()); err != nil {
-		return err
-	}
+	// Migration phase 3 (#7498): community control now arrives on the default shard (32);
+	// the non-protected shard (64) subscription has been dropped.
 	filters, publicKeys, err := m.collectFiltersAndKeys()
 	if err != nil {
 		return err


### PR DESCRIPTION
## What & why

**Phase 3** (final) of the single-shard migration (#7498), packaged as the v2.40 release.
Stacked on the v2.39 PR (#7504); base branch is `migration/phase2-v2.39`.

By v2.40 the previous release (v2.39) already **sends** community control on shard 32 and still
listens on both shards, so it is safe to stop listening on the non-protected shard (64) and
remove it entirely.

| Phase | Ver | Listen | Send |
|-|-|-|-|
| 1 | 2.38 | 32, 64 | 64 (#7495) |
| 2 | 2.39 | 32, 64 | 32 (#7504) |
| **3** | **2.40** | **32** | **32 ← this PR** |

## Change

- `DefaultFilters` / `InitCommunityFilters` (`filters_manager.go`): drop the shard-64 community
  control listener; keep only the default shard (32).
- `messenger_filter_init.go`: drop the non-protected shard subscription in `InitFilters`.
- `pkg/messaging/waku/config.go`: drop the non-protected shard from `DefaultShardedPubsubTopics`.
- Remove the now-unused `NonProtectedShardIndex`, `DefaultNonProtectedShard()` and
  `DefaultNonProtectedPubsubTopic()` from **both** `pkg/messaging/types/shard.go` and
  `pkg/messaging/waku/shard.go`.

## Migration B (version field) — no Phase 3 change

The version-field migration (#7499) is already complete after Phase 2 (#7504, send `version=0`).
Phase-1 receivers already decrypt regardless of the version label when they hold a key, and
`logos-delivery` will not pass a version field to transport — so there is nothing further to
retire on the receive side. This PR therefore carries the shard work only.

## Notes
- Draft. Base is `migration/phase2-v2.39` (#7504) so the diff shows only the Phase 3 delta.
- Verified with the cross-version chat compatibility suite (#7497) — see the v2.39↔v2.40 run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
