### PR TITLE
test: small improvements

### DIFF
--- a/tests-functional/README.MD
+++ b/tests-functional/README.MD
@@ -191,7 +191,7 @@ For more specific use cases, you can use these specialized fixtures:
   ```
 
 - **`waku_light_client`** (function-scoped):  
-  A simple parametrization fixture for enabling/disabling Waku light client mode.
+  A parametrization fixture for enabling/disabling Waku light client mode. Use `@parametrize_waku_light_client` from `waku_params.py` to run tests with both `wakuV2LightClient_False` and `wakuV2LightClient_True`. Example: `pytest -m rpc -k 'wakuV2LightClient_True' -v`.
 
 #### 3. Manual/Custom Backend Setup
 

--- a/tests-functional/clients/services/wakuext.py
+++ b/tests-functional/clients/services/wakuext.py
@@ -4,6 +4,7 @@ from typing import TypedDict, Union, Optional
 
 from clients.rpc import RpcClient
 from clients.services.service import Service
+from utils.rpc_helpers import list_or_empty
 from resources.enums import MessageContentType
 from utils.image_utils import ImageCropRect
 
@@ -555,7 +556,7 @@ class WakuextService(Service):
     def chats(self):
         params = []
         response = self.rpc_request("chats", params)
-        return response
+        return response or []
 
     def chat(self, chat_id: str):
         params = [chat_id]
@@ -565,12 +566,12 @@ class WakuextService(Service):
     def chats_preview(self, filter_type: int):
         params = [filter_type]
         response = self.rpc_request("chatsPreview", params)
-        return response
+        return list_or_empty(response)
 
     def active_chats(self):
         params = []
         response = self.rpc_request("activeChats", params)
-        return response
+        return response or []
 
     def mute_chat(self, chat_id: str):
         params = [chat_id]
@@ -700,12 +701,12 @@ class WakuextService(Service):
     def emoji_reactions_by_chat_id(self, sender_chat_id: str, limit: int):
         params = [sender_chat_id, None, limit]
         response = self.rpc_request(method="emojiReactionsByChatID", params=params)
-        return response
+        return list_or_empty(response)
 
     def emoji_reactions_by_chat_id_message_id(self, sender_chat_id: str, message_id: str):
         params = [sender_chat_id, message_id]
         response = self.rpc_request(method="emojiReactionsByChatIDMessageID", params=params)
-        return response
+        return list_or_empty(response)
 
     def get_saved_addresses(self, params=[]):
         response = self.rpc_request("getSavedAddresses", params)

--- a/tests-functional/conftest.py
+++ b/tests-functional/conftest.py
@@ -182,20 +182,12 @@ class SecretRedactingFilter(logging.Filter):
         return message
 
     def filter(self, record):
-        # Redact secrets in the log message
         if isinstance(record.msg, str):
-            message = record.getMessage()
-            record.msg = self.redact(message)
-
-        # Also redact secrets in args (if used with parameterized logging)
-        if record.args:
-            new_args = []
-            for arg in record.args:
-                redacted_arg = arg
-                if isinstance(arg, str):
-                    redacted_arg = self.redact(arg)
-                new_args.append(redacted_arg)
-            record.args = tuple(new_args)
+            if record.args:
+                record.msg = self.redact(record.getMessage())
+                record.args = ()
+            else:
+                record.msg = self.redact(record.msg)
 
         return True
 

--- a/tests-functional/tests/benchmark/test_basic_benchmark.py
+++ b/tests-functional/tests/benchmark/test_basic_benchmark.py
@@ -6,10 +6,11 @@ from clients.status_backend import StatusBackend
 from steps import messenger
 from utils import fake
 from utils.config import Config
+from waku_params import parametrize_waku_light_client
 
 
 @pytest.mark.benchmark
-@pytest.mark.parametrize("waku_light_client", [False, True], indirect=True, ids=["waku_light_client_False", "waku_light_client_True"])
+@parametrize_waku_light_client
 class TestBasicBenchmark:
     """Test StatusBackend performance.
 

--- a/tests-functional/tests/test_wakuext_chats.py
+++ b/tests-functional/tests/test_wakuext_chats.py
@@ -4,20 +4,21 @@ import pytest
 
 from resources.enums import ChatType, ChatPreviewFilterType, MuteType
 from steps import messenger
+from waku_params import parametrize_waku_light_client
 
 
 @pytest.mark.rpc
-@pytest.mark.parametrize("waku_light_client", [False, True], indirect=True, ids=["waku_light_client_False", "waku_light_client_True"])
+@parametrize_waku_light_client
 @pytest.mark.parametrize("backend_factory", [{"privileged": False}], indirect=True, ids=["privileged_False"])
 class TestChatActions:
 
     @pytest.fixture()
     def sender(self, backend_new_profile, waku_light_client):
-        return backend_new_profile("sender", waku_light_client)
+        return backend_new_profile("sender", waku_light_client=waku_light_client)
 
     @pytest.fixture()
     def receiver(self, backend_new_profile, waku_light_client):
-        return backend_new_profile("receiver", waku_light_client)
+        return backend_new_profile("receiver", waku_light_client=waku_light_client)
 
     def test_all_chats(self, sender, receiver):
         messenger.make_contacts(sender, receiver)
@@ -74,7 +75,6 @@ class TestChatActions:
         private_group_chat_id = messenger.join_private_group(admin=sender, member=receiver)
 
         chats = sender.wakuext_service.active_chats()
-        # TODO: Add more assertions on response
         assert len(chats) == 2
 
         sender.wakuext_service.deactivate_chat(private_group_chat_id, False)

--- a/tests-functional/tests/test_wakuext_contact_requests.py
+++ b/tests-functional/tests/test_wakuext_contact_requests.py
@@ -4,11 +4,12 @@ import pytest
 from resources.enums import MessageContentType
 from steps import async_messenger
 from clients.api import ApiResponseError
+from waku_params import parametrize_waku_light_client
 
 
 @pytest.mark.rpc
 @pytest.mark.asyncio
-@pytest.mark.parametrize("waku_light_client", [False, True], indirect=True, ids=["wakuV2LightClient_False", "wakuV2LightClient_True"])
+@parametrize_waku_light_client
 class TestContactRequests:
 
     @pytest.fixture

--- a/tests-functional/tests/test_wakuext_message_reactions.py
+++ b/tests-functional/tests/test_wakuext_message_reactions.py
@@ -6,6 +6,7 @@ from clients.api import ApiResponseError
 from clients.signals import SignalType
 from resources.enums import MessageContentType
 from steps import async_messenger
+from waku_params import parametrize_waku_light_client, parametrize_waku_light_client_non_lc
 
 
 @pytest.mark.rpc
@@ -20,14 +21,14 @@ class TestMessageReactions:
     async def receiver(self, async_backend_new_profile, waku_light_client):
         return await async_backend_new_profile("receiver", waku_light_client=waku_light_client)
 
-    @pytest.mark.parametrize("waku_light_client", [False, True], indirect=True, ids=["wakuV2LightClient_False", "wakuV2LightClient_True"])
+    @parametrize_waku_light_client
     async def test_one_to_one_message_reactions(self, sender, receiver, waku_light_client):
         """Test message reactions with different wakuV2LightClient configurations"""
         await async_messenger.make_contacts(sender, receiver)
         response = sender.wakuext_service.send_one_to_one_message(receiver.public_key, "test_message")
         message = async_messenger.get_message_by_content_type(response, content_type=MessageContentType.TEXT_PLAIN.value)[0]
         message_id, sender_chat_id = message["id"], message["chatId"]
-        receiver_chat_id = receiver.wakuext_service.chats()[0]["id"]
+        receiver_chat_id = sender.public_key
 
         # Send emoji reaction
         response = receiver.wakuext_service.send_emoji_reaction(receiver_chat_id, message_id, "2764")
@@ -89,14 +90,14 @@ class TestMessageReactions:
                 )
             )
 
-    @pytest.mark.parametrize("waku_light_client", [False], indirect=True, ids=["wakuV2LightClient_False"])
+    @parametrize_waku_light_client_non_lc
     async def test_limit_of_20_reactions(self, sender, receiver, waku_light_client):
         """Test that you cannot send more than 20 message reactions on a single message"""
         await async_messenger.make_contacts(sender, receiver)
         response = sender.wakuext_service.send_one_to_one_message(receiver.public_key, "test_message")
         message = async_messenger.get_message_by_content_type(response, content_type=MessageContentType.TEXT_PLAIN.value)[0]
         message_id, sender_chat_id = message["id"], message["chatId"]
-        receiver_chat_id = receiver.wakuext_service.chats()[0]["id"]
+        receiver_chat_id = sender.public_key
 
         # Send 20 emojis
         emojis = [

--- a/tests-functional/tests/test_wakuext_messages_fetching.py
+++ b/tests-functional/tests/test_wakuext_messages_fetching.py
@@ -1,10 +1,12 @@
 import pytest
 
 from steps import messenger
+from utils.rpc_helpers import messages_list
+from waku_params import parametrize_waku_light_client
 
 
 @pytest.mark.rpc
-@pytest.mark.parametrize("waku_light_client", [False, True], indirect=True, ids=["wakuV2LightClient_False", "wakuV2LightClient_True"])
+@parametrize_waku_light_client
 class TestFetchingChatMessages:
 
     @pytest.fixture()
@@ -102,7 +104,7 @@ class TestFetchingChatMessages:
         )
         # TODO: Add more assertions on response
 
-        messages = response.get("messages", [])
+        messages = messages_list(response)
         actual_texts = [message.get("text", "") for message in messages]
         assert sent_texts_one_to_one[0] in actual_texts
         assert text_group in actual_texts

--- a/tests-functional/tests/test_wakuext_messages_interacting.py
+++ b/tests-functional/tests/test_wakuext_messages_interacting.py
@@ -3,10 +3,11 @@ import pytest
 from steps import messenger
 from clients.services.wakuext import SendPinMessagePayload
 from clients.api import ApiResponseError
+from waku_params import parametrize_waku_light_client
 
 
 @pytest.mark.rpc
-@pytest.mark.parametrize("waku_light_client", [False, True], indirect=True, ids=["wakuV2LightClient_False", "wakuV2LightClient_True"])
+@parametrize_waku_light_client
 class TestInteractingWithChatMessages:
 
     @pytest.fixture()

--- a/tests-functional/tests/test_wakuext_messages_sending.py
+++ b/tests-functional/tests/test_wakuext_messages_sending.py
@@ -6,11 +6,12 @@ from clients.services.wakuext import SendChatMessagePayload
 from clients.signals import SignalType
 from resources.enums import MessageContentType
 from steps import async_messenger
+from waku_params import parametrize_waku_light_client
 
 
 @pytest.mark.rpc
 @pytest.mark.asyncio
-@pytest.mark.parametrize("waku_light_client", [False, True], indirect=True, ids=["wakuV2LightClient_False", "wakuV2LightClient_True"])
+@parametrize_waku_light_client
 class TestSendingChatMessages:
 
     @pytest.fixture

--- a/tests-functional/tests/waku_params.py
+++ b/tests-functional/tests/waku_params.py
@@ -1,0 +1,19 @@
+"""Shared pytest parametrization for waku light client tests."""
+
+import pytest
+
+# Fixture: ``waku_light_client``. Backend config key: ``wakuV2LightClient``.
+# ``ids`` match the backend key and ``pytest -k`` (e.g. ``-k 'wakuV2LightClient_True'``).
+parametrize_waku_light_client = pytest.mark.parametrize(
+    "waku_light_client",
+    [False, True],
+    indirect=True,
+    ids=["wakuV2LightClient_False", "wakuV2LightClient_True"],
+)
+
+parametrize_waku_light_client_non_lc = pytest.mark.parametrize(
+    "waku_light_client",
+    [False],
+    indirect=True,
+    ids=["wakuV2LightClient_False"],
+)

--- a/tests-functional/utils/rpc_helpers.py
+++ b/tests-functional/utils/rpc_helpers.py
@@ -1,0 +1,23 @@
+"""Normalize JSON-RPC results that may be null or use null list fields."""
+
+
+def list_or_empty(value) -> list:
+    """Return *value* if it is a list, else []."""
+    return value if isinstance(value, list) else []
+
+
+def _get_list(response, key: str) -> list:
+    if not isinstance(response, dict):
+        return []
+    value = response.get(key)
+    return value if isinstance(value, list) else []
+
+
+def messages_list(response) -> list:
+    """Extract ``messages`` from a wakuext response; null-safe for iteration."""
+    return _get_list(response, "messages")
+
+
+def emoji_reactions_list(response) -> list:
+    """Extract ``emojiReactions`` from sendEmojiReaction RPC; null-safe for iteration."""
+    return _get_list(response, "emojiReactions")


### PR DESCRIPTION
Changes:

- Null-safe RPC lists: wakuext methods return [] instead of None when Go sends JSON null (chats, active_chats, chats_preview, emoji reactions)
- rpc_helpers.py: list_or_empty, messages_list for handling of null list fields in responses
- Logging: SecretRedactingFilter no longer crashes when log messages contain %
- Light client parametrization: waku_params.py with shared @parametrize_waku_light_client and ids `wakuV2LightClient_False` / `wakuV2LightClient_True` (example: pytest -k 'wakuV2LightClient_True')
- Test fix: 1:1 reactions use sender.public_key as receiver’s chat id (not chats()[0])
- Docs: README note on waku_params and -k usage.