### PR TITLE
fix(rpc): debounce chain down status in health manager

### DIFF
--- a/internal/circuitbreaker/circuit_breaker.go
+++ b/internal/circuitbreaker/circuit_breaker.go
@@ -3,6 +3,8 @@ package circuitbreaker
 import (
 	"context"
 	"fmt"
+	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/afex/hystrix-go/hystrix"
@@ -55,7 +57,7 @@ func (cr *CommandResult) addCallStatus(providerName string, err error, startTime
 type Command struct {
 	ctx      context.Context
 	functors []*Functor
-	cancel   bool
+	cancel   atomic.Bool
 }
 
 func NewCommand(ctx context.Context, functors []*Functor) *Command {
@@ -74,7 +76,7 @@ func (cmd *Command) IsEmpty() bool {
 }
 
 func (cmd *Command) Cancel() {
-	cmd.cancel = true
+	cmd.cancel.Store(true)
 }
 
 type Config struct {
@@ -123,6 +125,45 @@ func accumulateCommandError(result CommandResult, circuitName string, err error)
 	return result
 }
 
+// sharedResult guards CommandResult against the hystrix goroutine that may
+// outlive DoC on timeout or cancellation.
+type sharedResult struct {
+	mu     sync.Mutex
+	result CommandResult
+}
+
+func (s *sharedResult) recordCall(providerName string, res []any, err error, startTime time.Time) FunctorCallStatus {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if err == nil {
+		s.result.res = res
+		s.result.err = nil
+	}
+	s.result.addCallStatus(providerName, err, startTime)
+	return s.result.functorCallStatuses[len(s.result.functorCallStatuses)-1]
+}
+
+func (s *sharedResult) accumulateError(name string, err error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.result = accumulateCommandError(s.result, name, err)
+}
+
+func (s *sharedResult) markCancelled() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.result.cancelled = true
+}
+
+func (s *sharedResult) snapshot() CommandResult {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	cp := s.result
+	cp.res = append([]any(nil), s.result.res...)
+	cp.functorCallStatuses = append([]FunctorCallStatus(nil), s.result.functorCallStatuses...)
+	return cp
+}
+
 // Execute the command in its circuit if set.
 // If the command's circuit is not configured, the circuit of the CircuitBreaker is used.
 // This is a blocking function.
@@ -131,15 +172,15 @@ func (cb *CircuitBreaker) Execute(cmd *Command) CommandResult {
 		return CommandResult{err: fmt.Errorf("command is nil or empty")}
 	}
 
-	var result CommandResult
+	var shared sharedResult
 	ctx := cmd.ctx
 	if ctx == nil {
 		ctx = context.Background()
 	}
 
 	for i, f := range cmd.functors {
-		if cmd.cancel {
-			result.cancelled = true
+		if cmd.cancel.Load() {
+			shared.markCancelled()
 			break
 		}
 
@@ -157,16 +198,10 @@ func (cb *CircuitBreaker) Execute(cmd *Command) CommandResult {
 		if i == len(cmd.functors)-1 || circuitName == "" {
 			res, execErr := f.exec()
 			err = execErr
-			if err == nil {
-				result.res = res
-				result.err = nil
-			}
-			result.addCallStatus(f.providerName, err, startTime)
+			status := shared.recordCall(f.providerName, res, err, startTime)
 
 			// Log error if present
 			if err != nil {
-				// Get the status that was just added
-				status := result.functorCallStatuses[len(result.functorCallStatuses)-1]
 				logutils.ZapLogger().Warn("direct execution error",
 					zap.String("provider", f.providerName),
 					zap.Error(err),
@@ -187,23 +222,16 @@ func (cb *CircuitBreaker) Execute(cmd *Command) CommandResult {
 				// We need to capture the execution time inside the hystrix function
 				execStartTime := time.Now()
 				res, err := f.exec()
-				// Write to result only if success
-				if err == nil {
-					result.res = res
-					result.err = nil
-				}
-				result.addCallStatus(f.providerName, err, execStartTime)
+				status := shared.recordCall(f.providerName, res, err, execStartTime)
 
 				// If the command has been cancelled, we don't count
 				// the error towards breaking the circuit, and then we break
-				if cmd.cancel {
-					result = accumulateCommandError(result, circuitName, err)
-					result.cancelled = true
+				if cmd.cancel.Load() {
+					shared.accumulateError(circuitName, err)
+					shared.markCancelled()
 					return nil
 				}
 				if err != nil {
-					// Get the status that was just added
-					status := result.functorCallStatuses[len(result.functorCallStatuses)-1]
 					logutils.ZapLogger().Warn("hystrix error",
 						zap.String("provider", f.providerName),
 						zap.Error(err),
@@ -216,11 +244,11 @@ func (cb *CircuitBreaker) Execute(cmd *Command) CommandResult {
 			break
 		}
 
-		result = accumulateCommandError(result, providerName, err)
+		shared.accumulateError(providerName, err)
 		// Let's abuse every provider with the same amount of MaxConcurrentRequests,
 		// keep iterating even in case of ErrMaxConcurrency error
 	}
-	return result
+	return shared.snapshot()
 }
 
 func (cb *CircuitBreaker) SetOverrideCircuitNameHandler(f func(string) string) {

--- a/internal/healthmanager/blockchain_health_manager.go
+++ b/internal/healthmanager/blockchain_health_manager.go
@@ -133,14 +133,13 @@ func (b *BlockchainHealthManager) aggregateStatus() BlockchainStatus {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 
-	// Collect statuses from all providers
-	providerStatuses := make([]rpcstatus.ProviderStatus, 0)
+	// Rebuild the blockchain aggregator from current per-chain snapshots.
+	// Avoids double-counting when multiple provider updates trigger re-aggregation.
+	newAgg := aggregator.NewAggregator("blockchain")
 	for _, provider := range b.providers {
-		providerStatuses = append(providerStatuses, provider.Status())
+		newAgg.Update(provider.Status())
 	}
-
-	// Update the aggregator with the new list of provider statuses
-	b.aggregator.UpdateBatch(providerStatuses)
+	b.aggregator = newAgg
 
 	// Get the new aggregated full and short status
 	return b.getStatusPerChain()
@@ -232,4 +231,32 @@ func (b *BlockchainHealthManager) Status() rpcstatus.ProviderStatus {
 	b.mu.RLock()
 	defer b.mu.RUnlock()
 	return b.aggregator.GetAggregatedStatus()
+}
+
+// Pause pauses all registered providers health managers.
+func (b *BlockchainHealthManager) Pause() {
+	b.mu.RLock()
+	providers := make([]*ProvidersHealthManager, 0, len(b.providers))
+	for _, provider := range b.providers {
+		providers = append(providers, provider)
+	}
+	b.mu.RUnlock()
+
+	for _, provider := range providers {
+		provider.Pause()
+	}
+}
+
+// Resume resumes all registered providers health managers.
+func (b *BlockchainHealthManager) Resume() {
+	b.mu.RLock()
+	providers := make([]*ProvidersHealthManager, 0, len(b.providers))
+	for _, provider := range b.providers {
+		providers = append(providers, provider)
+	}
+	b.mu.RUnlock()
+
+	for _, provider := range providers {
+		provider.Resume()
+	}
 }

--- a/internal/healthmanager/blockchain_health_manager_test.go
+++ b/internal/healthmanager/blockchain_health_manager_test.go
@@ -50,7 +50,7 @@ func (s *BlockchainHealthManagerSuite) assertBlockChainStatus(expected rpcstatus
 
 // Test registering a provider health manager
 func (s *BlockchainHealthManagerSuite) TestRegisterProvidersHealthManager() {
-	phm := NewProvidersHealthManager(1) // Create a real ProvidersHealthManager
+	phm := newTestProvidersHealthManager(1) // Create a real ProvidersHealthManager
 	err := s.manager.RegisterProvidersHealthManager(context.Background(), phm)
 	s.Require().NoError(err)
 
@@ -60,7 +60,7 @@ func (s *BlockchainHealthManagerSuite) TestRegisterProvidersHealthManager() {
 
 // Test status updates and notifications
 func (s *BlockchainHealthManagerSuite) TestStatusUpdateNotification() {
-	phm := NewProvidersHealthManager(1)
+	phm := newTestProvidersHealthManager(1)
 	err := s.manager.RegisterProvidersHealthManager(context.Background(), phm)
 	s.Require().NoError(err)
 	ch := s.manager.Subscribe()
@@ -79,8 +79,8 @@ func (s *BlockchainHealthManagerSuite) TestGetFullStatus() {
 	s.manager.Stop()
 	s.manager = NewBlockchainHealthManager()
 
-	phm1 := NewProvidersHealthManager(1)
-	phm2 := NewProvidersHealthManager(2)
+	phm1 := newTestProvidersHealthManager(1)
+	phm2 := newTestProvidersHealthManager(2)
 	ctx := context.Background()
 	err := s.manager.RegisterProvidersHealthManager(ctx, phm1)
 	s.Require().NoError(err)
@@ -203,7 +203,7 @@ func (s *BlockchainHealthManagerSuite) TestConcurrency() {
 	ctx, cancel := context.WithCancel(s.ctx)
 	defer cancel()
 	for i := 1; i <= chainsCount; i++ {
-		phm := NewProvidersHealthManager(uint64(i))
+		phm := newTestProvidersHealthManager(uint64(i))
 		err := s.manager.RegisterProvidersHealthManager(ctx, phm)
 		s.Require().NoError(err)
 	}
@@ -250,7 +250,7 @@ func (s *BlockchainHealthManagerSuite) TestMultipleStartAndStop() {
 
 func (s *BlockchainHealthManagerSuite) TestUnsubscribeOneOfMultipleSubscribers() {
 	// Create an instance of BlockchainHealthManager and register a provider manager
-	phm := NewProvidersHealthManager(1)
+	phm := newTestProvidersHealthManager(1)
 	ctx, cancel := context.WithCancel(s.ctx)
 	err := s.manager.RegisterProvidersHealthManager(ctx, phm)
 	s.Require().NoError(err)
@@ -287,7 +287,7 @@ func (s *BlockchainHealthManagerSuite) TestUnsubscribeOneOfMultipleSubscribers()
 
 func (s *BlockchainHealthManagerSuite) TestMixedProviderStatusInSingleChain() {
 	// Register a provider for chain 1
-	phm := NewProvidersHealthManager(1)
+	phm := newTestProvidersHealthManager(1)
 	err := s.manager.RegisterProvidersHealthManager(s.ctx, phm)
 	s.Require().NoError(err)
 
@@ -312,9 +312,9 @@ func (s *BlockchainHealthManagerSuite) TestMixedProviderStatusInSingleChain() {
 
 func (s *BlockchainHealthManagerSuite) TestInterleavedChainStatusChanges() {
 	// Register providers for chains 1, 2, and 3
-	phm1 := NewProvidersHealthManager(1)
-	phm2 := NewProvidersHealthManager(2)
-	phm3 := NewProvidersHealthManager(3)
+	phm1 := newTestProvidersHealthManager(1)
+	phm2 := newTestProvidersHealthManager(2)
+	phm3 := newTestProvidersHealthManager(3)
 	err := s.manager.RegisterProvidersHealthManager(s.ctx, phm1)
 	s.Require().NoError(err)
 	err = s.manager.RegisterProvidersHealthManager(s.ctx, phm2)
@@ -352,8 +352,8 @@ func (s *BlockchainHealthManagerSuite) TestInterleavedChainStatusChanges() {
 
 func (s *BlockchainHealthManagerSuite) TestDelayedChainUpdate() {
 	// Register providers for chains 1 and 2
-	phm1 := NewProvidersHealthManager(1)
-	phm2 := NewProvidersHealthManager(2)
+	phm1 := newTestProvidersHealthManager(1)
+	phm2 := newTestProvidersHealthManager(2)
 	err := s.manager.RegisterProvidersHealthManager(s.ctx, phm1)
 	s.Require().NoError(err)
 	err = s.manager.RegisterProvidersHealthManager(s.ctx, phm2)

--- a/internal/healthmanager/blockchain_health_manager_test.go
+++ b/internal/healthmanager/blockchain_health_manager_test.go
@@ -384,6 +384,34 @@ func (s *BlockchainHealthManagerSuite) TestDelayedChainUpdate() {
 	s.Equal(rpcstatus.StatusDown, shortStatus.StatusPerChain[2].Status) // Chain 2 is down
 }
 
+func (s *BlockchainHealthManagerSuite) TestPauseResumeSuppressesAndCoalescesProviderUpdates() {
+	phm := newTestProvidersHealthManager(1)
+	phm.SetDownDebounce(50 * time.Millisecond)
+	err := s.manager.RegisterProvidersHealthManager(s.ctx, phm)
+	s.Require().NoError(err)
+
+	ch := s.manager.Subscribe()
+	defer s.manager.Unsubscribe(ch)
+
+	phm.Update(s.ctx, []rpcstatus.RpcProviderCallStatus{
+		{Name: "provider1", Timestamp: time.Now(), Err: nil},
+	})
+	s.waitForUpdate(ch, rpcstatus.StatusUp, time.Second)
+
+	s.manager.Pause()
+	phm.Update(s.ctx, []rpcstatus.RpcProviderCallStatus{
+		{Name: "provider1", Timestamp: time.Now(), Err: errors.New("down")},
+	})
+	select {
+	case <-ch:
+		s.Fail("unexpected blockchain update while paused")
+	case <-time.After(120 * time.Millisecond):
+	}
+
+	s.manager.Resume()
+	s.waitForUpdate(ch, rpcstatus.StatusDown, 400*time.Millisecond)
+}
+
 func TestBlockchainHealthManagerSuite(t *testing.T) {
 	suite.Run(t, new(BlockchainHealthManagerSuite))
 }

--- a/internal/healthmanager/providers_health_manager.go
+++ b/internal/healthmanager/providers_health_manager.go
@@ -23,6 +23,7 @@ type ProvidersHealthManager struct {
 
 	downDebounce time.Duration
 	downTimer    *time.Timer
+	paused       bool
 }
 
 // NewProvidersHealthManager creates a new instance of ProvidersHealthManager with the given chain ID.
@@ -61,17 +62,29 @@ func (p *ProvidersHealthManager) doUpdate(callStatuses []rpcstatus.RpcProviderCa
 // Update processes a batch of provider call statuses, updates the aggregated status, and emits chain status changes if necessary.
 func (p *ProvidersHealthManager) Update(ctx context.Context, callStatuses []rpcstatus.RpcProviderCallStatus) {
 	shouldEmit, newStatus := p.doUpdate(callStatuses)
-	if !shouldEmit {
+
+	p.mu.RLock()
+	paused := p.paused
+	p.mu.RUnlock()
+	if paused {
+		if newStatus.Status != rpcstatus.StatusDown {
+			p.stopDownTimer()
+		}
 		return
 	}
 
 	// Defer Down emission until it persists; emit recovery to Up/Unknown immediately.
 	if newStatus.Status == rpcstatus.StatusDown {
-		p.armDownTimer()
+		if shouldEmit {
+			p.armDownTimer()
+		}
 		return
 	}
 
 	p.stopDownTimer()
+	if !shouldEmit {
+		return
+	}
 	p.emitChainStatus(ctx)
 
 	p.mu.Lock()
@@ -114,6 +127,10 @@ func (p *ProvidersHealthManager) emitDownIfStillDown() {
 	}
 
 	current := p.aggregator.GetAggregatedStatus()
+	if p.paused {
+		p.mu.Unlock()
+		return
+	}
 	if current.Status != rpcstatus.StatusDown {
 		p.mu.Unlock()
 		return
@@ -174,7 +191,50 @@ func (p *ProvidersHealthManager) ChainID() uint64 {
 
 // SetDownDebounce overrides the Down emission debounce window.
 func (p *ProvidersHealthManager) SetDownDebounce(d time.Duration) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
 	p.downDebounce = d
+}
+
+// Pause prevents emissions and clears any pending Down debounce timer.
+func (p *ProvidersHealthManager) Pause() {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.paused = true
+	if p.downTimer != nil {
+		p.downTimer.Stop()
+		p.downTimer = nil
+	}
+}
+
+// Resume reenables emissions and coalesces status updates to a single notification.
+func (p *ProvidersHealthManager) Resume() {
+	p.mu.Lock()
+	p.paused = false
+	if p.aggregator == nil {
+		p.mu.Unlock()
+		return
+	}
+
+	current := p.aggregator.GetAggregatedStatus()
+	shouldEmit := p.lastStatus == nil || p.lastStatus.Status != current.Status
+	p.mu.Unlock()
+
+	if !shouldEmit {
+		return
+	}
+
+	if current.Status == rpcstatus.StatusDown {
+		p.armDownTimer()
+		return
+	}
+
+	p.emitChainStatus(context.Background())
+
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	statusCopy := current
+	p.lastStatus = &statusCopy
 }
 
 // emitChainStatus sends a notification to all subscribers.

--- a/internal/healthmanager/providers_health_manager.go
+++ b/internal/healthmanager/providers_health_manager.go
@@ -4,10 +4,15 @@ import (
 	"context"
 	"fmt"
 	"sync"
+	"time"
 
+	status_common "github.com/status-im/status-go/common"
 	"github.com/status-im/status-go/internal/healthmanager/aggregator"
 	"github.com/status-im/status-go/internal/healthmanager/rpcstatus"
 )
+
+// DefaultDownDebounce delays Down emission to suppress short provider blips.
+const DefaultDownDebounce = 30 * time.Second
 
 type ProvidersHealthManager struct {
 	mu                  sync.RWMutex
@@ -15,6 +20,9 @@ type ProvidersHealthManager struct {
 	aggregator          *aggregator.Aggregator
 	subscriptionManager *SubscriptionManager
 	lastStatus          *rpcstatus.ProviderStatus
+
+	downDebounce time.Duration
+	downTimer    *time.Timer
 }
 
 // NewProvidersHealthManager creates a new instance of ProvidersHealthManager with the given chain ID.
@@ -25,6 +33,7 @@ func NewProvidersHealthManager(chainID uint64) *ProvidersHealthManager {
 		chainID:             chainID,
 		aggregator:          agg,
 		subscriptionManager: NewSubscriptionManager(),
+		downDebounce:        DefaultDownDebounce,
 	}
 }
 
@@ -56,11 +65,69 @@ func (p *ProvidersHealthManager) Update(ctx context.Context, callStatuses []rpcs
 		return
 	}
 
+	// Defer Down emission until it persists; emit recovery to Up/Unknown immediately.
+	if newStatus.Status == rpcstatus.StatusDown {
+		p.armDownTimer()
+		return
+	}
+
+	p.stopDownTimer()
 	p.emitChainStatus(ctx)
 
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	p.lastStatus = &newStatus
+}
+
+func (p *ProvidersHealthManager) armDownTimer() {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.downTimer != nil {
+		return
+	}
+	debounce := p.downDebounce
+	if debounce <= 0 {
+		debounce = DefaultDownDebounce
+	}
+	p.downTimer = time.AfterFunc(debounce, p.emitDownIfStillDown)
+}
+
+func (p *ProvidersHealthManager) stopDownTimer() {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.downTimer != nil {
+		p.downTimer.Stop()
+		p.downTimer = nil
+	}
+}
+
+// Uses background context because the request ctx is usually cancelled by the time the timer fires.
+func (p *ProvidersHealthManager) emitDownIfStillDown() {
+	defer status_common.LogOnPanic()
+
+	p.mu.Lock()
+	p.downTimer = nil
+
+	if p.aggregator == nil {
+		p.mu.Unlock()
+		return
+	}
+
+	current := p.aggregator.GetAggregatedStatus()
+	if current.Status != rpcstatus.StatusDown {
+		p.mu.Unlock()
+		return
+	}
+	if p.lastStatus != nil && p.lastStatus.Status == rpcstatus.StatusDown {
+		p.mu.Unlock()
+		return
+	}
+
+	statusCopy := current
+	p.lastStatus = &statusCopy
+	p.mu.Unlock()
+
+	p.emitChainStatus(context.Background())
 }
 
 // GetStatuses returns a copy of the current provider statuses.
@@ -84,6 +151,10 @@ func (p *ProvidersHealthManager) Unsubscribe(ch chan struct{}) {
 func (p *ProvidersHealthManager) Reset() {
 	p.mu.Lock()
 	defer p.mu.Unlock()
+	if p.downTimer != nil {
+		p.downTimer.Stop()
+		p.downTimer = nil
+	}
 	newAgg := aggregator.NewAggregator(fmt.Sprintf("%d", p.chainID))
 	p.aggregator = newAgg
 	p.lastStatus = nil

--- a/internal/healthmanager/providers_health_manager.go
+++ b/internal/healthmanager/providers_health_manager.go
@@ -172,6 +172,11 @@ func (p *ProvidersHealthManager) ChainID() uint64 {
 	return p.chainID
 }
 
+// SetDownDebounce overrides the Down emission debounce window.
+func (p *ProvidersHealthManager) SetDownDebounce(d time.Duration) {
+	p.downDebounce = d
+}
+
 // emitChainStatus sends a notification to all subscribers.
 func (p *ProvidersHealthManager) emitChainStatus(ctx context.Context) {
 	if p.subscriptionManager == nil {

--- a/internal/healthmanager/providers_health_manager_test.go
+++ b/internal/healthmanager/providers_health_manager_test.go
@@ -348,6 +348,63 @@ func (s *ProvidersHealthManagerSuite) TestRecoveryEmitsImmediately() {
 	s.assertChainStatus(rpcstatus.StatusUp)
 }
 
+func (s *ProvidersHealthManagerSuite) TestDownDebounceResetsAfterSilentRecovery() {
+	s.phm.downDebounce = 120 * time.Millisecond
+	ch := s.phm.Subscribe()
+	defer s.phm.Unsubscribe(ch)
+
+	s.phm.Update(context.Background(), upStatus("Provider1"))
+	s.expectNotification(ch, time.Second)
+
+	s.phm.Update(context.Background(), downStatus("Provider1"))
+	s.expectNoNotification(ch, 40*time.Millisecond)
+
+	// This recovery does not emit (lastStatus is still Up), but must still stop the previous timer.
+	s.phm.Update(context.Background(), upStatus("Provider1"))
+	s.expectNoNotification(ch, 10*time.Millisecond)
+
+	s.phm.Update(context.Background(), downStatus("Provider1"))
+	// If the first timer was not stopped, we'd see a Down event too early here.
+	s.expectNoNotification(ch, 90*time.Millisecond)
+	s.expectNotification(ch, 200*time.Millisecond)
+	s.assertChainStatus(rpcstatus.StatusDown)
+}
+
+func (s *ProvidersHealthManagerSuite) TestPauseStopsPendingDownTimer() {
+	s.phm.downDebounce = 100 * time.Millisecond
+	ch := s.phm.Subscribe()
+	defer s.phm.Unsubscribe(ch)
+
+	s.phm.Update(context.Background(), upStatus("Provider1"))
+	s.expectNotification(ch, time.Second)
+
+	s.phm.Update(context.Background(), downStatus("Provider1"))
+	s.expectNoNotification(ch, 30*time.Millisecond)
+
+	s.phm.Pause()
+	s.expectNoNotification(ch, 150*time.Millisecond)
+}
+
+func (s *ProvidersHealthManagerSuite) TestResumeCoalescesPausedUpdates() {
+	s.phm.downDebounce = 80 * time.Millisecond
+	ch := s.phm.Subscribe()
+	defer s.phm.Unsubscribe(ch)
+
+	s.phm.Update(context.Background(), upStatus("Provider1"))
+	s.expectNotification(ch, time.Second)
+	s.assertChainStatus(rpcstatus.StatusUp)
+
+	s.phm.Pause()
+	s.phm.Update(context.Background(), downStatus("Provider1"))
+	s.expectNoNotification(ch, 120*time.Millisecond)
+
+	// Resume should emit one coalesced Down only after debounce.
+	s.phm.Resume()
+	s.expectNoNotification(ch, 30*time.Millisecond)
+	s.expectNotification(ch, 200*time.Millisecond)
+	s.assertChainStatus(rpcstatus.StatusDown)
+}
+
 func TestProvidersHealthManagerSuite(t *testing.T) {
 	suite.Run(t, new(ProvidersHealthManagerSuite))
 }

--- a/internal/healthmanager/providers_health_manager_test.go
+++ b/internal/healthmanager/providers_health_manager_test.go
@@ -19,9 +19,17 @@ type ProvidersHealthManagerSuite struct {
 	phm *ProvidersHealthManager
 }
 
+// newTestProvidersHealthManager builds a ProvidersHealthManager with a short Down debounce for tests.
+func newTestProvidersHealthManager(chainID uint64) *ProvidersHealthManager {
+	phm := NewProvidersHealthManager(chainID)
+	phm.downDebounce = 20 * time.Millisecond
+	return phm
+}
+
 // SetupTest initializes the ProvidersHealthManager before each test
 func (s *ProvidersHealthManagerSuite) SetupTest() {
 	s.phm = NewProvidersHealthManager(1)
+	s.phm.downDebounce = 20 * time.Millisecond
 }
 
 // Helper method to update providers and wait for a notification on the given channel
@@ -260,6 +268,84 @@ func (s *ProvidersHealthManagerSuite) TestReset() {
 
 	// Verify chain ID remains the same
 	s.Equal(uint64(1), s.phm.ChainID(), "Chain ID should remain unchanged after reset")
+}
+
+// expectNotification fails if no notification arrives on ch within timeout.
+func (s *ProvidersHealthManagerSuite) expectNotification(ch <-chan struct{}, timeout time.Duration) {
+	select {
+	case <-ch:
+	case <-time.After(timeout):
+		s.Fail("Timeout waiting for chain status notification")
+	}
+}
+
+// expectNoNotification fails if any notification arrives on ch within timeout.
+func (s *ProvidersHealthManagerSuite) expectNoNotification(ch <-chan struct{}, timeout time.Duration) {
+	select {
+	case <-ch:
+		s.Fail("Unexpected chain status notification")
+	case <-time.After(timeout):
+	}
+}
+
+func downStatus(name string) []rpcstatus.RpcProviderCallStatus {
+	return []rpcstatus.RpcProviderCallStatus{{Name: name, Timestamp: time.Now(), Err: errors.New("critical error")}}
+}
+
+func upStatus(name string) []rpcstatus.RpcProviderCallStatus {
+	return []rpcstatus.RpcProviderCallStatus{{Name: name, Timestamp: time.Now(), Err: nil}}
+}
+
+func (s *ProvidersHealthManagerSuite) TestDownEmissionIsDebounced() {
+	s.phm.downDebounce = 150 * time.Millisecond
+	ch := s.phm.Subscribe()
+	defer s.phm.Unsubscribe(ch)
+
+	s.phm.Update(context.Background(), upStatus("Provider1"))
+	s.expectNotification(ch, time.Second)
+	s.assertChainStatus(rpcstatus.StatusUp)
+
+	s.phm.Update(context.Background(), downStatus("Provider1"))
+	s.assertChainStatus(rpcstatus.StatusDown)
+	s.expectNoNotification(ch, 50*time.Millisecond)
+
+	s.expectNotification(ch, time.Second)
+	s.assertChainStatus(rpcstatus.StatusDown)
+
+	s.phm.Update(context.Background(), downStatus("Provider1"))
+	s.expectNoNotification(ch, 50*time.Millisecond)
+}
+
+func (s *ProvidersHealthManagerSuite) TestShortDownDoesNotEmit() {
+	s.phm.downDebounce = 300 * time.Millisecond
+	ch := s.phm.Subscribe()
+	defer s.phm.Unsubscribe(ch)
+
+	s.phm.Update(context.Background(), upStatus("Provider1"))
+	s.expectNotification(ch, time.Second)
+
+	s.phm.Update(context.Background(), downStatus("Provider1"))
+	time.Sleep(50 * time.Millisecond)
+	s.phm.Update(context.Background(), upStatus("Provider1"))
+
+	s.expectNoNotification(ch, 400*time.Millisecond)
+	s.assertChainStatus(rpcstatus.StatusUp)
+}
+
+func (s *ProvidersHealthManagerSuite) TestRecoveryEmitsImmediately() {
+	s.phm.downDebounce = 100 * time.Millisecond
+	ch := s.phm.Subscribe()
+	defer s.phm.Unsubscribe(ch)
+
+	s.phm.Update(context.Background(), upStatus("Provider1"))
+	s.expectNotification(ch, time.Second)
+	s.phm.Update(context.Background(), downStatus("Provider1"))
+	s.expectNotification(ch, time.Second)
+	s.assertChainStatus(rpcstatus.StatusDown)
+
+	s.phm.Update(context.Background(), upStatus("Provider1"))
+	s.expectNotification(ch, 50*time.Millisecond)
+	s.assertChainStatus(rpcstatus.StatusUp)
 }
 
 func TestProvidersHealthManagerSuite(t *testing.T) {

--- a/internal/rpc/chain/blockchain_health_test.go
+++ b/internal/rpc/chain/blockchain_health_test.go
@@ -58,6 +58,7 @@ func (s *BlockchainHealthSuite) setupClients(chainIDs []uint64) {
 		}).AnyTimes()
 
 		phm := healthmanager.NewProvidersHealthManager(chainID)
+		phm.SetDownDebounce(20 * time.Millisecond)
 		client := NewClient([]ethclient.RPSLimitedEthClientInterface{mockEthClient}, chainID, phm)
 
 		err := s.blockchainHealthManager.RegisterProvidersHealthManager(ctx, phm)
@@ -270,7 +271,7 @@ func (s *BlockchainHealthSuite) TestGetFullStatus() {
 	// Verify overall aggregated status
 	overallStatus := fullStatus.Status
 	require.Equal(s.T(), rpcstatus.StatusUp, overallStatus.Status)
-	require.Equal(s.T(), duration1+duration2+duration3+duration4, overallStatus.TotalDuration)
+	require.Greater(s.T(), overallStatus.TotalDuration, time.Duration(0))
 	require.Equal(s.T(), int64(4), overallStatus.TotalRequests)
 	require.Equal(s.T(), int64(2), overallStatus.TotalTimeoutCount)
 

--- a/internal/rpc/chain/blockchain_health_test.go
+++ b/internal/rpc/chain/blockchain_health_test.go
@@ -210,6 +210,11 @@ func (s *BlockchainHealthSuite) TestGetFullStatus() {
 	// Wait for status event to be triggered before getting full status
 	s.waitForStatus(statusCh, rpcstatus.StatusUp)
 
+	// Wait until all provider updates from both chains are aggregated.
+	require.Eventually(s.T(), func() bool {
+		return s.blockchainHealthManager.GetFullStatus().Status.TotalRequests == 4
+	}, 2*time.Second, 10*time.Millisecond)
+
 	// Get the full status from the BlockchainHealthManager
 	fullStatus := s.blockchainHealthManager.GetFullStatus()
 
@@ -271,7 +276,7 @@ func (s *BlockchainHealthSuite) TestGetFullStatus() {
 	// Verify overall aggregated status
 	overallStatus := fullStatus.Status
 	require.Equal(s.T(), rpcstatus.StatusUp, overallStatus.Status)
-	require.Greater(s.T(), overallStatus.TotalDuration, time.Duration(0))
+	require.Equal(s.T(), duration1+duration2+duration3+duration4, overallStatus.TotalDuration)
 	require.Equal(s.T(), int64(4), overallStatus.TotalRequests)
 	require.Equal(s.T(), int64(2), overallStatus.TotalTimeoutCount)
 

--- a/internal/rpc/client.go
+++ b/internal/rpc/client.go
@@ -224,6 +224,9 @@ func (c *Client) getClientUsingCache(chainID uint64) (chain.ClientInterface, err
 	}
 
 	phm := healthmanager.NewProvidersHealthManager(chainID)
+	if c.IsPaused() {
+		phm.Pause()
+	}
 	err := c.healthMgr.RegisterProvidersHealthManager(context.Background(), phm)
 	if err != nil {
 		return nil, fmt.Errorf("register providers health manager: %s", err)
@@ -265,8 +268,10 @@ func (c *Client) getProviderRPCLimiter(provider params.RpcProvider) (*rpclimiter
 func (c *Client) SetPaused(paused bool) {
 	if paused {
 		c.MarkPaused()
+		c.healthMgr.Pause()
 	} else {
 		c.MarkResumed()
+		c.healthMgr.Resume()
 	}
 }
 

--- a/internal/rpc/client_test.go
+++ b/internal/rpc/client_test.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/brianvoe/gofakeit/v6"
 	"github.com/stretchr/testify/assert"
@@ -19,6 +20,8 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 
 	"github.com/status-im/status-go/internal/db/appdatabase"
+	healthmanager "github.com/status-im/status-go/internal/healthmanager"
+	"github.com/status-im/status-go/internal/healthmanager/rpcstatus"
 	"github.com/status-im/status-go/internal/rpc/chain/rpclimiter"
 	"github.com/status-im/status-go/internal/testutils"
 	"github.com/status-im/status-go/params"
@@ -169,4 +172,44 @@ func TestGetProviderRPCLimiterCircuitName(t *testing.T) {
 
 	// Limiter is shared per host regardless of chain.
 	require.Same(t, limiterChain1, limiterChain2)
+}
+
+func TestSetPausedPropagatesToProvidersHealthManager(t *testing.T) {
+	c := &Client{
+		healthMgr: healthmanager.NewBlockchainHealthManager(),
+	}
+	defer c.healthMgr.Stop()
+
+	phm := healthmanager.NewProvidersHealthManager(1)
+	phm.SetDownDebounce(50 * time.Millisecond)
+	require.NoError(t, c.healthMgr.RegisterProvidersHealthManager(context.Background(), phm))
+
+	ch := phm.Subscribe()
+	defer phm.Unsubscribe(ch)
+
+	phm.Update(context.Background(), []rpcstatus.RpcProviderCallStatus{
+		{Name: "provider1", Timestamp: time.Now(), Err: nil},
+	})
+	select {
+	case <-ch:
+	case <-time.After(time.Second):
+		t.Fatal("timeout waiting for initial Up notification")
+	}
+
+	c.SetPaused(true)
+	phm.Update(context.Background(), []rpcstatus.RpcProviderCallStatus{
+		{Name: "provider1", Timestamp: time.Now(), Err: fmt.Errorf("down")},
+	})
+	select {
+	case <-ch:
+		t.Fatal("unexpected notification while client is paused")
+	case <-time.After(120 * time.Millisecond):
+	}
+
+	c.SetPaused(false)
+	select {
+	case <-ch:
+	case <-time.After(300 * time.Millisecond):
+		t.Fatal("timeout waiting for debounced Down notification after resume")
+	}
 }

--- a/params/networkdefaults/default_networks_config.go
+++ b/params/networkdefaults/default_networks_config.go
@@ -323,7 +323,9 @@ var defaultNetworkSpecs = []networkSpec{
 		proxyNetworkName: "mainnet",
 		chainName:        "Katana",
 		providers: []providerSpec{
-			{providerType: providerTypeDirect, name: common.DirectCustom, directURL: security.NewSensitiveString("https://rpc.katana.network"), enableRpsLimiter: true},
+			{providerType: providerTypeDirect, name: common.DirectKatana, directURL: security.NewSensitiveString("https://rpc.katana.network"), enableRpsLimiter: true},
+			{providerType: providerTypeDirect, name: common.DirectConduit, directURL: security.NewSensitiveString("https://rpc.katanarpc.com"), enableRpsLimiter: true},
+			{providerType: providerTypeDirect, name: common.DirectTenderly, directURL: security.NewSensitiveString("https://katana.gateway.tenderly.co"), enableRpsLimiter: true},
 		},
 		blockExplorerURL:       "https://katanascan.com/",
 		chainColor:             "#F6FF0D",
@@ -344,10 +346,9 @@ var defaultNetworkSpecs = []networkSpec{
 		proxyNetworkName: "bokuto",
 		chainName:        "Katana Bokuto",
 		providers: []providerSpec{
-			{providerType: providerTypeEthRpcProxy, name: common.StatusSmartProxy},
-			// no support for katana on infura
-			// no support for katana on alchemy
-			{providerType: providerTypeDirect, name: common.DirectCustom, directURL: security.NewSensitiveString("https://rpc-bokuto.katanarpc.com"), enableRpsLimiter: true},
+			// no support for katana on infura or alchemy
+			{providerType: providerTypeDirect, name: common.DirectConduit, directURL: security.NewSensitiveString("https://rpc-bokuto.katanarpc.com"), enableRpsLimiter: true},
+			{providerType: providerTypeDirect, name: common.DirectTenderly, directURL: security.NewSensitiveString("https://katana-bokuto.gateway.tenderly.co"), enableRpsLimiter: true},
 		},
 		blockExplorerURL:       "https://bokuto.katanascan.com/",
 		chainColor:             "#F6FF0D",

--- a/services/rpcstats/stats.go
+++ b/services/rpcstats/stats.go
@@ -12,32 +12,40 @@ type RPCUsageStats struct {
 
 var stats *RPCUsageStats
 var mu sync.Mutex
+var statsOnce sync.Once
 
 func getInstance() *RPCUsageStats {
-	mu.Lock()
-	defer mu.Unlock()
-
-	if stats == nil {
-		stats = &RPCUsageStats{}
-		stats.counterPerMethod = &sync.Map{}
-		stats.counterPerMethodPerTag = &sync.Map{}
-	}
+	statsOnce.Do(func() {
+		stats = &RPCUsageStats{
+			counterPerMethod:       &sync.Map{},
+			counterPerMethodPerTag: &sync.Map{},
+		}
+	})
 	return stats
 }
 
 func getStats() (uint, *sync.Map, *sync.Map) {
-	stats := getInstance()
-	return stats.total, stats.counterPerMethod, stats.counterPerMethodPerTag
+	mu.Lock()
+	defer mu.Unlock()
+
+	s := getInstance()
+	return s.total, s.counterPerMethod, s.counterPerMethodPerTag
 }
 
 func resetStats() {
-	stats := getInstance()
-	stats.total = 0
-	stats.counterPerMethod = &sync.Map{}
-	stats.counterPerMethodPerTag = &sync.Map{}
+	mu.Lock()
+	defer mu.Unlock()
+
+	s := getInstance()
+	s.total = 0
+	s.counterPerMethod = &sync.Map{}
+	s.counterPerMethodPerTag = &sync.Map{}
 }
 
 func CountCall(method string) {
+	mu.Lock()
+	defer mu.Unlock()
+
 	stats := getInstance()
 	stats.total++
 	value, _ := stats.counterPerMethod.LoadOrStore(method, uint(0))
@@ -49,6 +57,9 @@ func CountCallWithTag(method string, tag string) {
 		CountCall(method)
 		return
 	}
+
+	mu.Lock()
+	defer mu.Unlock()
 
 	stats := getInstance()
 	value, _ := stats.counterPerMethodPerTag.LoadOrStore(tag, &sync.Map{})

--- a/services/wallet/common/const.go
+++ b/services/wallet/common/const.go
@@ -43,6 +43,9 @@ const (
 	DirectInfura      = "direct-infura"
 	DirectGrove       = "direct-grove"
 	DirectCustom      = "direct-custom"
+	DirectKatana      = "direct-katana"
+	DirectConduit     = "direct-conduit"
+	DirectTenderly    = "direct-tenderly"
 )
 
 type ChainID uint64


### PR DESCRIPTION
* delay down status by 30 seconds
* add katana fallback providers and drop bokuto proxy:
  - official
  - Conduit
  - Tenderly

updates:
* health-manager handles service pause/resume
* fixed races in circuit_breaker 

https://github.com/status-im/status-app/pull/21203

