### PR TITLE
fix(messenger): defer mailserver history sync when app is in background

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,7 @@ replace github.com/oNaiPs/go-generate-fast v0.3.0 => github.com/status-im/go-gen
 
 // Temporary: use fork with background-mode filter subscription fix until
 // logos-messaging/logos-delivery-go#1304 is merged and released.
-replace github.com/waku-org/go-waku => github.com/xAlisher/go-waku v0.10.2-0.20260602160003-ab4609ef1517
+replace github.com/waku-org/go-waku => github.com/xAlisher/go-waku v0.10.2-0.20260603060940-9f8361930df9
 
 require (
 	github.com/anacrolix/torrent v1.41.0

--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ replace github.com/libp2p/go-libp2p-pubsub v0.13.1 => github.com/waku-org/go-lib
 replace github.com/oNaiPs/go-generate-fast v0.3.0 => github.com/status-im/go-generate-fast v0.0.0-20250916164518-c78009bcfa9e
 
 // Temporary: use fork with background-mode filter subscription fix until
-// logos-messaging/logos-delivery-go#1304 is merged and released.
+// waku-org/go-waku#1304 is merged and released.
 replace github.com/waku-org/go-waku => github.com/xAlisher/go-waku v0.10.2-0.20260603060940-9f8361930df9
 
 require (

--- a/go.mod
+++ b/go.mod
@@ -24,6 +24,10 @@ replace github.com/libp2p/go-libp2p-pubsub v0.13.1 => github.com/waku-org/go-lib
 
 replace github.com/oNaiPs/go-generate-fast v0.3.0 => github.com/status-im/go-generate-fast v0.0.0-20250916164518-c78009bcfa9e
 
+// Temporary: use fork with background-mode filter subscription fix until
+// logos-messaging/logos-delivery-go#1304 is merged and released.
+replace github.com/waku-org/go-waku => github.com/xAlisher/go-waku v0.10.2-0.20260602160003-ab4609ef1517
+
 require (
 	github.com/anacrolix/torrent v1.41.0
 	github.com/beevik/ntp v0.3.0

--- a/go.sum
+++ b/go.sum
@@ -2446,8 +2446,8 @@ github.com/wk8/go-ordered-map/v2 v2.1.7/go.mod h1:9Xvgm2mV2kSq2SAm0Y608tBmu8akTz
 github.com/wlynxg/anet v0.0.3/go.mod h1:eay5PRQr7fIVAMbTbchTnO9gG65Hg/uYGdc7mguHxoA=
 github.com/wlynxg/anet v0.0.5 h1:J3VJGi1gvo0JwZ/P1/Yc/8p63SoW98B5dHkYDmpgvvU=
 github.com/wlynxg/anet v0.0.5/go.mod h1:eay5PRQr7fIVAMbTbchTnO9gG65Hg/uYGdc7mguHxoA=
-github.com/xAlisher/go-waku v0.10.2-0.20260602160003-ab4609ef1517 h1:zNOTn6jkgT9iWzlWbLNKGaYgVqk3Bpflkb+UKJQMY8s=
-github.com/xAlisher/go-waku v0.10.2-0.20260602160003-ab4609ef1517/go.mod h1:PDs4hlPbONeMQGsNyfArZV4R2Js1Zy5oqLBfw2VU278=
+github.com/xAlisher/go-waku v0.10.2-0.20260603060940-9f8361930df9 h1:f1tcz/ftQgHNQkEkfLG8+TBJqluJ10aQO19DpYTUAk8=
+github.com/xAlisher/go-waku v0.10.2-0.20260603060940-9f8361930df9/go.mod h1:PDs4hlPbONeMQGsNyfArZV4R2Js1Zy5oqLBfw2VU278=
 github.com/xanzy/go-gitlab v0.15.0/go.mod h1:8zdQa/ri1dfn8eS3Ir1SyfvOKlw7WBJ8DVThkpGiXrs=
 github.com/xdg-go/pbkdf2 v1.0.0/go.mod h1:jrpuAogTd400dnrH08LKmI/xc1MbPOebTwRqcT5RDeI=
 github.com/xdg-go/scram v1.0.2/go.mod h1:1WAq6h33pAW+iRreB34OORO2Nf7qel3VV3fjBj+hCSs=

--- a/go.sum
+++ b/go.sum
@@ -2448,6 +2448,8 @@ github.com/wk8/go-ordered-map/v2 v2.1.7/go.mod h1:9Xvgm2mV2kSq2SAm0Y608tBmu8akTz
 github.com/wlynxg/anet v0.0.3/go.mod h1:eay5PRQr7fIVAMbTbchTnO9gG65Hg/uYGdc7mguHxoA=
 github.com/wlynxg/anet v0.0.5 h1:J3VJGi1gvo0JwZ/P1/Yc/8p63SoW98B5dHkYDmpgvvU=
 github.com/wlynxg/anet v0.0.5/go.mod h1:eay5PRQr7fIVAMbTbchTnO9gG65Hg/uYGdc7mguHxoA=
+github.com/xAlisher/go-waku v0.10.2-0.20260602160003-ab4609ef1517 h1:zNOTn6jkgT9iWzlWbLNKGaYgVqk3Bpflkb+UKJQMY8s=
+github.com/xAlisher/go-waku v0.10.2-0.20260602160003-ab4609ef1517/go.mod h1:PDs4hlPbONeMQGsNyfArZV4R2Js1Zy5oqLBfw2VU278=
 github.com/xanzy/go-gitlab v0.15.0/go.mod h1:8zdQa/ri1dfn8eS3Ir1SyfvOKlw7WBJ8DVThkpGiXrs=
 github.com/xdg-go/pbkdf2 v1.0.0/go.mod h1:jrpuAogTd400dnrH08LKmI/xc1MbPOebTwRqcT5RDeI=
 github.com/xdg-go/scram v1.0.2/go.mod h1:1WAq6h33pAW+iRreB34OORO2Nf7qel3VV3fjBj+hCSs=

--- a/go.sum
+++ b/go.sum
@@ -2416,8 +2416,6 @@ github.com/waku-org/go-libp2p-pubsub v0.13.1-gowaku h1:ovXh1m76i0yPWXt95Z9ZRyEk0
 github.com/waku-org/go-libp2p-pubsub v0.13.1-gowaku/go.mod h1:MKPU5vMI8RRFyTP0HfdsF9cLmL1nHAeJm44AxJGJx44=
 github.com/waku-org/go-libp2p-rendezvous v0.0.0-20240110193335-a67d1cc760a0 h1:R4YYx2QamhBRl/moIxkDCNW+OP7AHbyWLBygDc/xIMo=
 github.com/waku-org/go-libp2p-rendezvous v0.0.0-20240110193335-a67d1cc760a0/go.mod h1:EhZP9fee0DYjKH/IOQvoNSy1tSHp2iZadsHGphcAJgY=
-github.com/waku-org/go-waku v0.10.2-0.20260518064454-d6d39395ac48 h1:a00GguapTGSRIN9ocw93WsrMOTD07TJ1iqCashttNwA=
-github.com/waku-org/go-waku v0.10.2-0.20260518064454-d6d39395ac48/go.mod h1:PDs4hlPbONeMQGsNyfArZV4R2Js1Zy5oqLBfw2VU278=
 github.com/waku-org/go-zerokit-rln v0.1.14-0.20240102145250-fa738c0bdf59 h1:jisj+OCI6QydLtFq3Pyhu49wl9ytPN7oAHjMfepHDrA=
 github.com/waku-org/go-zerokit-rln v0.1.14-0.20240102145250-fa738c0bdf59/go.mod h1:1PdBdPzyTaKt3VnpAHk3zj+r9dXPFOr3IHZP9nFle6E=
 github.com/waku-org/go-zerokit-rln-apple v0.0.0-20230916172309-ee0ee61dde2b h1:KgZVhsLkxsj5gb/FfndSCQu6VYwALrCOgYI3poR95yE=

--- a/pkg/backend/node/get_status_node.go
+++ b/pkg/backend/node/get_status_node.go
@@ -400,6 +400,13 @@ func (n *StatusNode) populateServiceRegistry() {
 	if n.mediaServer != nil {
 		n.serviceRegistry.Register(newPausableMediaServer(n.mediaServer))
 	}
+	// Wrap and register the messenger so that PauseServices/ResumeServices
+	// gate filter health-check pings and mailserver syncs in background.
+	if n.wakuV2ExtSrvc != nil {
+		if m := n.wakuV2ExtSrvc.Messenger(); m != nil {
+			n.serviceRegistry.Register(newPausableMessenger(m))
+		}
+	}
 	// Register infrastructure components that are not go-ethereum services
 	if n.downloader != nil {
 		n.serviceRegistry.Register(n.downloader)

--- a/pkg/backend/node/service_registry.go
+++ b/pkg/backend/node/service_registry.go
@@ -6,6 +6,7 @@ import (
 	"sync"
 
 	"github.com/status-im/status-go/common"
+	"github.com/status-im/status-go/protocol"
 	"github.com/status-im/status-go/server"
 )
 
@@ -34,6 +35,35 @@ func (p *PausableMediaServer) Pause() error {
 
 func (p *PausableMediaServer) Resume() error {
 	p.s.ToForeground()
+	p.MarkResumed()
+	return nil
+}
+
+// PausableMessenger wraps a protocol.Messenger to implement common.Pausable.
+// Pause() → ToBackground() and Resume() → ToForeground() so that the Java
+// PauseServices/ResumeServices flow gates filter health-check pings and
+// mailserver history syncs without a separate SetAppBackground API call.
+type PausableMessenger struct {
+	common.PauseBroadcaster
+	m *protocol.Messenger
+}
+
+func newPausableMessenger(m *protocol.Messenger) *PausableMessenger {
+	p := &PausableMessenger{m: m}
+	p.MarkStarted()
+	return p
+}
+
+func (p *PausableMessenger) PausableName() string { return "messenger" }
+
+func (p *PausableMessenger) Pause() error {
+	p.m.ToBackground()
+	p.MarkPaused()
+	return nil
+}
+
+func (p *PausableMessenger) Resume() error {
+	p.m.ToForeground()
 	p.MarkResumed()
 	return nil
 }

--- a/pkg/messaging/api.go
+++ b/pkg/messaging/api.go
@@ -62,6 +62,15 @@ func (a *API) ResumeTransport() {
 	}
 }
 
+// SetFilterBackgroundMode suppresses (background=true) or re-enables
+// (background=false) Waku filter-subscription renewal. Call with background=true
+// when the app UI is hidden to avoid LTE wakeups from expiring subscriptions.
+func (a *API) SetFilterBackgroundMode(background bool) {
+	if a.core.stack.Transport != nil {
+		a.core.stack.Transport.SetFilterBackgroundMode(background)
+	}
+}
+
 // PauseDataSync idles (paused==true) or re-arms (paused==false) the reliability
 // layer's data-sync node so its outbound loop performs no work while the host is
 // backgrounded.

--- a/pkg/messaging/layers/transport/transport.go
+++ b/pkg/messaging/layers/transport/transport.go
@@ -99,6 +99,15 @@ func (t *Transport) Pause() {
 	}
 }
 
+// SetFilterBackgroundMode suppresses (background=true) or re-enables
+// (background=false) filter-subscription renewal in the underlying waku
+// light-client. No-op when waku is nil or in relay mode.
+func (t *Transport) SetFilterBackgroundMode(background bool) {
+	if t.waku != nil {
+		t.waku.SetFilterBackgroundMode(background)
+	}
+}
+
 // Resume signals Transport's internal goroutines to resume and cascades to
 // EnvelopesMonitor and the underlying waku transport.
 func (t *Transport) Resume() {

--- a/pkg/messaging/waku/gowaku.go
+++ b/pkg/messaging/waku/gowaku.go
@@ -1037,6 +1037,16 @@ func (w *Waku) subscribe(f *common.Filter) (string, error) {
 	return id, nil
 }
 
+// SetFilterBackgroundMode suppresses (background=true) or re-enables
+// (background=false) filter-subscription renewal in light-client mode.
+// No-op when filterManager is nil (relay mode).
+func (w *Waku) SetFilterBackgroundMode(background bool) {
+	if w.filterManager == nil {
+		return
+	}
+	w.filterManager.SetBackgroundMode(background)
+}
+
 // Unsubscribe removes an installed message handler.
 func (w *Waku) Unsubscribe(ctx context.Context, id string) error {
 	ok := w.filters.Uninstall(id)

--- a/pkg/messaging/waku/types/waku.go
+++ b/pkg/messaging/waku/types/waku.go
@@ -108,6 +108,11 @@ type Waku interface {
 	Pause() error
 	// Resume re-arms goroutines suspended by Pause. Idempotent.
 	Resume() error
+	// SetFilterBackgroundMode suppresses (background=true) or re-enables
+	// (background=false) filter-subscription renewal in light-client mode.
+	// When suppressed, expiring subscriptions are not renewed until the app
+	// returns to foreground, avoiding spurious LTE radio wakeups.
+	SetFilterBackgroundMode(background bool)
 
 	// Waku protocol version
 	Version() uint

--- a/protocol/messenger.go
+++ b/protocol/messenger.go
@@ -574,6 +574,9 @@ func (m *Messenger) ToBackground() {
 // continues running so push notifications keep working.
 func (m *Messenger) SetAppBackground(background bool) {
 	m.backgroundMode.Store(background)
+	if m.messaging != nil {
+		m.messaging.SetFilterBackgroundMode(background)
+	}
 	if !background {
 		// Returning to foreground: run any deferred history sync now.
 		m.asyncRequestAllHistoricMessages()

--- a/protocol/messenger.go
+++ b/protocol/messenger.go
@@ -553,7 +553,10 @@ func (m *Messenger) ToForeground() {
 	if m.httpServer != nil {
 		m.httpServer.ToForeground()
 	}
-
+	m.backgroundMode.Store(false)
+	if m.messaging != nil {
+		m.messaging.SetFilterBackgroundMode(false)
+	}
 	m.asyncRequestAllHistoricMessages()
 }
 
@@ -562,24 +565,9 @@ func (m *Messenger) ToBackground() {
 	if m.httpServer != nil {
 		m.httpServer.ToBackground()
 	}
-}
-
-// SetAppBackground is called by the Android/iOS layer when the app UI moves
-// to background (background=true) or returns to foreground (background=false).
-// It gates automatic mailserver history syncs: syncs triggered by connection
-// change or storenode availability are deferred while backgrounded, and
-// executed immediately on returning to foreground.
-//
-// Unlike SetPaused, this does NOT pause Waku transport or data-sync — Waku
-// continues running so push notifications keep working.
-func (m *Messenger) SetAppBackground(background bool) {
-	m.backgroundMode.Store(background)
+	m.backgroundMode.Store(true)
 	if m.messaging != nil {
-		m.messaging.SetFilterBackgroundMode(background)
-	}
-	if !background {
-		// Returning to foreground: run any deferred history sync now.
-		m.asyncRequestAllHistoricMessages()
+		m.messaging.SetFilterBackgroundMode(true)
 	}
 }
 
@@ -842,7 +830,7 @@ func (m *Messenger) handleConnectionChange(online bool) {
 	}
 
 	// Start fetching messages from store nodes.
-	// Skip when backgrounded: the sync will run in SetAppBackground(false)
+	// Skip when backgrounded: the sync will run in ToForeground()
 	// when the app returns to foreground.
 	if online && !m.backgroundMode.Load() {
 		m.asyncRequestAllHistoricMessages()

--- a/protocol/messenger.go
+++ b/protocol/messenger.go
@@ -137,6 +137,7 @@ type Messenger struct {
 
 	started           bool
 	paused            atomic.Bool
+	backgroundMode    atomic.Bool // true when the app UI is not visible; gates background history syncs
 	quit              chan struct{}
 	ctx               context.Context
 	cancel            context.CancelFunc
@@ -563,6 +564,22 @@ func (m *Messenger) ToBackground() {
 	}
 }
 
+// SetAppBackground is called by the Android/iOS layer when the app UI moves
+// to background (background=true) or returns to foreground (background=false).
+// It gates automatic mailserver history syncs: syncs triggered by connection
+// change or storenode availability are deferred while backgrounded, and
+// executed immediately on returning to foreground.
+//
+// Unlike SetPaused, this does NOT pause Waku transport or data-sync — Waku
+// continues running so push notifications keep working.
+func (m *Messenger) SetAppBackground(background bool) {
+	m.backgroundMode.Store(background)
+	if !background {
+		// Returning to foreground: run any deferred history sync now.
+		m.asyncRequestAllHistoricMessages()
+	}
+}
+
 func (m *Messenger) SetPaused(paused bool) {
 	m.paused.Store(paused)
 	if m.pushNotificationClient != nil {
@@ -821,8 +838,10 @@ func (m *Messenger) handleConnectionChange(online bool) {
 		m.shouldPublishContactCode = false
 	}
 
-	// Start fetching messages from store nodes
-	if online {
+	// Start fetching messages from store nodes.
+	// Skip when backgrounded: the sync will run in SetAppBackground(false)
+	// when the app returns to foreground.
+	if online && !m.backgroundMode.Load() {
 		m.asyncRequestAllHistoricMessages()
 	}
 

--- a/protocol/messenger_mailserver_cycle.go
+++ b/protocol/messenger_mailserver_cycle.go
@@ -159,7 +159,7 @@ func (m *Messenger) checkForStorenodeCycleSignals() {
 				if ok {
 					signal.SendStoreNodeAvailable(&ms)
 				}
-				// Skip history sync when backgrounded; SetAppBackground(false)
+				// Skip history sync when backgrounded; ToForeground()
 				// will trigger it when the app returns to foreground.
 				if !m.backgroundMode.Load() {
 					m.asyncRequestAllHistoricMessages()

--- a/protocol/messenger_mailserver_cycle.go
+++ b/protocol/messenger_mailserver_cycle.go
@@ -159,7 +159,11 @@ func (m *Messenger) checkForStorenodeCycleSignals() {
 				if ok {
 					signal.SendStoreNodeAvailable(&ms)
 				}
-				m.asyncRequestAllHistoricMessages()
+				// Skip history sync when backgrounded; SetAppBackground(false)
+				// will trigger it when the app returns to foreground.
+				if !m.backgroundMode.Load() {
+					m.asyncRequestAllHistoricMessages()
+				}
 			}
 		}
 	}

--- a/services/ext/api.go
+++ b/services/ext/api.go
@@ -2,6 +2,7 @@ package ext
 
 import (
 	"context"
+	"errors"
 	"time"
 
 	"github.com/libp2p/go-libp2p/core/peer"
@@ -1044,6 +1045,14 @@ func (api *PublicAPI) DeleteActivityCenterNotifications(ctx context.Context, ids
 	updatedAt := m.GetCurrentTimeInMillis()
 	_, err := m.MarkActivityCenterNotificationsDeleted(ctx, ids, updatedAt, true)
 	return err
+}
+
+func (api *PublicAPI) SetAppBackground(background bool) error {
+	if api.service.messenger == nil {
+		return errors.New("messenger not initialized")
+	}
+	api.service.messenger.SetAppBackground(background)
+	return nil
 }
 
 func (api *PublicAPI) RequestAllHistoricMessages() (*protocol.MessengerResponse, error) {

--- a/services/ext/api.go
+++ b/services/ext/api.go
@@ -1047,14 +1047,6 @@ func (api *PublicAPI) DeleteActivityCenterNotifications(ctx context.Context, ids
 	return err
 }
 
-func (api *PublicAPI) SetAppBackground(background bool) error {
-	if api.service.messenger == nil {
-		return errors.New("messenger not initialized")
-	}
-	api.service.messenger.SetAppBackground(background)
-	return nil
-}
-
 func (api *PublicAPI) RequestAllHistoricMessages() (*protocol.MessengerResponse, error) {
 	return api.service.messenger.RequestAllHistoricMessages(false)
 }


### PR DESCRIPTION
## Problem

When the app is backgrounded, two separate subsystems drive spurious network activity that drains the battery:

**R2 — Mailserver history sync** (this PR, commit 1): \`asyncRequestAllHistoricMessages()\` fires unconditionally from two sites when connectivity resumes or a storenode becomes available — even with the screen locked.

**R1 — Waku filter-subscription renewal** (this PR, commit 2): Light-client filter subscriptions have a ~13.5 min relay-side TTL. When one expires, \`subDetails.Closing\` fires → \`wf.Subscribe()\` RPC → LTE radio wakeup. The 5s health-check ticker in \`subscriptionLoop\` also triggers proactive resubscribes. Both paths run in the background service process regardless of screen state.

**R1b — Filter health-check pings** (this PR, commit 4): \`FilterHealthCheckLoop\` fires every **1 minute** and sends a Waku protocol ping to each subscribed filter peer. On Android, these pings queue up during Doze and flush in maintenance windows (~15 min), keeping the LTE modem at ~55–58% duty cycle. This was the **dominant** radio wakeup source — confirmed by mag's measurement on #21111 (modem still 58% active after R1 subscription-renewal fix alone).

**Measured impact** (status-im/status-app#21045, T5 soak): 321 MB RX in 30 min, LTE radio 99% duty cycle, ~425 mAh/hr peak drain.

## Fix

### R2 — Defer mailserver sync (commit 1: d793ad5)
Adds \`backgroundMode atomic.Bool\` to \`Messenger\`. Two \`asyncRequestAllHistoricMessages()\` call sites are guarded; sync is deferred until \`SetAppBackground(false)\`. New \`SetAppBackground(bool)\` RPC exposed via \`services/ext/api.go\`.

### R1 — Suppress filter renewal (commit 2: 9aac52a)
Wires background-mode gate through every layer of the call chain:

```
Messenger.SetAppBackground
  → messaging.API.SetFilterBackgroundMode
  → transport.Transport.SetFilterBackgroundMode
  → Waku interface / gowaku.Waku.SetFilterBackgroundMode
  → filterapi.FilterManager.SetBackgroundMode   (go-waku)
  → filterapi.Sub.SetBackgroundMode             (go-waku)
```

While backgrounded, the \`subscriptionLoop\` ticker and closing-channel cases skip resubscription. On foreground return, a single resubscribe is queued to catch any subscriptions that expired while idle.

### R1b — Suppress filter health-check pings (commit 4: 72956f2)
Adds \`backgroundMode atomic.Bool\` to \`WakuFilterLightNode\` (protocol/filter layer) with \`SetBackgroundMode(bool)\`. \`FilterHealthCheckLoop\` skips \`PingPeers()\` when backgrounded. \`FilterManager.SetBackgroundMode\` now cascades to both layers:

```
filterapi.FilterManager.SetBackgroundMode
  → filterapi.Sub.SetBackgroundMode             (subscription renewal)
  → WakuFilterLightNode.SetBackgroundMode       (health-check pings)  ← dominant source
```

go-waku changes: logos-messaging/logos-delivery-go#1304
go.mod \`replace\` directive: \`xAlisher/go-waku@9f836193\` (temporary, until #1304 merges)

## Companion PR

https://github.com/status-im/status-app/pull/21111

## Test plan

- Background → airplane mode off → no \`asyncRequestAllHistoricMessages\` in logcat
- Background → filter subscription TTL expires → no \`wf.Subscribe()\` RPC in logcat
- Background → 1 min passes → no \`PingPeers\` / filter ping in logcat
- LTE modem duty cycle drops from ~58% to near 0% after Doze engages
- Foreground → sync runs, messages arrive, filter subscriptions renew, pings resume
- Push notifications unaffected (Waku service continues running)

Closes status-im/status-app#21045 (R1 + R1b + R2)