### PR TITLE
fix(rpc): remove proxy provider for katana

### DIFF
--- a/internal/healthmanager/aggregator/aggregator.go
+++ b/internal/healthmanager/aggregator/aggregator.go
@@ -143,7 +143,7 @@ func (a *Aggregator) ComputeAggregatedStatus() rpcstatus.ProviderStatus {
 		TotalErrorCount:   totalErrorCount,
 	}
 	if len(a.providerStatuses) == 0 {
-		aggregatedStatus.Status = rpcstatus.StatusDown
+		aggregatedStatus.Status = rpcstatus.StatusUnknown
 	} else if anyUp {
 		aggregatedStatus.Status = rpcstatus.StatusUp
 	} else if anyUnknown {

--- a/internal/healthmanager/aggregator/aggregator_test.go
+++ b/internal/healthmanager/aggregator/aggregator_test.go
@@ -137,7 +137,7 @@ func (suite *StatusAggregatorTestSuite) TestUpdate() {
 func (suite *StatusAggregatorTestSuite) TestComputeAggregatedStatus_NoProviders() {
 	aggStatus := suite.aggregator.ComputeAggregatedStatus()
 
-	assert.Equal(suite.T(), rpcstatus.StatusDown, aggStatus.Status, "Aggregated status should be 'down' when no providers are registered")
+	assert.Equal(suite.T(), rpcstatus.StatusUnknown, aggStatus.Status, "Aggregated status should be 'unknown' when there is no provider data yet")
 	assert.True(suite.T(), aggStatus.LastSuccessAt.IsZero(), "LastSuccessAt should be zero when no providers are registered")
 	assert.True(suite.T(), aggStatus.LastErrorAt.IsZero(), "LastErrorAt should be zero when no providers are registered")
 }

--- a/internal/healthmanager/providers_health_manager_test.go
+++ b/internal/healthmanager/providers_health_manager_test.go
@@ -59,7 +59,7 @@ func (s *ProvidersHealthManagerSuite) assertChainStatus(expected rpcstatus.Statu
 }
 
 func (s *ProvidersHealthManagerSuite) TestInitialStatus() {
-	s.assertChainStatus(rpcstatus.StatusDown)
+	s.assertChainStatus(rpcstatus.StatusUnknown)
 }
 
 func (s *ProvidersHealthManagerSuite) TestUpdateProviderStatuses() {
@@ -123,7 +123,7 @@ func (s *ProvidersHealthManagerSuite) TestUpdateProviderStatuses() {
 func (s *ProvidersHealthManagerSuite) TestChainStatusUpdatesOnce() {
 	ch := s.phm.Subscribe()
 	defer s.phm.Unsubscribe(ch)
-	s.assertChainStatus(rpcstatus.StatusDown)
+	s.assertChainStatus(rpcstatus.StatusUnknown)
 
 	// Update providers to Down
 	statuses := []rpcstatus.RpcProviderCallStatus{

--- a/internal/rpc/chain/client_health_test.go
+++ b/internal/rpc/chain/client_health_test.go
@@ -18,7 +18,7 @@ import (
 
 	healthManager "github.com/status-im/status-go/internal/healthmanager"
 	"github.com/status-im/status-go/internal/healthmanager/rpcstatus"
-	ethclient "github.com/status-im/status-go/internal/rpc/chain/ethclient"
+	"github.com/status-im/status-go/internal/rpc/chain/ethclient"
 	mockEthclient "github.com/status-im/status-go/internal/rpc/chain/ethclient/mock/client/ethclient"
 	"github.com/status-im/status-go/internal/rpc/chain/rpclimiter"
 )
@@ -167,7 +167,7 @@ func (s *ClientWithFallbackSuite) TestVMErrorDoesNotMarkChainDown() {
 	require.Equal(s.T(), providerStatuses["test0_provider"].Status, rpcstatus.StatusUp)
 }
 
-func (s *ClientWithFallbackSuite) TestNoClientsChainDown() {
+func (s *ClientWithFallbackSuite) TestNoClientsChainUnknown() {
 	s.setupClients(0)
 
 	ctx := context.Background()
@@ -179,7 +179,7 @@ func (s *ClientWithFallbackSuite) TestNoClientsChainDown() {
 
 	// THEN
 	chainStatus := s.providersHealthManager.Status()
-	require.Equal(s.T(), rpcstatus.StatusDown, chainStatus.Status)
+	require.Equal(s.T(), rpcstatus.StatusUnknown, chainStatus.Status)
 }
 
 func (s *ClientWithFallbackSuite) TestAllClientsDifferentErrors() {
@@ -233,11 +233,13 @@ func (s *ClientWithFallbackSuite) TestAllClientsNetworkErrors() {
 	require.Equal(s.T(), providerStatuses["test2_provider"].Status, rpcstatus.StatusDown)
 }
 
-func (s *ClientWithFallbackSuite) TestChainStatusDownWhenInitial() {
+func (s *ClientWithFallbackSuite) TestChainStatusUnknownWhenInitial() {
 	s.setupClients(2)
 
+	// Before any call the chain has no health data, so it is Unknown (not Down).
+	// This prevents a false "networks down" banner while the first request is in flight.
 	chainStatus := s.providersHealthManager.Status()
-	require.Equal(s.T(), rpcstatus.StatusDown, chainStatus.Status)
+	require.Equal(s.T(), rpcstatus.StatusUnknown, chainStatus.Status)
 }
 
 func TestClientWithFallbackSuite(t *testing.T) {

--- a/params/networkdefaults/default_networks_config.go
+++ b/params/networkdefaults/default_networks_config.go
@@ -323,9 +323,6 @@ var defaultNetworkSpecs = []networkSpec{
 		proxyNetworkName: "mainnet",
 		chainName:        "Katana",
 		providers: []providerSpec{
-			{providerType: providerTypeEthRpcProxy, name: common.StatusSmartProxy},
-			// no support for katana on infura
-			// no support for katana on alchemy
 			{providerType: providerTypeDirect, name: common.DirectCustom, directURL: security.NewSensitiveString("https://rpc.katana.network"), enableRpsLimiter: true},
 		},
 		blockExplorerURL:       "https://katanascan.com/",


### PR DESCRIPTION
Katana (chain 747474) rpc requests to `test.eth-rpc.status.im` proxy returned: "No providers available for this chain/network."

This removes the StatusSmartProxy provider from Katana Mainnet and Bokuto, leaving the direct endpoints (rpc.katana.network, rpc-bokuto.katanarpc.com) as the only providers

ref https://github.com/status-im/status-app/pull/21145