### PR TITLE
fix(contacts): hole in condition checking for unknown contact message

### DIFF
--- a/protocol/messenger_contact_requests_test.go
+++ b/protocol/messenger_contact_requests_test.go
@@ -841,6 +841,33 @@ func (s *MessengerContactRequestSuite) TestAcceptLatestContactRequestForContact(
 	s.Require().True(resp.Contacts[0].Mutual())
 }
 
+func (s *MessengerContactRequestSuite) TestAcceptLatestContactRequestForContactWhenMessageMissing() {
+	messageText := "hello!"
+
+	theirMessenger := s.newMessenger()
+
+	contactID := types.EncodeHex(crypto.FromECDSAPub(&theirMessenger.identity.PublicKey))
+	request := &requests.SendContactRequest{
+		ID:      contactID,
+		Message: messageText,
+	}
+	s.sendContactRequest(request, s.m)
+	contactRequest := s.receiveContactRequest(messageText, theirMessenger)
+
+	err := theirMessenger.persistence.DeleteMessage(contactRequest.ID)
+	s.Require().NoError(err)
+
+	myID := types.EncodeHex(crypto.FromECDSAPub(&s.m.identity.PublicKey))
+	resp, err := theirMessenger.AcceptLatestContactRequestForContact(context.Background(), &requests.AcceptLatestContactRequestForContact{ID: types.Hex2Bytes(myID)})
+	s.Require().NoError(err)
+	s.Require().NotNil(resp)
+
+	contactRequestMsg := s.findFirstByContentType(resp.Messages(), protobuf.ChatMessage_CONTACT_REQUEST)
+	s.Require().NotNil(contactRequestMsg)
+	s.Require().Equal(defaultContactRequestID(myID), contactRequestMsg.ID)
+	s.Require().Equal(common.ContactRequestStateAccepted, contactRequestMsg.ContactRequestState)
+}
+
 func (s *MessengerContactRequestSuite) TestDismissLatestContactRequestForContact() {
 	messageText := "hello!"
 
@@ -869,6 +896,33 @@ func (s *MessengerContactRequestSuite) TestDismissLatestContactRequestForContact
 	s.Require().Equal(resp.ActivityCenterNotifications()[0].ID.String(), contactRequest.ID)
 	s.Require().NotNil(resp.ActivityCenterNotifications()[0].Message)
 	s.Require().Equal(common.ContactRequestStateDismissed, resp.ActivityCenterNotifications()[0].Message.ContactRequestState)
+}
+
+func (s *MessengerContactRequestSuite) TestDismissLatestContactRequestForContactWhenMessageMissing() {
+	messageText := "hello!"
+
+	theirMessenger := s.newMessenger()
+
+	contactID := types.EncodeHex(crypto.FromECDSAPub(&theirMessenger.identity.PublicKey))
+	request := &requests.SendContactRequest{
+		ID:      contactID,
+		Message: messageText,
+	}
+	s.sendContactRequest(request, s.m)
+	contactRequest := s.receiveContactRequest(messageText, theirMessenger)
+
+	err := theirMessenger.persistence.DeleteMessage(contactRequest.ID)
+	s.Require().NoError(err)
+
+	myID := types.EncodeHex(crypto.FromECDSAPub(&s.m.identity.PublicKey))
+	resp, err := theirMessenger.DismissLatestContactRequestForContact(context.Background(), &requests.DismissLatestContactRequestForContact{ID: types.Hex2Bytes(myID)})
+	s.Require().NoError(err)
+	s.Require().NotNil(resp)
+
+	contactRequestMsg := s.findFirstByContentType(resp.Messages(), protobuf.ChatMessage_CONTACT_REQUEST)
+	s.Require().NotNil(contactRequestMsg)
+	s.Require().Equal(defaultContactRequestID(myID), contactRequestMsg.ID)
+	s.Require().Equal(common.ContactRequestStateDismissed, contactRequestMsg.ContactRequestState)
 }
 
 func (s *MessengerContactRequestSuite) TestPairedDevicesRemoveContact() {

--- a/protocol/messenger_contacts.go
+++ b/protocol/messenger_contacts.go
@@ -1196,9 +1196,10 @@ func (m *Messenger) retrieveLatestContactRequestIDForContact(contactID string) (
 	}
 
 	contactRequestID, err := m.persistence.LatestPendingContactRequestIDForContact(contactID)
-	if err == common.ErrRecordNotFound {
+	if err == common.ErrRecordNotFound || (err == nil && contactRequestID == "") {
 		// No pending request found, use a default one
 		contactRequestID = defaultContactRequestID(contactID)
+		err = nil
 	}
 	return contactRequestID, err
 }


### PR DESCRIPTION
Fixes https://github.com/status-im/status-app/issues/21067

I had previously done a fix that addresses this issue: https://github.com/status-im/status-go/pull/7165

But turns out there was still a hole in the logic, because the persistence could return just an empty ID, so it would skip my bypass and just error later. Plus, I had forgotten to reset the error.

This fix addresses the hole and adds tests.

I wasn't able to actually test this e2e, because the bug is almost impossible to reproduce, since it requires paired devices and lost messages.