### PR TITLE
refactor(transport): decode received messages at most once per key

### DIFF
--- a/pkg/messaging/layers/transport/transport.go
+++ b/pkg/messaging/layers/transport/transport.go
@@ -220,12 +220,15 @@ func (t *Transport) receiveLoop() {
 	}
 }
 
-// handleReceivedMessage routes a received message to every listening filter on
+// handleReceivedMessage routes a received message to the listening filters on
 // its (pubsub, content) topic and buffers the decoded result. A content topic
 // is only a 4-byte hash of the chat id, so distinct chats can collide on it;
-// each candidate is therefore decoded with its own key, and a successful
-// authenticated decrypt is what confirms the message belongs to that filter
-// (replacing the old per-filter key-hash match).
+// a successful authenticated decrypt is what confirms which key — and hence
+// which filters — the message belongs to (replacing the old per-filter
+// key-hash match). Since a message decrypts with exactly one key, candidates
+// are grouped by key: decoding is attempted at most once per distinct key,
+// stops at the first key that succeeds, and the decoded message is fanned out
+// to every filter sharing that key.
 func (t *Transport) handleReceivedMessage(msg *types.ReceivedMessage) {
 	if msg == nil {
 		return
@@ -236,7 +239,13 @@ func (t *Transport) handleReceivedMessage(msg *types.ReceivedMessage) {
 		return
 	}
 
-	var matched bool
+	type keyGroup struct {
+		symKey  []byte
+		privKey *ecdsa.PrivateKey
+		filters []*Filter
+	}
+	var order []string // group iteration order, deterministic over candidates
+	groups := make(map[string]*keyGroup)
 	for _, filter := range candidates {
 		// Filters that exist only so we can publish never receive.
 		if !filter.Listen {
@@ -248,27 +257,55 @@ func (t *Transport) handleReceivedMessage(msg *types.ReceivedMessage) {
 			continue
 		}
 
-		decoded, err := t.decode(msg, symKey, privKey)
+		var fingerprint string
+		if symKey != nil {
+			fingerprint = "s:" + string(symKey)
+		} else {
+			fingerprint = "a:" + string(crypto.FromECDSAPub(&privKey.PublicKey))
+		}
+
+		group := groups[fingerprint]
+		if group == nil {
+			group = &keyGroup{symKey: symKey, privKey: privKey}
+			groups[fingerprint] = group
+			order = append(order, fingerprint)
+		}
+		group.filters = append(group.filters, filter)
+	}
+
+	var matched bool
+	for _, fingerprint := range order {
+		group := groups[fingerprint]
+
+		decoded, err := t.decode(msg, group.symKey, group.privKey)
 		if err != nil {
-			// Wrong key for this filter (e.g. a colliding chat's message); skip.
+			// Wrong key (e.g. a colliding chat's message); try the next one.
 			continue
 		}
 
-		message := toMessage(decoded, filter, msg, privKey)
-		t.receivedMu.Lock()
-		byHash := t.received[filter.FilterID]
-		if byHash == nil {
-			byHash = make(map[string]*types.Message)
-			t.received[filter.FilterID] = byHash
+		for _, filter := range group.filters {
+			t.bufferMessage(filter.FilterID, toMessage(decoded, filter, msg, group.privKey))
 		}
-		byHash[types2.EncodeHex(message.Hash)] = message
-		t.receivedMu.Unlock()
 		matched = true
+		break // only one key can authenticate a given message
 	}
 
 	if matched {
 		t.matchedPublisher.Publish(struct{}{})
 	}
+}
+
+// bufferMessage stores a decoded message in the per-filter receive buffer,
+// keyed by envelope hash, until RetrieveRawAll drains it.
+func (t *Transport) bufferMessage(filterID string, message *types.Message) {
+	t.receivedMu.Lock()
+	defer t.receivedMu.Unlock()
+	byHash := t.received[filterID]
+	if byHash == nil {
+		byHash = make(map[string]*types.Message)
+		t.received[filterID] = byHash
+	}
+	byHash[types2.EncodeHex(message.Hash)] = message
 }
 
 // filterKeys resolves the key material used to decode messages received on a

--- a/pkg/messaging/layers/transport/transport_test.go
+++ b/pkg/messaging/layers/transport/transport_test.go
@@ -1,6 +1,7 @@
 package transport
 
 import (
+	"crypto/rand"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -180,6 +181,87 @@ func TestReceiveVersionZeroDecodesAsV1(t *testing.T) {
 	require.Len(t, msgs, 1, "version=0 message should be decoded as WakuV1")
 	require.Equal(t, payload, msgs[0].Payload)
 	require.Equal(t, crypto.FromECDSAPub(&identity.PublicKey), msgs[0].Sig)
+}
+
+// TestReceiveSharedKeyFanOut covers the decode-once grouping in
+// handleReceivedMessage: filters listening on the same (pubsub, content) topic
+// with the same symmetric key form one key group — the payload is decrypted
+// once and the decoded message fanned out to every filter in the group — while
+// a colliding filter (same topic, different key) stays in its own group and
+// receives nothing because its decrypt fails.
+func TestReceiveSharedKeyFanOut(t *testing.T) {
+	db, err := testutils.SetupTestMemorySQLDB(testutils.NewTestDBInitializer([]*bindata.AssetSource{
+		{Names: migrations.AssetNames(), AssetFunc: migrations.Asset},
+	}))
+	require.NoError(t, err)
+
+	logger := testutils.MustCreateTestLogger()
+	defer func() { _ = logger.Sync() }()
+
+	waku, err := wakuv3.New(nil, &wakuv3.DefaultConfig, logger, nil, func([]byte, peer.AddrInfo, error) {}, nil)
+	require.NoError(t, err)
+
+	identity, err := crypto.GenerateKey()
+	require.NoError(t, err)
+
+	tr, err := NewTransport(waku, identity, NewSQLiteKeysPersistence(db), NewSQLiteProcessedMessageIDsCachePersistence(db), nil, logger)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = tr.Stop() })
+
+	sharedKey := make([]byte, 32)
+	_, err = rand.Read(sharedKey)
+	require.NoError(t, err)
+	sharedKeyID, err := waku.AddSymKeyDirect(sharedKey)
+	require.NoError(t, err)
+
+	otherKey := make([]byte, 32)
+	_, err = rand.Read(otherKey)
+	require.NoError(t, err)
+	otherKeyID, err := waku.AddSymKeyDirect(otherKey)
+	require.NoError(t, err)
+
+	// Install three listening filters on the same (pubsub, content) topic
+	// directly in the manager: two sharing a key, one colliding with its own.
+	contentTopic := wakutypes.BytesToTopic(ToTopic("shared-chat"))
+	mkFilter := func(filterID, chatID, symKeyID string) *Filter {
+		return &Filter{
+			ChatID:       chatID,
+			FilterID:     filterID,
+			SymKeyID:     symKeyID,
+			ContentTopic: contentTopic,
+			PubsubTopic:  wakuv3.DefaultShardPubsubTopic(),
+			Listen:       true,
+		}
+	}
+	sharedA := mkFilter("filter-shared-a", "chat-a", sharedKeyID)
+	sharedB := mkFilter("filter-shared-b", "chat-b", sharedKeyID)
+	collider := mkFilter("filter-collider", "chat-c", otherKeyID)
+	for _, f := range []*Filter{sharedA, sharedB, collider} {
+		tr.filters.filters[f.FilterID] = f
+	}
+
+	payload := []byte("fan out once")
+	encoded, err := rfc26.Encode(payload, sharedKey, nil, identity)
+	require.NoError(t, err)
+
+	tr.handleReceivedMessage(&wakutypes.ReceivedMessage{
+		Hash:         []byte{0xfa, 0x07},
+		ContentTopic: contentTopic.ContentTopic(),
+		PubsubTopic:  wakuv3.DefaultShardPubsubTopic(),
+		Payload:      encoded,
+		Version:      1,
+		Timestamp:    time.Now().UnixNano(),
+	})
+
+	result, err := tr.RetrieveRawAll()
+	require.NoError(t, err)
+
+	// Both shared-key filters got the decoded message; the collider got nothing.
+	require.Len(t, result[*sharedA], 1)
+	require.Equal(t, payload, result[*sharedA][0].Payload)
+	require.Len(t, result[*sharedB], 1)
+	require.Equal(t, payload, result[*sharedB][0].Payload)
+	require.Empty(t, result[*collider])
 }
 
 func TestCleanFiltersLoopPausesAndResumesByLifecycle(t *testing.T) {


### PR DESCRIPTION
Follow-up to #7524, which lifted rfc26 decoding into the Transport.

`handleReceivedMessage` attempted a decode per candidate filter, although a given message decrypts with exactly one key. Candidates listening on the message's (pubsub, content) topic are now grouped by their decode key: the rfc26 decode runs at most once per distinct key, stops at the first key that authenticates, and the decoded message is fanned out to every filter sharing that key. Colliding chats (content topics are a 4-byte hash of the chat id) are still disambiguated by the authenticated decrypt — a wrong-key group simply fails and the next key is tried.

No interface changes; the per-filter receive buffer and `RetrieveRawAll` semantics are unchanged. Adds `TestReceiveSharedKeyFanOut` covering shared-key fan-out plus a colliding filter receiving nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)