### PR TITLE
test(functional): cross-version chat compat tests (full/light matrix) based before #7495/#7500 [10.34.x]

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -539,6 +539,15 @@ test-functional: export USE_LOGOS_STORAGE := $(USE_LOGOS_STORAGE)
 test-functional:
 	@./scripts/run_functional_tests.sh
 
+test-functional-compatibility: generate
+test-functional-compatibility: export FUNCTIONAL_TESTS_DOCKER_UID ?= $(call sh, id -u)
+test-functional-compatibility: export FUNCTIONAL_TESTS_REPORT_CODECOV ?= false
+test-functional-compatibility: export USE_LOGOS_STORAGE := $(USE_LOGOS_STORAGE)
+test-functional-compatibility: export FUNCTIONAL_TESTS_MARKER := compatibility
+test-functional-compatibility: export FUNCTIONAL_TESTS_RERUNS := 1
+test-functional-compatibility: ##@tests Cross-version chat compatibility smoke tests (set PEER_IMAGES or PEER_REFS)
+	@./scripts/run_functional_tests.sh
+
 benchmark: export FUNCTIONAL_TESTS_DOCKER_UID ?= $(call sh, id -u)
 benchmark:
 	@./scripts/run_benchmark.sh

--- a/_assets/ci/Jenkinsfile.tests-rpc-compat
+++ b/_assets/ci/Jenkinsfile.tests-rpc-compat
@@ -1,0 +1,111 @@
+#!/usr/bin/env groovy
+library 'status-jenkins-lib@v1.9.39'
+
+pipeline {
+  agent {
+    docker {
+      label 'linuxcontainer'
+      image 'harbor.status.im/infra/ci-build-containers:linux-base-1.0.0'
+      args '--volume=/nix:/nix ' +
+           '--volume=/etc/nix:/etc/nix ' +
+           '--volume=/var/run/docker.sock:/var/run/docker.sock ' +
+           '--network=host ' +
+           '--user jenkins'
+    }
+  }
+
+  parameters {
+    string(
+      name: 'BRANCH',
+      defaultValue: 'develop',
+      description: 'Name of branch to build.'
+    )
+    string(
+      name: 'PEER_IMAGES',
+      defaultValue: '',
+      description: 'Space-separated peer (old release) backend images. Highest priority. ' +
+                   'Empty => resolved from PEER_REFS.'
+    )
+    string(
+      name: 'PEER_REFS',
+      defaultValue: '',
+      description: 'Space-separated git refs to resolve peer images from (e.g. "v10.33.0 v10.32.0"). ' +
+                   'Empty => 2 latest release tags.'
+    )
+    choice(
+      name: 'FUNCTIONAL_TESTS_LOG_LEVEL',
+      choices: ['DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL'],
+      description: 'pytest log level'
+    )
+  }
+
+  options {
+    timestamps()
+    /* Prevent Jenkins jobs from running forever. Higher than tests-rpc: this job also
+       builds the peer (old release) backends from source before running the tests. */
+    timeout(time: 90, unit: 'MINUTES')
+    disableConcurrentBuilds()
+    disableRestartFromStage()
+    /* manage how many builds we keep */
+    buildDiscarder(logRotator(
+      numToKeepStr: '10',
+      daysToKeepStr: '30',
+      artifactNumToKeepStr: '10',
+      artifactDaysToKeepStr: '30',
+    ))
+  }
+
+  environment {
+    PLATFORM = 'tests-rpc-compat'
+    PKG_URL = "${currentBuild.absoluteUrl}/consoleText"
+
+    /* Hack-fix for params not being set in env on first job run. */
+    BRANCH =                     "${params.BRANCH}"
+    PEER_IMAGES =                "${params.PEER_IMAGES}"
+    PEER_REFS =                  "${params.PEER_REFS}"
+    FUNCTIONAL_TESTS_LOG_LEVEL = "${params.FUNCTIONAL_TESTS_LOG_LEVEL}"
+    FUNCTIONAL_TESTS_CONTAINER_PREFIX = "${env.BUILD_TAG}"
+  }
+
+  stages {
+    stage('Compatibility Tests') {
+      steps { script {
+        withCredentials([
+          usernamePassword(
+            credentialsId: "api-proxy-devel",
+            usernameVariable: 'STATUS_BUILD_PROXY_USER',
+            passwordVariable: 'STATUS_BUILD_PROXY_PASSWORD'
+          ),
+        ]) {
+          nix.develop('make test-functional-compatibility', pure: false)
+        }
+      } }
+    }
+  } // stages
+
+  post {
+    always {
+      script {
+        archiveArtifacts(
+          artifacts: 'tests-functional/reports/*.xml, tests-functional/logs/*.log',
+          allowEmptyArchive: true,
+        )
+        junit(
+          testResults: 'tests-functional/reports/*.xml',
+          skipOldReports: true,
+          skipPublishingChecks: true,
+          skipMarkingBuildUnstable: true,
+        )
+      }
+    }
+    success { script { github.notifyPR(true) } }
+    failure { script { github.notifyPR(false) } }
+    cleanup {
+      sh '''
+        docker ps -a --filter "name=${FUNCTIONAL_TESTS_CONTAINER_PREFIX}" -q | xargs -r docker rm -f
+      '''
+      cleanWs()
+      dir(env.WORKSPACE_TMP) { deleteDir() }
+    }
+  } // post
+} // pipeline

--- a/scripts/run_functional_tests.sh
+++ b/scripts/run_functional_tests.sh
@@ -10,6 +10,10 @@ source "${GIT_ROOT}/scripts/codecov.sh"
 : "${FUNCTIONAL_TESTS_REPORT_CODECOV:=false}"
 : "${FUNCTIONAL_TESTS_BUILD_TAGS:=gowaku_no_rln}"
 : "${USE_LOGOS_STORAGE:=false}"
+: "${FUNCTIONAL_TESTS_MARKER:=rpc}"
+: "${FUNCTIONAL_TESTS_RERUNS:=2}"
+: "${PEER_IMAGES:=}"
+: "${PEER_REFS:=}"
 
 echo -e "${GRN}Running functional tests${RST}"
 
@@ -87,6 +91,52 @@ fi
 
 echo -e "${GRN}wakufleet-scanner completed successfully${RST}"
 
+# Resolve peer (old) backend images for cross-version compatibility tests.
+peer_image_args=()
+if [[ "${FUNCTIONAL_TESTS_MARKER}" == "compatibility" ]]; then
+  echo -e "${GRN}Preparing peer images for compatibility tests${RST}"
+  resolved_peer_images=()
+  if [[ -n "${PEER_IMAGES}" ]]; then
+    for img in ${PEER_IMAGES}; do
+      docker pull "${img}" || { echo -e "${RED}Failed to pull peer image ${img}${RST}"; exit 1; }
+      resolved_peer_images+=("${img}")
+    done
+  else
+   if [[ -z "${PEER_REFS}" ]]; then
+      echo "${GRN}Fetching git tags to determine peer refs${RST}"
+      git fetch --tags --quiet || true
+      PEER_REFS="$(git tag --sort=-v:refname 2>/dev/null | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | awk -F. '!seen[$1"."$2]++' | head -2 | paste -sd' ' -)"
+    fi
+    if [[ -z "${PEER_REFS}" ]]; then
+      echo -e "${RED}No peer refs available. Set PEER_REFS or PEER_IMAGES.${RST}"
+      exit 1
+    fi
+    echo "${GRN}Peer refs:${RST} ${PEER_REFS}"
+    # TODO: drop worktree build once released backend images are published to Harbor.
+    for ref in ${PEER_REFS}; do
+      ref_slug="$(printf '%s' "${ref}" | tr -c 'A-Za-z0-9_.-' '-' | sed 's/^[-.]*//; s/[-.]*$//')"
+      peer_image="statusgo-peer-${ref_slug}"
+      if ! docker image inspect "${peer_image}" > /dev/null 2>&1; then
+        echo -e "${GRN}Building peer backend ${ref} -> ${peer_image}${RST}"
+        git rev-parse --verify --quiet "${ref}^{commit}" > /dev/null || git fetch --tags origin "${ref}"
+        peer_worktree="$(mktemp -d)"
+        git worktree add --force --detach "${peer_worktree}" "${ref}"
+        if ! docker build "${peer_worktree}" --build-arg "build_tags=${FUNCTIONAL_TESTS_BUILD_TAGS}" --tag "${peer_image}"; then
+          echo -e "${RED}Failed to build peer backend ${ref}${RST}"
+          git worktree remove --force "${peer_worktree}" || true
+          exit 1
+        fi
+        git worktree remove --force "${peer_worktree}"
+      fi
+      resolved_peer_images+=("${peer_image}")
+    done
+  fi
+  for img in ${resolved_peer_images[@]+"${resolved_peer_images[@]}"}; do
+    peer_image_args+=(--peer-docker-image="${img}")
+  done
+  echo -e "${GRN}Peer images:${RST} ${resolved_peer_images[*]+${resolved_peer_images[*]}}"
+fi
+
 # Set up virtual environment
 venv_path="${root_path}/.venv"
 
@@ -106,11 +156,12 @@ pip install -r "${root_path}/requirements.txt"
 
 # Run functional tests
 echo -e "${GRN}Running tests${RST}, HEAD: $(git rev-parse HEAD)"
-pytest --reruns 2 -m rpc -c "${root_path}/pytest.ini" -n 12 \
+pytest --reruns "${FUNCTIONAL_TESTS_RERUNS}" -m "${FUNCTIONAL_TESTS_MARKER}" -c "${root_path}/pytest.ini" -n 12 \
   --dist load\
   --log-cli-level="${FUNCTIONAL_TESTS_LOG_LEVEL}" \
   --docker_project_name="${project_name}" \
   --docker-image=${image_name} \
+  ${peer_image_args[@]+"${peer_image_args[@]}"} \
   --codecov_dir="${binary_coverage_reports_path}" \
   --logs-dir="${logs_path}" \
   --junitxml="${test_results_path}/report.xml" \

--- a/tests-functional/clients/services/wakuext.py
+++ b/tests-functional/clients/services/wakuext.py
@@ -442,6 +442,11 @@ class WakuextService(Service):
         response = self.rpc_request("leaveCommunity", params)
         return response
 
+    def ban_user_from_community(self, community_id: str, user: str, delete_all_messages: bool = False):
+        params = [{"communityId": community_id, "user": user, "deleteAllMessages": delete_all_messages}]
+        response = self.rpc_request("banUserFromCommunity", params)
+        return response
+
     def set_light_client(self, enabled=True):
         params = [{"enabled": enabled}]
         response = self.rpc_request("setLightClient", params)

--- a/tests-functional/clients/statusgo_container.py
+++ b/tests-functional/clients/statusgo_container.py
@@ -26,7 +26,7 @@ class StatusGoContainer:
     container = None
     _port_lock = threading.Lock()  # Thread-safe port allocation for parallel backend creation
 
-    def __init__(self, cmd, ports=None, privileged=False, container_name_suffix=""):
+    def __init__(self, cmd, ports=None, privileged=False, container_name_suffix="", image=None):
         if ports is None:
             ports = {}
 
@@ -46,7 +46,7 @@ class StatusGoContainer:
         self.network_name = f"{docker_project_name}_default"
         git_commit = os.popen("git rev-parse --short HEAD").read().strip()
         identifier = os.environ.get("BUILD_ID") if os.environ.get("CI") else git_commit
-        image_name = Config.docker_image or f"statusgo-{identifier}:latest"
+        image_name = image or Config.docker_image or f"statusgo-{identifier}:latest"
         self.container_name = f"{docker_project_name}-{identifier}{container_name_suffix}"
         coverage_path = Config.codecov_dir if Config.codecov_dir else os.path.abspath("./coverage/binary")
 
@@ -408,6 +408,7 @@ class PushNotificationServerContainer(StatusGoContainer):
 class StatusBackendContainer(StatusGoContainer):
     def __init__(self, privileged=False, ipv6=False, **kwargs):
         connector_enabled = kwargs.get("connector_enabled", False)
+        image = kwargs.get("image")
 
         self.ipv6 = ipv6
         self.ports = StatusPortsMappings(
@@ -427,7 +428,9 @@ class StatusBackendContainer(StatusGoContainer):
         self.url = f"http://{_localhost(ipv6)}:{self.ports.backend.host_port}"
         self.connector_ws_url = f"ws://{_localhost(ipv6)}:{self.ports.connector.host_port}" if self.ports.connector else ""
 
-        super().__init__(entrypoint, self.ports.ports(ipv6), privileged, container_name_suffix=f"-status-backend-{self.ports.backend.host_port}")
+        super().__init__(
+            entrypoint, self.ports.ports(ipv6), privileged, container_name_suffix=f"-status-backend-{self.ports.backend.host_port}", image=image
+        )
 
         if kwargs.get("bridge_network", False):
             self.connect_to_bridge_network()

--- a/tests-functional/conftest.py
+++ b/tests-functional/conftest.py
@@ -34,6 +34,14 @@ def pytest_addoption(parser):
         default="",
     )
     parser.addoption(
+        "--peer-docker-image",
+        action="append",
+        help="status-go image for the OTHER (peer) chat participant in cross-version "
+        "compatibility tests. Repeatable; each value adds one peer version to run against. "
+        "Empty => use --docker-image (vut<->vut).",
+        default=None,
+    )
+    parser.addoption(
         "--codecov_dir",
         action="store",
         help="",
@@ -132,6 +140,7 @@ def pytest_configure(config):
     Config.password = config.getoption("--password")
     Config.docker_project_name = config.getoption("--docker_project_name")
     Config.docker_image = config.getoption("--docker-image")
+    Config.peer_docker_images = config.getoption("--peer-docker-image") or []
     Config.codecov_dir = config.getoption("--codecov_dir")
     Config.logs_dir = config.getoption("--logs-dir")
     Config.benchmark_results_dir = config.getoption("--benchmark-results-dir")
@@ -149,6 +158,7 @@ def pytest_report_header(config):
     port_range_info = f"port range: {port_range[0]}-{port_range[-1]} ({len(port_range)} ports)" if port_range else "port range: empty"
     return [
         f"docker image: {Config.docker_image}",
+        f"peer docker images: {Config.peer_docker_images or '(same as docker image)'}",
         f"waku fleets config file: {config.option.waku_fleets_config}",
         f"waku fleet: {config.option.waku_fleet}",
         f"push fleets config file: {config.option.push_fleets_config}",

--- a/tests-functional/pytest.ini
+++ b/tests-functional/pytest.ini
@@ -25,3 +25,4 @@ markers =
     benchmark
     connector
     ens
+    compatibility: cross-version chat compatibility smoke tests (version under test <-> previous releases)

--- a/tests-functional/steps/messenger.py
+++ b/tests-functional/steps/messenger.py
@@ -214,6 +214,45 @@ def private_group_message(message_count, private_group_id, sender=None, receiver
         )
 
 
+def add_group_member(admin, group_id, new_member, observers):
+    start = {observer.public_key: len(observer.received_signals[SignalType.MESSAGES_NEW]) for observer in observers}
+    response = admin.wakuext_service.add_members_to_group_chat(group_id, [new_member.public_key])
+    expected_message = get_message_by_content_type(
+        response,
+        content_type=MessageContentType.SYSTEM_MESSAGE_CONTENT_PRIVATE_GROUP.value,
+        message_pattern=f"@{admin.public_key} has added @{new_member.public_key}",
+    )[0]
+    for observer in observers:
+        with observer.expect_signal(SignalType.MESSAGES_NEW, pattern=expected_message.get("id"), timeout=60, start=start[observer.public_key]):
+            pass
+    return response
+
+
+def remove_group_member(admin, group_id, member, observers):
+    start = {observer.public_key: len(observer.received_signals[SignalType.MESSAGES_NEW]) for observer in observers}
+    response = admin.wakuext_service.remove_member_from_group_chat(group_id, member.public_key)
+    expected_message = get_message_by_content_type(
+        response,
+        content_type=MessageContentType.SYSTEM_MESSAGE_CONTENT_PRIVATE_GROUP.value,
+        message_pattern=f"@{member.public_key} left the group",
+    )[0]
+    for observer in observers:
+        with observer.expect_signal(SignalType.MESSAGES_NEW, pattern=expected_message.get("id"), timeout=60, start=start[observer.public_key]):
+            pass
+    return response
+
+
+def leave_group(node, group_id, observers=()):
+    start = {observer.public_key: len(observer.received_signals[SignalType.MESSAGES_NEW]) for observer in observers}
+    response = node.wakuext_service.leave_group_chat(group_id, True)
+    for observer in observers:
+        with observer.expect_signal(
+            SignalType.MESSAGES_NEW, pattern=f"@{node.public_key} left the group", timeout=60, start=start[observer.public_key]
+        ):
+            pass
+    return response
+
+
 # --- Community operations ---
 
 
@@ -696,6 +735,13 @@ def check_node_joined_community(node, joined, community_id):
     assert response.get("joined") is joined
 
 
+def ban_community_member(owner, community_id, member):
+    response = owner.wakuext_service.ban_user_from_community(community_id, member.public_key)
+    communities = [c for c in response.get("communities", []) if c.get("id") == community_id]
+    assert communities, f"banned community {community_id} not in response"
+    return response
+
+
 # --- One-to-one message operations ---
 
 
@@ -733,11 +779,10 @@ def one_to_one_message(message_count, sender=None, receiver=None):
 def community_messages(message_chat_id, message_count, sender=None, receiver=None):
     start_index = len(receiver.received_signals[SignalType.MESSAGES_NEW])
     total_signals_before = sum(len(v) for v in receiver.received_signals.values())
-    logging.info(
-        "community_messages: start_index=%d, total_signals_before=%d, ws_url=%s",
-        start_index,
-        total_signals_before,
-        getattr(receiver, "url", "unknown"),
+    logger.info(
+        f"community_messages: start_index={start_index}, "
+        f"total_signals_before={total_signals_before}, "
+        f"ws_url={getattr(receiver, 'url', 'unknown')}"
     )
 
     sent_messages = []
@@ -750,13 +795,10 @@ def community_messages(message_chat_id, message_count, sender=None, receiver=Non
 
     messages_new_after_send = len(receiver.received_signals[SignalType.MESSAGES_NEW])
     total_signals_after_send = sum(len(v) for v in receiver.received_signals.values())
-    logging.info(
-        "community_messages: all %d messages sent, MESSAGES_NEW count=%d (was %d), total_signals=%d (was %d)",
-        message_count,
-        messages_new_after_send,
-        start_index,
-        total_signals_after_send,
-        total_signals_before,
+    logger.info(
+        f"community_messages: all {message_count} messages sent, "
+        f"MESSAGES_NEW count={messages_new_after_send} (was {start_index}), "
+        f"total_signals={total_signals_after_send} (was {total_signals_before})"
     )
 
     for i, expected_message in enumerate(sent_messages):

--- a/tests-functional/tests/test_chat_compatibility.py
+++ b/tests-functional/tests/test_chat_compatibility.py
@@ -12,20 +12,33 @@ def pytest_generate_tests(metafunc):
 
 
 @pytest.mark.compatibility
+@pytest.mark.parametrize(
+    ("vut_light", "peer_light"),
+    [
+        pytest.param(False, False, id="full-full"),
+        pytest.param(False, True, id="full-light"),
+        pytest.param(True, False, id="light-full"),
+        pytest.param(True, True, id="light-light"),
+    ],
+)
 class TestChatCompatibility:
-    """Cross-version chat smoke: vut (build under test) talks to peer (a released backend)."""
+    """Cross-version chat smoke: vut (build under test) talks to peer (a released backend).
+
+    Each test runs in a full/light waku mode matrix: vut runs in the first mode,
+    peer and third run in the second.
+    """
 
     @pytest.fixture()
-    def vut(self, backend_new_profile):
-        return backend_new_profile("vut")
+    def vut(self, backend_new_profile, vut_light):
+        return backend_new_profile("vut", waku_light_client=vut_light)
 
     @pytest.fixture()
-    def peer(self, backend_new_profile, peer_image):
-        return backend_new_profile("peer", image=peer_image)
+    def peer(self, backend_new_profile, peer_image, peer_light):
+        return backend_new_profile("peer", image=peer_image, waku_light_client=peer_light)
 
     @pytest.fixture()
-    def third(self, backend_new_profile, peer_image):
-        return backend_new_profile("third", image=peer_image)
+    def third(self, backend_new_profile, peer_image, peer_light):
+        return backend_new_profile("third", image=peer_image, waku_light_client=peer_light)
 
     def test_one_to_one_compatibility(self, vut, peer):
         messenger.make_contacts(vut, peer)

--- a/tests-functional/tests/test_chat_compatibility.py
+++ b/tests-functional/tests/test_chat_compatibility.py
@@ -1,0 +1,62 @@
+import pytest
+
+from steps import messenger
+from utils.config import Config
+
+
+def pytest_generate_tests(metafunc):
+    if "peer_image" in metafunc.fixturenames:
+        images = Config.peer_docker_images or ([Config.docker_image] if Config.docker_image else [])
+        ids = [(image.split(":")[-1] or "self") for image in images]
+        metafunc.parametrize("peer_image", images, ids=ids)
+
+
+@pytest.mark.compatibility
+class TestChatCompatibility:
+    """Cross-version chat smoke: vut (build under test) talks to peer (a released backend)."""
+
+    @pytest.fixture()
+    def vut(self, backend_new_profile):
+        return backend_new_profile("vut")
+
+    @pytest.fixture()
+    def peer(self, backend_new_profile, peer_image):
+        return backend_new_profile("peer", image=peer_image)
+
+    @pytest.fixture()
+    def third(self, backend_new_profile, peer_image):
+        return backend_new_profile("third", image=peer_image)
+
+    def test_one_to_one_compatibility(self, vut, peer):
+        messenger.make_contacts(vut, peer)
+        messenger.one_to_one_message(1, sender=vut, receiver=peer)
+        messenger.one_to_one_message(1, sender=peer, receiver=vut)
+
+    def test_group_chat_compatibility(self, vut, peer, third):
+        messenger.make_contacts(vut, peer)
+        messenger.make_contacts(vut, third)
+
+        group_id = messenger.join_private_group(admin=vut, member=peer)
+        messenger.private_group_message(2, group_id, sender=vut, receiver=peer)
+
+        messenger.add_group_member(vut, group_id, third, observers=[peer, third])
+        messenger.private_group_message(2, group_id, sender=vut, receiver=third)
+
+        messenger.remove_group_member(vut, group_id, third, observers=[peer])
+        messenger.private_group_message(2, group_id, sender=peer, receiver=vut)
+
+        messenger.leave_group(peer, group_id, observers=[vut])
+
+    def test_community_compatibility(self, vut, peer, third):
+        community_id = messenger.create_community(vut)
+
+        chat_id = messenger.join_community(member=peer, admin=vut, community_id=community_id)
+        messenger.community_messages(chat_id, 2, sender=vut, receiver=peer)
+
+        messenger.join_community(member=third, admin=vut, community_id=community_id)
+        messenger.community_messages(chat_id, 2, sender=vut, receiver=third)
+
+        messenger.ban_community_member(vut, community_id, third)
+        messenger.community_messages(chat_id, 2, sender=peer, receiver=vut)
+
+        messenger.leave_the_community(peer, community_id)

--- a/tests-functional/utils/config.py
+++ b/tests-functional/utils/config.py
@@ -12,6 +12,7 @@ class Config:
     password: str = ""  # FIXME: remove
     docker_project_name: str = ""
     docker_image: str = ""
+    peer_docker_images: List[str] = field(default_factory=list)
     codecov_dir: str = ""
     logs_dir: str = ""
     benchmark_results_dir: str = ""


### PR DESCRIPTION
Testing-only twin of #7544: the same cherry-picks of #7497 (`0faecca`) and #7542 (`4bf8bfa`, light-client matrix), but based on `95e4730` — the `release/10.34.x` commit just before the #7495 (default-shard listen) and #7500 (version=0 decode) cherry-picks landed.

Purpose: compare `tests-rpc-compat` results with #7544 to see whether the light-client matrix failures depend on the #7495/#7500 changes. Not intended to be merged as-is.

Same conflict resolutions as #7544 (`logger.info` f-strings in `steps/messenger.py`; only the `compatibility` marker in `pytest.ini`). Cherry-picked files are byte-identical to #7544's branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)