### PR TITLE
refactor(waku): remove key storage from the waku adapter

### DIFF
--- a/pkg/messaging/core.go
+++ b/pkg/messaging/core.go
@@ -29,10 +29,6 @@ import (
 	"github.com/status-im/status-go/pkg/pubsub"
 )
 
-var (
-	ErrWakuIdentityInjectionFailure = errors.New("failed to inject identity into waku")
-)
-
 type Core struct {
 	config
 
@@ -260,16 +256,6 @@ func newWaku(params wakuParams) (*wakuv3.Waku, error) {
 	)
 	if err != nil {
 		return nil, err
-	}
-
-	// Inject the identity into Waku
-	err = waku.DeleteKeyPairs()
-	if err != nil {
-		return nil, err
-	}
-	_, err = waku.AddKeyPair(params.identity)
-	if err != nil {
-		return nil, ErrWakuIdentityInjectionFailure
 	}
 
 	return waku, nil

--- a/pkg/messaging/layers/transport/filter.go
+++ b/pkg/messaging/layers/transport/filter.go
@@ -10,8 +10,6 @@ type Filter struct {
 	ChatID string `json:"chatId"`
 	// FilterID the whisper filter id generated
 	FilterID string `json:"filterId"`
-	// SymKeyID is the symmetric key id used for symmetric filters
-	SymKeyID string `json:"symKeyId"`
 	// OneToOne tells us if we need to use asymmetric encryption for this chat
 	OneToOne bool `json:"oneToOne"`
 	// Identity is the public key of the other recipient for non-public filters.

--- a/pkg/messaging/layers/transport/filters_manager.go
+++ b/pkg/messaging/layers/transport/filters_manager.go
@@ -4,14 +4,17 @@ import (
 	"bytes"
 	"context"
 	"crypto/ecdsa"
+	"crypto/sha256"
 	"encoding/hex"
 	"sync"
 
 	"github.com/pkg/errors"
 	"go.uber.org/zap"
+	"golang.org/x/crypto/pbkdf2"
 
 	messagingtypes "github.com/status-im/status-go/pkg/messaging/types"
 	wakuv2 "github.com/status-im/status-go/pkg/messaging/waku"
+	wakucommon "github.com/status-im/status-go/pkg/messaging/waku/common"
 	"github.com/status-im/status-go/pkg/messaging/waku/types"
 )
 
@@ -22,14 +25,6 @@ type RawFilter struct {
 }
 
 type FiltersService interface {
-	AddKeyPair(key *ecdsa.PrivateKey) (string, error)
-	DeleteKeyPair(keyID string) bool
-
-	AddSymKeyDirect(key []byte) (string, error)
-	AddSymKeyFromPassword(password string) (string, error)
-	GetSymKey(id string) ([]byte, error)
-	DeleteSymKey(id string) bool
-
 	Subscribe(pubsubTopic string, contentTopics [][]byte) (string, error)
 	Unsubscribe(ctx context.Context, id string) error
 	UnsubscribeMany(ids []string) error
@@ -45,10 +40,16 @@ type FiltersManager struct {
 	filters     map[string]*Filter
 	// asymKeys maps an asymmetric filter's FilterID to the private key used to
 	// decode messages received on it. Symmetric keys are resolved on demand via
-	// keysManager.RawSymKey(SymKeyID) (the same path the send side uses), so only
-	// the asymmetric keys — which are not otherwise reachable from a persisted
+	// SymKey(SymKeyID) (the same path the send side uses), so only the
+	// asymmetric keys — which are not otherwise reachable from a persisted
 	// Filter — are held here. Runtime-only; never persisted.
 	asymKeys map[string]*ecdsa.PrivateKey
+	// symKeys maps a filter's SymKeyID to the symmetric key used to encode and
+	// decode messages on it. Runtime-only: ids are regenerated when filters are
+	// recreated on startup; the password-derived key material itself is cached
+	// by chat id in keys and persisted.
+	symKeyMu sync.RWMutex
+	symKeys  map[string][]byte
 }
 
 // NewFiltersManager returns a new filtersManager.
@@ -69,8 +70,46 @@ func NewFiltersManager(persistence KeysPersistence, service FiltersService, priv
 		keys:        keys,
 		filters:     make(map[string]*Filter),
 		asymKeys:    make(map[string]*ecdsa.PrivateKey),
+		symKeys:     make(map[string][]byte),
 		logger:      logger.With(zap.Namespace("filtersManager")),
 	}, nil
+}
+
+// SymKey returns the symmetric key stored under the given id, as referenced by
+// a filter's SymKeyID.
+func (f *FiltersManager) SymKey(id string) ([]byte, error) {
+	f.symKeyMu.RLock()
+	defer f.symKeyMu.RUnlock()
+	if key := f.symKeys[id]; key != nil {
+		return key, nil
+	}
+	return nil, errors.New("non-existent key ID")
+}
+
+// addSymKey stores the key under a freshly generated id and returns it.
+func (f *FiltersManager) addSymKey(key []byte) (string, error) {
+	if len(key) != wakucommon.AESKeyLength {
+		return "", errors.Errorf("wrong key size: %d", len(key))
+	}
+
+	id, err := wakucommon.GenerateRandomID()
+	if err != nil {
+		return "", errors.Wrap(err, "failed to generate ID")
+	}
+
+	f.symKeyMu.Lock()
+	defer f.symKeyMu.Unlock()
+	if f.symKeys[id] != nil {
+		return "", errors.New("failed to generate unique ID")
+	}
+	f.symKeys[id] = key
+	return id, nil
+}
+
+func (f *FiltersManager) deleteSymKey(id string) {
+	f.symKeyMu.Lock()
+	defer f.symKeyMu.Unlock()
+	delete(f.symKeys, id)
 }
 
 // WatchersByTopic returns the filters interested in the given (pubsubTopic,
@@ -318,7 +357,7 @@ func (f *FiltersManager) Remove(ctx context.Context, filtersToRemove ...*Filter)
 			return err
 		}
 		if filter.SymKeyID != "" {
-			f.service.DeleteSymKey(filter.SymKeyID)
+			f.deleteSymKey(filter.SymKeyID)
 		}
 		delete(f.asymKeys, filter.FilterID)
 		for k, v := range f.filters {
@@ -350,7 +389,7 @@ func (f *FiltersManager) RemoveNoListenFilters() error {
 
 	for _, filter := range filters {
 		if filter.SymKeyID != "" {
-			f.service.DeleteSymKey(filter.SymKeyID)
+			f.deleteSymKey(filter.SymKeyID)
 		}
 		delete(f.asymKeys, filter.FilterID)
 		for k, v := range f.filters {
@@ -644,32 +683,24 @@ func (f *FiltersManager) LoadContactCode(pubKey *ecdsa.PublicKey) (*Filter, erro
 
 // addSymmetric adds a symmetric key filter
 func (f *FiltersManager) addSymmetric(chatID string, pubsubTopic string) (*RawFilter, error) {
-	var symKeyID string
-	var err error
-
 	topic := ToTopic(chatID)
 	topics := [][]byte{topic}
 
 	symKey, ok := f.keys[chatID]
-	if ok {
-		symKeyID, err = f.service.AddSymKeyDirect(symKey)
-		if err != nil {
-			return nil, err
-		}
-	} else {
-		symKeyID, err = f.service.AddSymKeyFromPassword(chatID)
-		if err != nil {
-			return nil, err
-		}
-		if symKey, err = f.service.GetSymKey(symKeyID); err != nil {
-			return nil, err
-		}
+	if !ok {
+		// kdf should run no less than 0.1 seconds on an average computer,
+		// because it's an once in a session experience
+		symKey = pbkdf2.Key([]byte(chatID), nil, 65356, wakucommon.AESKeyLength, sha256.New)
 		f.keys[chatID] = symKey
 
-		err = f.persistence.Add(chatID, symKey)
-		if err != nil {
+		if err := f.persistence.Add(chatID, symKey); err != nil {
 			return nil, err
 		}
+	}
+
+	symKeyID, err := f.addSymKey(symKey)
+	if err != nil {
+		return nil, err
 	}
 
 	id, err := f.service.Subscribe(pubsubTopic, topics)
@@ -690,10 +721,6 @@ func (f *FiltersManager) addSymmetric(chatID string, pubsubTopic string) (*RawFi
 func (f *FiltersManager) addAsymmetric(chatID string, pubsubTopic string, identity *ecdsa.PrivateKey) (*RawFilter, error) {
 	topic := ToTopic(chatID)
 	topics := [][]byte{topic}
-
-	if _, err := f.service.AddKeyPair(identity); err != nil {
-		return nil, err
-	}
 
 	id, err := f.service.Subscribe(pubsubTopic, topics)
 	if err != nil {

--- a/pkg/messaging/layers/transport/filters_manager.go
+++ b/pkg/messaging/layers/transport/filters_manager.go
@@ -18,12 +18,6 @@ import (
 	"github.com/status-im/status-go/pkg/messaging/waku/types"
 )
 
-type RawFilter struct {
-	FilterID string
-	Topic    types.TopicType
-	SymKeyID string
-}
-
 type FiltersService interface {
 	Subscribe(pubsubTopic string, contentTopics [][]byte) (string, error)
 	Unsubscribe(ctx context.Context, id string) error
@@ -38,16 +32,12 @@ type FiltersManager struct {
 	logger      *zap.Logger
 	mutex       sync.Mutex
 	filters     map[string]*Filter
-	// asymKeys maps an asymmetric filter's FilterID to the private key used to
-	// decode messages received on it. Symmetric keys are resolved on demand via
-	// SymKey(SymKeyID) (the same path the send side uses), so only the
-	// asymmetric keys — which are not otherwise reachable from a persisted
-	// Filter — are held here. Runtime-only; never persisted.
+	// asymKeys and symKeys map a filter's FilterID to the key material used to
+	// encode and decode messages on it (exactly one of them has an entry per
+	// keyed filter). Runtime-only: FilterIDs are regenerated when filters are
+	// recreated on startup, and the password-derived symmetric key material
+	// itself is cached by chat id in keys and persisted.
 	asymKeys map[string]*ecdsa.PrivateKey
-	// symKeys maps a filter's SymKeyID to the symmetric key used to encode and
-	// decode messages on it. Runtime-only: ids are regenerated when filters are
-	// recreated on startup; the password-derived key material itself is cached
-	// by chat id in keys and persisted.
 	symKeyMu sync.RWMutex
 	symKeys  map[string][]byte
 }
@@ -75,41 +65,31 @@ func NewFiltersManager(persistence KeysPersistence, service FiltersService, priv
 	}, nil
 }
 
-// SymKey returns the symmetric key stored under the given id, as referenced by
-// a filter's SymKeyID.
-func (f *FiltersManager) SymKey(id string) ([]byte, error) {
+// SymKey returns the symmetric key used to encode and decode messages on the
+// filter with the given FilterID, if it is a symmetric filter.
+func (f *FiltersManager) SymKey(filterID string) ([]byte, bool) {
 	f.symKeyMu.RLock()
 	defer f.symKeyMu.RUnlock()
-	if key := f.symKeys[id]; key != nil {
-		return key, nil
-	}
-	return nil, errors.New("non-existent key ID")
+	key, ok := f.symKeys[filterID]
+	return key, ok
 }
 
-// addSymKey stores the key under a freshly generated id and returns it.
-func (f *FiltersManager) addSymKey(key []byte) (string, error) {
+// addSymKey stores the symmetric key of the filter with the given FilterID.
+func (f *FiltersManager) addSymKey(filterID string, key []byte) error {
 	if len(key) != wakucommon.AESKeyLength {
-		return "", errors.Errorf("wrong key size: %d", len(key))
-	}
-
-	id, err := wakucommon.GenerateRandomID()
-	if err != nil {
-		return "", errors.Wrap(err, "failed to generate ID")
+		return errors.Errorf("wrong key size: %d", len(key))
 	}
 
 	f.symKeyMu.Lock()
 	defer f.symKeyMu.Unlock()
-	if f.symKeys[id] != nil {
-		return "", errors.New("failed to generate unique ID")
-	}
-	f.symKeys[id] = key
-	return id, nil
+	f.symKeys[filterID] = key
+	return nil
 }
 
-func (f *FiltersManager) deleteSymKey(id string) {
+func (f *FiltersManager) deleteSymKey(filterID string) {
 	f.symKeyMu.Lock()
 	defer f.symKeyMu.Unlock()
-	delete(f.symKeys, id)
+	delete(f.symKeys, filterID)
 }
 
 // WatchersByTopic returns the filters interested in the given (pubsubTopic,
@@ -237,7 +217,7 @@ func (f *FiltersManager) InitCommunityFilters(communityFiltersToInitialize []Com
 		for _, pubsubTopic := range topics {
 			pk := &cf.PrivKey.PublicKey
 			identityStr := PublicKeyToStr(pk)
-			rawFilter, err := f.addAsymmetric(identityStr, pubsubTopic, cf.PrivKey)
+			id, topic, err := f.addAsymmetric(identityStr, pubsubTopic, cf.PrivKey)
 			if err != nil {
 				f.logger.Debug("could not register community filter", zap.Error(err))
 				return nil, err
@@ -246,9 +226,9 @@ func (f *FiltersManager) InitCommunityFilters(communityFiltersToInitialize []Com
 			filterID := identityStr + "-admin" + pubsubTopic
 			filter := &Filter{
 				ChatID:       filterID,
-				FilterID:     rawFilter.FilterID,
+				FilterID:     id,
 				PubsubTopic:  pubsubTopic,
-				ContentTopic: rawFilter.Topic,
+				ContentTopic: topic,
 				Identity:     identityStr,
 				Listen:       true,
 				OneToOne:     true,
@@ -256,7 +236,7 @@ func (f *FiltersManager) InitCommunityFilters(communityFiltersToInitialize []Com
 
 			f.filters[filterID] = filter
 
-			f.logger.Debug("registering filter for", zap.String("chatID", filterID), zap.String("type", "community"), zap.String("pubsubTopic", pubsubTopic), zap.String("contentTopic", rawFilter.Topic.String()))
+			f.logger.Debug("registering filter for", zap.String("chatID", filterID), zap.String("type", "community"), zap.String("pubsubTopic", pubsubTopic), zap.String("contentTopic", topic.String()))
 
 			filters = append(filters, filter)
 		}
@@ -356,9 +336,7 @@ func (f *FiltersManager) Remove(ctx context.Context, filtersToRemove ...*Filter)
 		if err := f.service.Unsubscribe(ctx, filter.FilterID); err != nil {
 			return err
 		}
-		if filter.SymKeyID != "" {
-			f.deleteSymKey(filter.SymKeyID)
-		}
+		f.deleteSymKey(filter.FilterID)
 		delete(f.asymKeys, filter.FilterID)
 		for k, v := range f.filters {
 			if filter.FilterID == v.FilterID {
@@ -388,9 +366,7 @@ func (f *FiltersManager) RemoveNoListenFilters() error {
 	}
 
 	for _, filter := range filters {
-		if filter.SymKeyID != "" {
-			f.deleteSymKey(filter.SymKeyID)
-		}
+		f.deleteSymKey(filter.FilterID)
 		delete(f.asymKeys, filter.FilterID)
 		for k, v := range f.filters {
 			if filter.FilterID == v.FilterID {
@@ -450,7 +426,7 @@ func (f *FiltersManager) LoadPersonal(publicKey *ecdsa.PublicKey, identity *ecds
 
 	// We set up a filter so we can publish,
 	// but we discard envelopes if listen is false.
-	filter, err := f.addAsymmetric(chatID, "", identity)
+	id, topic, err := f.addAsymmetric(chatID, "", identity)
 	if err != nil {
 		f.logger.Debug("could not register personal topic filter", zap.Error(err))
 		return nil, err
@@ -458,8 +434,8 @@ func (f *FiltersManager) LoadPersonal(publicKey *ecdsa.PublicKey, identity *ecds
 
 	chat := &Filter{
 		ChatID:       chatID,
-		FilterID:     filter.FilterID,
-		ContentTopic: filter.Topic,
+		FilterID:     id,
+		ContentTopic: topic,
 		Identity:     PublicKeyToStr(publicKey),
 		Listen:       listen,
 		OneToOne:     true,
@@ -467,7 +443,7 @@ func (f *FiltersManager) LoadPersonal(publicKey *ecdsa.PublicKey, identity *ecds
 
 	f.filters[chatID] = chat
 
-	f.logger.Debug("registering filter for", zap.String("chatID", chatID), zap.String("type", "personal"), zap.String("topic", filter.Topic.String()))
+	f.logger.Debug("registering filter for", zap.String("chatID", chatID), zap.String("type", "personal"), zap.String("topic", topic.String()))
 
 	return chat, nil
 
@@ -488,7 +464,7 @@ func (f *FiltersManager) loadPartitioned(publicKey *ecdsa.PublicKey, identity *e
 
 	// We set up a filter so we can publish,
 	// but we discard envelopes if listen is false.
-	filter, err := f.addAsymmetric(chatID, "", identity)
+	id, topic, err := f.addAsymmetric(chatID, "", identity)
 	if err != nil {
 		f.logger.Debug("could not register partitioned topic", zap.String("chatID", chatID), zap.Error(err))
 		return nil, err
@@ -496,8 +472,8 @@ func (f *FiltersManager) loadPartitioned(publicKey *ecdsa.PublicKey, identity *e
 
 	chat := &Filter{
 		ChatID:       chatID,
-		FilterID:     filter.FilterID,
-		ContentTopic: filter.Topic,
+		FilterID:     id,
+		ContentTopic: topic,
 		Identity:     PublicKeyToStr(publicKey),
 		Listen:       listen,
 		Ephemeral:    ephemeral,
@@ -506,7 +482,7 @@ func (f *FiltersManager) loadPartitioned(publicKey *ecdsa.PublicKey, identity *e
 
 	f.filters[chatID] = chat
 
-	f.logger.Debug("registering filter for", zap.String("chatID", chatID), zap.String("type", "partitioned"), zap.String("topic", filter.Topic.String()))
+	f.logger.Debug("registering filter for", zap.String("chatID", chatID), zap.String("type", "partitioned"), zap.String("topic", topic.String()))
 
 	return chat, nil
 }
@@ -523,7 +499,7 @@ func (f *FiltersManager) LoadNegotiated(secret messagingtypes.NegotiatedSecret) 
 	}
 
 	keyString := hex.EncodeToString(secret.Key)
-	filter, err := f.addSymmetric(keyString, "")
+	id, topic, err := f.addSymmetric(keyString, "")
 	if err != nil {
 		f.logger.Debug("could not register negotiated topic", zap.Error(err))
 		return nil, err
@@ -531,9 +507,8 @@ func (f *FiltersManager) LoadNegotiated(secret messagingtypes.NegotiatedSecret) 
 
 	chat := &Filter{
 		ChatID:       chatID,
-		ContentTopic: filter.Topic,
-		SymKeyID:     filter.SymKeyID,
-		FilterID:     filter.FilterID,
+		ContentTopic: topic,
+		FilterID:     id,
 		Identity:     PublicKeyToStr(secret.PublicKey),
 		Negotiated:   true,
 		Listen:       true,
@@ -542,7 +517,7 @@ func (f *FiltersManager) LoadNegotiated(secret messagingtypes.NegotiatedSecret) 
 
 	f.filters[chat.ChatID] = chat
 
-	f.logger.Debug("registering filter for", zap.String("chatID", chatID), zap.String("type", "negotiated"), zap.String("topic", filter.Topic.String()))
+	f.logger.Debug("registering filter for", zap.String("chatID", chatID), zap.String("type", "negotiated"), zap.String("topic", topic.String()))
 
 	return chat, nil
 }
@@ -579,14 +554,14 @@ func (f *FiltersManager) LoadDiscovery() ([]*Filter, error) {
 		OneToOne:  true,
 	}
 
-	discoveryResponse, err := f.addAsymmetric(personalDiscoveryChat.ChatID, personalDiscoveryChat.PubsubTopic, f.privateKey)
+	id, topic, err := f.addAsymmetric(personalDiscoveryChat.ChatID, personalDiscoveryChat.PubsubTopic, f.privateKey)
 	if err != nil {
 		f.logger.Debug("could not register discovery topic", zap.String("chatID", personalDiscoveryChat.ChatID), zap.Error(err))
 		return nil, err
 	}
 
-	personalDiscoveryChat.ContentTopic = discoveryResponse.Topic
-	personalDiscoveryChat.FilterID = discoveryResponse.FilterID
+	personalDiscoveryChat.ContentTopic = topic
+	personalDiscoveryChat.FilterID = id
 
 	f.filters[personalDiscoveryChat.ChatID] = personalDiscoveryChat
 
@@ -620,7 +595,7 @@ func (f *FiltersManager) LoadPublic(chatID string, pubsubTopic string) (*Filter,
 		return chat, nil
 	}
 
-	filterAndTopic, err := f.addSymmetric(chatID, pubsubTopic)
+	id, topic, err := f.addSymmetric(chatID, pubsubTopic)
 	if err != nil {
 		f.logger.Debug("could not register public chat topic", zap.String("chatID", chatID), zap.Error(err))
 		return nil, err
@@ -628,9 +603,8 @@ func (f *FiltersManager) LoadPublic(chatID string, pubsubTopic string) (*Filter,
 
 	chat := &Filter{
 		ChatID:       chatID,
-		FilterID:     filterAndTopic.FilterID,
-		SymKeyID:     filterAndTopic.SymKeyID,
-		ContentTopic: filterAndTopic.Topic,
+		FilterID:     id,
+		ContentTopic: topic,
 		PubsubTopic:  pubsubTopic,
 		Listen:       true,
 		OneToOne:     false,
@@ -641,7 +615,7 @@ func (f *FiltersManager) LoadPublic(chatID string, pubsubTopic string) (*Filter,
 	f.logger.Debug("registering filter for",
 		zap.String("chatID", chatID),
 		zap.String("type", "public"),
-		zap.String("ContentTopic", filterAndTopic.Topic.String()),
+		zap.String("ContentTopic", topic.String()),
 		zap.String("PubsubTopic", pubsubTopic),
 	)
 
@@ -659,7 +633,7 @@ func (f *FiltersManager) LoadContactCode(pubKey *ecdsa.PublicKey) (*Filter, erro
 		return f.filters[chatID], nil
 	}
 
-	contactCodeFilter, err := f.addSymmetric(chatID, "")
+	id, topic, err := f.addSymmetric(chatID, "")
 	if err != nil {
 		f.logger.Debug("could not register contact code topic", zap.String("chatID", chatID), zap.Error(err))
 		return nil, err
@@ -667,22 +641,22 @@ func (f *FiltersManager) LoadContactCode(pubKey *ecdsa.PublicKey) (*Filter, erro
 
 	chat := &Filter{
 		ChatID:       chatID,
-		FilterID:     contactCodeFilter.FilterID,
-		ContentTopic: contactCodeFilter.Topic,
-		SymKeyID:     contactCodeFilter.SymKeyID,
+		FilterID:     id,
+		ContentTopic: topic,
 		Identity:     PublicKeyToStr(pubKey),
 		Listen:       true,
 	}
 
 	f.filters[chatID] = chat
 
-	f.logger.Debug("registering filter for", zap.String("chatID", chatID), zap.String("type", "contact-code"), zap.String("topic", contactCodeFilter.Topic.String()))
+	f.logger.Debug("registering filter for", zap.String("chatID", chatID), zap.String("type", "contact-code"), zap.String("topic", topic.String()))
 
 	return chat, nil
 }
 
-// addSymmetric adds a symmetric key filter
-func (f *FiltersManager) addSymmetric(chatID string, pubsubTopic string) (*RawFilter, error) {
+// addSymmetric registers a symmetric filter's wire subscription and key,
+// returning the new FilterID and the filter's content topic.
+func (f *FiltersManager) addSymmetric(chatID string, pubsubTopic string) (string, types.TopicType, error) {
 	topic := ToTopic(chatID)
 	topics := [][]byte{topic}
 
@@ -694,42 +668,38 @@ func (f *FiltersManager) addSymmetric(chatID string, pubsubTopic string) (*RawFi
 		f.keys[chatID] = symKey
 
 		if err := f.persistence.Add(chatID, symKey); err != nil {
-			return nil, err
+			return "", types.TopicType{}, err
 		}
-	}
-
-	symKeyID, err := f.addSymKey(symKey)
-	if err != nil {
-		return nil, err
 	}
 
 	id, err := f.service.Subscribe(pubsubTopic, topics)
 	if err != nil {
-		return nil, err
+		return "", types.TopicType{}, err
 	}
 
-	return &RawFilter{
-		FilterID: id,
-		SymKeyID: symKeyID,
-		Topic:    types.BytesToTopic(topic),
-	}, nil
+	if err := f.addSymKey(id, symKey); err != nil {
+		return "", types.TopicType{}, err
+	}
+
+	return id, types.BytesToTopic(topic), nil
 }
 
-// addAsymmetricFilter adds a filter with our private key. Whether the filter
-// actually receives messages is governed by its Listen flag: non-listening
-// filters are skipped during routing in handleReceivedMessage.
-func (f *FiltersManager) addAsymmetric(chatID string, pubsubTopic string, identity *ecdsa.PrivateKey) (*RawFilter, error) {
+// addAsymmetric registers an asymmetric filter's wire subscription and key,
+// returning the new FilterID and the filter's content topic. Whether the
+// filter actually receives messages is governed by its Listen flag:
+// non-listening filters are skipped during routing in handleReceivedMessage.
+func (f *FiltersManager) addAsymmetric(chatID string, pubsubTopic string, identity *ecdsa.PrivateKey) (string, types.TopicType, error) {
 	topic := ToTopic(chatID)
 	topics := [][]byte{topic}
 
 	id, err := f.service.Subscribe(pubsubTopic, topics)
 	if err != nil {
-		return nil, err
+		return "", types.TopicType{}, err
 	}
 
 	f.asymKeys[id] = identity
 
-	return &RawFilter{FilterID: id, Topic: types.BytesToTopic(topic)}, nil
+	return id, types.BytesToTopic(topic), nil
 }
 
 // GetNegotiated returns a negotiated chat given an identity

--- a/pkg/messaging/layers/transport/transport.go
+++ b/pkg/messaging/layers/transport/transport.go
@@ -268,19 +268,17 @@ func (t *Transport) bufferMessage(filterID string, message *types.Message) {
 }
 
 // filterKeys resolves the key material used to decode messages received on a
-// filter. Symmetric keys come from the FiltersManager's key store via the
-// filter's SymKeyID (the same path the send side uses); asymmetric private keys
-// come from its runtime map. Exactly one of the returned keys is non-nil.
+// filter. Both symmetric and asymmetric keys come from the FiltersManager's
+// runtime maps, keyed by FilterID (the same path the send side uses). Exactly
+// one of the returned keys is non-nil.
 func (t *Transport) filterKeys(filter *Filter) (symKey []byte, privKey *ecdsa.PrivateKey, err error) {
-	if filter.SymKeyID != "" {
-		symKey, err = t.filters.SymKey(filter.SymKeyID)
-		return symKey, nil, err
+	if symKey, ok := t.filters.SymKey(filter.FilterID); ok {
+		return symKey, nil, nil
 	}
-	privKey, ok := t.filters.AsymKey(filter.FilterID)
-	if !ok {
-		return nil, nil, errors.New("no decode key for filter")
+	if privKey, ok := t.filters.AsymKey(filter.FilterID); ok {
+		return nil, privKey, nil
 	}
-	return nil, privKey, nil
+	return nil, nil, errors.New("no decode key for filter")
 }
 
 // decode reverses the rfc26 payload codec using the filter's key material.
@@ -454,9 +452,9 @@ func (t *Transport) SendPublic(ctx context.Context, newMessage *types.NewMessage
 		return nil, err
 	}
 
-	symKey, err := t.filters.SymKey(filter.SymKeyID)
-	if err != nil {
-		return nil, err
+	symKey, ok := t.filters.SymKey(filter.FilterID)
+	if !ok {
+		return nil, errors.New("no sym key found for filter")
 	}
 
 	encoded, err := t.encode(newMessage.Payload, symKey, nil)
@@ -476,9 +474,9 @@ func (t *Transport) SendPrivateWithSharedSecret(ctx context.Context, newMessage 
 		return nil, err
 	}
 
-	symKey, err := t.filters.SymKey(filter.SymKeyID)
-	if err != nil {
-		return nil, err
+	symKey, ok := t.filters.SymKey(filter.FilterID)
+	if !ok {
+		return nil, errors.New("no sym key found for filter")
 	}
 
 	encoded, err := t.encode(newMessage.Payload, symKey, nil)

--- a/pkg/messaging/layers/transport/transport.go
+++ b/pkg/messaging/layers/transport/transport.go
@@ -30,55 +30,18 @@ var (
 	ErrNoMailservers = errors.New("no configured mailservers")
 )
 
-type transportKeysManager struct {
-	waku types.Waku
-
-	// Identity of the current user.
-	privateKey *ecdsa.PrivateKey
-
-	passToSymKeyMutex sync.RWMutex
-	passToSymKeyCache map[string]string
-}
-
-func (m *transportKeysManager) AddOrGetKeyPair(priv *ecdsa.PrivateKey) (string, error) {
-	// caching is handled in waku
-	return m.waku.AddKeyPair(priv)
-}
-
-func (m *transportKeysManager) AddOrGetSymKeyFromPassword(password string) (string, error) {
-	m.passToSymKeyMutex.Lock()
-	defer m.passToSymKeyMutex.Unlock()
-
-	if val, ok := m.passToSymKeyCache[password]; ok {
-		return val, nil
-	}
-
-	id, err := m.waku.AddSymKeyFromPassword(password)
-	if err != nil {
-		return id, err
-	}
-
-	m.passToSymKeyCache[password] = id
-
-	return id, nil
-}
-
-func (m *transportKeysManager) RawSymKey(id string) ([]byte, error) {
-	return m.waku.GetSymKey(id)
-}
-
 type Option func(*Transport) error
 
 // Transport is a transport based on Whisper service.
 type Transport struct {
 	gocommon.PauseBroadcaster
 
-	waku        types.Waku
-	api         MessagingAPI // backend used to send messages and read received envelopes
-	keysManager *transportKeysManager
-	filters     *FiltersManager
-	logger      *zap.Logger
-	cache       ProcessedMessageIDsCachePersistence
+	waku       types.Waku
+	api        MessagingAPI      // backend used to send messages and read received envelopes
+	privateKey *ecdsa.PrivateKey // identity of the current user
+	filters    *FiltersManager
+	logger     *zap.Logger
+	cache      ProcessedMessageIDsCachePersistence
 
 	envelopesMonitor *EnvelopesMonitor
 	cleanFiltersFn   func() error
@@ -163,11 +126,7 @@ func NewTransport(
 		cache:            messageIDsCachePersistence,
 		envelopesMonitor: envelopesMonitor,
 		quit:             make(chan struct{}),
-		keysManager: &transportKeysManager{
-			waku:              waku,
-			privateKey:        privateKey,
-			passToSymKeyCache: make(map[string]string),
-		},
+		privateKey:       privateKey,
 		filters:          filtersManager,
 		logger:           logger.With(zap.Namespace("Transport")),
 		received:         make(map[string]map[string]*types.Message),
@@ -309,12 +268,12 @@ func (t *Transport) bufferMessage(filterID string, message *types.Message) {
 }
 
 // filterKeys resolves the key material used to decode messages received on a
-// filter. Symmetric keys come from the waku key store via the filter's SymKeyID
-// (the same path the send side uses); asymmetric private keys come from the
-// FiltersManager's runtime map. Exactly one of the returned keys is non-nil.
+// filter. Symmetric keys come from the FiltersManager's key store via the
+// filter's SymKeyID (the same path the send side uses); asymmetric private keys
+// come from its runtime map. Exactly one of the returned keys is non-nil.
 func (t *Transport) filterKeys(filter *Filter) (symKey []byte, privKey *ecdsa.PrivateKey, err error) {
 	if filter.SymKeyID != "" {
-		symKey, err = t.keysManager.RawSymKey(filter.SymKeyID)
+		symKey, err = t.filters.SymKey(filter.SymKeyID)
 		return symKey, nil, err
 	}
 	privKey, ok := t.filters.AsymKey(filter.FilterID)
@@ -495,7 +454,7 @@ func (t *Transport) SendPublic(ctx context.Context, newMessage *types.NewMessage
 		return nil, err
 	}
 
-	symKey, err := t.keysManager.RawSymKey(filter.SymKeyID)
+	symKey, err := t.filters.SymKey(filter.SymKeyID)
 	if err != nil {
 		return nil, err
 	}
@@ -517,7 +476,7 @@ func (t *Transport) SendPrivateWithSharedSecret(ctx context.Context, newMessage 
 		return nil, err
 	}
 
-	symKey, err := t.keysManager.RawSymKey(filter.SymKeyID)
+	symKey, err := t.filters.SymKey(filter.SymKeyID)
 	if err != nil {
 		return nil, err
 	}
@@ -531,7 +490,7 @@ func (t *Transport) SendPrivateWithSharedSecret(ctx context.Context, newMessage 
 }
 
 func (t *Transport) SendPrivateWithPartitioned(ctx context.Context, newMessage *types.NewMessage, publicKey *ecdsa.PublicKey) ([]byte, error) {
-	filter, err := t.filters.LoadPartitioned(publicKey, t.keysManager.privateKey, false)
+	filter, err := t.filters.LoadPartitioned(publicKey, t.privateKey, false)
 	if err != nil {
 		return nil, err
 	}
@@ -545,7 +504,7 @@ func (t *Transport) SendPrivateWithPartitioned(ctx context.Context, newMessage *
 }
 
 func (t *Transport) SendPrivateOnPersonalTopic(ctx context.Context, newMessage *types.NewMessage, publicKey *ecdsa.PublicKey) ([]byte, error) {
-	filter, err := t.filters.LoadPersonal(publicKey, t.keysManager.privateKey, false)
+	filter, err := t.filters.LoadPersonal(publicKey, t.privateKey, false)
 	if err != nil {
 		return nil, err
 	}
@@ -595,7 +554,7 @@ func (t *Transport) cleanFilters() error {
 // Exactly one of symKey or recipient must be non-nil. The message is always
 // signed with the local identity key.
 func (t *Transport) encode(payload []byte, symKey []byte, recipient *ecdsa.PublicKey) ([]byte, error) {
-	return rfc26.Encode(payload, symKey, recipient, t.keysManager.privateKey)
+	return rfc26.Encode(payload, symKey, recipient, t.privateKey)
 }
 
 // Track records sent envelopes for delivery monitoring. It is the

--- a/pkg/messaging/layers/transport/transport_test.go
+++ b/pkg/messaging/layers/transport/transport_test.go
@@ -64,7 +64,7 @@ func TestReceivePushPath(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, filter.Listen)
 
-	symKey, err := tr.keysManager.RawSymKey(filter.SymKeyID)
+	symKey, err := tr.filters.SymKey(filter.SymKeyID)
 	require.NoError(t, err)
 
 	payload := []byte("hello receive path")
@@ -157,7 +157,7 @@ func TestReceiveVersionZeroDecodesAsV1(t *testing.T) {
 	filter, err := tr.JoinPublic("test-public-chat")
 	require.NoError(t, err)
 
-	symKey, err := tr.keysManager.RawSymKey(filter.SymKeyID)
+	symKey, err := tr.filters.SymKey(filter.SymKeyID)
 	require.NoError(t, err)
 
 	payload := []byte("hello version zero")
@@ -211,13 +211,13 @@ func TestReceiveSharedKeyFanOut(t *testing.T) {
 	sharedKey := make([]byte, 32)
 	_, err = rand.Read(sharedKey)
 	require.NoError(t, err)
-	sharedKeyID, err := waku.AddSymKeyDirect(sharedKey)
+	sharedKeyID, err := tr.filters.addSymKey(sharedKey)
 	require.NoError(t, err)
 
 	otherKey := make([]byte, 32)
 	_, err = rand.Read(otherKey)
 	require.NoError(t, err)
-	otherKeyID, err := waku.AddSymKeyDirect(otherKey)
+	otherKeyID, err := tr.filters.addSymKey(otherKey)
 	require.NoError(t, err)
 
 	// Install three listening filters on the same (pubsub, content) topic

--- a/pkg/messaging/layers/transport/transport_test.go
+++ b/pkg/messaging/layers/transport/transport_test.go
@@ -64,8 +64,8 @@ func TestReceivePushPath(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, filter.Listen)
 
-	symKey, err := tr.filters.SymKey(filter.SymKeyID)
-	require.NoError(t, err)
+	symKey, ok := tr.filters.SymKey(filter.FilterID)
+	require.True(t, ok)
 
 	payload := []byte("hello receive path")
 	encoded, err := rfc26.Encode(payload, symKey, nil, identity)
@@ -157,8 +157,8 @@ func TestReceiveVersionZeroDecodesAsV1(t *testing.T) {
 	filter, err := tr.JoinPublic("test-public-chat")
 	require.NoError(t, err)
 
-	symKey, err := tr.filters.SymKey(filter.SymKeyID)
-	require.NoError(t, err)
+	symKey, ok := tr.filters.SymKey(filter.FilterID)
+	require.True(t, ok)
 
 	payload := []byte("hello version zero")
 	encoded, err := rfc26.Encode(payload, symKey, nil, identity)
@@ -211,31 +211,27 @@ func TestReceiveSharedKeyFanOut(t *testing.T) {
 	sharedKey := make([]byte, 32)
 	_, err = rand.Read(sharedKey)
 	require.NoError(t, err)
-	sharedKeyID, err := tr.filters.addSymKey(sharedKey)
-	require.NoError(t, err)
 
 	otherKey := make([]byte, 32)
 	_, err = rand.Read(otherKey)
-	require.NoError(t, err)
-	otherKeyID, err := tr.filters.addSymKey(otherKey)
 	require.NoError(t, err)
 
 	// Install three listening filters on the same (pubsub, content) topic
 	// directly in the manager: two sharing a key, one colliding with its own.
 	contentTopic := wakutypes.BytesToTopic(ToTopic("shared-chat"))
-	mkFilter := func(filterID, chatID, symKeyID string) *Filter {
+	mkFilter := func(filterID, chatID string, symKey []byte) *Filter {
+		require.NoError(t, tr.filters.addSymKey(filterID, symKey))
 		return &Filter{
 			ChatID:       chatID,
 			FilterID:     filterID,
-			SymKeyID:     symKeyID,
 			ContentTopic: contentTopic,
 			PubsubTopic:  wakuv3.DefaultShardPubsubTopic(),
 			Listen:       true,
 		}
 	}
-	sharedA := mkFilter("filter-shared-a", "chat-a", sharedKeyID)
-	sharedB := mkFilter("filter-shared-b", "chat-b", sharedKeyID)
-	collider := mkFilter("filter-collider", "chat-c", otherKeyID)
+	sharedA := mkFilter("filter-shared-a", "chat-a", sharedKey)
+	sharedB := mkFilter("filter-shared-b", "chat-b", sharedKey)
+	collider := mkFilter("filter-collider", "chat-c", otherKey)
 	for _, f := range []*Filter{sharedA, sharedB, collider} {
 		tr.filters.filters[f.FilterID] = f
 	}

--- a/pkg/messaging/waku/gowaku.go
+++ b/pkg/messaging/waku/gowaku.go
@@ -25,7 +25,6 @@ package wakuv2
 import (
 	"context"
 	"crypto/ecdsa"
-	"crypto/sha256"
 	"errors"
 	"fmt"
 	"math"
@@ -46,11 +45,9 @@ import (
 
 	"go.uber.org/zap"
 
-	"golang.org/x/crypto/pbkdf2"
 	"golang.org/x/time/rate"
 
 	gethcommon "github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/event"
 	"github.com/ethereum/go-ethereum/p2p/enode"
@@ -136,10 +133,6 @@ type Waku struct {
 
 	// Light-client filter protocol; tracks wire subscriptions made via Subscribe.
 	filterManager *filterapi.FilterManager
-
-	privateKeys map[string]*ecdsa.PrivateKey // Private key storage
-	symKeys     map[string][]byte            // Symmetric key storage
-	keyMu       sync.RWMutex                 // Mutex associated with key stores
 
 	envelopeCache *ttlcache.Cache[gethcommon.Hash, bool] // [Hash of envelope -> Processed] cache
 	poolMu        sync.RWMutex                           // Mutex to sync the message and expiration pools
@@ -241,8 +234,6 @@ func New(nodeKey *ecdsa.PrivateKey, cfg *Config, logger *zap.Logger, ts timesour
 
 	waku := &Waku{
 		cfg:                             cfg,
-		privateKeys:                     make(map[string]*ecdsa.PrivateKey),
-		symKeys:                         make(map[string][]byte),
 		envelopeCache:                   newTTLCache(),
 		msgQueue:                        make(chan *common.ReceivedMessage, messageQueueLimit),
 		topicHealthStatusChan:           make(chan peermanager.TopicHealthStatus, 100),
@@ -771,171 +762,6 @@ func newReceivedMessage(e *common.ReceivedMessage) *types.ReceivedMessage {
 		Version:      msg.GetVersion(),
 		Timestamp:    msg.GetTimestamp(),
 	}
-}
-
-// DeleteKeyPair deletes the specified key if it exists.
-func (w *Waku) DeleteKeyPair(key string) bool {
-	deterministicID, err := toDeterministicID(key, common.KeyIDSize)
-	if err != nil {
-		return false
-	}
-
-	w.keyMu.Lock()
-	defer w.keyMu.Unlock()
-
-	if w.privateKeys[deterministicID] != nil {
-		delete(w.privateKeys, deterministicID)
-		return true
-	}
-	return false
-}
-
-// AddKeyPair imports a asymmetric private key and returns it identifier.
-func (w *Waku) AddKeyPair(key *ecdsa.PrivateKey) (string, error) {
-	id, err := makeDeterministicID(hexutil.Encode(crypto.FromECDSAPub(&key.PublicKey)), common.KeyIDSize)
-	if err != nil {
-		return "", err
-	}
-	if w.HasKeyPair(id) {
-		return id, nil // no need to re-inject
-	}
-
-	w.keyMu.Lock()
-	w.privateKeys[id] = key
-	w.keyMu.Unlock()
-
-	return id, nil
-}
-
-// SelectKeyPair adds cryptographic identity, and makes sure
-// that it is the only private key known to the node.
-func (w *Waku) SelectKeyPair(key *ecdsa.PrivateKey) error {
-	id, err := makeDeterministicID(hexutil.Encode(crypto.FromECDSAPub(&key.PublicKey)), common.KeyIDSize)
-	if err != nil {
-		return err
-	}
-
-	w.keyMu.Lock()
-	defer w.keyMu.Unlock()
-
-	w.privateKeys = make(map[string]*ecdsa.PrivateKey) // reset key store
-	w.privateKeys[id] = key
-
-	return nil
-}
-
-// DeleteKeyPairs removes all cryptographic identities known to the node
-func (w *Waku) DeleteKeyPairs() error {
-	w.keyMu.Lock()
-	defer w.keyMu.Unlock()
-
-	w.privateKeys = make(map[string]*ecdsa.PrivateKey)
-
-	return nil
-}
-
-// HasKeyPair checks if the waku node is configured with the private key
-// of the specified public pair.
-func (w *Waku) HasKeyPair(id string) bool {
-	deterministicID, err := toDeterministicID(id, common.KeyIDSize)
-	if err != nil {
-		return false
-	}
-
-	w.keyMu.RLock()
-	defer w.keyMu.RUnlock()
-	return w.privateKeys[deterministicID] != nil
-}
-
-// GetPrivateKey retrieves the private key of the specified identity.
-func (w *Waku) GetPrivateKey(id string) (*ecdsa.PrivateKey, error) {
-	deterministicID, err := toDeterministicID(id, common.KeyIDSize)
-	if err != nil {
-		return nil, err
-	}
-
-	w.keyMu.RLock()
-	defer w.keyMu.RUnlock()
-	key := w.privateKeys[deterministicID]
-	if key == nil {
-		return nil, fmt.Errorf("invalid id")
-	}
-	return key, nil
-}
-
-// AddSymKeyDirect stores the key, and returns its id.
-func (w *Waku) AddSymKeyDirect(key []byte) (string, error) {
-	if len(key) != common.AESKeyLength {
-		return "", fmt.Errorf("wrong key size: %d", len(key))
-	}
-
-	id, err := common.GenerateRandomID()
-	if err != nil {
-		return "", fmt.Errorf("failed to generate ID: %s", err)
-	}
-
-	w.keyMu.Lock()
-	defer w.keyMu.Unlock()
-
-	if w.symKeys[id] != nil {
-		return "", fmt.Errorf("failed to generate unique ID")
-	}
-	w.symKeys[id] = key
-	return id, nil
-}
-
-// AddSymKeyFromPassword generates the key from password, stores it, and returns its id.
-func (w *Waku) AddSymKeyFromPassword(password string) (string, error) {
-	id, err := common.GenerateRandomID()
-	if err != nil {
-		return "", fmt.Errorf("failed to generate ID: %s", err)
-	}
-	if w.HasSymKey(id) {
-		return "", fmt.Errorf("failed to generate unique ID")
-	}
-
-	// kdf should run no less than 0.1 seconds on an average computer,
-	// because it's an once in a session experience
-	derived := pbkdf2.Key([]byte(password), nil, 65356, common.AESKeyLength, sha256.New)
-
-	w.keyMu.Lock()
-	defer w.keyMu.Unlock()
-
-	// double check is necessary, because deriveKeyMaterial() is very slow
-	if w.symKeys[id] != nil {
-		return "", fmt.Errorf("critical error: failed to generate unique ID")
-	}
-	w.symKeys[id] = derived
-	return id, nil
-}
-
-// HasSymKey returns true if there is a key associated with the given id.
-// Otherwise returns false.
-func (w *Waku) HasSymKey(id string) bool {
-	w.keyMu.RLock()
-	defer w.keyMu.RUnlock()
-	return w.symKeys[id] != nil
-}
-
-// DeleteSymKey deletes the key associated with the name string if it exists.
-func (w *Waku) DeleteSymKey(id string) bool {
-	w.keyMu.Lock()
-	defer w.keyMu.Unlock()
-	if w.symKeys[id] != nil {
-		delete(w.symKeys, id)
-		return true
-	}
-	return false
-}
-
-// GetSymKey returns the symmetric key associated with the given id.
-func (w *Waku) GetSymKey(id string) ([]byte, error) {
-	w.keyMu.RLock()
-	defer w.keyMu.RUnlock()
-	if w.symKeys[id] != nil {
-		return w.symKeys[id], nil
-	}
-	return nil, fmt.Errorf("non-existent key ID")
 }
 
 // Subscribe registers a wire subscription for the given content topics on the
@@ -1850,41 +1676,6 @@ func (w *Waku) PeerID() peer.ID {
 
 func (w *Waku) Peerstore() peerstore.Peerstore {
 	return w.node.Host().Peerstore()
-}
-
-// validatePrivateKey checks the format of the given private key.
-func validatePrivateKey(k *ecdsa.PrivateKey) bool {
-	if k == nil || k.D == nil || k.D.Sign() == 0 {
-		return false
-	}
-	return common.ValidatePublicKey(&k.PublicKey)
-}
-
-// makeDeterministicID generates a deterministic ID, based on a given input
-func makeDeterministicID(input string, keyLen int) (id string, err error) {
-	buf := pbkdf2.Key([]byte(input), nil, 4096, keyLen, sha256.New)
-	if !common.ValidateDataIntegrity(buf, common.KeyIDSize) {
-		return "", fmt.Errorf("error in GenerateDeterministicID: failed to generate key")
-	}
-	id = gethcommon.Bytes2Hex(buf)
-	return id, err
-}
-
-// toDeterministicID reviews incoming id, and transforms it to format
-// expected internally be private key store. Originally, public keys
-// were used as keys, now random keys are being used. And in order to
-// make it easier to consume, we now allow both random IDs and public
-// keys to be passed.
-func toDeterministicID(id string, expectedLen int) (string, error) {
-	if len(id) != (expectedLen * 2) { // we received hex key, so number of chars in id is doubled
-		var err error
-		id, err = makeDeterministicID(id, expectedLen)
-		if err != nil {
-			return "", err
-		}
-	}
-
-	return id, nil
 }
 
 func FormatPeerStats(wakuNode *node.WakuNode) types.PeerStats {

--- a/pkg/messaging/waku/types/waku.go
+++ b/pkg/messaging/waku/types/waku.go
@@ -2,7 +2,6 @@ package types
 
 import (
 	"context"
-	"crypto/ecdsa"
 	"encoding/json"
 	"sync"
 	"time"
@@ -78,16 +77,6 @@ func (u *ConnStatusSubscription) Send(s ConnStatus) bool {
 	return true
 }
 
-type WakuKeyManager interface {
-	// GetPrivateKey retrieves the private key of the specified identity.
-	GetPrivateKey(id string) (*ecdsa.PrivateKey, error)
-	// AddKeyPair imports a asymmetric private key and returns a deterministic identifier.
-	AddKeyPair(key *ecdsa.PrivateKey) (string, error)
-	// DeleteKeyPairs deletes all the keys
-	DeleteKeyPairs() error
-	GetSymKey(id string) ([]byte, error)
-}
-
 // Whisper represents a dark communication interface through the Ethereum
 // network, using its very own P2P communication layer.
 type Waku interface {
@@ -131,19 +120,8 @@ type Waku interface {
 	// GetCurrentTime returns current time.
 	GetCurrentTime() uint64
 
-	// GetPrivateKey retrieves the private key of the specified identity.
-	GetPrivateKey(id string) (*ecdsa.PrivateKey, error)
-
 	SubscribeEnvelopeEvents(events chan<- EnvelopeEvent) Subscription
 
-	// AddKeyPair imports a asymmetric private key and returns a deterministic identifier.
-	AddKeyPair(key *ecdsa.PrivateKey) (string, error)
-	// DeleteKeyPair deletes the key with the specified ID if it exists.
-	DeleteKeyPair(keyID string) bool
-	AddSymKeyDirect(key []byte) (string, error)
-	AddSymKeyFromPassword(password string) (string, error)
-	DeleteSymKey(id string) bool
-	GetSymKey(id string) ([]byte, error)
 	MaxMessageSize() uint32
 
 	// Subscribe registers a wire subscription for the given content topics on


### PR DESCRIPTION
Follow-up to #7524 / #7541 / #7543: with decoding owned by the transport and the Filter machinery gone, the waku adapter never used the keys it stored — the private-key store was write-only, and the symmetric-key store was just an id→key map the transport round-tripped through.

**Commit 1 — relocate key storage out of the adapter:**
- Symmetric key store moves into `FiltersManager`, next to the existing `asymKeys` map. Chat-name key derivation (pbkdf2 params) is unchanged, so derived keys stay wire-compatible.
- `wakuv2.Waku` loses `privateKeys`/`symKeys` and all 11 key methods; the `types.Waku` interface loses its key methods; the unused `WakuKeyManager` interface is deleted.
- The write-only identity injection in `messaging.Core` (`DeleteKeyPairs`/`AddKeyPair`) and the dead `transportKeysManager` (its `AddOrGetKeyPair`/`AddOrGetSymKeyFromPassword` had no callers) are removed; `Transport` keeps the identity key directly.

**Commit 2 — drop the SymKeyID indirection:**
- Sym keys are keyed by `FilterID`, parallel to `asymKeys`; `Filter.SymKeyID` and `RawFilter` are deleted (`SymKeyID` never left the transport package — the `ChatFilter` adapter doesn't map it).
- Fixes a key-cleanup leak: `API.RemoveFilters` round-trips filters through `ChatFilter`, which dropped `SymKeyID`, so `Remove` never deleted the sym key. `FilterID` survives the round-trip.

Key material, derivation and filter routing are identical; only where keys live and how they're addressed changes.

Next (separate PR): extract `FiltersService` from `FiltersManager` — wire-subscription management moves behind `MessagingAPI` (declarative `SyncSubscriptions`), with the `topicPair → wire-sub id` map inside the waku adapter so the seam is swappable with logos-delivery.

🤖 Generated with [Claude Code](https://claude.com/claude-code)