### PR TITLE
refactor: on-demand Status-owned StoreClient internals (delete go-waku store cycle)

### DIFF
--- a/nix/pkgs/status-go/library/default.nix
+++ b/nix/pkgs/status-go/library/default.nix
@@ -11,7 +11,7 @@ let
 in pkgs.buildGoModule {
   pname = "status-go";
   src = builtins.path { path = ./../../../..; name = "status-go-library"; };
-  vendorHash = "sha256-+zAazKqLCV4I4axBqITVWqjJ+BXGl1YTmGO6evWtqaQ=";
+  vendorHash = "sha256-p3NQemuslvRFSmSZHS9fcklXEec+QC6N4LxFfGamE+U=";
 
   inherit meta version;
 

--- a/pkg/messaging/api_store_nodes.go
+++ b/pkg/messaging/api_store_nodes.go
@@ -2,38 +2,12 @@ package messaging
 
 import (
 	"context"
-	"time"
 
 	"github.com/libp2p/go-libp2p/core/peer"
-	"github.com/waku-org/go-waku/waku/v2/api/history"
 
 	adapters "github.com/status-im/status-go/pkg/messaging/adapters"
 	types "github.com/status-im/status-go/pkg/messaging/types"
 )
-
-// These methods ideally shouldn't be exposed as they reveal implementation details
-// of how the messaging module retrieves historic messages. This is a transitional
-// approach pending Waku SDK integration.
-
-func (a *API) GetActiveStorenode() peer.AddrInfo {
-	return a.core.stack.Transport.GetActiveStorenode()
-}
-
-func (a *API) DisconnectActiveStorenode(ctx context.Context, backoffReason time.Duration, shouldCycle bool) {
-	a.core.stack.Transport.DisconnectActiveStorenode(ctx, backoffReason, shouldCycle)
-}
-
-func (a *API) OnStorenodeChanged() <-chan peer.ID {
-	return a.core.stack.Transport.OnStorenodeChanged()
-}
-
-func (a *API) OnStorenodeNotWorking() <-chan struct{} {
-	return a.core.stack.Transport.OnStorenodeNotWorking()
-}
-
-func (a *API) OnStorenodeAvailable() <-chan peer.ID {
-	return a.core.stack.Transport.OnStorenodeAvailable()
-}
 
 // Query retrieves historic messages for a single batch (one pubsub topic and its
 // content topics over [batch.From, batch.To]). The store node is selected
@@ -50,6 +24,16 @@ func (a *API) Query(
 	return a.core.stack.Transport.Query(ctx, *adapters.ToWakuBatch(&batch), pageLimit, shouldProcessNextPage, processEnvelopes)
 }
 
-func (a *API) SetStorenodeConfigProvider(c history.StorenodeConfigProvider) {
-	a.core.stack.Transport.SetStorenodeConfigProvider(c)
+// SetStorenodes sets the storenodes the StoreClient may query. Called once at
+// startup. Storenodes whose addressing info can't be resolved are skipped.
+func (a *API) SetStorenodes(nodes []types.StoreNode) {
+	addrInfos := make([]peer.AddrInfo, 0, len(nodes))
+	for _, node := range nodes {
+		info, err := node.PeerInfo()
+		if err != nil {
+			continue
+		}
+		addrInfos = append(addrInfos, info)
+	}
+	a.core.stack.Transport.SetStorenodes(addrInfos)
 }

--- a/pkg/messaging/api_store_nodes.go
+++ b/pkg/messaging/api_store_nodes.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/libp2p/go-libp2p/core/peer"
+	"go.uber.org/zap"
 
 	adapters "github.com/status-im/status-go/pkg/messaging/adapters"
 	types "github.com/status-im/status-go/pkg/messaging/types"
@@ -31,9 +32,15 @@ func (a *API) SetStorenodes(nodes []types.StoreNode) {
 	for _, node := range nodes {
 		info, err := node.PeerInfo()
 		if err != nil {
+			a.core.logger.Warn("skipping storenode with unresolvable peer info",
+				zap.String("id", node.ID), zap.String("name", node.Name), zap.Error(err))
 			continue
 		}
 		addrInfos = append(addrInfos, info)
+	}
+	if len(addrInfos) == 0 && len(nodes) > 0 {
+		a.core.logger.Warn("no usable storenodes after resolving peer info; history queries will fail until reconfigured",
+			zap.Int("configured", len(nodes)))
 	}
 	a.core.stack.Transport.SetStorenodes(addrInfos)
 }

--- a/pkg/messaging/layers/transport/transport.go
+++ b/pkg/messaging/layers/transport/transport.go
@@ -10,8 +10,6 @@ import (
 	"github.com/pkg/errors"
 	"go.uber.org/zap"
 
-	"github.com/waku-org/go-waku/waku/v2/api/history"
-
 	"github.com/ethereum/go-ethereum/common"
 
 	gocommon "github.com/status-im/status-go/common"
@@ -782,14 +780,6 @@ func (t *Transport) ConfirmMessageDelivered(messageID string) {
 	t.waku.ConfirmMessageDelivered(commHashes)
 }
 
-func (t *Transport) GetActiveStorenode() peer.AddrInfo {
-	return t.waku.GetActiveStorenode()
-}
-
-func (t *Transport) DisconnectActiveStorenode(ctx context.Context, backoffReason time.Duration, shouldCycle bool) {
-	t.waku.DisconnectActiveStorenode(ctx, backoffReason, shouldCycle)
-}
-
 // SubscribeFilterMatched returns a channel notified (non-blocking, coalescing) whenever
 // an incoming envelope matches at least one installed filter. Callers must call
 // UnsubscribeFilterMatched with the returned channel when done.
@@ -804,22 +794,6 @@ func (t *Transport) UnsubscribeFilterMatched(ch chan struct{}) {
 	t.matchedPublisher.Unsubscribe(ch)
 }
 
-func (t *Transport) OnStorenodeChanged() <-chan peer.ID {
-	return t.waku.OnStorenodeChanged()
-}
-
-func (t *Transport) OnStorenodeNotWorking() <-chan struct{} {
-	return t.waku.OnStorenodeNotWorking()
-}
-
-func (t *Transport) OnStorenodeAvailable() <-chan peer.ID {
-	return t.waku.OnStorenodeAvailable()
-}
-
-func (t *Transport) IsStorenodeAvailable(peerID peer.ID) bool {
-	return t.waku.IsStorenodeAvailable(peerID)
-}
-
 // Query retrieves historic messages for a single batch, selecting the store node
 // internally (no peer argument). See waku.StoreClient.
 func (t *Transport) Query(
@@ -832,6 +806,7 @@ func (t *Transport) Query(
 	return t.waku.StoreQuery(ctx, batch, pageLimit, shouldProcessNextPage, processEnvelopes)
 }
 
-func (t *Transport) SetStorenodeConfigProvider(c history.StorenodeConfigProvider) {
-	t.waku.SetStorenodeConfigProvider(c)
+// SetStorenodes sets the storenodes the StoreClient may query. Called once at startup.
+func (t *Transport) SetStorenodes(nodes []peer.AddrInfo) {
+	t.waku.SetStorenodes(nodes)
 }

--- a/pkg/messaging/waku/gowaku.go
+++ b/pkg/messaging/waku/gowaku.go
@@ -56,10 +56,7 @@ import (
 	pubsub "github.com/libp2p/go-libp2p-pubsub"
 	"github.com/libp2p/go-libp2p/core/metrics"
 
-	commonapi "github.com/waku-org/go-waku/waku/v2/api/common"
 	filterapi "github.com/waku-org/go-waku/waku/v2/api/filter"
-	"github.com/waku-org/go-waku/waku/v2/api/history"
-	"github.com/waku-org/go-waku/waku/v2/api/missing"
 	"github.com/waku-org/go-waku/waku/v2/api/publish"
 	"github.com/waku-org/go-waku/waku/v2/dnsdisc"
 	"github.com/waku-org/go-waku/waku/v2/onlinechecker"
@@ -179,9 +176,7 @@ type Waku struct {
 	// "ConnectionChange received with Offline=false"
 	stateInitialized bool
 
-	StorenodeCycle   *history.StorenodeCycle
-	HistoryRetriever *history.HistoryRetriever
-	storeClient      *StoreClient
+	storeClient *StoreClient
 
 	logger *zap.Logger
 
@@ -851,11 +846,9 @@ func (w *Waku) Start() error {
 		return fmt.Errorf("failed to start go-waku node: %v", err)
 	}
 
-	w.StorenodeCycle = history.NewStorenodeCycle(w.logger, commonapi.NewDefaultPinger(w.node.Host()))
-	w.HistoryRetriever = history.NewHistoryRetriever(missing.NewDefaultStorenodeRequestor(w.node.Store()), NewHistoryProcessorWrapper(w), w.logger)
-	w.storeClient = NewStoreClient(w.StorenodeCycle, w.HistoryRetriever, w.GetPubsubTopic, w.logger)
-
-	w.StorenodeCycle.Start(w.ctx)
+	selector := newStoreSelector()
+	pager := newStorePager(wakuStoreRequestor{store: w.node.Store()}, NewHistoryProcessorWrapper(w), w.logger)
+	w.storeClient = NewStoreClient(selector, pager, w.GetPubsubTopic, w.logger)
 
 	w.logger.Info("WakuV2 PeerID", zap.Stringer("id", w.node.Host().ID()))
 
@@ -1113,40 +1106,10 @@ func (w *Waku) startMessageSender() error {
 		sender.WithMessageSentEmitter(w.node.Host())
 	}
 
-	if w.cfg.EnableStoreConfirmationForMessagesSent {
-		msgStoredChan := make(chan gethcommon.Hash, 1000)
-		msgExpiredChan := make(chan gethcommon.Hash, 1000)
-		messageSentCheck := NewMessageSentCheck(w.ctx, publish.NewDefaultStorenodeMessageVerifier(w.node.Store()), w.StorenodeCycle, w.node.Timesource(), msgStoredChan, msgExpiredChan, w.logger)
-		sender.WithMessageSentCheck(messageSentCheck)
-
-		w.wg.Add(1)
-		go func() {
-			defer gocommon.LogOnPanic()
-			defer w.wg.Done()
-			for {
-				select {
-				case <-w.ctx.Done():
-					return
-				case hash := <-msgStoredChan:
-					w.SendEnvelopeEvent(common.EnvelopeEvent{
-						Hash:  hash,
-						Event: common.EventEnvelopeSent,
-					})
-					if w.metricsHandler != nil {
-						w.metricsHandler.PushMessageCheckSuccess()
-					}
-				case hash := <-msgExpiredChan:
-					w.SendEnvelopeEvent(common.EnvelopeEvent{
-						Hash:  hash,
-						Event: common.EventEnvelopeExpired,
-					})
-					if w.metricsHandler != nil {
-						w.metricsHandler.PushMessageCheckFailure()
-					}
-				}
-			}
-		}()
-	}
+	// NOTE: store-based sent confirmation (EnableStoreConfirmationForMessagesSent /
+	// MessageSentCheck) was removed together with the go-waku storenode cycle it
+	// depended on. Sent/missed recovery moves to the Logos Delivery Messaging API
+	// (#7526 Phase 2).
 
 	if !w.cfg.UseThrottledPublish || testing.Testing() {
 		// To avoid delaying the tests, or for when we dont want to rate limit, we set up an infinite rate limiter,
@@ -1665,24 +1628,9 @@ func FormatPeerConnFailures(wakuNode *node.WakuNode) map[string]int {
 	return p
 }
 
-func (w *Waku) GetActiveStorenode() peer.AddrInfo {
-	return w.StorenodeCycle.GetActiveStorenodePeerInfo()
-}
-
-func (w *Waku) OnStorenodeChanged() <-chan peer.ID {
-	return w.StorenodeCycle.StorenodeChangedEmitter.Subscribe()
-}
-
-func (w *Waku) OnStorenodeNotWorking() <-chan struct{} {
-	return w.StorenodeCycle.StorenodeNotWorkingEmitter.Subscribe()
-}
-
-func (w *Waku) OnStorenodeAvailable() <-chan peer.ID {
-	return w.StorenodeCycle.StorenodeAvailableEmitter.Subscribe()
-}
-
-func (w *Waku) SetStorenodeConfigProvider(c history.StorenodeConfigProvider) {
-	w.StorenodeCycle.SetStorenodeConfigProvider(c)
+// SetStorenodes sets the storenodes the StoreClient may query. Called once at startup.
+func (w *Waku) SetStorenodes(nodes []peer.AddrInfo) {
+	w.storeClient.SetStorenodes(nodes)
 }
 
 // StoreQuery retrieves historic messages for a single batch via the StoreClient
@@ -1695,20 +1643,6 @@ func (w *Waku) StoreQuery(
 	processEnvelopes bool,
 ) error {
 	return w.storeClient.Query(ctx, batch, pageLimit, shouldProcessNextPage, processEnvelopes)
-}
-
-func (w *Waku) IsStorenodeAvailable(peerID peer.ID) bool {
-	return w.StorenodeCycle.IsStorenodeAvailable(peerID)
-}
-
-func (w *Waku) DisconnectActiveStorenode(ctx context.Context, backoff time.Duration, shouldCycle bool) {
-	w.StorenodeCycle.Lock()
-	defer w.StorenodeCycle.Unlock()
-
-	w.StorenodeCycle.DisconnectActiveStorenode(backoff)
-	if shouldCycle {
-		w.StorenodeCycle.Cycle(ctx)
-	}
 }
 
 func (w *Waku) Metrics() string {

--- a/pkg/messaging/waku/gowaku.go
+++ b/pkg/messaging/waku/gowaku.go
@@ -1106,10 +1106,43 @@ func (w *Waku) startMessageSender() error {
 		sender.WithMessageSentEmitter(w.node.Host())
 	}
 
-	// NOTE: store-based sent confirmation (EnableStoreConfirmationForMessagesSent /
-	// MessageSentCheck) was removed together with the go-waku storenode cycle it
-	// depended on. Sent/missed recovery moves to the Logos Delivery Messaging API
-	// (#7526 Phase 2).
+	if w.cfg.EnableStoreConfirmationForMessagesSent {
+		msgStoredChan := make(chan gethcommon.Hash, 1000)
+		msgExpiredChan := make(chan gethcommon.Hash, 1000)
+		// The store node is selected on demand by the StoreClient (the go-waku
+		// storenode cycle is gone); MessageSentCheck queries it by hash to confirm
+		// that published messages propagated.
+		messageSentCheck := NewMessageSentCheck(w.ctx, publish.NewDefaultStorenodeMessageVerifier(w.node.Store()), storeClientPeerProvider{w.storeClient}, w.node.Timesource(), msgStoredChan, msgExpiredChan, w.logger)
+		sender.WithMessageSentCheck(messageSentCheck)
+
+		w.wg.Add(1)
+		go func() {
+			defer gocommon.LogOnPanic()
+			defer w.wg.Done()
+			for {
+				select {
+				case <-w.ctx.Done():
+					return
+				case hash := <-msgStoredChan:
+					w.SendEnvelopeEvent(common.EnvelopeEvent{
+						Hash:  hash,
+						Event: common.EventEnvelopeSent,
+					})
+					if w.metricsHandler != nil {
+						w.metricsHandler.PushMessageCheckSuccess()
+					}
+				case hash := <-msgExpiredChan:
+					w.SendEnvelopeEvent(common.EnvelopeEvent{
+						Hash:  hash,
+						Event: common.EventEnvelopeExpired,
+					})
+					if w.metricsHandler != nil {
+						w.metricsHandler.PushMessageCheckFailure()
+					}
+				}
+			}
+		}()
+	}
 
 	if !w.cfg.UseThrottledPublish || testing.Testing() {
 		// To avoid delaying the tests, or for when we dont want to rate limit, we set up an infinite rate limiter,

--- a/pkg/messaging/waku/history_processor_wrapper.go
+++ b/pkg/messaging/waku/history_processor_wrapper.go
@@ -3,7 +3,6 @@ package wakuv2
 import (
 	"github.com/libp2p/go-libp2p/core/peer"
 
-	"github.com/waku-org/go-waku/waku/v2/api/history"
 	"github.com/waku-org/go-waku/waku/v2/protocol"
 
 	"github.com/status-im/status-go/pkg/messaging/waku/common"
@@ -13,7 +12,7 @@ type HistoryProcessorWrapper struct {
 	waku *Waku
 }
 
-func NewHistoryProcessorWrapper(waku *Waku) history.HistoryProcessor {
+func NewHistoryProcessorWrapper(waku *Waku) *HistoryProcessorWrapper {
 	return &HistoryProcessorWrapper{waku}
 }
 

--- a/pkg/messaging/waku/message_publishing.go
+++ b/pkg/messaging/waku/message_publishing.go
@@ -97,10 +97,13 @@ func (w *Waku) publishEnvelope(envelope *protocol.Envelope) {
 		return
 	}
 
-	if !w.cfg.EnableStoreConfirmationForMessagesSent {
-		w.SendEnvelopeEvent(common.EnvelopeEvent{
-			Hash:  gethcommon.BytesToHash(envelope.Hash().Bytes()),
-			Event: common.EventEnvelopeSent,
-		})
-	}
+	// Emit the envelope-sent event on successful publish. Store-confirmed sent
+	// (EnableStoreConfirmationForMessagesSent / MessageSentCheck) was removed with
+	// the go-waku storenode cycle it depended on, so the publish ack is now the
+	// only "sent" signal until the Logos Delivery Messaging API restores store
+	// confirmation (#7526 Phase 2).
+	w.SendEnvelopeEvent(common.EnvelopeEvent{
+		Hash:  gethcommon.BytesToHash(envelope.Hash().Bytes()),
+		Event: common.EventEnvelopeSent,
+	})
 }

--- a/pkg/messaging/waku/message_publishing.go
+++ b/pkg/messaging/waku/message_publishing.go
@@ -97,13 +97,13 @@ func (w *Waku) publishEnvelope(envelope *protocol.Envelope) {
 		return
 	}
 
-	// Emit the envelope-sent event on successful publish. Store-confirmed sent
-	// (EnableStoreConfirmationForMessagesSent / MessageSentCheck) was removed with
-	// the go-waku storenode cycle it depended on, so the publish ack is now the
-	// only "sent" signal until the Logos Delivery Messaging API restores store
-	// confirmation (#7526 Phase 2).
-	w.SendEnvelopeEvent(common.EnvelopeEvent{
-		Hash:  gethcommon.BytesToHash(envelope.Hash().Bytes()),
-		Event: common.EventEnvelopeSent,
-	})
+	// When store confirmation is enabled, MessageSentCheck emits EventEnvelopeSent
+	// once a store node confirms the message propagated; otherwise the publish ack
+	// is the only "sent" signal.
+	if !w.cfg.EnableStoreConfirmationForMessagesSent {
+		w.SendEnvelopeEvent(common.EnvelopeEvent{
+			Hash:  gethcommon.BytesToHash(envelope.Hash().Bytes()),
+			Event: common.EventEnvelopeSent,
+		})
+	}
 }

--- a/pkg/messaging/waku/store_client.go
+++ b/pkg/messaging/waku/store_client.go
@@ -3,74 +3,59 @@ package wakuv2
 import (
 	"context"
 	"errors"
-	"time"
 
 	"go.uber.org/zap"
-	"google.golang.org/protobuf/proto"
 
-	"github.com/waku-org/go-waku/waku/v2/api/history"
-	"github.com/waku-org/go-waku/waku/v2/protocol"
-	"github.com/waku-org/go-waku/waku/v2/protocol/store"
+	"github.com/libp2p/go-libp2p/core/peer"
 
 	common "github.com/status-im/status-go/pkg/messaging/waku/common"
 	types "github.com/status-im/status-go/pkg/messaging/waku/types"
 )
 
-// storenodeAvailableTimeout bounds how long Query waits for a usable store node
-// before giving up. It mirrors the timeout historically used by the store-node
-// request manager in the protocol package, and guarantees that a caller passing
-// a deadline-less context (e.g. the long-lived messenger context) cannot block
-// forever when no store node is reachable.
-const storenodeAvailableTimeout = 30 * time.Second
+// maxStoreQueryAttempts bounds how many storenodes Query tries before giving up.
+const maxStoreQueryAttempts = 3
 
-// ErrStorenodeNotAvailable is returned by StoreClient.Query when no store node
-// becomes available within storenodeAvailableTimeout.
-var ErrStorenodeNotAvailable = errors.New("store node is not available")
+// ErrNoStorenodesReachable is returned when no configured storenode could serve
+// the query (none configured, or all attempts failed).
+var ErrNoStorenodesReachable = errors.New("no store node could serve the query")
 
-// StoreClient is the single status-go seam for historic-message retrieval. It
-// hides store-node selection behind one method (Query), so callers no longer
-// thread a peer through the go-waku quartet
-// (WaitForAvailableStoreNode → GetActiveStorenodePeerInfo →
-// PerformStorenodeTask → HistoryRetriever.Query).
-//
-// It is a facade over two collaborators, keeping their responsibilities separate:
-//   - selector ("cycle"): which peer, health, failover, pinning.
-//   - pager ("retriever"): cursor loop, topic chunking, early-stop, dispatch.
-//
-// Invariant: a peer is selected once per Query and reused for every page of that
-// query; failover happens only at a query boundary (a fresh Query), never
-// mid-pagination — a store cursor is bound to the peer that issued it.
-//
-// Phase 1 wraps the existing go-waku machinery unchanged. Phase 2 will swap the
-// collaborators for the Logos Delivery store call without touching callers.
+// StoreClient is the single status-go seam for historic-message retrieval: one
+// Query method, no peer argument. It selects a storenode on demand — no health
+// checks, no background cycle, no pinning — and fails over to another node if a
+// query fails. Phase 2 will swap the pager's wire call for the Logos Delivery
+// store FFI without touching callers.
 type StoreClient struct {
-	cycle              *history.StorenodeCycle
-	retriever          *history.HistoryRetriever
+	selector           *storeSelector
+	pager              *storePager
 	resolvePubsubTopic func(string) string
 	logger             *zap.Logger
 }
 
-// NewStoreClient builds a StoreClient over an existing storenode cycle (selector)
-// and history retriever (pager). resolvePubsubTopic maps an empty pubsub topic to
-// the configured default shard topic (see Waku.GetPubsubTopic).
-func NewStoreClient(cycle *history.StorenodeCycle, retriever *history.HistoryRetriever, resolvePubsubTopic func(string) string, logger *zap.Logger) *StoreClient {
+func NewStoreClient(selector *storeSelector, pager *storePager, resolvePubsubTopic func(string) string, logger *zap.Logger) *StoreClient {
 	return &StoreClient{
-		cycle:              cycle,
-		retriever:          retriever,
+		selector:           selector,
+		pager:              pager,
 		resolvePubsubTopic: resolvePubsubTopic,
 		logger:             logger.Named("store-client"),
 	}
 }
 
+// SetStorenodes sets the storenodes Query may use. Called once at startup.
+func (sc *StoreClient) SetStorenodes(nodes []peer.AddrInfo) {
+	sc.selector.setStorenodes(nodes)
+}
+
+// HasStorenodes reports whether any storenode is configured (used to gate sync).
+func (sc *StoreClient) HasStorenodes() bool {
+	return sc.selector.hasStorenodes()
+}
+
 // Query retrieves historic messages for a single batch (one pubsub topic and its
-// content topics over [batch.From, batch.To]) from a single store node, selecting
-// the peer itself and paginating until the range is exhausted or
-// shouldProcessNextPage stops it early.
-//
-// pageLimit is the page size of the first request; shouldProcessNextPage (may be
-// nil) decides, per page, whether to fetch the next one and with which size;
-// processEnvelopes controls whether fetched envelopes are passed to the message
-// pipeline synchronously.
+// content topics over [batch.From, batch.To]). It tries storenodes in turn until
+// one serves the whole query; on a mid-query failure it restarts on the next node
+// (a store cursor is bound to the node that issued it). pageLimit is the first
+// page size; shouldProcessNextPage (may be nil) is the per-page early-stop;
+// processEnvelopes controls synchronous handling of fetched envelopes.
 func (sc *StoreClient) Query(
 	ctx context.Context,
 	batch types.MailserverBatch,
@@ -78,26 +63,35 @@ func (sc *StoreClient) Query(
 	shouldProcessNextPage func(int) (bool, uint64),
 	processEnvelopes bool,
 ) error {
-	// selector: wait for and pin a store node. The wait is bounded so a
-	// deadline-less ctx cannot block indefinitely when no node is reachable.
-	waitCtx, cancel := context.WithTimeout(ctx, storenodeAvailableTimeout)
-	defer cancel()
-	if !sc.cycle.WaitForAvailableStoreNode(waitCtx) {
-		return ErrStorenodeNotAvailable
+	candidates := sc.selector.candidates()
+	if len(candidates) == 0 {
+		return ErrNoStorenodesReachable
 	}
-	storenode := sc.cycle.GetActiveStorenodePeerInfo()
 
-	// pager: run every page of this query against the pinned peer.
-	// PerformStorenodeTask retries the same peer and only fails over across
-	// whole-Query boundaries, never mid-pagination.
-	return sc.cycle.PerformStorenodeTask(func() error {
-		criteria := store.FilterCriteria{
-			TimeStart:     proto.Int64(batch.From.UnixNano()),
-			TimeEnd:       proto.Int64(batch.To.UnixNano()),
-			ContentFilter: protocol.NewContentFilter(sc.resolvePubsubTopic(batch.PubsubTopic), sc.contentTopics(batch)...),
+	pubsubTopic := sc.resolvePubsubTopic(batch.PubsubTopic)
+	contentTopics := sc.contentTopics(batch)
+
+	var lastErr error
+	for i, node := range candidates {
+		if i >= maxStoreQueryAttempts {
+			break
 		}
-		return sc.retriever.Query(ctx, criteria, storenode, pageLimit, shouldProcessNextPage, processEnvelopes)
-	}, history.WithPeerID(storenode.ID))
+		err := sc.pager.run(ctx, node, pubsubTopic, contentTopics, batch.From, batch.To, pageLimit, shouldProcessNextPage, processEnvelopes)
+		if err == nil {
+			return nil
+		}
+		if ctx.Err() != nil {
+			return err // caller cancelled — don't keep trying
+		}
+		lastErr = err
+		sc.logger.Debug("store query failed, trying next storenode",
+			zap.Stringer("peerID", node.ID), zap.Error(err))
+	}
+
+	if lastErr == nil {
+		lastErr = ErrNoStorenodesReachable
+	}
+	return lastErr
 }
 
 func (sc *StoreClient) contentTopics(batch types.MailserverBatch) []string {

--- a/pkg/messaging/waku/store_client.go
+++ b/pkg/messaging/waku/store_client.go
@@ -78,11 +78,13 @@ func (sc *StoreClient) Query(
 		}
 		err := sc.pager.run(ctx, node, pubsubTopic, contentTopics, batch.From, batch.To, pageLimit, shouldProcessNextPage, processEnvelopes)
 		if err == nil {
+			sc.selector.markSuccess(node.ID)
 			return nil
 		}
 		if ctx.Err() != nil {
 			return err // caller cancelled — don't keep trying
 		}
+		sc.selector.markFailure(node.ID)
 		lastErr = err
 		sc.logger.Debug("store query failed, trying next storenode",
 			zap.Stringer("peerID", node.ID), zap.Error(err))

--- a/pkg/messaging/waku/store_client.go
+++ b/pkg/messaging/waku/store_client.go
@@ -50,6 +50,27 @@ func (sc *StoreClient) HasStorenodes() bool {
 	return sc.selector.hasStorenodes()
 }
 
+// nextStorenode returns a currently-eligible storenode to query, or an empty
+// AddrInfo if none are configured. Selection is on demand (there is no
+// persistent active node); used by MessageSentCheck via storeClientPeerProvider.
+func (sc *StoreClient) nextStorenode() peer.AddrInfo {
+	candidates := sc.selector.candidates()
+	if len(candidates) == 0 {
+		return peer.AddrInfo{}
+	}
+	return candidates[0]
+}
+
+// storeClientPeerProvider adapts the StoreClient's on-demand storenode selection
+// to the single-peer GetActiveStorenodePeerInfo seam MessageSentCheck expects.
+// There is no persistent "active" storenode — each call returns a currently
+// eligible one (empty if none configured).
+type storeClientPeerProvider struct{ client *StoreClient }
+
+func (p storeClientPeerProvider) GetActiveStorenodePeerInfo() peer.AddrInfo {
+	return p.client.nextStorenode()
+}
+
 // Query retrieves historic messages for a single batch (one pubsub topic and its
 // content topics over [batch.From, batch.To]). It tries storenodes in turn until
 // one serves the whole query; on a mid-query failure it restarts on the next node

--- a/pkg/messaging/waku/store_internals_test.go
+++ b/pkg/messaging/waku/store_internals_test.go
@@ -1,0 +1,208 @@
+package wakuv2
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/libp2p/go-libp2p/core/peer"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"github.com/waku-org/go-waku/waku/v2/protocol"
+	storepb "github.com/waku-org/go-waku/waku/v2/protocol/store/pb"
+
+	types "github.com/status-im/status-go/pkg/messaging/waku/types"
+)
+
+// --- fakes ---
+
+type fakeRequestor struct {
+	mu       sync.Mutex
+	requests []*storepb.StoreQueryRequest
+	respond  func(req *storepb.StoreQueryRequest, callIdx int) ([]*storepb.WakuMessageKeyValue, []byte, error)
+}
+
+func (f *fakeRequestor) query(_ context.Context, _ peer.AddrInfo, req *storepb.StoreQueryRequest) ([]*storepb.WakuMessageKeyValue, []byte, error) {
+	f.mu.Lock()
+	idx := len(f.requests)
+	f.requests = append(f.requests, req)
+	f.mu.Unlock()
+	return f.respond(req, idx)
+}
+
+func (f *fakeRequestor) calls() []*storepb.StoreQueryRequest {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	out := make([]*storepb.StoreQueryRequest, len(f.requests))
+	copy(out, f.requests)
+	return out
+}
+
+// recordingProcessor satisfies envelopeProcessor. The tests return empty message
+// sets, so OnEnvelope is never invoked; it exists only to construct a pager.
+type recordingProcessor struct{}
+
+func (p *recordingProcessor) OnEnvelope(*protocol.Envelope, bool) error    { return nil }
+func (p *recordingProcessor) OnRequestFailed([]byte, peer.AddrInfo, error) {}
+
+func newPager(r storeRequestor) *storePager {
+	return newStorePager(r, &recordingProcessor{}, zap.NewNop())
+}
+
+func emptyResponse(_ *storepb.StoreQueryRequest, _ int) ([]*storepb.WakuMessageKeyValue, []byte, error) {
+	return nil, nil, nil
+}
+
+// --- selector ---
+
+func TestStoreSelectorCandidates(t *testing.T) {
+	s := newStoreSelector()
+	require.False(t, s.hasStorenodes())
+	require.Empty(t, s.candidates())
+
+	nodes := []peer.AddrInfo{{ID: "a"}, {ID: "b"}, {ID: "c"}}
+	s.setStorenodes(nodes)
+	require.True(t, s.hasStorenodes())
+	require.ElementsMatch(t, nodes, s.candidates())
+}
+
+// --- chunking ---
+
+func TestChunkContentTopics(t *testing.T) {
+	require.Nil(t, chunkContentTopics(nil, 10))
+
+	topics := make([]string, 25)
+	for i := range topics {
+		topics[i] = string(rune('a' + i))
+	}
+	chunks := chunkContentTopics(topics, 10)
+	require.Len(t, chunks, 3)
+	require.Len(t, chunks[0], 10)
+	require.Len(t, chunks[1], 10)
+	require.Len(t, chunks[2], 5)
+}
+
+// --- pager ---
+
+func TestStorePagerCursorPagination(t *testing.T) {
+	r := &fakeRequestor{respond: func(_ *storepb.StoreQueryRequest, idx int) ([]*storepb.WakuMessageKeyValue, []byte, error) {
+		if idx == 0 {
+			return nil, []byte("cursor-1"), nil // first page returns a cursor
+		}
+		return nil, nil, nil // second page completes the window
+	}}
+	to := time.Now()
+	from := to.Add(-time.Hour)
+	require.NoError(t, newPager(r).run(context.Background(), peer.AddrInfo{ID: "n"}, "pubsub", []string{"ct"}, from, to, 10, nil, false))
+
+	calls := r.calls()
+	require.Len(t, calls, 2)
+	require.Nil(t, calls[0].PaginationCursor)
+	require.Equal(t, []byte("cursor-1"), calls[1].PaginationCursor)
+}
+
+func TestStorePagerSplitsByWindow(t *testing.T) {
+	r := &fakeRequestor{respond: emptyResponse}
+	to := time.Now()
+	from := to.Add(-50 * time.Hour) // > 2x the 24h window
+	require.NoError(t, newPager(r).run(context.Background(), peer.AddrInfo{ID: "n"}, "pubsub", []string{"ct"}, from, to, 10, nil, false))
+
+	calls := r.calls()
+	require.Len(t, calls, 3)                               // 24h + 24h + 2h
+	require.Equal(t, to.UnixNano(), *calls[0].TimeEnd)     // newest window first
+	require.Equal(t, from.UnixNano(), *calls[2].TimeStart) // oldest window reaches from
+	for _, c := range calls {
+		require.LessOrEqual(t, *c.TimeEnd-*c.TimeStart, maxStoreRequestWindow.Nanoseconds())
+	}
+}
+
+func TestStorePagerEarlyStop(t *testing.T) {
+	r := &fakeRequestor{respond: func(_ *storepb.StoreQueryRequest, _ int) ([]*storepb.WakuMessageKeyValue, []byte, error) {
+		return nil, []byte("more"), nil // always offers another page
+	}}
+	stopAfterFirst := func(int) (bool, uint64) { return false, 0 }
+	to := time.Now()
+	from := to.Add(-time.Hour)
+	require.NoError(t, newPager(r).run(context.Background(), peer.AddrInfo{ID: "n"}, "pubsub", []string{"ct"}, from, to, 10, stopAfterFirst, false))
+
+	require.Len(t, r.calls(), 1) // stopped despite the cursor
+}
+
+func TestStorePagerChunksContentTopics(t *testing.T) {
+	r := &fakeRequestor{respond: emptyResponse}
+	topics := make([]string, 15)
+	for i := range topics {
+		topics[i] = string(rune('a' + i))
+	}
+	to := time.Now()
+	from := to.Add(-time.Hour)
+	require.NoError(t, newPager(r).run(context.Background(), peer.AddrInfo{ID: "n"}, "pubsub", topics, from, to, 10, nil, false))
+
+	calls := r.calls()
+	require.Len(t, calls, 2) // 10 + 5
+	seen := map[string]struct{}{}
+	for _, c := range calls {
+		require.LessOrEqual(t, len(c.ContentTopics), maxContentTopicsPerRequest)
+		for _, ct := range c.ContentTopics {
+			seen[ct] = struct{}{}
+		}
+	}
+	require.Len(t, seen, 15)
+}
+
+// --- StoreClient failover ---
+
+func newClient(r storeRequestor, nodes []peer.AddrInfo) *StoreClient {
+	sel := newStoreSelector()
+	sel.setStorenodes(nodes)
+	resolve := func(s string) string {
+		if s == "" {
+			return "default"
+		}
+		return s
+	}
+	return NewStoreClient(sel, newStorePager(r, &recordingProcessor{}, zap.NewNop()), resolve, zap.NewNop())
+}
+
+func batch() types.MailserverBatch {
+	return types.MailserverBatch{
+		From:        time.Now().Add(-time.Hour),
+		To:          time.Now(),
+		PubsubTopic: "pubsub",
+		Topics:      []types.TopicType{{1, 2, 3, 4}},
+	}
+}
+
+func TestStoreClientFailsOverToNextNode(t *testing.T) {
+	r := &fakeRequestor{respond: func(_ *storepb.StoreQueryRequest, idx int) ([]*storepb.WakuMessageKeyValue, []byte, error) {
+		if idx == 0 {
+			return nil, nil, errors.New("first node down")
+		}
+		return nil, nil, nil
+	}}
+	sc := newClient(r, []peer.AddrInfo{{ID: "n1"}, {ID: "n2"}})
+
+	require.NoError(t, sc.Query(context.Background(), batch(), 10, nil, false))
+	require.Len(t, r.calls(), 2) // failed over from the first node to the second
+}
+
+func TestStoreClientReturnsErrorWhenAllNodesFail(t *testing.T) {
+	r := &fakeRequestor{respond: func(_ *storepb.StoreQueryRequest, _ int) ([]*storepb.WakuMessageKeyValue, []byte, error) {
+		return nil, nil, errors.New("down")
+	}}
+	sc := newClient(r, []peer.AddrInfo{{ID: "n1"}, {ID: "n2"}, {ID: "n3"}, {ID: "n4"}})
+
+	require.Error(t, sc.Query(context.Background(), batch(), 10, nil, false))
+	require.Len(t, r.calls(), maxStoreQueryAttempts) // bounded number of attempts
+}
+
+func TestStoreClientNoStorenodes(t *testing.T) {
+	r := &fakeRequestor{respond: emptyResponse}
+	sc := newClient(r, nil)
+
+	require.ErrorIs(t, sc.Query(context.Background(), batch(), 10, nil, false), ErrNoStorenodesReachable)
+	require.Empty(t, r.calls())
+}

--- a/pkg/messaging/waku/store_internals_test.go
+++ b/pkg/messaging/waku/store_internals_test.go
@@ -69,6 +69,27 @@ func TestStoreSelectorCandidates(t *testing.T) {
 	require.ElementsMatch(t, nodes, s.candidates())
 }
 
+func TestStoreSelectorDownScoresFailedNode(t *testing.T) {
+	s := newStoreSelector()
+	s.setStorenodes([]peer.AddrInfo{{ID: "a"}, {ID: "b"}, {ID: "c"}})
+
+	// A failed node falls to the back of the candidate list but stays present as a fallback.
+	s.markFailure("b")
+	got := s.candidates()
+	require.Len(t, got, 3)
+	require.Equal(t, peer.ID("b"), got[len(got)-1].ID)
+
+	// With only one node not in backoff, it is always offered first.
+	s.markFailure("a")
+	require.Equal(t, peer.ID("c"), s.candidates()[0].ID)
+
+	// A successful query clears the backoff, so that node is no longer forced last.
+	s.markSuccess("a")
+	got = s.candidates()
+	require.Equal(t, peer.ID("b"), got[len(got)-1].ID)
+	require.NotEqual(t, peer.ID("b"), got[0].ID)
+}
+
 // --- chunking ---
 
 func TestChunkContentTopics(t *testing.T) {

--- a/pkg/messaging/waku/store_pager.go
+++ b/pkg/messaging/waku/store_pager.go
@@ -1,0 +1,187 @@
+package wakuv2
+
+import (
+	"context"
+	"encoding/hex"
+	"sync"
+	"time"
+
+	"github.com/libp2p/go-libp2p/core/peer"
+	"go.uber.org/zap"
+	"google.golang.org/protobuf/proto"
+
+	"github.com/waku-org/go-waku/waku/v2/protocol"
+	storepb "github.com/waku-org/go-waku/waku/v2/protocol/store/pb"
+)
+
+const (
+	// maxContentTopicsPerRequest is the store protocol's per-request content-topic limit.
+	maxContentTopicsPerRequest = 10
+	// maxStoreRequestWindow caps a single request's time range; larger ranges are
+	// walked one window at a time, newest first.
+	maxStoreRequestWindow = 24 * time.Hour
+	// maxConcurrentStoreRequests bounds in-flight requests within one Query.
+	maxConcurrentStoreRequests = 3
+	storeRequestTimeout        = 30 * time.Second
+)
+
+// envelopeProcessor consumes messages fetched from a storenode.
+type envelopeProcessor interface {
+	OnEnvelope(env *protocol.Envelope, processEnvelopes bool) error
+	OnRequestFailed(requestID []byte, peerInfo peer.AddrInfo, err error)
+}
+
+// storePager reads a time range of historic messages from a single storenode. It
+// splits content topics into store-protocol-sized requests, walks the range in
+// <=24h windows, follows pagination cursors, and stops early when the caller's
+// shouldProcessNextPage says so. The storenode is fixed for the whole run, so
+// cursors stay valid.
+type storePager struct {
+	requestor storeRequestor
+	processor envelopeProcessor
+	logger    *zap.Logger
+}
+
+func newStorePager(requestor storeRequestor, processor envelopeProcessor, logger *zap.Logger) *storePager {
+	return &storePager{
+		requestor: requestor,
+		processor: processor,
+		logger:    logger.Named("store-pager"),
+	}
+}
+
+// run fetches [from,to] for pubsubTopic+contentTopics from peerInfo. pageLimit is
+// the first page size; shouldProcessNextPage (may be nil) decides per page whether
+// to continue and with which size; processEnvelopes controls synchronous handling.
+// Content-topic chunks are fetched concurrently; the first error aborts the rest.
+func (p *storePager) run(
+	ctx context.Context,
+	peerInfo peer.AddrInfo,
+	pubsubTopic string,
+	contentTopics []string,
+	from, to time.Time,
+	pageLimit uint64,
+	shouldProcessNextPage func(int) (bool, uint64),
+	processEnvelopes bool,
+) error {
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	var (
+		wg       sync.WaitGroup
+		sem      = make(chan struct{}, maxConcurrentStoreRequests)
+		mu       sync.Mutex
+		firstErr error
+	)
+
+	for _, chunk := range chunkContentTopics(contentTopics, maxContentTopicsPerRequest) {
+		wg.Add(1)
+		go func(contentTopics []string) {
+			defer wg.Done()
+			select {
+			case sem <- struct{}{}:
+				defer func() { <-sem }()
+			case <-ctx.Done():
+				return
+			}
+
+			if err := p.fetchChunk(ctx, peerInfo, pubsubTopic, contentTopics, from, to, pageLimit, shouldProcessNextPage, processEnvelopes); err != nil {
+				mu.Lock()
+				if firstErr == nil {
+					firstErr = err
+					cancel() // stop sibling chunks
+				}
+				mu.Unlock()
+			}
+		}(chunk)
+	}
+
+	wg.Wait()
+	return firstErr
+}
+
+// fetchChunk paginates one content-topic chunk over [from,to], newest <=24h window
+// first, following cursors until each window is exhausted or shouldProcessNextPage
+// stops it early.
+func (p *storePager) fetchChunk(
+	ctx context.Context,
+	peerInfo peer.AddrInfo,
+	pubsubTopic string,
+	contentTopics []string,
+	from, to time.Time,
+	pageLimit uint64,
+	shouldProcessNextPage func(int) (bool, uint64),
+	processEnvelopes bool,
+) error {
+	limit := pageLimit
+
+	for windowEnd := to; windowEnd.After(from); {
+		windowStart := from
+		if windowEnd.Sub(from) > maxStoreRequestWindow {
+			windowStart = windowEnd.Add(-maxStoreRequestWindow)
+		}
+
+		var cursor []byte
+		for {
+			if ctx.Err() != nil {
+				return ctx.Err()
+			}
+
+			requestID := protocol.GenerateRequestID()
+			request := &storepb.StoreQueryRequest{
+				RequestId:        hex.EncodeToString(requestID),
+				IncludeData:      true,
+				PubsubTopic:      proto.String(pubsubTopic),
+				ContentTopics:    contentTopics,
+				TimeStart:        proto.Int64(windowStart.UnixNano()),
+				TimeEnd:          proto.Int64(windowEnd.UnixNano()),
+				PaginationCursor: cursor,
+				PaginationLimit:  proto.Uint64(limit),
+			}
+
+			reqCtx, reqCancel := context.WithTimeout(ctx, storeRequestTimeout)
+			messages, nextCursor, err := p.requestor.query(reqCtx, peerInfo, request)
+			reqCancel()
+			if err != nil {
+				p.processor.OnRequestFailed(requestID, peerInfo, err)
+				return err
+			}
+
+			for _, mkv := range messages {
+				env := protocol.NewEnvelope(mkv.Message, mkv.Message.GetTimestamp(), mkv.GetPubsubTopic())
+				if err := p.processor.OnEnvelope(env, processEnvelopes); err != nil {
+					return err
+				}
+			}
+
+			if shouldProcessNextPage != nil {
+				var processNext bool
+				processNext, limit = shouldProcessNextPage(len(messages))
+				if !processNext {
+					return nil
+				}
+			}
+
+			if nextCursor == nil {
+				break // this window is exhausted
+			}
+			cursor = nextCursor
+		}
+
+		windowEnd = windowStart
+	}
+
+	return nil
+}
+
+func chunkContentTopics(contentTopics []string, size int) [][]string {
+	var chunks [][]string
+	for i := 0; i < len(contentTopics); i += size {
+		end := i + size
+		if end > len(contentTopics) {
+			end = len(contentTopics)
+		}
+		chunks = append(chunks, contentTopics[i:end])
+	}
+	return chunks
+}

--- a/pkg/messaging/waku/store_pager.go
+++ b/pkg/messaging/waku/store_pager.go
@@ -12,6 +12,8 @@ import (
 
 	"github.com/waku-org/go-waku/waku/v2/protocol"
 	storepb "github.com/waku-org/go-waku/waku/v2/protocol/store/pb"
+
+	gocommon "github.com/status-im/status-go/common"
 )
 
 const (
@@ -20,7 +22,8 @@ const (
 	// maxStoreRequestWindow caps a single request's time range; larger ranges are
 	// walked one window at a time, newest first.
 	maxStoreRequestWindow = 24 * time.Hour
-	// maxConcurrentStoreRequests bounds in-flight requests within one Query.
+	// maxConcurrentStoreRequests bounds in-flight store requests across the whole
+	// pager (shared by every concurrent Query, not per-Query).
 	maxConcurrentStoreRequests = 3
 	storeRequestTimeout        = 30 * time.Second
 )
@@ -40,6 +43,10 @@ type storePager struct {
 	requestor storeRequestor
 	processor envelopeProcessor
 	logger    *zap.Logger
+
+	// sem bounds concurrent store requests across all run calls (a single pager
+	// instance is shared by every Query), not just within one run.
+	sem chan struct{}
 }
 
 func newStorePager(requestor storeRequestor, processor envelopeProcessor, logger *zap.Logger) *storePager {
@@ -47,13 +54,19 @@ func newStorePager(requestor storeRequestor, processor envelopeProcessor, logger
 		requestor: requestor,
 		processor: processor,
 		logger:    logger.Named("store-pager"),
+		sem:       make(chan struct{}, maxConcurrentStoreRequests),
 	}
 }
 
 // run fetches [from,to] for pubsubTopic+contentTopics from peerInfo. pageLimit is
 // the first page size; shouldProcessNextPage (may be nil) decides per page whether
 // to continue and with which size; processEnvelopes controls synchronous handling.
-// Content-topic chunks are fetched concurrently; the first error aborts the rest.
+//
+// Content-topic chunks are fetched concurrently, EXCEPT when shouldProcessNextPage
+// is set: an early-stop callback is stateful (it tracks what it has found and
+// mutates the page size), so chunks then run sequentially to keep its semantics
+// deterministic. Either way, the pager-wide semaphore bounds total in-flight
+// requests.
 func (p *storePager) run(
 	ctx context.Context,
 	peerInfo peer.AddrInfo,
@@ -64,28 +77,33 @@ func (p *storePager) run(
 	shouldProcessNextPage func(int) (bool, uint64),
 	processEnvelopes bool,
 ) error {
+	chunks := chunkContentTopics(contentTopics, maxContentTopicsPerRequest)
+
+	// Sequential when the caller needs ordered early-stop semantics, or when
+	// there is nothing to parallelize.
+	if shouldProcessNextPage != nil || len(chunks) <= 1 {
+		for _, chunk := range chunks {
+			if err := p.fetchChunkBounded(ctx, peerInfo, pubsubTopic, chunk, from, to, pageLimit, shouldProcessNextPage, processEnvelopes); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
 	var (
 		wg       sync.WaitGroup
-		sem      = make(chan struct{}, maxConcurrentStoreRequests)
 		mu       sync.Mutex
 		firstErr error
 	)
-
-	for _, chunk := range chunkContentTopics(contentTopics, maxContentTopicsPerRequest) {
+	for _, chunk := range chunks {
 		wg.Add(1)
 		go func(contentTopics []string) {
+			defer gocommon.LogOnPanic()
 			defer wg.Done()
-			select {
-			case sem <- struct{}{}:
-				defer func() { <-sem }()
-			case <-ctx.Done():
-				return
-			}
-
-			if err := p.fetchChunk(ctx, peerInfo, pubsubTopic, contentTopics, from, to, pageLimit, shouldProcessNextPage, processEnvelopes); err != nil {
+			if err := p.fetchChunkBounded(ctx, peerInfo, pubsubTopic, contentTopics, from, to, pageLimit, shouldProcessNextPage, processEnvelopes); err != nil {
 				mu.Lock()
 				if firstErr == nil {
 					firstErr = err
@@ -98,6 +116,26 @@ func (p *storePager) run(
 
 	wg.Wait()
 	return firstErr
+}
+
+// fetchChunkBounded acquires the pager-wide concurrency slot, then paginates the chunk.
+func (p *storePager) fetchChunkBounded(
+	ctx context.Context,
+	peerInfo peer.AddrInfo,
+	pubsubTopic string,
+	contentTopics []string,
+	from, to time.Time,
+	pageLimit uint64,
+	shouldProcessNextPage func(int) (bool, uint64),
+	processEnvelopes bool,
+) error {
+	select {
+	case p.sem <- struct{}{}:
+		defer func() { <-p.sem }()
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+	return p.fetchChunk(ctx, peerInfo, pubsubTopic, contentTopics, from, to, pageLimit, shouldProcessNextPage, processEnvelopes)
 }
 
 // fetchChunk paginates one content-topic chunk over [from,to], newest <=24h window

--- a/pkg/messaging/waku/store_requestor.go
+++ b/pkg/messaging/waku/store_requestor.go
@@ -1,0 +1,33 @@
+package wakuv2
+
+import (
+	"context"
+
+	"github.com/libp2p/go-libp2p/core/peer"
+
+	"github.com/waku-org/go-waku/waku/v2/protocol/store"
+	storepb "github.com/waku-org/go-waku/waku/v2/protocol/store/pb"
+)
+
+// storeRequestor performs one raw store-query request against a single storenode.
+// It is the only seam that talks to the store transport, which keeps the pager
+// unit-testable and lets Phase 2 swap go-waku's store client for the Logos
+// Delivery store FFI here without touching the pager.
+type storeRequestor interface {
+	query(ctx context.Context, peerInfo peer.AddrInfo, request *storepb.StoreQueryRequest) (messages []*storepb.WakuMessageKeyValue, cursor []byte, err error)
+}
+
+// wakuStoreRequestor is the go-waku-backed storeRequestor: the request rides the
+// go-waku node's libp2p host (this is the remaining go-waku/libp2p coupling that
+// Phase 2 removes).
+type wakuStoreRequestor struct {
+	store *store.WakuStore
+}
+
+func (r wakuStoreRequestor) query(ctx context.Context, peerInfo peer.AddrInfo, request *storepb.StoreQueryRequest) ([]*storepb.WakuMessageKeyValue, []byte, error) {
+	result, err := r.store.RequestRaw(ctx, peerInfo, request)
+	if err != nil {
+		return nil, nil, err
+	}
+	return result.Messages(), result.Cursor(), nil
+}

--- a/pkg/messaging/waku/store_selector.go
+++ b/pkg/messaging/waku/store_selector.go
@@ -1,0 +1,73 @@
+package wakuv2
+
+import (
+	"context"
+	"math/rand"
+	"net"
+	"runtime"
+	"sync"
+
+	"github.com/libp2p/go-libp2p/core/peer"
+)
+
+// bootstrapDNS overrides the system resolver on mobile, where DNS resolution is
+// unreliable (status-mobile #19581).
+const bootstrapDNS = "8.8.8.8:53"
+
+var overrideDNS = runtime.GOOS == "android" || runtime.GOOS == "ios"
+
+var dnsOverrideOnce sync.Once
+
+func applyMobileDNSOverride() {
+	if !overrideDNS {
+		return
+	}
+	dnsOverrideOnce.Do(func() {
+		var dialer net.Dialer
+		net.DefaultResolver = &net.Resolver{
+			PreferGo: false,
+			Dial: func(ctx context.Context, _, _ string) (net.Conn, error) {
+				return dialer.DialContext(ctx, "udp", bootstrapDNS)
+			},
+		}
+	})
+}
+
+// storeSelector hands out storenodes to query. With no health checks there is no
+// "active"/"available" node and no background cycle: it simply holds the
+// configured list (set once) and offers candidates in random order so a query can
+// fail over from one node to the next.
+type storeSelector struct {
+	mu    sync.RWMutex
+	nodes []peer.AddrInfo
+}
+
+func newStoreSelector() *storeSelector {
+	applyMobileDNSOverride()
+	return &storeSelector{}
+}
+
+// setStorenodes replaces the candidate list. Called once at startup.
+func (s *storeSelector) setStorenodes(nodes []peer.AddrInfo) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.nodes = nodes
+}
+
+func (s *storeSelector) hasStorenodes() bool {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return len(s.nodes) > 0
+}
+
+// candidates returns the storenodes to try for one query, shuffled so load is
+// spread and so Query can attempt them in turn until one answers.
+func (s *storeSelector) candidates() []peer.AddrInfo {
+	s.mu.RLock()
+	nodes := make([]peer.AddrInfo, len(s.nodes))
+	copy(nodes, s.nodes)
+	s.mu.RUnlock()
+
+	rand.Shuffle(len(nodes), func(i, j int) { nodes[i], nodes[j] = nodes[j], nodes[i] })
+	return nodes
+}

--- a/pkg/messaging/waku/store_selector.go
+++ b/pkg/messaging/waku/store_selector.go
@@ -2,6 +2,7 @@ package wakuv2
 
 import (
 	"math/rand"
+	"slices"
 	"sync"
 	"time"
 
@@ -13,8 +14,9 @@ const storeFailureBackoff = 2 * time.Minute
 
 // storeSelector hands out storenodes to query. With no health checks there is no
 // "active"/"available" node and no background cycle: it holds the configured list
-// (set once) and offers candidates in random order, deprioritizing nodes that
-// recently failed a query so a healthy node is tried first.
+// (set once, shuffled so different clients prefer different nodes) and offers
+// candidates in that fixed order, deprioritizing nodes that recently failed a
+// query so a healthy node is tried first.
 type storeSelector struct {
 	mu           sync.RWMutex
 	nodes        []peer.AddrInfo
@@ -25,11 +27,15 @@ func newStoreSelector() *storeSelector {
 	return &storeSelector{backoffUntil: make(map[peer.ID]time.Time)}
 }
 
-// setStorenodes replaces the candidate list. Called once at startup.
+// setStorenodes replaces the candidate list. Called once at startup. The list is
+// copied (so later caller mutation can't change it) and shuffled once, so
+// different clients prefer different storenodes — load spreads across the fleet
+// without the per-query churn of reshuffling on every call.
 func (s *storeSelector) setStorenodes(nodes []peer.AddrInfo) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	s.nodes = nodes
+	s.nodes = slices.Clone(nodes)
+	rand.Shuffle(len(s.nodes), func(i, j int) { s.nodes[i], s.nodes[j] = s.nodes[j], s.nodes[i] })
 }
 
 func (s *storeSelector) hasStorenodes() bool {
@@ -52,12 +58,13 @@ func (s *storeSelector) markSuccess(id peer.ID) {
 	delete(s.backoffUntil, id)
 }
 
-// candidates returns the storenodes to try for one query: nodes not in failure
-// backoff first (shuffled to spread load), then recently-failed nodes (also
-// shuffled) as a last resort — so Query prefers healthy nodes but can still fall
-// back when every node has failed recently.
+// candidates returns the storenodes to try for one query, in the fixed startup
+// order: nodes not in failure backoff first, then recently-failed nodes as a
+// last resort. Query sticks to the first healthy node and only moves on when it
+// fails (which backs it off, demoting it here) or once its backoff expires.
 func (s *storeSelector) candidates() []peer.AddrInfo {
 	s.mu.RLock()
+	defer s.mu.RUnlock()
 	now := time.Now()
 	var ready, backedOff []peer.AddrInfo
 	for _, n := range s.nodes {
@@ -67,9 +74,5 @@ func (s *storeSelector) candidates() []peer.AddrInfo {
 			ready = append(ready, n)
 		}
 	}
-	s.mu.RUnlock()
-
-	rand.Shuffle(len(ready), func(i, j int) { ready[i], ready[j] = ready[j], ready[i] })
-	rand.Shuffle(len(backedOff), func(i, j int) { backedOff[i], backedOff[j] = backedOff[j], backedOff[i] })
 	return append(ready, backedOff...)
 }

--- a/pkg/messaging/waku/store_selector.go
+++ b/pkg/messaging/waku/store_selector.go
@@ -1,50 +1,28 @@
 package wakuv2
 
 import (
-	"context"
 	"math/rand"
-	"net"
-	"runtime"
 	"sync"
+	"time"
 
 	"github.com/libp2p/go-libp2p/core/peer"
 )
 
-// bootstrapDNS overrides the system resolver on mobile, where DNS resolution is
-// unreliable (status-mobile #19581).
-const bootstrapDNS = "8.8.8.8:53"
-
-var overrideDNS = runtime.GOOS == "android" || runtime.GOOS == "ios"
-
-var dnsOverrideOnce sync.Once
-
-func applyMobileDNSOverride() {
-	if !overrideDNS {
-		return
-	}
-	dnsOverrideOnce.Do(func() {
-		var dialer net.Dialer
-		net.DefaultResolver = &net.Resolver{
-			PreferGo: false,
-			Dial: func(ctx context.Context, _, _ string) (net.Conn, error) {
-				return dialer.DialContext(ctx, "udp", bootstrapDNS)
-			},
-		}
-	})
-}
+// storeFailureBackoff is how long a storenode is deprioritized after a failed query.
+const storeFailureBackoff = 2 * time.Minute
 
 // storeSelector hands out storenodes to query. With no health checks there is no
-// "active"/"available" node and no background cycle: it simply holds the
-// configured list (set once) and offers candidates in random order so a query can
-// fail over from one node to the next.
+// "active"/"available" node and no background cycle: it holds the configured list
+// (set once) and offers candidates in random order, deprioritizing nodes that
+// recently failed a query so a healthy node is tried first.
 type storeSelector struct {
-	mu    sync.RWMutex
-	nodes []peer.AddrInfo
+	mu           sync.RWMutex
+	nodes        []peer.AddrInfo
+	backoffUntil map[peer.ID]time.Time
 }
 
 func newStoreSelector() *storeSelector {
-	applyMobileDNSOverride()
-	return &storeSelector{}
+	return &storeSelector{backoffUntil: make(map[peer.ID]time.Time)}
 }
 
 // setStorenodes replaces the candidate list. Called once at startup.
@@ -60,14 +38,38 @@ func (s *storeSelector) hasStorenodes() bool {
 	return len(s.nodes) > 0
 }
 
-// candidates returns the storenodes to try for one query, shuffled so load is
-// spread and so Query can attempt them in turn until one answers.
+// markFailure deprioritizes a storenode for storeFailureBackoff after a failed query.
+func (s *storeSelector) markFailure(id peer.ID) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.backoffUntil[id] = time.Now().Add(storeFailureBackoff)
+}
+
+// markSuccess clears any backoff for a storenode after a successful query.
+func (s *storeSelector) markSuccess(id peer.ID) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delete(s.backoffUntil, id)
+}
+
+// candidates returns the storenodes to try for one query: nodes not in failure
+// backoff first (shuffled to spread load), then recently-failed nodes (also
+// shuffled) as a last resort — so Query prefers healthy nodes but can still fall
+// back when every node has failed recently.
 func (s *storeSelector) candidates() []peer.AddrInfo {
 	s.mu.RLock()
-	nodes := make([]peer.AddrInfo, len(s.nodes))
-	copy(nodes, s.nodes)
+	now := time.Now()
+	var ready, backedOff []peer.AddrInfo
+	for _, n := range s.nodes {
+		if until, ok := s.backoffUntil[n.ID]; ok && now.Before(until) {
+			backedOff = append(backedOff, n)
+		} else {
+			ready = append(ready, n)
+		}
+	}
 	s.mu.RUnlock()
 
-	rand.Shuffle(len(nodes), func(i, j int) { nodes[i], nodes[j] = nodes[j], nodes[i] })
-	return nodes
+	rand.Shuffle(len(ready), func(i, j int) { ready[i], ready[j] = ready[j], ready[i] })
+	rand.Shuffle(len(backedOff), func(i, j int) { backedOff[i], backedOff[j] = backedOff[j], backedOff[i] })
+	return append(ready, backedOff...)
 }

--- a/pkg/messaging/waku/types/waku.go
+++ b/pkg/messaging/waku/types/waku.go
@@ -11,8 +11,6 @@ import (
 	"github.com/multiformats/go-multiaddr"
 	"github.com/pborman/uuid"
 
-	"github.com/waku-org/go-waku/waku/v2/api/history"
-
 	"github.com/ethereum/go-ethereum/common"
 
 	"github.com/status-im/status-go/internal/connection"
@@ -139,20 +137,8 @@ type Waku interface {
 	// PeerID returns node's PeerID
 	PeerID() peer.ID
 
-	// GetActiveStorenode returns the peer AddrInfo of the currently active storenode. It will be empty if no storenode is active
-	GetActiveStorenode() peer.AddrInfo
-
-	// OnStorenodeChanged is triggered when a new storenode is promoted to become the active storenode or when the active storenode is removed
-	OnStorenodeChanged() <-chan peer.ID
-
-	// OnStorenodeNotWorking is triggered when the last active storenode fails to return results consistently
-	OnStorenodeNotWorking() <-chan struct{}
-
-	// OnStorenodeAvailable is triggered when there is a new active storenode selected
-	OnStorenodeAvailable() <-chan peer.ID
-
-	// SetStorenodeConfigProvider will set the configuration provider for the storenode cycle
-	SetStorenodeConfigProvider(c history.StorenodeConfigProvider)
+	// SetStorenodes sets the storenodes the StoreClient may query. Called once at startup.
+	SetStorenodes(nodes []peer.AddrInfo)
 
 	// StoreQuery retrieves historic messages for a single batch, selecting the
 	// store node internally (no peer argument). See waku.StoreClient.
@@ -163,12 +149,6 @@ type Waku interface {
 		shouldProcessNextPage func(int) (bool, uint64),
 		processEnvelopes bool,
 	) error
-
-	// IsStorenodeAvailable is used to determine whether a storenode is available or not
-	IsStorenodeAvailable(peerID peer.ID) bool
-
-	// DisconnectActiveStorenode will trigger a disconnection of the active storenode, and potentially execute a cycling so a new storenode is promoted
-	DisconnectActiveStorenode(ctx context.Context, backoff time.Duration, shouldCycle bool)
 }
 
 type MailserverBatch struct {

--- a/protocol/messenger.go
+++ b/protocol/messenger.go
@@ -681,6 +681,12 @@ func (m *Messenger) Start() (*MessengerResponse, error) {
 		}()
 	}
 
+	// Storenodes are now configured: request any history missed while offline.
+	// This is the cycle-free replacement for the storenode-availability signal
+	// (OnStorenodeAvailable) that previously triggered the sync, and it avoids
+	// racing SetStorenodes against the network-online trigger.
+	m.asyncRequestAllHistoricMessages()
+
 	controlledCommunities, err := m.communitiesManager.Controlled()
 	if err != nil {
 		return nil, err

--- a/protocol/messenger.go
+++ b/protocol/messenger.go
@@ -669,7 +669,7 @@ func (m *Messenger) Start() (*MessengerResponse, error) {
 		return nil, err
 	}
 
-	m.messaging.SetStorenodeConfigProvider(m)
+	m.messaging.SetStorenodes(response.StoreNodes)
 
 	if m.config.enablePinnedBootstrap {
 		go func() {
@@ -681,9 +681,6 @@ func (m *Messenger) Start() (*MessengerResponse, error) {
 		}()
 	}
 
-	m.shutdownWaitGroup.Add(1)
-	go m.checkForStorenodeCycleSignals()
-
 	controlledCommunities, err := m.communitiesManager.Controlled()
 	if err != nil {
 		return nil, err
@@ -694,15 +691,6 @@ func (m *Messenger) Start() (*MessengerResponse, error) {
 		go func() {
 			defer gocommon.LogOnPanic()
 			defer m.shutdownWaitGroup.Done()
-
-			select {
-			case <-m.quit:
-				return
-			case <-m.ctx.Done():
-				return
-			case <-m.messaging.OnStorenodeAvailable():
-			}
-
 			m.InitHistoryArchiveTasks(controlledCommunities)
 		}()
 	}

--- a/protocol/messenger_mailserver.go
+++ b/protocol/messenger_mailserver.go
@@ -29,17 +29,13 @@ const (
 	oneDayDuration   = 24 * time.Hour
 	oneMonthDuration = 31 * oneDayDuration
 
-	backoffByUserAction = 0 * time.Second
-
 	historicSyncMinInterval = 20 * time.Second
 )
 
 var ErrNoFiltersForChat = errors.New("no filter registered for given chat")
 
 func (m *Messenger) shouldSync() (bool, error) {
-	if !m.started ||
-		m.messaging.GetActiveStorenode().ID == "" ||
-		!m.Online() {
+	if !m.started || !m.Online() {
 		return false, nil
 	}
 
@@ -48,8 +44,15 @@ func (m *Messenger) shouldSync() (bool, error) {
 		m.logger.Error("failed to get use mailservers", zap.Error(err))
 		return false, err
 	}
+	if !useMailserver {
+		return false, nil
+	}
 
-	return useMailserver, nil
+	mailservers, err := m.AllMailservers()
+	if err != nil {
+		return false, err
+	}
+	return len(mailservers) > 0, nil
 }
 
 func (m *Messenger) scheduleSyncChat(chat *Chat) (bool, error) {
@@ -709,8 +712,6 @@ func (m *Messenger) ToggleUseMailservers(value bool) error {
 	if err != nil {
 		return err
 	}
-
-	m.messaging.DisconnectActiveStorenode(m.ctx, backoffByUserAction, value)
 
 	return nil
 }

--- a/protocol/messenger_mailserver.go
+++ b/protocol/messenger_mailserver.go
@@ -30,6 +30,14 @@ const (
 	oneMonthDuration = 31 * oneDayDuration
 
 	historicSyncMinInterval = 20 * time.Second
+
+	// historicSyncRetryInterval and historicSyncRetryTimeout bound the login
+	// history-fetch retry. On login the libp2p host is freshly recreated and no
+	// storenode is connected yet, so the first attempt can fail before a
+	// storenode is dialable; with the go-waku storenode cycle gone nothing else
+	// retriggers the fetch, so asyncRequestAllHistoricMessages retries here.
+	historicSyncRetryInterval = 5 * time.Second
+	historicSyncRetryTimeout  = 3 * time.Minute
 )
 
 var ErrNoFiltersForChat = errors.New("no filter registered for given chat")
@@ -302,7 +310,6 @@ func (m *Messenger) withHistoricSyncInFlight(now time.Time, fn func() (*Messenge
 	}
 
 	m.historicSyncInFlight = true
-	m.lastHistoricSyncRequestAt = now
 	m.historicSyncMu.Unlock()
 	defer func() {
 		m.historicSyncMu.Lock()
@@ -310,7 +317,17 @@ func (m *Messenger) withHistoricSyncInFlight(now time.Time, fn func() (*Messenge
 		m.historicSyncMu.Unlock()
 	}()
 
-	return fn()
+	resp, err := fn()
+	if err == nil {
+		// Only a completed sync arms the throttle. A failed attempt (e.g. no
+		// storenode reachable in the instant right after login, before
+		// SetStorenodes/peer dialing) must not block the retry that succeeds
+		// once a storenode is dialable.
+		m.historicSyncMu.Lock()
+		m.lastHistoricSyncRequestAt = now
+		m.historicSyncMu.Unlock()
+	}
+	return resp, err
 }
 
 func getPrioritizedBatches() []int {

--- a/protocol/messenger_mailserver_cycle.go
+++ b/protocol/messenger_mailserver_cycle.go
@@ -1,13 +1,11 @@
 package protocol
 
 import (
-	"github.com/libp2p/go-libp2p/core/peer"
 	"go.uber.org/zap"
 
 	gocommon "github.com/status-im/status-go/common"
 	"github.com/status-im/status-go/params"
 	messagingtypes "github.com/status-im/status-go/pkg/messaging/types"
-	"github.com/status-im/status-go/signal"
 )
 
 func (m *Messenger) AllMailservers() ([]messagingtypes.StoreNode, error) {
@@ -56,115 +54,4 @@ func (m *Messenger) asyncRequestAllHistoricMessages() {
 			m.logger.Error("failed to request historic messages", zap.Error(err))
 		}
 	}()
-}
-
-func (m *Messenger) GetPinnedStorenode() (peer.AddrInfo, error) {
-	fleet, err := m.getFleet()
-	if err != nil {
-		return peer.AddrInfo{}, err
-	}
-
-	pinnedMailservers, err := m.settings.GetPinnedMailservers()
-	if err != nil {
-		return peer.AddrInfo{}, err
-	}
-
-	pinnedMailserver, ok := pinnedMailservers[fleet]
-	if !ok {
-		return peer.AddrInfo{}, nil
-	}
-
-	allMailservers, err := m.allMailserversByFleet(fleet)
-	if err != nil {
-		return peer.AddrInfo{}, err
-	}
-
-	for _, c := range allMailservers {
-		if c.ID == pinnedMailserver {
-			return c.PeerInfo()
-		}
-	}
-
-	return peer.AddrInfo{}, nil
-}
-
-func (m *Messenger) UseStorenodes() (bool, error) {
-	return m.settings.CanUseMailservers()
-}
-
-func (m *Messenger) Storenodes() ([]peer.AddrInfo, error) {
-	mailservers, err := m.AllMailservers()
-	if err != nil {
-		return nil, err
-	}
-
-	var result []peer.AddrInfo
-	for _, m := range mailservers {
-
-		peerInfo, err := m.PeerInfo()
-		if err != nil {
-			return nil, err
-		}
-		result = append(result, peerInfo)
-	}
-
-	return result, nil
-}
-
-func (m *Messenger) checkForStorenodeCycleSignals() {
-	defer gocommon.LogOnPanic()
-	defer m.shutdownWaitGroup.Done()
-
-	changed := m.messaging.OnStorenodeChanged()
-	notWorking := m.messaging.OnStorenodeNotWorking()
-	available := m.messaging.OnStorenodeAvailable()
-
-	allMailservers, err := m.AllMailservers()
-	if err != nil {
-		m.logger.Error("Could not retrieve mailserver list", zap.Error(err))
-		return
-	}
-
-	mailserverMap := make(map[peer.ID]messagingtypes.StoreNode)
-	for _, ms := range allMailservers {
-		peerID, err := ms.PeerID()
-		if err != nil {
-			m.logger.Error("could not retrieve peerID", zap.Error(err))
-			return
-		}
-		mailserverMap[peerID] = ms
-	}
-
-	for {
-		select {
-		case <-m.quit:
-			return
-		case <-m.ctx.Done():
-			return
-		case <-notWorking:
-			signal.SendStoreNodeNotWorking()
-
-		case activeMailserver := <-changed:
-			if activeMailserver != "" {
-				ms, ok := mailserverMap[activeMailserver]
-				if ok {
-					signal.SendStoreNodeChanged(&ms)
-				}
-			} else {
-				signal.SendStoreNodeChanged(nil)
-			}
-		case activeMailserver := <-available:
-			if activeMailserver != "" {
-				ms, ok := mailserverMap[activeMailserver]
-				if ok {
-					signal.SendStoreNodeAvailable(&ms)
-				}
-				// Skip history sync when backgrounded; SetPaused(false)
-				// will trigger it when the app returns to foreground.
-				if !m.isPaused() {
-					m.asyncRequestAllHistoricMessages()
-				}
-			}
-		}
-	}
 }

--- a/protocol/messenger_mailserver_cycle.go
+++ b/protocol/messenger_mailserver_cycle.go
@@ -1,6 +1,8 @@
 package protocol
 
 import (
+	"time"
+
 	"go.uber.org/zap"
 
 	gocommon "github.com/status-im/status-go/common"
@@ -49,9 +51,28 @@ func (m *Messenger) asyncRequestAllHistoricMessages() {
 
 	go func() {
 		defer gocommon.LogOnPanic()
-		_, err := m.requestAllHistoricMessages(true, false)
-		if err != nil {
-			m.logger.Error("failed to request historic messages", zap.Error(err))
+		// On login the libp2p host is freshly (re)created and no storenode is
+		// connected yet, so the first attempt can fail with "no store node
+		// reachable" before a storenode is dialable. The go-waku storenode cycle
+		// that used to retrigger the fetch is gone, so retry with backoff until a
+		// storenode serves the query (or we give up). Once one attempt succeeds
+		// it arms the throttle, so concurrent/later triggers no-op.
+		deadline := time.Now().Add(historicSyncRetryTimeout)
+		for {
+			_, err := m.requestAllHistoricMessages(true, false)
+			if err == nil {
+				return
+			}
+			if time.Now().After(deadline) {
+				m.logger.Error("failed to request historic messages after retries", zap.Error(err))
+				return
+			}
+			m.logger.Warn("failed to request historic messages, retrying", zap.Error(err))
+			select {
+			case <-m.quit:
+				return
+			case <-time.After(historicSyncRetryInterval):
+			}
 		}
 	}()
 }

--- a/signal/events_shhext.go
+++ b/signal/events_shhext.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 
 	"github.com/libp2p/go-libp2p/core/peer"
-	"github.com/multiformats/go-multiaddr"
 
 	"github.com/ethereum/go-ethereum/common/hexutil"
 
@@ -54,15 +53,6 @@ const (
 	// EventBackupPerformed is triggered when a backup has been performed
 	EventBackupPerformed = "backup.performed"
 
-	// EventMailserverAvailable is triggered when a mailserver becomes available
-	EventMailserverAvailable = "mailserver.available"
-
-	// EventMailserverChanged is triggered when switching the active mailserver
-	EventMailserverChanged = "mailserver.changed"
-
-	// EventMailserverNotWorking is triggered when the mailserver has failed to connect or failed to respond to requests
-	EventMailserverNotWorking = "mailserver.not.working"
-
 	// EventUpdateAvailable is triggered after a update verification is performed
 	EventUpdateAvailable = "update.available"
 )
@@ -105,11 +95,6 @@ type DecryptMessageFailedSignal struct {
 type BundleAddedSignal struct {
 	Identity       string `json:"identity"`
 	InstallationID string `json:"installationID"`
-}
-
-type StoreNodeSignal struct {
-	Address *multiaddr.Multiaddr `json:"address"`
-	ID      string               `json:"id"`
 }
 
 type Filter struct {
@@ -218,25 +203,4 @@ func SendNewMessages(obj json.Marshaler) {
 
 func LocalMessageBackupDone() {
 	send(EventLocalMessageBackupDone, interface{}(nil))
-}
-
-func sendStoreNodeSignal(ms *types2.StoreNode, event string) {
-	msSignal := StoreNodeSignal{}
-	if ms != nil {
-		msSignal.Address = ms.Addr
-		msSignal.ID = ms.ID
-	}
-	send(event, msSignal)
-}
-
-func SendStoreNodeAvailable(ms *types2.StoreNode) {
-	sendStoreNodeSignal(ms, EventMailserverAvailable)
-}
-
-func SendStoreNodeChanged(ms *types2.StoreNode) {
-	sendStoreNodeSignal(ms, EventMailserverChanged)
-}
-
-func SendStoreNodeNotWorking() {
-	sendStoreNodeSignal(nil, EventMailserverNotWorking)
 }

--- a/tests-functional/tests/test_discovery.py
+++ b/tests-functional/tests/test_discovery.py
@@ -19,8 +19,11 @@ class TestDiscovery:
         full_ids: set[str] = set()
 
         known_nodes = {
-            # Boot nodes available in the fleet
+            # Boot node in the fleet: every client is expected to discover and stay
+            # connected to it.
             "16Uiu2HAm3vFYHkGRURyJ6F7bwDyzMLtPEuCg4DU89T7km2u8Fjyb": "boot-1",
+            # Store node: queried on demand by the StoreClient, so it is NOT expected
+            # to be a persistent peer. Kept here only to label it in the peer dumps.
             "16Uiu2HAmCDqxtfF1DwBqs7UJ4TgSnjoh6j1RtE1hhQxLLao84jLi": "store",
         }
 
@@ -72,7 +75,10 @@ class TestDiscovery:
 
         # Build sets for expectations
         all_node_ids = set(nodes.keys())
-        boot_ids = {k for k, v in known_nodes.items() if v in ("boot-1", "store")}
+        # Only the boot node is expected as a persistent peer. The store node is
+        # contacted on demand by the StoreClient (there is no storenode cycle keeping
+        # it connected), so it is intentionally excluded from the expectations.
+        boot_ids = {k for k, v in known_nodes.items() if v == "boot-1"}
 
         # Pre-build expected peers per node (static expectations)
         expected_by_node: dict[str, set[str]] = {}


### PR DESCRIPTION
Companion PR: https://github.com/status-im/status-app/pull/21380

Closes #7567. Part of #7563 (also advances #7568 — history-reconciliation policy; see Behaviour changes). Builds on #7572 (Status-owned `MessageSentCheck`, now merged).

Replaces the `StoreClient`'s go-waku `api/history` internals (`StorenodeCycle` + `HistoryRetriever`) with a minimal Status-owned selector + pager. The cycle's "active storenode" state only existed to wait out async health-checks; with none, storenode selection is on-demand at query time, with failover. Prep for #7526 Phase 2 (Logos Delivery store FFI).

Store-based sent-confirmation is kept: the Status-owned `MessageSentCheck` (#7572) is wired to the on-demand `StoreClient`, so `EnableStoreConfirmationForMessagesSent` behaves as before. (Missing-message verification was removed separately in #7559.)

### Behaviour changes to sanity-check
- **History fetch is event-driven, not availability-driven (#7568).** It no longer fires on every `OnStorenodeAvailable`; instead it runs on offline→online transitions — login, app-foreground, reconnect, and community-join. A continuously-connected client stops issuing redundant store queries, and re-enabling mailservers (`ToggleUseMailservers`) no longer triggers a fetch on its own.
- App-facing `mailserver.*` signals removed (`available`/`changed`/`not-working`). status-app consumes `changed`/`not-working` (its "mailserver working/not-working" UI indicator), so the client must drop that signal wiring — already in progress via its node-management cleanup. **No RPC or C-binding methods were removed** (the removed Go methods are all internal).
- No pinning / RTT preference; the storenode list is set once at startup (a runtime fleet change needs a restart).
- `InitHistoryArchiveTasks` runs at startup instead of waiting for a storenode-available signal.
- `test_discovery` no longer expects the store node as a persistent peer (it is queried on demand).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
