### PR TITLE
fix: high battery consumption

### DIFF
--- a/internal/rpc/chain/rpclimiter/rpc_limiter.go
+++ b/internal/rpc/chain/rpclimiter/rpc_limiter.go
@@ -232,14 +232,19 @@ type RPCRpsLimiter struct {
 	callersOnWaitForRequestsMutex sync.RWMutex
 
 	quit chan struct{}
+
+	pauseBroadcaster *gocommon.PauseBroadcaster
 }
 
-func NewRPCRpsLimiter() *RPCRpsLimiter {
+// NewRPCRpsLimiter creates a rate limiter. pauseBroadcaster (owned by the rpc.Client) that lets
+// the limiter stop its 1s ticker while the app is backgrounded — RPC traffic is paused then.
+func NewRPCRpsLimiter(pauseBroadcaster *gocommon.PauseBroadcaster) *RPCRpsLimiter {
 
 	limiter := RPCRpsLimiter{
 		uuid:                 uuid.New(),
 		maxRequestsPerSecond: defaultMaxRequestsPerSecond,
 		quit:                 make(chan struct{}),
+		pauseBroadcaster:     pauseBroadcaster,
 	}
 
 	limiter.start()
@@ -259,17 +264,40 @@ func (rl *RPCRpsLimiter) ReduceLimit() {
 func (rl *RPCRpsLimiter) start() {
 	go func() {
 		defer gocommon.LogOnPanic()
-		ticker := time.NewTicker(tickerInterval)
-		defer ticker.Stop()
-		for {
-			select {
-			case <-ticker.C:
-				rl.onTick()
-			case <-rl.quit:
-				return
-			}
+
+		var pauseCh <-chan bool
+		if rl.pauseBroadcaster != nil {
+			sub := rl.pauseBroadcaster.Subscribe()
+			defer sub.Unsubscribe()
+			pauseCh = sub.C()
+		} else {
+			ch := make(chan bool, 1)
+			ch <- false
+			pauseCh = ch
 		}
+
+		pt := gocommon.NewPausableTicker(gocommon.PausableTickerConfig{
+			Interval: tickerInterval,
+			OnTick: func() {
+				rl.onTick()
+			},
+			OnPauseChanged: func(paused bool) {
+				if paused {
+					rl.releaseAllWaiters()
+				}
+			},
+		}, pauseCh)
+		pt.Run(rl.quit)
 	}()
+}
+
+func (rl *RPCRpsLimiter) releaseAllWaiters() {
+	rl.callersOnWaitForRequestsMutex.Lock()
+	defer rl.callersOnWaitForRequestsMutex.Unlock()
+	for _, callerOnWait := range rl.callersOnWaitForRequests {
+		callerOnWait.ch <- true
+	}
+	rl.callersOnWaitForRequests = nil
 }
 
 func (rl *RPCRpsLimiter) onTick() {

--- a/internal/rpc/client.go
+++ b/internal/rpc/client.go
@@ -62,6 +62,8 @@ type EthClientGetter interface {
 // Client manages RPC clients for multiple chains with
 // multiple providers for each chain.
 type Client struct {
+	appCommon.PauseBroadcaster
+
 	rpcClientsMutex    sync.RWMutex
 	rpcClients         map[uint64]chain.ClientInterface
 	rpsLimiterMutex    sync.RWMutex
@@ -246,10 +248,18 @@ func (c *Client) getProviderRPCLimiter(provider params.RpcProvider) (*rpclimiter
 		return limiter, limiterKey, nil
 	}
 
-	// Create a new limiter and store it
-	limiter := rpclimiter.NewRPCRpsLimiter()
+	limiter := rpclimiter.NewRPCRpsLimiter(&c.PauseBroadcaster)
 	c.limiterPerProvider[limiterKey] = limiter
 	return limiter, limiterKey, nil
+}
+
+// SetPaused stops/resumes the 1s tickers of every RPC rate limiter owned by this Client.
+func (c *Client) SetPaused(paused bool) {
+	if paused {
+		c.MarkPaused()
+	} else {
+		c.MarkResumed()
+	}
 }
 
 func (c *Client) getEthClients(network *params.Network) []ethclient.RPSLimitedEthClientInterface {

--- a/internal/transactions/transactor_test.go
+++ b/internal/transactions/transactor_test.go
@@ -60,7 +60,7 @@ func (s *TransactorSuite) SetupTest() {
 	chainID := gethparams.AllEthashProtocolChanges.ChainID.Uint64()
 
 	ethClients := []ethclient.RPSLimitedEthClientInterface{
-		ethclient.NewRPSLimitedEthClient(s.client, rpclimiter.NewRPCRpsLimiter(), "local-1-chain-id-1-circuit", "local-1-chain-id-1-provider"),
+		ethclient.NewRPSLimitedEthClient(s.client, rpclimiter.NewRPCRpsLimiter(nil), "local-1-chain-id-1-circuit", "local-1-chain-id-1-provider"),
 	}
 	localClient := chain.NewClient(ethClients, chainID, nil)
 	ethClientGetter := mock_rpcclient.NewMockEthClientGetter(s.txServiceMockCtrl)

--- a/pkg/backend/geth_backend.go
+++ b/pkg/backend/geth_backend.go
@@ -2108,6 +2108,11 @@ func (b *StatusBackend) PauseServices(names []string) error {
 	if b.statusNode == nil {
 		return nil
 	}
+
+	if rpcClient := b.statusNode.RPCClient(); rpcClient != nil {
+		rpcClient.SetPaused(true)
+	}
+
 	return b.statusNode.ServiceRegistry().PauseMultiple(names)
 }
 
@@ -2116,6 +2121,11 @@ func (b *StatusBackend) ResumeServices(names []string) error {
 	if b.statusNode == nil {
 		return nil
 	}
+
+	if rpcClient := b.statusNode.RPCClient(); rpcClient != nil {
+		rpcClient.SetPaused(false)
+	}
+
 	return b.statusNode.ServiceRegistry().ResumeMultiple(names)
 }
 

--- a/protocol/ens/verifier.go
+++ b/protocol/ens/verifier.go
@@ -25,6 +25,8 @@ import (
 
 const contractQueryTimeout = 5000 * time.Millisecond
 
+const ensVerifyInterval = 30 * time.Second
+
 type Verifier struct {
 	online          bool
 	persistence     *Persistence
@@ -35,6 +37,8 @@ type Verifier struct {
 	contractAddress string
 	quit            chan struct{}
 	quitWg          sync.WaitGroup
+
+	pause gocommon.PauseBroadcaster
 }
 
 func New(logger *zap.Logger, timesource timesource.Provider, db *sql.DB, rpcEndpoint, contractAddress string) *Verifier {
@@ -102,26 +106,33 @@ func (v *Verifier) SetOnline(online bool) {
 	v.online = online
 }
 
+// SetPaused stops/resumes the periodic ENS verification ticker.
+func (v *Verifier) SetPaused(paused bool) {
+	if paused {
+		v.pause.MarkPaused()
+	} else {
+		v.pause.MarkResumed()
+	}
+}
+
 func (v *Verifier) verifyLoop() {
 	defer gocommon.LogOnPanic()
 	defer v.quitWg.Done()
-	ticker := time.NewTicker(30 * time.Second)
-	defer ticker.Stop()
-	for {
-		select {
-		case <-v.quit:
-			return
-		case <-ticker.C:
+
+	sub := v.pause.Subscribe()
+	defer sub.Unsubscribe()
+	pt := gocommon.NewPausableTicker(gocommon.PausableTickerConfig{
+		Interval: ensVerifyInterval,
+		OnTick: func() {
 			if !v.online || v.rpcEndpoint == "" || v.contractAddress == "" {
-				continue
+				return
 			}
-			err := v.verify(context.Background(), v.rpcEndpoint, v.contractAddress)
-			if err != nil {
+			if err := v.verify(context.Background(), v.rpcEndpoint, v.contractAddress); err != nil {
 				v.logger.Error("verify loop failed", zap.Error(err))
 			}
-
-		}
-	}
+		},
+	}, sub.C())
+	pt.Run(v.quit)
 }
 
 func (v *Verifier) Subscribe() chan []*VerificationRecord {

--- a/protocol/messenger.go
+++ b/protocol/messenger.go
@@ -565,6 +565,9 @@ func (m *Messenger) ToBackground() {
 
 func (m *Messenger) SetPaused(paused bool) {
 	m.paused.Store(paused)
+	if m.ensVerifier != nil {
+		m.ensVerifier.SetPaused(paused)
+	}
 	if m.pushNotificationClient != nil {
 		if paused {
 			m.pushNotificationClient.Offline()


### PR DESCRIPTION
This PR contains 2 commits:

1. fix(rpclimiter): pause rate-limiter tickers in background

Convert the per-client 1s ticker to common.PausableTicker driven by a
package PauseBroadcaster, toggled from PauseServices/ResumeServices.
Eliminates ~5 (one per chain) CPU wakeups/sec in the backgrounded status-go
process (the top background-wakeup source) with onTick logic unchanged.

2. chore(ens): pause verification ticker in background

Convert verifyLoop to common.PausableTicker driven by a PauseBroadcaster
on the Verifier, toggled from messenger.SetPaused. Stops the 30s RPC
verification loop entirely while backgrounded instead of waking every 30s.
onTick guard logic unchanged.