### PR TITLE
feat: introduce StoreClient facade to decouple store access from go-waku

### DIFF
--- a/pkg/messaging/api_store_nodes.go
+++ b/pkg/messaging/api_store_nodes.go
@@ -35,23 +35,19 @@ func (a *API) OnStorenodeAvailable() <-chan peer.ID {
 	return a.core.stack.Transport.OnStorenodeAvailable()
 }
 
-func (a *API) WaitForAvailableStoreNode(ctx context.Context) bool {
-	return a.core.stack.Transport.WaitForAvailableStoreNode(ctx)
-}
-
-func (a *API) PerformStorenodeTask(fn func() error, opts ...history.StorenodeTaskOption) error {
-	return a.core.stack.Transport.PerformStorenodeTask(fn, opts...)
-}
-
-func (a *API) ProcessMailserverBatch(
+// Query retrieves historic messages for a single batch (one pubsub topic and its
+// content topics over [batch.From, batch.To]). The store node is selected
+// internally — callers no longer pass a peer. shouldProcessNextPage (may be nil)
+// is the per-page early-stop; processEnvelopes controls synchronous handling of
+// fetched envelopes.
+func (a *API) Query(
 	ctx context.Context,
 	batch types.StoreNodeBatch,
-	storenode peer.AddrInfo,
 	pageLimit uint64,
 	shouldProcessNextPage func(int) (bool, uint64),
 	processEnvelopes bool,
 ) error {
-	return a.core.stack.Transport.ProcessMailserverBatch(ctx, *adapters.ToWakuBatch(&batch), storenode, pageLimit, shouldProcessNextPage, processEnvelopes)
+	return a.core.stack.Transport.Query(ctx, *adapters.ToWakuBatch(&batch), pageLimit, shouldProcessNextPage, processEnvelopes)
 }
 
 func (a *API) SetStorenodeConfigProvider(c history.StorenodeConfigProvider) {

--- a/pkg/messaging/layers/transport/transport.go
+++ b/pkg/messaging/layers/transport/transport.go
@@ -762,27 +762,20 @@ func (t *Transport) OnStorenodeAvailable() <-chan peer.ID {
 	return t.waku.OnStorenodeAvailable()
 }
 
-func (t *Transport) WaitForAvailableStoreNode(ctx context.Context) bool {
-	return t.waku.WaitForAvailableStoreNode(ctx)
-}
-
 func (t *Transport) IsStorenodeAvailable(peerID peer.ID) bool {
 	return t.waku.IsStorenodeAvailable(peerID)
 }
 
-func (t *Transport) PerformStorenodeTask(fn func() error, opts ...history.StorenodeTaskOption) error {
-	return t.waku.PerformStorenodeTask(fn, opts...)
-}
-
-func (t *Transport) ProcessMailserverBatch(
+// Query retrieves historic messages for a single batch, selecting the store node
+// internally (no peer argument). See waku.StoreClient.
+func (t *Transport) Query(
 	ctx context.Context,
 	batch types.MailserverBatch,
-	storenode peer.AddrInfo,
 	pageLimit uint64,
 	shouldProcessNextPage func(int) (bool, uint64),
 	processEnvelopes bool,
 ) error {
-	return t.waku.ProcessMailserverBatch(ctx, batch, storenode, pageLimit, shouldProcessNextPage, processEnvelopes)
+	return t.waku.StoreQuery(ctx, batch, pageLimit, shouldProcessNextPage, processEnvelopes)
 }
 
 func (t *Transport) SetStorenodeConfigProvider(c history.StorenodeConfigProvider) {

--- a/pkg/messaging/waku/gowaku.go
+++ b/pkg/messaging/waku/gowaku.go
@@ -43,7 +43,6 @@ import (
 	"github.com/libp2p/go-libp2p/core/peerstore"
 	"github.com/multiformats/go-multiaddr"
 	"github.com/prometheus/client_golang/prometheus"
-	"google.golang.org/protobuf/proto"
 
 	"go.uber.org/zap"
 
@@ -74,7 +73,6 @@ import (
 	"github.com/waku-org/go-waku/waku/v2/protocol/filter"
 	"github.com/waku-org/go-waku/waku/v2/protocol/lightpush"
 	"github.com/waku-org/go-waku/waku/v2/protocol/peer_exchange"
-	"github.com/waku-org/go-waku/waku/v2/protocol/store"
 	"github.com/waku-org/go-waku/waku/v2/utils"
 
 	"github.com/waku-org/go-waku/waku/v2/node"
@@ -183,6 +181,7 @@ type Waku struct {
 
 	StorenodeCycle   *history.StorenodeCycle
 	HistoryRetriever *history.HistoryRetriever
+	storeClient      *StoreClient
 
 	logger *zap.Logger
 
@@ -1034,6 +1033,7 @@ func (w *Waku) Start() error {
 
 	w.StorenodeCycle = history.NewStorenodeCycle(w.logger, commonapi.NewDefaultPinger(w.node.Host()))
 	w.HistoryRetriever = history.NewHistoryRetriever(missing.NewDefaultStorenodeRequestor(w.node.Store()), NewHistoryProcessorWrapper(w), w.logger)
+	w.storeClient = NewStoreClient(w.StorenodeCycle, w.HistoryRetriever, w.GetPubsubTopic, w.logger)
 
 	w.StorenodeCycle.Start(w.ctx)
 
@@ -1951,43 +1951,24 @@ func (w *Waku) OnStorenodeAvailable() <-chan peer.ID {
 	return w.StorenodeCycle.StorenodeAvailableEmitter.Subscribe()
 }
 
-func (w *Waku) WaitForAvailableStoreNode(ctx context.Context) bool {
-	return w.StorenodeCycle.WaitForAvailableStoreNode(ctx)
-}
-
 func (w *Waku) SetStorenodeConfigProvider(c history.StorenodeConfigProvider) {
 	w.StorenodeCycle.SetStorenodeConfigProvider(c)
 }
 
-func (w *Waku) ProcessMailserverBatch(
+// StoreQuery retrieves historic messages for a single batch via the StoreClient
+// facade, which selects the store node itself (no peer argument).
+func (w *Waku) StoreQuery(
 	ctx context.Context,
 	batch types.MailserverBatch,
-	storenode peer.AddrInfo,
 	pageLimit uint64,
 	shouldProcessNextPage func(int) (bool, uint64),
 	processEnvelopes bool,
 ) error {
-	pubsubTopic := w.GetPubsubTopic(batch.PubsubTopic)
-	contentTopics := []string{}
-	for _, topic := range batch.Topics {
-		contentTopics = append(contentTopics, common.BytesToTopic(topic.Bytes()).ContentTopic())
-	}
-
-	criteria := store.FilterCriteria{
-		TimeStart:     proto.Int64(batch.From.UnixNano()),
-		TimeEnd:       proto.Int64(batch.To.UnixNano()),
-		ContentFilter: protocol.NewContentFilter(pubsubTopic, contentTopics...),
-	}
-
-	return w.HistoryRetriever.Query(ctx, criteria, storenode, pageLimit, shouldProcessNextPage, processEnvelopes)
+	return w.storeClient.Query(ctx, batch, pageLimit, shouldProcessNextPage, processEnvelopes)
 }
 
 func (w *Waku) IsStorenodeAvailable(peerID peer.ID) bool {
 	return w.StorenodeCycle.IsStorenodeAvailable(peerID)
-}
-
-func (w *Waku) PerformStorenodeTask(fn func() error, opts ...history.StorenodeTaskOption) error {
-	return w.StorenodeCycle.PerformStorenodeTask(fn, opts...)
 }
 
 func (w *Waku) DisconnectActiveStorenode(ctx context.Context, backoff time.Duration, shouldCycle bool) {

--- a/pkg/messaging/waku/store_client.go
+++ b/pkg/messaging/waku/store_client.go
@@ -1,0 +1,109 @@
+package wakuv2
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"go.uber.org/zap"
+	"google.golang.org/protobuf/proto"
+
+	"github.com/waku-org/go-waku/waku/v2/api/history"
+	"github.com/waku-org/go-waku/waku/v2/protocol"
+	"github.com/waku-org/go-waku/waku/v2/protocol/store"
+
+	common "github.com/status-im/status-go/pkg/messaging/waku/common"
+	types "github.com/status-im/status-go/pkg/messaging/waku/types"
+)
+
+// storenodeAvailableTimeout bounds how long Query waits for a usable store node
+// before giving up. It mirrors the timeout historically used by the store-node
+// request manager in the protocol package, and guarantees that a caller passing
+// a deadline-less context (e.g. the long-lived messenger context) cannot block
+// forever when no store node is reachable.
+const storenodeAvailableTimeout = 30 * time.Second
+
+// ErrStorenodeNotAvailable is returned by StoreClient.Query when no store node
+// becomes available within storenodeAvailableTimeout.
+var ErrStorenodeNotAvailable = errors.New("store node is not available")
+
+// StoreClient is the single status-go seam for historic-message retrieval. It
+// hides store-node selection behind one method (Query), so callers no longer
+// thread a peer through the go-waku quartet
+// (WaitForAvailableStoreNode → GetActiveStorenodePeerInfo →
+// PerformStorenodeTask → HistoryRetriever.Query).
+//
+// It is a facade over two collaborators, keeping their responsibilities separate:
+//   - selector ("cycle"): which peer, health, failover, pinning.
+//   - pager ("retriever"): cursor loop, topic chunking, early-stop, dispatch.
+//
+// Invariant: a peer is selected once per Query and reused for every page of that
+// query; failover happens only at a query boundary (a fresh Query), never
+// mid-pagination — a store cursor is bound to the peer that issued it.
+//
+// Phase 1 wraps the existing go-waku machinery unchanged. Phase 2 will swap the
+// collaborators for the Logos Delivery store call without touching callers.
+type StoreClient struct {
+	cycle              *history.StorenodeCycle
+	retriever          *history.HistoryRetriever
+	resolvePubsubTopic func(string) string
+	logger             *zap.Logger
+}
+
+// NewStoreClient builds a StoreClient over an existing storenode cycle (selector)
+// and history retriever (pager). resolvePubsubTopic maps an empty pubsub topic to
+// the configured default shard topic (see Waku.GetPubsubTopic).
+func NewStoreClient(cycle *history.StorenodeCycle, retriever *history.HistoryRetriever, resolvePubsubTopic func(string) string, logger *zap.Logger) *StoreClient {
+	return &StoreClient{
+		cycle:              cycle,
+		retriever:          retriever,
+		resolvePubsubTopic: resolvePubsubTopic,
+		logger:             logger.Named("store-client"),
+	}
+}
+
+// Query retrieves historic messages for a single batch (one pubsub topic and its
+// content topics over [batch.From, batch.To]) from a single store node, selecting
+// the peer itself and paginating until the range is exhausted or
+// shouldProcessNextPage stops it early.
+//
+// pageLimit is the page size of the first request; shouldProcessNextPage (may be
+// nil) decides, per page, whether to fetch the next one and with which size;
+// processEnvelopes controls whether fetched envelopes are passed to the message
+// pipeline synchronously.
+func (sc *StoreClient) Query(
+	ctx context.Context,
+	batch types.MailserverBatch,
+	pageLimit uint64,
+	shouldProcessNextPage func(int) (bool, uint64),
+	processEnvelopes bool,
+) error {
+	// selector: wait for and pin a store node. The wait is bounded so a
+	// deadline-less ctx cannot block indefinitely when no node is reachable.
+	waitCtx, cancel := context.WithTimeout(ctx, storenodeAvailableTimeout)
+	defer cancel()
+	if !sc.cycle.WaitForAvailableStoreNode(waitCtx) {
+		return ErrStorenodeNotAvailable
+	}
+	storenode := sc.cycle.GetActiveStorenodePeerInfo()
+
+	// pager: run every page of this query against the pinned peer.
+	// PerformStorenodeTask retries the same peer and only fails over across
+	// whole-Query boundaries, never mid-pagination.
+	return sc.cycle.PerformStorenodeTask(func() error {
+		criteria := store.FilterCriteria{
+			TimeStart:     proto.Int64(batch.From.UnixNano()),
+			TimeEnd:       proto.Int64(batch.To.UnixNano()),
+			ContentFilter: protocol.NewContentFilter(sc.resolvePubsubTopic(batch.PubsubTopic), sc.contentTopics(batch)...),
+		}
+		return sc.retriever.Query(ctx, criteria, storenode, pageLimit, shouldProcessNextPage, processEnvelopes)
+	}, history.WithPeerID(storenode.ID))
+}
+
+func (sc *StoreClient) contentTopics(batch types.MailserverBatch) []string {
+	contentTopics := make([]string, 0, len(batch.Topics))
+	for _, topic := range batch.Topics {
+		contentTopics = append(contentTopics, common.BytesToTopic(topic.Bytes()).ContentTopic())
+	}
+	return contentTopics
+}

--- a/pkg/messaging/waku/types/waku.go
+++ b/pkg/messaging/waku/types/waku.go
@@ -175,17 +175,14 @@ type Waku interface {
 	// OnStorenodeAvailable is triggered when there is a new active storenode selected
 	OnStorenodeAvailable() <-chan peer.ID
 
-	// WaitForAvailableStoreNode will wait for a storenode to be available depending on the context
-	WaitForAvailableStoreNode(ctx context.Context) bool
-
 	// SetStorenodeConfigProvider will set the configuration provider for the storenode cycle
 	SetStorenodeConfigProvider(c history.StorenodeConfigProvider)
 
-	// ProcessMailserverBatch will receive a criteria and storenode and execute a query
-	ProcessMailserverBatch(
+	// StoreQuery retrieves historic messages for a single batch, selecting the
+	// store node internally (no peer argument). See waku.StoreClient.
+	StoreQuery(
 		ctx context.Context,
 		batch MailserverBatch,
-		storenode peer.AddrInfo,
 		pageLimit uint64,
 		shouldProcessNextPage func(int) (bool, uint64),
 		processEnvelopes bool,
@@ -193,8 +190,6 @@ type Waku interface {
 
 	// IsStorenodeAvailable is used to determine whether a storenode is available or not
 	IsStorenodeAvailable(peerID peer.ID) bool
-
-	PerformStorenodeTask(fn func() error, opts ...history.StorenodeTaskOption) error
 
 	// DisconnectActiveStorenode will trigger a disconnection of the active storenode, and potentially execute a cycling so a new storenode is promoted
 	DisconnectActiveStorenode(ctx context.Context, backoff time.Duration, shouldCycle bool)

--- a/protocol/messenger_communities.go
+++ b/protocol/messenger_communities.go
@@ -3574,8 +3574,6 @@ func (m *Messenger) InitHistoryArchiveTasks(communities []*communities.Community
 	defer utils.LogOnPanic()
 	m.logger.Debug("initializing history archive tasks")
 
-	peerInfo := m.messaging.GetActiveStorenode()
-
 	for _, c := range communities {
 
 		if c.Joined() {
@@ -3642,7 +3640,7 @@ func (m *Messenger) InitHistoryArchiveTasks(communities []*communities.Community
 			}
 
 			// Request possibly missed waku messages for community
-			_, err = m.syncFiltersFrom(peerInfo, filters, uint32(latestWakuMessageTimestamp))
+			_, err = m.syncFiltersFrom(filters, uint32(latestWakuMessageTimestamp))
 			if err != nil {
 				m.logger.Error("failed to request missing messages", zap.Error(err))
 				continue

--- a/protocol/messenger_mailserver.go
+++ b/protocol/messenger_mailserver.go
@@ -5,12 +5,9 @@ import (
 	"sort"
 	"time"
 
-	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/pkg/errors"
 	"go.uber.org/zap"
 	"golang.org/x/exp/maps"
-
-	"github.com/waku-org/go-waku/waku/v2/api/history"
 
 	gocommon "github.com/status-im/status-go/common"
 	"github.com/status-im/status-go/internal/connection"
@@ -68,52 +65,17 @@ func (m *Messenger) scheduleSyncChat(chat *Chat) (bool, error) {
 
 	go func() {
 		defer gocommon.LogOnPanic()
-		peerInfo := m.messaging.GetActiveStorenode()
-		_, err = m.performStorenodeTask(func() (*MessengerResponse, error) {
-			response, err := m.syncChatWithFilters(peerInfo, chat.ID)
-
-			if err != nil {
-				m.logger.Error("failed to sync chat", zap.Error(err))
-				return nil, err
-			}
-
-			if m.config.messengerSignalsHandler != nil {
-				m.config.messengerSignalsHandler.MessengerResponse(response)
-			}
-			return response, nil
-		}, history.WithPeerID(peerInfo.ID))
+		response, err := m.syncChatWithFilters(chat.ID)
 		if err != nil {
-			m.logger.Error("failed to perform mailserver request", zap.Error(err))
+			m.logger.Error("failed to sync chat", zap.Error(err))
+			return
+		}
+
+		if m.config.messengerSignalsHandler != nil {
+			m.config.messengerSignalsHandler.MessengerResponse(response)
 		}
 	}()
 	return true, nil
-}
-
-func (m *Messenger) performStorenodeTask(task func() (*MessengerResponse, error), opts ...history.StorenodeTaskOption) (*MessengerResponse, error) {
-	responseCh := make(chan *MessengerResponse, 1)
-	err := m.messaging.PerformStorenodeTask(func() error {
-		r, err := task()
-		if err != nil {
-			return err
-		}
-
-		select {
-		case <-m.ctx.Done():
-			return m.ctx.Err()
-		case responseCh <- r:
-			return nil
-		}
-	}, opts...)
-	if err != nil {
-		return nil, err
-	}
-
-	select {
-	case r := <-responseCh:
-		return r, nil
-	case <-m.ctx.Done():
-		return nil, m.ctx.Err()
-	}
 }
 
 func (m *Messenger) scheduleSyncFilters(filters types2.ChatFilters) (bool, error) {
@@ -129,22 +91,14 @@ func (m *Messenger) scheduleSyncFilters(filters types2.ChatFilters) (bool, error
 
 	go func() {
 		defer gocommon.LogOnPanic()
-		peerInfo := m.messaging.GetActiveStorenode()
-		_, err := m.performStorenodeTask(func() (*MessengerResponse, error) {
-			response, err := m.syncFilters(peerInfo, filters)
-
-			if err != nil {
-				m.logger.Error("failed to sync filter", zap.Error(err))
-				return nil, err
-			}
-
-			if m.config.messengerSignalsHandler != nil {
-				m.config.messengerSignalsHandler.MessengerResponse(response)
-			}
-			return response, nil
-		}, history.WithPeerID(peerInfo.ID))
+		response, err := m.syncFilters(filters)
 		if err != nil {
-			m.logger.Error("failed to perform mailserver request", zap.Error(err))
+			m.logger.Error("failed to sync filter", zap.Error(err))
+			return
+		}
+
+		if m.config.messengerSignalsHandler != nil {
+			m.config.messengerSignalsHandler.MessengerResponse(response)
 		}
 	}()
 	return true, nil
@@ -208,13 +162,13 @@ func (m *Messenger) topicsForChat(chatID string) (string, []types2.ContentTopic,
 	return filters[0].PubsubTopic(), contentTopics, nil
 }
 
-func (m *Messenger) syncChatWithFilters(peerInfo peer.AddrInfo, chatID string) (*MessengerResponse, error) {
+func (m *Messenger) syncChatWithFilters(chatID string) (*MessengerResponse, error) {
 	filters, err := m.filtersForChat(chatID)
 	if err != nil {
 		return nil, err
 	}
 
-	return m.syncFilters(peerInfo, filters)
+	return m.syncFilters(filters)
 }
 
 func (m *Messenger) defaultSyncPeriodFromNow() (uint32, error) {
@@ -309,23 +263,10 @@ func (m *Messenger) requestAllHistoricMessages(withRetries bool, aggregateRespon
 			}
 		}()
 
-		peerInfo := m.messaging.GetActiveStorenode()
-
-		if withRetries {
-			response, err := m.performStorenodeTask(func() (*MessengerResponse, error) {
-				return m.syncFilters(peerInfo, filters)
-			}, history.WithPeerID(peerInfo.ID))
-			if err != nil {
-				return nil, err
-			}
-			if aggregateResponses && response != nil {
-				allResponses.AddChats(response.Chats())
-				allResponses.AddMessages(response.Messages())
-			}
-			return allResponses, nil
-		}
-
-		response, err := m.syncFilters(peerInfo, filters)
+		// Retry and failover are handled per query by the StoreClient (it pins a
+		// store node for the whole query and fails over only at query boundaries),
+		// so withRetries no longer selects a separate retry wrapper.
+		response, err := m.syncFilters(filters)
 		if err != nil {
 			return nil, err
 		}
@@ -406,7 +347,7 @@ func getPrioritizedBatches() []int {
 	return []int{1, 5, 10}
 }
 
-func (m *Messenger) syncFiltersFrom(peerInfo peer.AddrInfo, filters types2.ChatFilters, lastRequest uint32) (*MessengerResponse, error) {
+func (m *Messenger) syncFiltersFrom(filters types2.ChatFilters, lastRequest uint32) (*MessengerResponse, error) {
 	canSync, err := m.canSyncWithStoreNodes()
 	if err != nil {
 		return nil, err
@@ -545,7 +486,7 @@ func (m *Messenger) syncFiltersFrom(peerInfo peer.AddrInfo, filters types2.ChatF
 		batchKeys := maps.Keys(batches[pubsubTopic])
 		sort.Ints(batchKeys)
 		for _, k := range batchKeys {
-			err := m.processMailserverBatch(peerInfo, batches[pubsubTopic][k])
+			err := m.processMailserverBatch(batches[pubsubTopic][k])
 			if err != nil {
 				m.logger.Error("error syncing topics", zap.Error(err))
 				return nil, err
@@ -604,8 +545,8 @@ func (m *Messenger) syncFiltersFrom(peerInfo peer.AddrInfo, filters types2.ChatF
 	return response, nil
 }
 
-func (m *Messenger) syncFilters(peerInfo peer.AddrInfo, filters types2.ChatFilters) (*MessengerResponse, error) {
-	return m.syncFiltersFrom(peerInfo, filters, 0)
+func (m *Messenger) syncFilters(filters types2.ChatFilters) (*MessengerResponse, error) {
+	return m.syncFiltersFrom(filters, 0)
 }
 
 func (m *Messenger) calculateGapForChat(chat *Chat, from uint32) (*common.Message, error) {
@@ -656,7 +597,10 @@ func (m *Messenger) ConnectionChanged(state connection.State) {
 	m.connectionState = state
 }
 
-func (m *Messenger) processMailserverBatch(peerInfo peer.AddrInfo, batch types2.StoreNodeBatch) error {
+// processMailserverBatch queries the store for a single batch, applying the
+// mobile-network gate. The store node is selected internally by the StoreClient
+// (no peer argument).
+func (m *Messenger) processMailserverBatch(batch types2.StoreNodeBatch) error {
 	canSync, err := m.canSyncWithStoreNodes()
 	if err != nil {
 		return err
@@ -665,10 +609,10 @@ func (m *Messenger) processMailserverBatch(peerInfo peer.AddrInfo, batch types2.
 		return nil
 	}
 
-	return m.messaging.ProcessMailserverBatch(m.ctx, batch, peerInfo, defaultStoreNodeRequestPageSize, nil, false)
+	return m.messaging.Query(m.ctx, batch, defaultStoreNodeRequestPageSize, nil, false)
 }
 
-func (m *Messenger) processMailserverBatchWithOptions(peerInfo peer.AddrInfo, batch types2.StoreNodeBatch, pageLimit uint64, shouldProcessNextPage func(int) (bool, uint64), processEnvelopes bool) error {
+func (m *Messenger) processMailserverBatchWithOptions(batch types2.StoreNodeBatch, pageLimit uint64, shouldProcessNextPage func(int) (bool, uint64), processEnvelopes bool) error {
 	canSync, err := m.canSyncWithStoreNodes()
 	if err != nil {
 		return err
@@ -677,7 +621,7 @@ func (m *Messenger) processMailserverBatchWithOptions(peerInfo peer.AddrInfo, ba
 		return nil
 	}
 
-	return m.messaging.ProcessMailserverBatch(m.ctx, batch, peerInfo, pageLimit, shouldProcessNextPage, processEnvelopes)
+	return m.messaging.Query(m.ctx, batch, pageLimit, shouldProcessNextPage, processEnvelopes)
 }
 
 func (m *Messenger) SyncChatFromSyncedFrom(chatID string) (uint32, error) {
@@ -686,61 +630,55 @@ func (m *Messenger) SyncChatFromSyncedFrom(chatID string) (uint32, error) {
 		return 0, ErrChatNotFound
 	}
 
-	peerInfo := m.messaging.GetActiveStorenode()
-	var from uint32
-	_, err := m.performStorenodeTask(func() (*MessengerResponse, error) {
-		canSync, err := m.canSyncWithStoreNodes()
-		if err != nil {
-			return nil, err
-		}
-		if !canSync {
-			return nil, nil
-		}
+	canSync, err := m.canSyncWithStoreNodes()
+	if err != nil {
+		return 0, err
+	}
+	if !canSync {
+		return 0, nil
+	}
 
-		pubsubTopic, topics, err := m.topicsForChat(chatID)
-		if err != nil {
-			return nil, nil
-		}
+	pubsubTopic, topics, err := m.topicsForChat(chatID)
+	if err != nil {
+		return 0, nil
+	}
 
-		defaultSyncPeriod, err := m.settings.GetDefaultSyncPeriod()
-		if err != nil {
-			return nil, err
-		}
-
-		batch := types2.StoreNodeBatch{
-			ChatIDs:     []string{chatID},
-			To:          time.Unix(int64(chat.SyncedFrom), 0),
-			From:        time.Unix(int64(chat.SyncedFrom-defaultSyncPeriod), 0),
-			PubsubTopic: pubsubTopic,
-			Topics:      topics,
-		}
-		if m.config.messengerSignalsHandler != nil {
-			m.config.messengerSignalsHandler.HistoryRequestStarted(1)
-		}
-
-		err = m.processMailserverBatch(peerInfo, batch)
-		if err != nil {
-			return nil, err
-		}
-
-		if m.config.messengerSignalsHandler != nil {
-			m.config.messengerSignalsHandler.HistoryRequestCompleted()
-		}
-		if chat.SyncedFrom == 0 || chat.SyncedFrom > uint32(batch.From.Unix()) {
-			chat.SyncedFrom = uint32(batch.From.Unix())
-		}
-
-		m.logger.Debug("setting sync timestamps", zap.Int64("from", batch.From.Unix()), zap.Int64("to", int64(chat.SyncedTo)), zap.String("chatID", chatID))
-
-		err = m.persistence.SetSyncTimestamps(uint32(batch.From.Unix()), chat.SyncedTo, chat.ID)
-		from = uint32(batch.From.Unix())
-		return nil, err
-	}, history.WithPeerID(peerInfo.ID))
+	defaultSyncPeriod, err := m.settings.GetDefaultSyncPeriod()
 	if err != nil {
 		return 0, err
 	}
 
-	return from, nil
+	batch := types2.StoreNodeBatch{
+		ChatIDs:     []string{chatID},
+		To:          time.Unix(int64(chat.SyncedFrom), 0),
+		From:        time.Unix(int64(chat.SyncedFrom-defaultSyncPeriod), 0),
+		PubsubTopic: pubsubTopic,
+		Topics:      topics,
+	}
+	if m.config.messengerSignalsHandler != nil {
+		m.config.messengerSignalsHandler.HistoryRequestStarted(1)
+	}
+
+	err = m.processMailserverBatch(batch)
+	if err != nil {
+		return 0, err
+	}
+
+	if m.config.messengerSignalsHandler != nil {
+		m.config.messengerSignalsHandler.HistoryRequestCompleted()
+	}
+	if chat.SyncedFrom == 0 || chat.SyncedFrom > uint32(batch.From.Unix()) {
+		chat.SyncedFrom = uint32(batch.From.Unix())
+	}
+
+	m.logger.Debug("setting sync timestamps", zap.Int64("from", batch.From.Unix()), zap.Int64("to", int64(chat.SyncedTo)), zap.String("chatID", chatID))
+
+	err = m.persistence.SetSyncTimestamps(uint32(batch.From.Unix()), chat.SyncedTo, chat.ID)
+	if err != nil {
+		return 0, err
+	}
+
+	return uint32(batch.From.Unix()), nil
 }
 
 func (m *Messenger) FillGaps(chatID string, messageIDs []string) error {
@@ -787,8 +725,7 @@ func (m *Messenger) FillGaps(chatID string, messageIDs []string) error {
 		m.config.messengerSignalsHandler.HistoryRequestStarted(1)
 	}
 
-	peerID := m.messaging.GetActiveStorenode()
-	err = m.processMailserverBatch(peerID, batch)
+	err = m.processMailserverBatch(batch)
 	if err != nil {
 		return err
 	}
@@ -823,51 +760,46 @@ func (m *Messenger) fetchMessages(chatID string, duration time.Duration) (uint32
 		return 0, ErrChatNotFound
 	}
 
-	peerInfo := m.messaging.GetActiveStorenode()
-	_, err := m.performStorenodeTask(func() (*MessengerResponse, error) {
-		canSync, err := m.canSyncWithStoreNodes()
-		if err != nil {
-			return nil, err
-		}
-		if !canSync {
-			return nil, nil
-		}
+	canSync, err := m.canSyncWithStoreNodes()
+	if err != nil {
+		return 0, err
+	}
+	if !canSync {
+		return uint32(from.Unix()), nil
+	}
 
-		m.logger.Debug("fetching messages", zap.String("chatID", chatID), zap.Stringer("peerID", peerInfo.ID))
-		pubsubTopic, topics, err := m.topicsForChat(chatID)
-		if err != nil {
-			return nil, nil
-		}
+	m.logger.Debug("fetching messages", zap.String("chatID", chatID))
+	pubsubTopic, topics, err := m.topicsForChat(chatID)
+	if err != nil {
+		return uint32(from.Unix()), nil
+	}
 
-		batch := types2.StoreNodeBatch{
-			ChatIDs:     []string{chatID},
-			From:        from,
-			To:          to,
-			PubsubTopic: pubsubTopic,
-			Topics:      topics,
-		}
-		if m.config.messengerSignalsHandler != nil {
-			m.config.messengerSignalsHandler.HistoryRequestStarted(1)
-		}
+	batch := types2.StoreNodeBatch{
+		ChatIDs:     []string{chatID},
+		From:        from,
+		To:          to,
+		PubsubTopic: pubsubTopic,
+		Topics:      topics,
+	}
+	if m.config.messengerSignalsHandler != nil {
+		m.config.messengerSignalsHandler.HistoryRequestStarted(1)
+	}
 
-		err = m.processMailserverBatch(peerInfo, batch)
-		if err != nil {
-			return nil, err
-		}
+	err = m.processMailserverBatch(batch)
+	if err != nil {
+		return 0, err
+	}
 
-		if m.config.messengerSignalsHandler != nil {
-			m.config.messengerSignalsHandler.HistoryRequestCompleted()
-		}
-		if chat.SyncedFrom == 0 || chat.SyncedFrom > uint32(batch.From.Second()) {
-			chat.SyncedFrom = uint32(batch.From.Second())
-		}
+	if m.config.messengerSignalsHandler != nil {
+		m.config.messengerSignalsHandler.HistoryRequestCompleted()
+	}
+	if chat.SyncedFrom == 0 || chat.SyncedFrom > uint32(batch.From.Second()) {
+		chat.SyncedFrom = uint32(batch.From.Second())
+	}
 
-		m.logger.Debug("setting sync timestamps", zap.Int64("from", batch.From.Unix()), zap.Int64("to", int64(chat.SyncedTo)), zap.String("chatID", chatID))
+	m.logger.Debug("setting sync timestamps", zap.Int64("from", batch.From.Unix()), zap.Int64("to", int64(chat.SyncedTo)), zap.String("chatID", chatID))
 
-		err = m.persistence.SetSyncTimestamps(uint32(batch.From.Unix()), chat.SyncedTo, chat.ID)
-		from = batch.From
-		return nil, err
-	}, history.WithPeerID(peerInfo.ID))
+	err = m.persistence.SetSyncTimestamps(uint32(batch.From.Unix()), chat.SyncedTo, chat.ID)
 	if err != nil {
 		return 0, err
 	}

--- a/protocol/messenger_store_node_request_manager.go
+++ b/protocol/messenger_store_node_request_manager.go
@@ -4,9 +4,6 @@ import (
 	"context"
 	"fmt"
 	"sync"
-	"time"
-
-	"github.com/waku-org/go-waku/waku/v2/api/history"
 
 	"go.uber.org/zap"
 
@@ -17,10 +14,6 @@ import (
 	"github.com/status-im/status-go/protocol/contacts"
 
 	"github.com/status-im/status-go/protocol/communities"
-)
-
-const (
-	storeNodeAvailableTimeout = 30 * time.Second
 )
 
 // StoreNodeRequestStats is used in tests
@@ -447,13 +440,6 @@ func (r *storeNodeRequest) routine() {
 
 	communityID := r.requestID.getCommunityID()
 
-	ctx, cancel := context.WithTimeout(r.ctx, storeNodeAvailableTimeout)
-	defer cancel()
-	if !r.manager.messenger.messaging.WaitForAvailableStoreNode(ctx) {
-		r.result.err = fmt.Errorf("store node is not available")
-		return
-	}
-
 	// Check if community already exists locally and get Clock.
 	if r.requestID.RequestType == storeNodeCommunityRequest {
 		localCommunity, _ := r.manager.messenger.communitiesManager.GetByIDString(communityID)
@@ -465,23 +451,22 @@ func (r *storeNodeRequest) routine() {
 	// Start store node request
 	from, to := r.manager.messenger.calculateMailserverTimeBounds(oneMonthDuration)
 
-	storeNode := r.manager.messenger.messaging.GetActiveStorenode()
-	_, err := r.manager.messenger.performStorenodeTask(func() (*MessengerResponse, error) {
-		batch := types2.StoreNodeBatch{
-			From:        from,
-			To:          to,
-			PubsubTopic: r.pubsubTopic,
-			Topics:      []types2.ContentTopic{r.contentTopic},
-		}
-		r.manager.logger.Info("perform store node request", zap.Any("batch", batch))
-		if r.manager.onPerformingBatch != nil {
-			r.manager.onPerformingBatch(batch)
-		}
+	batch := types2.StoreNodeBatch{
+		From:        from,
+		To:          to,
+		PubsubTopic: r.pubsubTopic,
+		Topics:      []types2.ContentTopic{r.contentTopic},
+	}
+	r.manager.logger.Info("perform store node request", zap.Any("batch", batch))
+	if r.manager.onPerformingBatch != nil {
+		r.manager.onPerformingBatch(batch)
+	}
 
-		return nil, r.manager.messenger.processMailserverBatchWithOptions(storeNode, batch, r.config.InitialPageSize, r.shouldFetchNextPage, true)
-	}, history.WithPeerID(storeNode.ID))
-
-	r.result.err = err
+	// processMailserverBatchWithOptions applies the mobile-network gate and then
+	// queries: the StoreClient selects and pins the store node itself (waiting up
+	// to storenodeAvailableTimeout for one), paginating with shouldFetchNextPage
+	// as the early-stop. It returns ErrStorenodeNotAvailable if none is reachable.
+	r.result.err = r.manager.messenger.processMailserverBatchWithOptions(batch, r.config.InitialPageSize, r.shouldFetchNextPage, true)
 }
 
 func (r *storeNodeRequest) start() {


### PR DESCRIPTION
Phase 1 of #7526 — a status-go-only decoupling seam ahead of the Logos Delivery store swap. **No FFI, no go-waku removal, no behavior change.**

## What

Introduces a `StoreClient` facade (`pkg/messaging/waku`) over the storenode cycle (selector) and history retriever (pager), exposing a single `Query(...)` that selects the store node itself — collapsing the `WaitForAvailableStoreNode` / `GetActiveStorenodePeerInfo` / `PerformStorenodeTask` / `HistoryRetriever.Query` quartet that callers previously glued together with a hand-threaded peer.

- `Query` is surfaced on the messaging API + transport; the quartet is removed from the public surface (`GetActiveStorenode` stays — it still backs `shouldSync` and missing-message verification).
- Invariant: one peer is selected per `Query` and reused for every page; failover happens only at a query boundary, never mid-pagination (a store cursor is bound to its peer).
- History-sync (`messenger_mailserver.go`) and community/contact-fetch (`messenger_store_node_request_manager.go`) callers migrated to `Query`, dropping manual peer selection and the `performStorenodeTask` wrappers.

## Why

Decouples the call sites from go-waku now, so the eventual Logos Delivery Messaging API swap (Phase 2, separate ticket) is contained to the facade internals. Part of logos-messaging/pm#380.

## Notes for reviewers

- `RequestAllHistoricMessages`'s `withRetries` is now effectively a no-op — retry/failover is inherent to every `Query` per the invariant above; the param is kept so external callers are unchanged.
- Multi-batch history sync now fails over per batch instead of restarting the whole sync; observable message-fetching behaviour is unchanged.
- Net −120 LOC. `go build` + `go vet` are clean across `pkg/messaging`, `protocol`, `services/ext`, `cmd`, `pkg/backend`, `server/pairing`; protocol's network/fleet integration suite compiles but isn't run here.

Closes #7526

🤖 Generated with [Claude Code](https://claude.com/claude-code)
