### PR TITLE
fix(push): Route contact request pushes to Activity Center

### DIFF
--- a/protocol/protobuf/push_notifications.proto
+++ b/protocol/protobuf/push_notifications.proto
@@ -79,6 +79,7 @@ message PushNotification {
     MESSAGE = 1;
     MENTION = 2;
     REQUEST_TO_JOIN_COMMUNITY = 3;
+    CONTACT_REQUEST = 4;
   }
   bytes author = 7;
 }

--- a/protocol/pushnotificationclient/client.go
+++ b/protocol/pushnotificationclient/client.go
@@ -1073,8 +1073,13 @@ func (c *Client) handleDirectMessageSent(sentMessage *messagingevents.SentMessag
 		chatID = message.ChatId
 	}
 
+	notificationType := protobuf.PushNotification_MESSAGE
+	if message.ContentType == protobuf.ChatMessage_CONTACT_REQUEST {
+		notificationType = protobuf.PushNotification_CONTACT_REQUEST
+	}
+
 	// we send the notifications and return the info of the devices notified
-	infos, err := c.SendNotification(publicKey, installationIDs, trackedMessageIDs[0], chatID, protobuf.PushNotification_MESSAGE)
+	infos, err := c.SendNotification(publicKey, installationIDs, trackedMessageIDs[0], chatID, notificationType)
 	if err != nil {
 		return err
 	}
@@ -1084,7 +1089,7 @@ func (c *Client) handleDirectMessageSent(sentMessage *messagingevents.SentMessag
 		for _, messageID := range trackedMessageIDs {
 
 			c.config.Logger.Debug("marking as sent ", zap.String("messageID", types.EncodeHex(messageID)), zap.String("id", i.InstallationID))
-			if err := c.notifiedOn(publicKey, i.InstallationID, messageID, chatID, protobuf.PushNotification_MESSAGE); err != nil {
+			if err := c.notifiedOn(publicKey, i.InstallationID, messageID, chatID, notificationType); err != nil {
 				return err
 			}
 

--- a/protocol/pushnotificationserver/gorush.go
+++ b/protocol/pushnotificationserver/gorush.go
@@ -15,9 +15,11 @@ import (
 const defaultNewMessageNotificationText = "New message in Messenger"
 const defaultMentionNotificationText = "New mention or reply in Communities"
 const defaultRequestToJoinCommunityNotificationText = "Someone requested to join a community you are an admin of"
+const defaultContactRequestNotificationText = "Someone sent you a contact request"
 
-const deepLinkChats = "status-app://chats"       // plain messages -> messenger
-const deepLinkActivityCenter = "status-app://ac" // mentions, community requests, etc. -> activity center
+const deepLinkChats = "status-app://chats"                      // plain messages -> messenger
+const deepLinkActivityCenter = "status-app://ac"                // mentions, community requests, etc. -> activity center
+const deepLinkContactRequests = "status-app://contact-requests" // contact requests -> activity center contact requests
 
 type GoRushRequestData struct {
 	EncryptedMessage string `json:"encryptedMessage"`
@@ -67,6 +69,8 @@ func PushNotificationRegistrationToGoRushRequest(requestAndRegistrations []*Requ
 			text = defaultNewMessageNotificationText
 		} else if request.Type == protobuf.PushNotification_REQUEST_TO_JOIN_COMMUNITY {
 			text = defaultRequestToJoinCommunityNotificationText
+		} else if request.Type == protobuf.PushNotification_CONTACT_REQUEST {
+			text = defaultContactRequestNotificationText
 		} else {
 			text = defaultMentionNotificationText
 		}
@@ -78,6 +82,8 @@ func PushNotificationRegistrationToGoRushRequest(requestAndRegistrations []*Requ
 			pushType = "alert"
 			if request.Type == protobuf.PushNotification_MESSAGE {
 				deepLink = deepLinkChats
+			} else if request.Type == protobuf.PushNotification_CONTACT_REQUEST {
+				deepLink = deepLinkContactRequests
 			} else {
 				deepLink = deepLinkActivityCenter
 			}

--- a/protocol/pushnotificationserver/gorush_test.go
+++ b/protocol/pushnotificationserver/gorush_test.go
@@ -69,6 +69,19 @@ func TestPushNotificationRegistrationToGoRushRequest(t *testing.T) {
 				TokenType:   protobuf.PushNotificationRegistration_FIREBASE_TOKEN,
 			},
 		},
+		{
+			Request: &protobuf.PushNotification{
+				ChatId:         chatID,
+				Type:           protobuf.PushNotification_CONTACT_REQUEST,
+				PublicKey:      publicKey2,
+				InstallationId: installationID3,
+				Message:        message3,
+			},
+			Registration: &protobuf.PushNotificationRegistration{
+				DeviceToken: token3,
+				TokenType:   protobuf.PushNotificationRegistration_APN_TOKEN,
+			},
+		},
 	}
 
 	expectedRequests := &GoRushRequest{
@@ -106,6 +119,21 @@ func TestPushNotificationRegistrationToGoRushRequest(t *testing.T) {
 					EncryptedMessage: hexMessage3,
 					ChatID:           types.EncodeHex(chatID),
 					PublicKey:        types.EncodeHex(publicKey2),
+				},
+			},
+			{
+				Tokens:           []string{token3},
+				Platform:         platform1,
+				Message:          defaultContactRequestNotificationText,
+				ContentAvailable: true,
+				Sound:            "default",
+				Priority:         "high",
+				PushType:         "alert",
+				Data: &GoRushRequestData{
+					EncryptedMessage: hexMessage3,
+					ChatID:           types.EncodeHex(chatID),
+					PublicKey:        types.EncodeHex(publicKey2),
+					DeepLink:         deepLinkContactRequests,
 				},
 			},
 		},
@@ -153,6 +181,7 @@ func TestGoRushRequestDeepLinkByType(t *testing.T) {
 		{"message", protobuf.PushNotification_MESSAGE, deepLinkChats},
 		{"mention", protobuf.PushNotification_MENTION, deepLinkActivityCenter},
 		{"community request", protobuf.PushNotification_REQUEST_TO_JOIN_COMMUNITY, deepLinkActivityCenter},
+		{"contact request", protobuf.PushNotification_CONTACT_REQUEST, deepLinkContactRequests},
 		{"unknown", protobuf.PushNotification_UNKNOWN_PUSH_NOTIFICATION_TYPE, deepLinkActivityCenter},
 	}
 	for _, tc := range cases {

--- a/protocol/pushnotificationserver/server.go
+++ b/protocol/pushnotificationserver/server.go
@@ -392,7 +392,7 @@ func (s *Server) buildPushNotificationReport(pn *protobuf.PushNotification, regi
 	} else if registration.AccessToken != pn.AccessToken {
 		s.config.Logger.Debug("invalid token")
 		report.Error = protobuf.PushNotificationReport_WRONG_TOKEN
-	} else if (s.isMessageNotification(pn) && !s.isValidMessageNotification(pn, registration)) || (s.isMentionNotification(pn) && !s.isValidMentionNotification(pn, registration)) || (s.isRequestToJoinCommunityNotification(pn) && !s.isValidRequestToJoinCommunityNotification(pn, registration)) {
+	} else if (s.isMessageNotification(pn) && !s.isValidMessageNotification(pn, registration)) || (s.isMentionNotification(pn) && !s.isValidMentionNotification(pn, registration)) || (s.isRequestToJoinCommunityNotification(pn) && !s.isValidRequestToJoinCommunityNotification(pn, registration)) || (s.isContactRequestNotification(pn) && !s.isValidContactRequestNotification(pn, registration)) {
 		s.config.Logger.Debug("filtered notification")
 		// We report as successful but don't send the notification
 		// for privacy reasons, as otherwise we would disclose that
@@ -564,4 +564,15 @@ func (s *Server) isRequestToJoinCommunityNotification(pn *protobuf.PushNotificat
 // the author is not blocked
 func (s *Server) isValidRequestToJoinCommunityNotification(pn *protobuf.PushNotification, registration *protobuf.PushNotificationRegistration) bool {
 	return s.isRequestToJoinCommunityNotification(pn) && !s.contains(registration.BlockedChatList, pn.Author)
+}
+
+func (s *Server) isContactRequestNotification(pn *protobuf.PushNotification) bool {
+	return pn.Type == protobuf.PushNotification_CONTACT_REQUEST
+}
+
+// isValidContactRequestNotification checks:
+// this is a contact request
+// the author is not blocked
+func (s *Server) isValidContactRequestNotification(pn *protobuf.PushNotification, registration *protobuf.PushNotificationRegistration) bool {
+	return s.isContactRequestNotification(pn) && !s.contains(registration.BlockedChatList, pn.Author)
 }

--- a/protocol/pushnotificationserver/server_test.go
+++ b/protocol/pushnotificationserver/server_test.go
@@ -691,6 +691,12 @@ func (s *ServerSuite) TestBuildPushNotificationReport() {
 		ChatId:      chatID,
 		AccessToken: accessToken,
 	}
+	validContactRequestPN := &protobuf.PushNotification{
+		Type:        protobuf.PushNotification_CONTACT_REQUEST,
+		ChatId:      chatID,
+		Author:      author,
+		AccessToken: accessToken,
+	}
 	validRegistration := &protobuf.PushNotificationRegistration{
 		AccessToken:             accessToken,
 		BlockedChatList:         blockedChatList,
@@ -725,6 +731,17 @@ func (s *ServerSuite) TestBuildPushNotificationReport() {
 		{
 			name:         "valid mention",
 			pn:           validMentionPN,
+			registration: validRegistration,
+			expectedResponse: &reportResult{
+				sendNotification: true,
+				report: &protobuf.PushNotificationReport{
+					Success: true,
+				},
+			},
+		},
+		{
+			name:         "valid contact request",
+			pn:           validContactRequestPN,
 			registration: validRegistration,
 			expectedResponse: &reportResult{
 				sendNotification: true,
@@ -872,6 +889,22 @@ func (s *ServerSuite) TestBuildPushNotificationReport() {
 			name: "blocked chat list mention",
 			pn: &protobuf.PushNotification{
 				Type:        protobuf.PushNotification_MENTION,
+				Author:      blockedAuthor,
+				ChatId:      chatID,
+				AccessToken: accessToken,
+			},
+			registration: validRegistration,
+			expectedResponse: &reportResult{
+				sendNotification: false,
+				report: &protobuf.PushNotificationReport{
+					Success: true,
+				},
+			},
+		},
+		{
+			name: "blocked contact request author",
+			pn: &protobuf.PushNotification{
+				Type:        protobuf.PushNotification_CONTACT_REQUEST,
 				Author:      blockedAuthor,
 				ChatId:      chatID,
 				AccessToken: accessToken,

--- a/tests-functional/tests/test_push_notification_server.py
+++ b/tests-functional/tests/test_push_notification_server.py
@@ -11,6 +11,7 @@ from utils import keys
 
 APN_TOPIC = "im.status.ethereum"
 DEFAULT_PUSH_MESSAGE = "New message in Messenger"
+CONTACT_REQUEST_PUSH_MESSAGE = "Someone sent you a contact request"
 
 
 @pytest.fixture
@@ -37,14 +38,14 @@ def push_notification_server(gorush_stub):
     server.shutdown()
 
 
-def expect_push_notification(gorush, sender, receiver):
+def expect_push_notification(gorush, sender, receiver, expected_message=DEFAULT_PUSH_MESSAGE):
     requests = gorush.wait_for_requests()
     assert len(requests) == 1, "Expected 1 push notification to be received"
 
     push = requests[0]
     assert len(push["tokens"]) == 1 and push["tokens"][0] == receiver.device_id, "Expected only Bob device_id in push notification tokens"
     assert push["platform"] == receiver.device_platform.value
-    assert push["message"] == DEFAULT_PUSH_MESSAGE
+    assert push["message"] == expected_message
     assert push["data"]["publicKey"] == keys.shake256(bytes.fromhex(receiver.compressed_public_key()[2:]))
     assert push["data"]["chatId"] == keys.shake256(sender.public_key.encode("utf-8"))
 
@@ -77,7 +78,7 @@ class TestPushNotificationServer:
 
         # Make contacts, this should force delivery of a push notification
         messenger.make_contacts(sender, receiver)
-        expect_push_notification(gorush, sender, receiver)
+        expect_push_notification(gorush, sender, receiver, CONTACT_REQUEST_PUSH_MESSAGE)
 
         # Send a message from Alice to Bob
         sender.wakuext_service.send_one_to_one_message(receiver.public_key, f"Message {uuid.uuid4()}")


### PR DESCRIPTION
# Description

Add a dedicated contact request push notification type and classify contact request messages with it before sending remote push notifications.

Map contact request APNS payloads to `status-app://contact-requests` so tapping the notification opens the Activity Center Contact requests group instead of the chats list. Also add server-side filtering for blocked contact request authors and cover the new mapping in push notification tests.

Closes `status-app` PR: https://github.com/status-im/status-app/pull/21189
