### PR TITLE
feat(transport): decode incoming version=0 payloads as WakuV1 (#7499 phase 1)

### DIFF
--- a/pkg/messaging/layers/transport/transport.go
+++ b/pkg/messaging/layers/transport/transport.go
@@ -289,14 +289,17 @@ func (t *Transport) filterKeys(filter *Filter) (symKey []byte, privKey *ecdsa.Pr
 	return nil, privKey, nil
 }
 
-// decode reverses the rfc26 payload codec using the filter's key material. A
-// WakuMessage with version==0 is unencrypted and passed through unchanged
-// (preserving prior reception behaviour).
+// decode reverses the rfc26 payload codec using the filter's key material.
+//
+// The WakuMessage `version` field is deliberately ignored here, as part of the
+// migration to retire it (status-im/status-go#7499): the rfc26 codec is
+// independent of `version`, and the caller only reaches this point with a
+// decryption key (keyless filters are skipped in handleReceivedMessage), so we
+// always decrypt. status-go only ever emitted version==1, so a keyed version==0
+// envelope is never genuine plaintext; once senders start advertising version==0
+// (a later migration step) those messages must still decrypt here. Previously
+// version==0 was passed through unencrypted — that phase-0 behaviour is removed.
 func (t *Transport) decode(msg *types.ReceivedMessage, symKey []byte, privKey *ecdsa.PrivateKey) (*rfc26.DecodedPayload, error) {
-	if msg.Version == 0 {
-		return &rfc26.DecodedPayload{Data: msg.Payload}, nil
-	}
-
 	keyInfo := &rfc26.KeyInfo{}
 	switch {
 	case privKey != nil:

--- a/pkg/messaging/layers/transport/transport_test.go
+++ b/pkg/messaging/layers/transport/transport_test.go
@@ -129,6 +129,59 @@ func TestReceivePushPath(t *testing.T) {
 	require.Empty(t, result)
 }
 
+// TestReceiveVersionZeroDecodesAsV1 covers the WakuMessage version-field
+// migration (status-im/status-go#7499): an incoming message whose payload is
+// rfc26-encrypted but whose envelope advertises version=0 must still be
+// decrypted on a keyed filter (treated the same as version=1), now that senders
+// advertise version=0. Previously version=0 was passed through as plaintext.
+func TestReceiveVersionZeroDecodesAsV1(t *testing.T) {
+	db, err := testutils.SetupTestMemorySQLDB(testutils.NewTestDBInitializer([]*bindata.AssetSource{
+		{Names: migrations.AssetNames(), AssetFunc: migrations.Asset},
+	}))
+	require.NoError(t, err)
+
+	logger := testutils.MustCreateTestLogger()
+	defer func() { _ = logger.Sync() }()
+
+	waku, err := wakuv3.New(nil, &wakuv3.DefaultConfig, logger, nil, func([]byte, peer.AddrInfo, error) {}, nil)
+	require.NoError(t, err)
+
+	identity, err := crypto.GenerateKey()
+	require.NoError(t, err)
+
+	tr, err := NewTransport(waku, identity, NewSQLiteKeysPersistence(db), NewSQLiteProcessedMessageIDsCachePersistence(db), nil, logger)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = tr.Stop() })
+
+	filter, err := tr.JoinPublic("test-public-chat")
+	require.NoError(t, err)
+
+	symKey, err := tr.keysManager.RawSymKey(filter.SymKeyID)
+	require.NoError(t, err)
+
+	payload := []byte("hello version zero")
+	encoded, err := rfc26.Encode(payload, symKey, nil, identity)
+	require.NoError(t, err)
+
+	// The payload is rfc26-encrypted but the envelope is labeled version=0.
+	tr.handleReceivedMessage(&wakutypes.ReceivedMessage{
+		Hash:         []byte{0xde, 0xad},
+		ContentTopic: filter.ContentTopic.ContentTopic(),
+		PubsubTopic:  wakuv3.DefaultShardPubsubTopic(),
+		Payload:      encoded,
+		Version:      0,
+		Timestamp:    time.Now().UnixNano(),
+	})
+
+	result, err := tr.RetrieveRawAll()
+	require.NoError(t, err)
+
+	msgs := result[*filter]
+	require.Len(t, msgs, 1, "version=0 message should be decoded as WakuV1")
+	require.Equal(t, payload, msgs[0].Payload)
+	require.Equal(t, crypto.FromECDSAPub(&identity.PublicKey), msgs[0].Sig)
+}
+
 func TestCleanFiltersLoopPausesAndResumesByLifecycle(t *testing.T) {
 	originalInterval := cleanFiltersLoopInterval
 	cleanFiltersLoopInterval = 20 * time.Millisecond


### PR DESCRIPTION
Initially introduced here, but couldn't be cherry-picked as is:
- https://github.com/status-im/status-go/pull/7500
