### PR TITLE
feat(communities): publish community control on the default shard (32) (#7498 phase 2)

### DIFF
--- a/internal/protocol/messenger_communities.go
+++ b/internal/protocol/messenger_communities.go
@@ -368,7 +368,7 @@ func (m *Messenger) handleCommunitiesSubscription(c chan *communities.Subscripti
 					Sender:              community.PrivateKey(),
 					SkipEncryptionLayer: true,
 					MessageType:         protobuf.ApplicationMetadataMessage_COMMUNITY_USER_KICKED,
-					PubsubTopic:         messagingtypes.DefaultNonProtectedPubsubTopic(),
+					PubsubTopic:         messagingtypes.DefaultShardPubsubTopic(),
 				}
 
 				_, err = m.sender.SendPrivate(context.Background(), pk, rawMessage)
@@ -760,7 +760,7 @@ func (m *Messenger) handleCommunitySharedAddressesRequest(state *ReceivedMessage
 		CommunityID:         community.ID(),
 		SkipEncryptionLayer: true,
 		MessageType:         protobuf.ApplicationMetadataMessage_COMMUNITY_SHARED_ADDRESSES_RESPONSE,
-		PubsubTopic:         messagingtypes.DefaultNonProtectedPubsubTopic(),
+		PubsubTopic:         messagingtypes.DefaultShardPubsubTopic(),
 		ResendType:          common.ResendTypeRawMessage,
 		ResendMethod:        common.ResendMethodSendPrivate,
 		Recipients:          []*ecdsa.PublicKey{signer},
@@ -1533,7 +1533,7 @@ func (m *Messenger) RequestToJoinCommunity(request *requests.RequestToJoinCommun
 		ResendType:          common.ResendTypeRawMessage,
 		SkipEncryptionLayer: true,
 		MessageType:         protobuf.ApplicationMetadataMessage_COMMUNITY_REQUEST_TO_JOIN,
-		PubsubTopic:         messagingtypes.DefaultNonProtectedPubsubTopic(),
+		PubsubTopic:         messagingtypes.DefaultShardPubsubTopic(),
 		Priority:            &messagingtypes.HighPriority,
 	}
 
@@ -1924,7 +1924,7 @@ func (m *Messenger) CancelRequestToJoinCommunity(ctx context.Context, request *r
 		CommunityID:         community.ID(),
 		SkipEncryptionLayer: true,
 		MessageType:         protobuf.ApplicationMetadataMessage_COMMUNITY_CANCEL_REQUEST_TO_JOIN,
-		PubsubTopic:         messagingtypes.DefaultNonProtectedPubsubTopic(),
+		PubsubTopic:         messagingtypes.DefaultShardPubsubTopic(),
 		ResendType:          common.ResendTypeRawMessage,
 		Priority:            &messagingtypes.HighPriority,
 	}
@@ -2080,7 +2080,7 @@ func (m *Messenger) acceptRequestToJoinCommunity(requestToJoin *communities.Requ
 			CommunityID:         community.ID(),
 			SkipEncryptionLayer: true,
 			MessageType:         protobuf.ApplicationMetadataMessage_COMMUNITY_REQUEST_TO_JOIN_RESPONSE,
-			PubsubTopic:         messagingtypes.DefaultNonProtectedPubsubTopic(),
+			PubsubTopic:         messagingtypes.DefaultShardPubsubTopic(),
 			ResendType:          common.ResendTypeRawMessage,
 			ResendMethod:        common.ResendMethodSendPrivate,
 			Recipients:          []*ecdsa.PublicKey{pk},


### PR DESCRIPTION
Iterates #7498

Phase 2 of the single-shard migration, for 2.40. Re-applied on `develop` from the closed draft #7504.

# Description

1. Switched the five community-control send sites in `internal/protocol/messenger_communities.go` from the non-protected shard (64) to the default shard (32) — request to join, cancel request to join, request-to-join response, user kicked, shared-addresses response.

Listening is unchanged (both 32 and 64, from phase 1 #7538), so a 2.38/2.39 peer already listens on 32 and receives these, and this build still receives their shard-64 traffic.

| Phase | App version | Listening | Sending |
|-|-|-|-|
| 1 | 2.38 | 32, 64 | 64 (#7538) |
| — | 2.39 | 32, 64 | 64 |
| **2** | **2.40** | 32, 64 | **32 ← this PR** |
| — | 2.41 | 32, 64 | 32 |
| 3 | 2.42 | 32 | 32 (#7505) |

<details>
<summary>AI-made decisions</summary>

- Re-applied rather than rebased: `protocol/` moved to `internal/protocol/` since the branch was cut, so the old branch conflicted wholesale.
- Phase 3 (drop the 64 listener, #7505) lands in 2.42, two releases after this one, so that no peer inside the support window still publishes on 64; not included here.
- The shard-64 listener and the phase-1 comment in `DefaultFilters` are left untouched — they go away in phase 3.

</details>
