### PR TITLE
fix(cr): only add accepted cr message when it was not accepted before

### DIFF
--- a/protocol/messenger_contact_requests_test.go
+++ b/protocol/messenger_contact_requests_test.go
@@ -671,8 +671,13 @@ func (s *MessengerContactRequestSuite) TestAliceSeesOnlyOneAcceptFromBob() {
 	s.acceptContactRequest(contactRequest, alice, bob)
 
 	// Accept contact request again
-	_, err := bob.AcceptContactRequest(context.Background(), &requests.AcceptContactRequest{ID: types.Hex2Bytes(contactRequest.ID), ContactID: contactRequest.From})
+	secondAcceptResp, err := bob.AcceptContactRequest(context.Background(), &requests.AcceptContactRequest{ID: types.Hex2Bytes(contactRequest.ID), ContactID: contactRequest.From})
 	s.Require().NoError(err)
+	s.Require().NotNil(secondAcceptResp)
+
+	// A repeated accept must not produce a duplicate "accepted" system message.
+	secondAcceptMutualStateUpdate := s.findFirstByContentType(secondAcceptResp.Messages(), protobuf.ChatMessage_SYSTEM_MESSAGE_MUTUAL_EVENT_ACCEPTED)
+	s.Require().Nil(secondAcceptMutualStateUpdate)
 
 	// Check we don't have extra messages on Alice's side
 	resp, err := WaitOnMessengerResponse(alice,

--- a/protocol/messenger_contacts.go
+++ b/protocol/messenger_contacts.go
@@ -315,6 +315,7 @@ func (m *Messenger) updateAcceptedContactRequest(response *MessengerResponse, co
 		return nil, err
 	}
 
+	previouslyAccepted := contactRequest.ContactRequestState == common.ContactRequestStateAccepted
 	contactRequest.ContactRequestState = common.ContactRequestStateAccepted
 
 	err = m.persistence.SetContactRequestState(contactRequest.ID, contactRequest.ContactRequestState)
@@ -388,22 +389,24 @@ func (m *Messenger) updateAcceptedContactRequest(response *MessengerResponse, co
 	response.AddMessage(contactRequest)
 	response.AddContact(contact)
 
-	// Add mutual state update message for incoming contact request
-	clock, timestamp := chat.NextClockAndTimestamp(m.getTimesource())
-	updateMessage, err := m.prepareMutualStateUpdateMessage(contact.ID, contacts.MutualStateUpdateTypeAdded, clock, timestamp, true)
-	if err != nil {
-		return nil, err
-	}
+	// Add mutual state update message only on first acceptance.
+	if !previouslyAccepted {
+		clock, timestamp := chat.NextClockAndTimestamp(m.getTimesource())
+		updateMessage, err := m.prepareMutualStateUpdateMessage(contact.ID, contacts.MutualStateUpdateTypeAdded, clock, timestamp, true)
+		if err != nil {
+			return nil, err
+		}
 
-	err = m.prepareMessage(updateMessage, m.httpServer)
-	if err != nil {
-		return nil, err
+		err = m.prepareMessage(updateMessage, m.httpServer)
+		if err != nil {
+			return nil, err
+		}
+		err = m.persistence.SaveMessages([]*common.Message{updateMessage})
+		if err != nil {
+			return nil, err
+		}
+		response.AddMessage(updateMessage)
 	}
-	err = m.persistence.SaveMessages([]*common.Message{updateMessage})
-	if err != nil {
-		return nil, err
-	}
-	response.AddMessage(updateMessage)
 	response.AddChat(chat)
 
 	return response, nil

--- a/protocol/messenger_handler.go
+++ b/protocol/messenger_handler.go
@@ -912,6 +912,7 @@ func (m *Messenger) handleAcceptContactRequestMessage(state *ReceivedMessageStat
 	previouslyAccepted := request != nil && request.ContactRequestState == common.ContactRequestStateAccepted
 
 	contact := state.CurrentMessageState.Contact
+	wasMutual := contact.Mutual()
 
 	// The request message will be added to the response here
 	processingResponse, err := m.handleAcceptContactRequest(state.Response, contact, request, clock)
@@ -941,8 +942,8 @@ func (m *Messenger) handleAcceptContactRequestMessage(state *ReceivedMessageStat
 			chat.Active = true
 		}
 
-		// Add mutual state update message for incoming contact request
-		if !previouslyAccepted {
+		// Add mutual state update message only when transitioning to mutual.
+		if !wasMutual && contact.Mutual() && !previouslyAccepted {
 			clock, timestamp := chat.NextClockAndTimestamp(m.getTimesource())
 
 			updateMessage, err := m.prepareMutualStateUpdateMessage(contact.ID, contacts.MutualStateUpdateTypeAdded, clock, timestamp, false)


### PR DESCRIPTION
Fixes https://github.com/status-im/status-app/issues/21043

status-app PR: https://github.com/status-im/status-app/pull/21118

## Summary

This PR fixes duplicate contact acceptance system messages.

When a contact request acceptance is processed repeatedly, the app could add another “accepted your contact request” system message even when the relationship was already accepted/mutual.  
This change ensures the accepted mutual-state system message is only added on first acceptance, not on repeated accept events.

## What Changed

- Added a first-acceptance guard in messenger_contacts.go so accepted mutual-state messages are created only when the contact request was not already accepted.
- Tightened inbound accept handling in messenger_handler.go so accepted mutual-state messages are emitted only when transitioning to mutual and not previously accepted.
- Added regression assertions in messenger_contact_requests_test.go to verify a second accept does not produce another accepted system message.

## Behavior Impact

- First-time acceptance behavior remains unchanged.
- Repeated acceptance no longer produces duplicate “accepted” system messages.
- Contact/message state updates and notification flows remain intact.

## Validation

Passed targeted tests:

- go test ./protocol -run TestMessengerContactRequestSuite/TestAliceSeesOnlyOneAcceptFromBob -count=1
- go test ./protocol -run TestMessengerContactRequestSuite/(TestReceiveAndAcceptContactRequestTwice|TestAcceptLatestContactRequestForContact) -count=1

## Risk

Low.

- The change is scoped to acceptance-message emission conditions.
- Main risk is unintended suppression of legitimate first-time accepted system messages; targeted acceptance-flow tests were updated and passed to cover this.