### PR TITLE
fix(wallet): treat unmapped market tokens as non-critical errors

### DIFF
--- a/internal/circuitbreaker/circuit_breaker.go
+++ b/internal/circuitbreaker/circuit_breaker.go
@@ -55,9 +55,10 @@ func (cr *CommandResult) addCallStatus(providerName string, err error, startTime
 }
 
 type Command struct {
-	ctx      context.Context
-	functors []*Functor
-	cancel   atomic.Bool
+	ctx                       context.Context
+	functors                  []*Functor
+	cancel                    atomic.Bool
+	nonFailureErrorClassifier func(error) bool
 }
 
 func NewCommand(ctx context.Context, functors []*Functor) *Command {
@@ -77,6 +78,14 @@ func (cmd *Command) IsEmpty() bool {
 
 func (cmd *Command) Cancel() {
 	cmd.cancel.Store(true)
+}
+
+func (cmd *Command) SetNonFailureErrorClassifier(classifier func(error) bool) {
+	cmd.nonFailureErrorClassifier = classifier
+}
+
+func (cmd *Command) shouldIgnoreFailure(err error) bool {
+	return err != nil && cmd.nonFailureErrorClassifier != nil && cmd.nonFailureErrorClassifier(err)
 }
 
 type Config struct {
@@ -185,6 +194,7 @@ func (cb *CircuitBreaker) Execute(cmd *Command) CommandResult {
 		}
 
 		var err error
+		var skippedErr error
 		circuitName := f.circuitName
 		providerName := f.providerName
 		if cb.circuitNameHandler != nil {
@@ -231,6 +241,10 @@ func (cb *CircuitBreaker) Execute(cmd *Command) CommandResult {
 					shared.markCancelled()
 					return nil
 				}
+				if cmd.shouldIgnoreFailure(err) {
+					skippedErr = err
+					return nil
+				}
 				if err != nil {
 					logutils.ZapLogger().Warn("hystrix error",
 						zap.String("provider", f.providerName),
@@ -239,6 +253,9 @@ func (cb *CircuitBreaker) Execute(cmd *Command) CommandResult {
 				}
 				return err
 			}, nil)
+		}
+		if err == nil && skippedErr != nil {
+			err = skippedErr
 		}
 		if err == nil {
 			break

--- a/internal/circuitbreaker/circuit_breaker_test.go
+++ b/internal/circuitbreaker/circuit_breaker_test.go
@@ -647,3 +647,32 @@ func TestCircuitBreaker_ErrorLogging(t *testing.T) {
 		assert.True(t, duration >= 0)
 	})
 }
+
+func TestExecuteIgnoresNonFailureErrorForCircuitAndTriesNextProvider(t *testing.T) {
+	cb := NewCircuitBreaker(Config{
+		Timeout:               1000,
+		MaxConcurrentRequests: 10,
+		SleepWindow:           1000,
+		ErrorPercentThreshold: 1,
+	})
+	mappingErr := errors.New("token not mapped")
+
+	first := NewFunctor(func() ([]any, error) {
+		return nil, mappingErr
+	}, "market-provider-1", "provider-1")
+	second := NewFunctor(func() ([]any, error) {
+		return []any{"ok"}, nil
+	}, "market-provider-2", "provider-2")
+
+	cmd := NewCommand(context.Background(), []*Functor{first, second})
+	cmd.SetNonFailureErrorClassifier(func(err error) bool {
+		return errors.Is(err, mappingErr)
+	})
+
+	result := cb.Execute(cmd)
+	require.NoError(t, result.Error())
+	require.Equal(t, []any{"ok"}, result.Result())
+	require.Len(t, result.FunctorCallStatuses(), 2)
+	require.Error(t, result.FunctorCallStatuses()[0].Err)
+	require.NoError(t, result.FunctorCallStatuses()[1].Err)
+}

--- a/internal/healthmanager/provider_errors/provider_errors.go
+++ b/internal/healthmanager/provider_errors/provider_errors.go
@@ -277,6 +277,19 @@ func IsIgnorableForConnectivity(err error) bool {
 	if err == nil {
 		return false
 	}
+	// For joined errors ignore only if all components are ignorable
+	if u, ok := err.(interface{ Unwrap() []error }); ok {
+		errs := u.Unwrap()
+		if len(errs) == 0 {
+			return false
+		}
+		for _, e := range errs {
+			if !IsIgnorableForConnectivity(e) {
+				return false
+			}
+		}
+		return true
+	}
 	return errors.Is(err, context.Canceled) ||
 		IsNonCriticalRpcError(err) ||
 		IsNonCriticalProviderError(err)

--- a/internal/healthmanager/provider_errors/provider_errors.go
+++ b/internal/healthmanager/provider_errors/provider_errors.go
@@ -26,6 +26,7 @@ const (
 	ProviderErrorTypeNone                    ProviderErrorType = "none"
 	ProviderErrorTypeContextCanceled         ProviderErrorType = "context_canceled"
 	ProviderErrorTypeContextDeadlineExceeded ProviderErrorType = "context_deadline"
+	ProviderErrorTypeDataUnavailable         ProviderErrorType = "data_unavailable"
 	ProviderErrorTypeConnection              ProviderErrorType = "connection"
 	ProviderErrorTypeNotAuthorized           ProviderErrorType = "not_authorized"
 	ProviderErrorTypeForbidden               ProviderErrorType = "forbidden"
@@ -37,6 +38,8 @@ const (
 	ProviderErrorTypeAuthRotating            ProviderErrorType = "auth_rotating"
 	ProviderErrorTypeOther                   ProviderErrorType = "other"
 )
+
+var ErrDataUnavailable = errors.New("requested data not available from provider")
 
 // IsConnectionError checks if the error is related to network issues.
 func IsConnectionError(err error) bool {
@@ -225,6 +228,9 @@ func determineProviderErrorType(err error) ProviderErrorType {
 	if errors.Is(err, puzzleauth.ErrAuthRotating) {
 		return ProviderErrorTypeAuthRotating
 	}
+	if errors.Is(err, ErrDataUnavailable) {
+		return ProviderErrorTypeDataUnavailable
+	}
 	if IsConnectionError(err) {
 		return ProviderErrorTypeConnection
 	}
@@ -258,9 +264,20 @@ func IsNonCriticalProviderError(err error) bool {
 	errorType := determineProviderErrorType(err)
 
 	switch errorType {
-	case ProviderErrorTypeNone, ProviderErrorTypeContextCanceled, ProviderErrorTypeContentTooLarge, ProviderErrorTypeRateLimit, ProviderErrorTypeAuthRotating:
+	case ProviderErrorTypeNone, ProviderErrorTypeContextCanceled, ProviderErrorTypeContentTooLarge, ProviderErrorTypeRateLimit, ProviderErrorTypeAuthRotating, ProviderErrorTypeDataUnavailable:
 		return true
 	default:
 		return false
 	}
+}
+
+// IsIgnorableForConnectivity reports whether the error should not flip
+// provider/chain connectivity status to "down".
+func IsIgnorableForConnectivity(err error) bool {
+	if err == nil {
+		return false
+	}
+	return errors.Is(err, context.Canceled) ||
+		IsNonCriticalRpcError(err) ||
+		IsNonCriticalProviderError(err)
 }

--- a/internal/healthmanager/provider_errors/provider_errors_test.go
+++ b/internal/healthmanager/provider_errors/provider_errors_test.go
@@ -169,3 +169,30 @@ func TestIsIgnorableForConnectivity(t *testing.T) {
 		t.Error("IsIgnorableForConnectivity should be false for unrelated errors")
 	}
 }
+
+func TestIsIgnorableForConnectivity_JoinedErrors(t *testing.T) {
+	connectionErr := &net.OpError{Op: "dial", Err: errors.New("connection refused")}
+
+	// Joined errors are ignorable only when every component is ignorable.
+	mixed := fmt.Errorf("%w, provider2.error: %w", ErrDataUnavailable, connectionErr)
+	if IsIgnorableForConnectivity(mixed) {
+		t.Error("IsIgnorableForConnectivity should be false when a joined error contains a connectivity failure")
+	}
+
+	allIgnorable := fmt.Errorf("%w, provider2.error: %w", ErrDataUnavailable, context.Canceled)
+	if !IsIgnorableForConnectivity(allIgnorable) {
+		t.Error("IsIgnorableForConnectivity should be true when all joined errors are ignorable")
+	}
+
+	// Same shape as circuitbreaker.accumulateCommandError: leaves are single-wrapped.
+	nested := fmt.Errorf("%w, provider2.error: %w",
+		fmt.Errorf("provider1.error: %w", ErrDataUnavailable),
+		fmt.Errorf("call failed: %w", connectionErr))
+	if IsIgnorableForConnectivity(nested) {
+		t.Error("IsIgnorableForConnectivity should be false for nested joined errors with a connectivity failure")
+	}
+
+	if IsIgnorableForConnectivity(errors.Join()) {
+		t.Error("IsIgnorableForConnectivity should be false for nil joined error")
+	}
+}

--- a/internal/healthmanager/provider_errors/provider_errors_test.go
+++ b/internal/healthmanager/provider_errors/provider_errors_test.go
@@ -139,3 +139,33 @@ func TestIsNonCriticalProviderError_PuzzleAuthRotating(t *testing.T) {
 		t.Error("IsNonCriticalProviderError should be false for unrelated errors")
 	}
 }
+
+func TestDetermineProviderErrorType_DataUnavailable(t *testing.T) {
+	if got := determineProviderErrorType(ErrDataUnavailable); got != ProviderErrorTypeDataUnavailable {
+		t.Errorf("determineProviderErrorType(ErrDataUnavailable) = %q, want %q", got, ProviderErrorTypeDataUnavailable)
+	}
+
+	wrapped := fmt.Errorf("wrapped: %w", ErrDataUnavailable)
+	if got := determineProviderErrorType(wrapped); got != ProviderErrorTypeDataUnavailable {
+		t.Errorf("determineProviderErrorType(wrapped ErrDataUnavailable) = %q, want %q", got, ProviderErrorTypeDataUnavailable)
+	}
+}
+
+func TestIsNonCriticalProviderError_DataUnavailable(t *testing.T) {
+	requireErr := fmt.Errorf("wrapped: %w", ErrDataUnavailable)
+	if !IsNonCriticalProviderError(requireErr) {
+		t.Error("IsNonCriticalProviderError should be true for wrapped ErrDataUnavailable")
+	}
+	if !IsNonCriticalProviderError(ErrDataUnavailable) {
+		t.Error("IsNonCriticalProviderError should be true for bare ErrDataUnavailable")
+	}
+}
+
+func TestIsIgnorableForConnectivity(t *testing.T) {
+	if !IsIgnorableForConnectivity(fmt.Errorf("wrapped: %w", ErrDataUnavailable)) {
+		t.Error("IsIgnorableForConnectivity should be true for wrapped ErrDataUnavailable")
+	}
+	if IsIgnorableForConnectivity(errors.New("fatal provider error")) {
+		t.Error("IsIgnorableForConnectivity should be false for unrelated errors")
+	}
+}

--- a/services/wallet/collectibles/collectibles_status.go
+++ b/services/wallet/collectibles/collectibles_status.go
@@ -1,7 +1,6 @@
 package collectibles
 
 import (
-	"context"
 	"errors"
 	"sync"
 
@@ -86,19 +85,7 @@ func (o *Manager) setChainConnected(chainID walletCommon.ChainID, connected bool
 }
 
 func isCollectiblesIgnorableError(err error) bool {
-	if err == nil {
-		return false
-	}
-	if errors.Is(err, context.Canceled) {
-		return true
-	}
-	if provider_errors.IsNonCriticalRpcError(err) {
-		return true
-	}
-	if provider_errors.IsNonCriticalProviderError(err) {
-		return true
-	}
-	return false
+	return provider_errors.IsIgnorableForConnectivity(err)
 }
 
 func logProviderSearchErr(method, providerID string, chainID walletCommon.ChainID, err error) {

--- a/services/wallet/market/market.go
+++ b/services/wallet/market/market.go
@@ -2,6 +2,7 @@ package market
 
 import (
 	"context"
+	"errors"
 	"sync"
 	"time"
 
@@ -11,6 +12,7 @@ import (
 	"github.com/ethereum/go-ethereum/event"
 
 	"github.com/status-im/status-go/internal/circuitbreaker"
+	provider_errors "github.com/status-im/status-go/internal/healthmanager/provider_errors"
 	"github.com/status-im/status-go/internal/logutils"
 	"github.com/status-im/status-go/services/wallet/thirdparty"
 	tokentypes "github.com/status-im/status-go/services/wallet/token/types"
@@ -100,6 +102,7 @@ func (pm *Manager) setIsConnected(value bool) {
 
 func (pm *Manager) makeCall(providers []thirdparty.MarketDataProvider, f func(provider thirdparty.MarketDataProvider) (interface{}, error)) (interface{}, error) {
 	cmd := circuitbreaker.NewCommand(context.Background(), nil)
+	cmd.SetNonFailureErrorClassifier(provider_errors.IsIgnorableForConnectivity)
 	for _, provider := range providers {
 		provider := provider
 		// FIXME: we might want a different circuitName. See other uses of NewFunctor
@@ -111,14 +114,50 @@ func (pm *Manager) makeCall(providers []thirdparty.MarketDataProvider, f func(pr
 	}
 
 	result := pm.circuitbreaker.Execute(cmd)
-	pm.setIsConnected(result.Error() == nil)
+	isConnectivityError := result.Error() != nil && !provider_errors.IsIgnorableForConnectivity(result.Error())
+	pm.setIsConnected(!isConnectivityError)
 
 	if result.Error() != nil {
-		logutils.ZapLogger().Error("Error fetching prices", zap.Error(result.Error()))
+		if provider_errors.IsIgnorableForConnectivity(result.Error()) {
+			logutils.ZapLogger().Warn("market data unavailable for token mapping", zap.Error(result.Error()))
+		} else {
+			logutils.ZapLogger().Error("Error fetching prices", zap.Error(result.Error()))
+		}
 		return nil, result.Error()
 	}
 
 	return result.Result()[0], nil
+}
+
+func (pm *Manager) fetchHistoricalPricesWithFallback(
+	token *tokentypes.Token,
+	call func(provider thirdparty.MarketDataProvider, token *tokentypes.Token) ([]thirdparty.HistoricalPrice, error),
+) ([]thirdparty.HistoricalPrice, error) {
+	var sibling *tokentypes.Token
+	if allTokens, err := pm.tokenManager.GetTokensForFetchingMarketData(); err == nil {
+		sibling = tokentypes.EthereumMainnetSibling(token, allTokens)
+	}
+
+	for _, t := range []*tokentypes.Token{token, sibling} {
+		if t == nil {
+			continue
+		}
+
+		result, err := pm.makeCall(pm.providers, func(provider thirdparty.MarketDataProvider) (interface{}, error) {
+			return call(provider, t)
+		})
+		if err == nil {
+			return result.([]thirdparty.HistoricalPrice), nil
+		}
+		if !errors.Is(err, thirdparty.ErrTokenNotMapped) {
+			return nil, err
+		}
+	}
+
+	logutils.ZapLogger().Warn("no mapped market history token found",
+		zap.String("tokenKey", token.Key()),
+		zap.String("crossChainID", token.CrossChainID))
+	return []thirdparty.HistoricalPrice{}, nil
 }
 
 func (pm *Manager) getTokensByKeys(tokensKeys []string) (tokens []*tokentypes.Token, err error) {
@@ -136,17 +175,9 @@ func (pm *Manager) FetchHistoricalDailyPrices(tokenKey string, currency string, 
 		return nil, err
 	}
 
-	result, err := pm.makeCall(pm.providers, func(provider thirdparty.MarketDataProvider) (interface{}, error) {
-		return provider.FetchHistoricalDailyPrices(token, currency, limit, allData, aggregate)
+	return pm.fetchHistoricalPricesWithFallback(token, func(provider thirdparty.MarketDataProvider, t *tokentypes.Token) ([]thirdparty.HistoricalPrice, error) {
+		return provider.FetchHistoricalDailyPrices(t, currency, limit, allData, aggregate)
 	})
-
-	if err != nil {
-		logutils.ZapLogger().Error("Error fetching prices", zap.Error(err))
-		return nil, err
-	}
-
-	prices := result.([]thirdparty.HistoricalPrice)
-	return prices, nil
 }
 
 func (pm *Manager) FetchHistoricalHourlyPrices(tokenKey string, currency string, limit int, aggregate int) ([]thirdparty.HistoricalPrice, error) {
@@ -155,17 +186,9 @@ func (pm *Manager) FetchHistoricalHourlyPrices(tokenKey string, currency string,
 		return nil, err
 	}
 
-	result, err := pm.makeCall(pm.providers, func(provider thirdparty.MarketDataProvider) (interface{}, error) {
-		return provider.FetchHistoricalHourlyPrices(token, currency, limit, aggregate)
+	return pm.fetchHistoricalPricesWithFallback(token, func(provider thirdparty.MarketDataProvider, t *tokentypes.Token) ([]thirdparty.HistoricalPrice, error) {
+		return provider.FetchHistoricalHourlyPrices(t, currency, limit, aggregate)
 	})
-
-	if err != nil {
-		logutils.ZapLogger().Error("Error fetching prices", zap.Error(err))
-		return nil, err
-	}
-
-	prices := result.([]thirdparty.HistoricalPrice)
-	return prices, nil
 }
 
 // FetchTokenMarketValues fetches market values for a given token keys and currency. If no tokens are provided, all tokens are fetched.

--- a/services/wallet/market/market.go
+++ b/services/wallet/market/market.go
@@ -114,18 +114,18 @@ func (pm *Manager) makeCall(providers []thirdparty.MarketDataProvider, f func(pr
 	}
 
 	result := pm.circuitbreaker.Execute(cmd)
-	isConnectivityError := result.Error() != nil && !provider_errors.IsIgnorableForConnectivity(result.Error())
-	pm.setIsConnected(!isConnectivityError)
-
-	if result.Error() != nil {
-		if provider_errors.IsIgnorableForConnectivity(result.Error()) {
-			logutils.ZapLogger().Warn("market data unavailable for token mapping", zap.Error(result.Error()))
+	if err := result.Error(); err != nil {
+		isIgnorableError := provider_errors.IsIgnorableForConnectivity(err)
+		pm.setIsConnected(isIgnorableError)
+		if isIgnorableError {
+			logutils.ZapLogger().Warn("market data unavailable for token mapping", zap.Error(err))
 		} else {
-			logutils.ZapLogger().Error("Error fetching prices", zap.Error(result.Error()))
+			logutils.ZapLogger().Error("Error fetching prices", zap.Error(err))
 		}
-		return nil, result.Error()
+		return nil, err
 	}
 
+	pm.setIsConnected(true)
 	return result.Result()[0], nil
 }
 
@@ -149,7 +149,7 @@ func (pm *Manager) fetchHistoricalPricesWithFallback(
 		if err == nil {
 			return result.([]thirdparty.HistoricalPrice), nil
 		}
-		if !errors.Is(err, thirdparty.ErrTokenNotMapped) {
+		if !(provider_errors.IsIgnorableForConnectivity(err) && errors.Is(err, thirdparty.ErrTokenNotMapped)) {
 			return nil, err
 		}
 	}

--- a/services/wallet/market/market_feed_test.go
+++ b/services/wallet/market/market_feed_test.go
@@ -50,11 +50,8 @@ func (s *MarketTestSuite) TestEventOnRpsError() {
 	// WHEN
 	_, err := manager.FetchPrices(s.tokensKeys, s.currencies)
 	s.Require().Error(err, "expected error from FetchPrices due to MockPriceProviderWithError")
-	event, ok := s.feedSub.WaitForEvent(5 * time.Second)
-	s.Require().True(ok, "expected an event, but none was received")
-
-	// THEN
-	s.Require().Equal(event.Type, EventMarketStatusChanged)
+	_, ok := s.feedSub.WaitForEvent(500 * time.Millisecond)
+	s.Require().False(ok, "expected no status event for non-critical rate limit error")
 }
 
 func (s *MarketTestSuite) TestEventOnNetworkError() {

--- a/services/wallet/market/market_test.go
+++ b/services/wallet/market/market_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/status-im/go-wallet-sdk/pkg/tokens/types"
 
+	walletcommon "github.com/status-im/status-go/services/wallet/common"
 	"github.com/status-im/status-go/services/wallet/thirdparty"
 	tokentypes "github.com/status-im/status-go/services/wallet/token/types"
 )
@@ -163,4 +164,124 @@ func TestFetchPriceErrorFirstProvider(t *testing.T) {
 			require.Equal(t, rst[tokenKey][currency], mockPrices[tokenKey][currency])
 		}
 	}
+}
+
+type staticTokenManager struct {
+	tokensByKey map[string]*tokentypes.Token
+}
+
+func newStaticTokenManager(tokens ...*tokentypes.Token) *staticTokenManager {
+	tokensByKey := make(map[string]*tokentypes.Token, len(tokens))
+	for _, token := range tokens {
+		tokensByKey[token.Key()] = token
+	}
+	return &staticTokenManager{tokensByKey: tokensByKey}
+}
+
+func (m *staticTokenManager) GetTokensForFetchingMarketData() ([]*tokentypes.Token, error) {
+	tokens := make([]*tokentypes.Token, 0, len(m.tokensByKey))
+	for _, token := range m.tokensByKey {
+		tokens = append(tokens, token)
+	}
+	return tokens, nil
+}
+
+func (m *staticTokenManager) GetTokensByKeysForFetchingMarketData(tokenKeys []string) ([]*tokentypes.Token, error) {
+	tokens := make([]*tokentypes.Token, 0, len(tokenKeys))
+	for _, key := range tokenKeys {
+		if token, ok := m.tokensByKey[key]; ok {
+			tokens = append(tokens, token)
+		}
+	}
+	return tokens, nil
+}
+
+func (m *staticTokenManager) GetTokenByKey(tokenKey string) (*tokentypes.Token, error) {
+	token, ok := m.tokensByKey[tokenKey]
+	if !ok {
+		return nil, fmt.Errorf("token not found for key: %s", tokenKey)
+	}
+	return token, nil
+}
+
+type historicalPriceProvider struct {
+	id            string
+	historyByKey  map[string][]thirdparty.HistoricalPrice
+	defaultErr    error
+	requestedKeys []string
+}
+
+func (p *historicalPriceProvider) ID() string {
+	if p.id == "" {
+		return "historical-provider"
+	}
+	return p.id
+}
+
+func (p *historicalPriceProvider) FetchPrices(tokens []*tokentypes.Token, currencies []string) (map[string]map[string]float64, error) {
+	return map[string]map[string]float64{}, nil
+}
+
+func (p *historicalPriceProvider) FetchHistoricalDailyPrices(token *tokentypes.Token, currency string, limit int, allData bool, aggregate int) ([]thirdparty.HistoricalPrice, error) {
+	p.requestedKeys = append(p.requestedKeys, token.Key())
+	if history, ok := p.historyByKey[token.Key()]; ok {
+		return history, nil
+	}
+	return nil, p.defaultErr
+}
+
+func (p *historicalPriceProvider) FetchHistoricalHourlyPrices(token *tokentypes.Token, currency string, limit int, aggregate int) ([]thirdparty.HistoricalPrice, error) {
+	return p.FetchHistoricalDailyPrices(token, currency, limit, false, aggregate)
+}
+
+func (p *historicalPriceProvider) FetchTokenMarketValues(tokens []*tokentypes.Token, currency string) (map[string]thirdparty.TokenMarketValues, error) {
+	return map[string]thirdparty.TokenMarketValues{}, nil
+}
+
+func (p *historicalPriceProvider) FetchTokenDetails(tokens []*tokentypes.Token) (map[string]thirdparty.TokenDetails, error) {
+	return map[string]thirdparty.TokenDetails{}, nil
+}
+
+func TestFetchHistoricalDailyPricesFallsBackToMainnetSibling(t *testing.T) {
+	baseToken := &tokentypes.Token{Token: &types.Token{
+		ChainID:      walletcommon.BaseMainnet,
+		Address:      common.HexToAddress("0x662015ec830df08c0fc45896fab726542e8ac09e"),
+		CrossChainID: walletcommon.StatusMainnetTokenCrossChainID,
+	}}
+	ethToken := &tokentypes.Token{Token: &types.Token{
+		ChainID:      walletcommon.EthereumMainnet,
+		Address:      common.HexToAddress("0x744d70fdbe2ba4cf95131626614a1763df805b9e"),
+		CrossChainID: walletcommon.StatusMainnetTokenCrossChainID,
+	}}
+
+	provider := &historicalPriceProvider{
+		historyByKey: map[string][]thirdparty.HistoricalPrice{
+			ethToken.Key(): []thirdparty.HistoricalPrice{{Timestamp: 1000, Value: 0.1}},
+		},
+		defaultErr: thirdparty.ErrTokenNotMapped,
+	}
+
+	manager := NewManager([]thirdparty.MarketDataProvider{provider}, newStaticTokenManager(baseToken, ethToken), &event.Feed{})
+	prices, err := manager.FetchHistoricalDailyPrices(baseToken.Key(), "usd", 30, false, 1)
+	require.NoError(t, err)
+	require.Equal(t, []thirdparty.HistoricalPrice{{Timestamp: 1000, Value: 0.1}}, prices)
+	require.Equal(t, []string{baseToken.Key(), ethToken.Key()}, provider.requestedKeys)
+}
+
+func TestFetchHistoricalDailyPricesReturnsEmptyAndStaysConnectedForUnmappedToken(t *testing.T) {
+	baseToken := &tokentypes.Token{Token: &types.Token{
+		ChainID:      walletcommon.BaseMainnet,
+		Address:      common.HexToAddress("0x662015ec830df08c0fc45896fab726542e8ac09e"),
+		CrossChainID: walletcommon.StatusMainnetTokenCrossChainID,
+	}}
+
+	provider := &historicalPriceProvider{
+		defaultErr: thirdparty.ErrTokenNotMapped,
+	}
+
+	manager := NewManager([]thirdparty.MarketDataProvider{provider}, newStaticTokenManager(baseToken), &event.Feed{})
+	prices, err := manager.FetchHistoricalDailyPrices(baseToken.Key(), "usd", 30, false, 1)
+	require.NoError(t, err)
+	require.Empty(t, prices)
+	require.True(t, manager.IsConnected)
 }

--- a/services/wallet/market/market_test.go
+++ b/services/wallet/market/market_test.go
@@ -3,6 +3,7 @@ package market
 import (
 	"errors"
 	"fmt"
+	"net"
 	"testing"
 
 	"go.uber.org/mock/gomock"
@@ -14,6 +15,7 @@ import (
 
 	"github.com/status-im/go-wallet-sdk/pkg/tokens/types"
 
+	provider_errors "github.com/status-im/status-go/internal/healthmanager/provider_errors"
 	walletcommon "github.com/status-im/status-go/services/wallet/common"
 	"github.com/status-im/status-go/services/wallet/thirdparty"
 	tokentypes "github.com/status-im/status-go/services/wallet/token/types"
@@ -266,6 +268,33 @@ func TestFetchHistoricalDailyPricesFallsBackToMainnetSibling(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, []thirdparty.HistoricalPrice{{Timestamp: 1000, Value: 0.1}}, prices)
 	require.Equal(t, []string{baseToken.Key(), ethToken.Key()}, provider.requestedKeys)
+}
+
+func TestFetchHistoricalDailyPricesPropagatesJoinedUnmappedAndConnectivityError(t *testing.T) {
+	baseToken := &tokentypes.Token{Token: &types.Token{
+		ChainID:      walletcommon.BaseMainnet,
+		Address:      common.HexToAddress("0x662015ec830df08c0fc45896fab726542e8ac09e"),
+		CrossChainID: walletcommon.StatusMainnetTokenCrossChainID,
+	}}
+
+	unmappedProvider := &historicalPriceProvider{
+		id:         "unmapped-provider",
+		defaultErr: thirdparty.ErrTokenNotMapped,
+	}
+	failingProvider := &historicalPriceProvider{
+		id:         "failing-provider",
+		defaultErr: &net.OpError{Op: "dial", Err: errors.New("connection refused")},
+	}
+
+	manager := NewManager(
+		[]thirdparty.MarketDataProvider{unmappedProvider, failingProvider},
+		newStaticTokenManager(baseToken),
+		&event.Feed{},
+	)
+	prices, err := manager.FetchHistoricalDailyPrices(baseToken.Key(), "usd", 30, false, 1)
+	require.Error(t, err)
+	require.Nil(t, prices)
+	require.False(t, provider_errors.IsIgnorableForConnectivity(err))
 }
 
 func TestFetchHistoricalDailyPricesReturnsEmptyAndStaysConnectedForUnmappedToken(t *testing.T) {

--- a/services/wallet/thirdparty/market/coingecko/client.go
+++ b/services/wallet/thirdparty/market/coingecko/client.go
@@ -330,7 +330,7 @@ func (c *Client) FetchHistoricalDailyPrices(token *tokentypes.Token, currency st
 
 	coingeckoToken, ok := coingeckoTokensByTokenKey[token.Key()]
 	if !ok {
-		return nil, fmt.Errorf("coingecko id not found for token %s", token.Key())
+		return nil, fmt.Errorf("%w: coingecko id not found for token %s", thirdparty.ErrTokenNotMapped, token.Key())
 	}
 
 	var days string

--- a/services/wallet/thirdparty/market/coingecko/client_test.go
+++ b/services/wallet/thirdparty/market/coingecko/client_test.go
@@ -3,6 +3,7 @@ package coingecko
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -21,6 +22,33 @@ import (
 
 	"github.com/stretchr/testify/require"
 )
+
+func TestFetchHistoricalDailyPricesReturnsErrTokenNotMapped(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/coins/list", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`[]`))
+	})
+
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	geckoClient := &Client{
+		httpClient: thirdparty.NewHTTPClient(),
+		baseURL:    srv.URL,
+	}
+
+	token := &tokentypes.Token{
+		Token: &types.Token{
+			ChainID: common.BaseMainnet,
+			Address: gethcommon.HexToAddress("0x662015ec830df08c0fc45896fab726542e8ac09e"),
+		},
+	}
+
+	_, err := geckoClient.FetchHistoricalDailyPrices(token, "usd", 30, false, 1)
+	require.Error(t, err)
+	require.True(t, errors.Is(err, thirdparty.ErrTokenNotMapped))
+}
 
 func TestCoingeckoAPIKeyInQueryProOverDemo(t *testing.T) {
 	var sawQuery string

--- a/services/wallet/thirdparty/market_types.go
+++ b/services/wallet/thirdparty/market_types.go
@@ -2,7 +2,14 @@ package thirdparty
 
 //go:generate go tool mockgen -package=mock_thirdparty -source=market_types.go -destination=mock/market_types.go
 
-import tokentypes "github.com/status-im/status-go/services/wallet/token/types"
+import (
+	"fmt"
+
+	provider_errors "github.com/status-im/status-go/internal/healthmanager/provider_errors"
+	tokentypes "github.com/status-im/status-go/services/wallet/token/types"
+)
+
+var ErrTokenNotMapped = fmt.Errorf("%w: token not mapped to market data provider", provider_errors.ErrDataUnavailable)
 
 type HistoricalPrice struct {
 	Timestamp int64   `json:"time"`

--- a/services/wallet/token/types/token.go
+++ b/services/wallet/token/types/token.go
@@ -9,6 +9,8 @@ import (
 	"github.com/ethereum/go-ethereum/common/hexutil"
 
 	"github.com/status-im/go-wallet-sdk/pkg/tokens/types"
+
+	walletcommon "github.com/status-im/status-go/services/wallet/common"
 )
 
 const (
@@ -46,6 +48,24 @@ type TokenList struct {
 	*types.TokenList
 
 	Tokens []*Token `json:"tokens"` // tokens from the `types.TokenList` are shadowed by this field
+}
+
+// EthereumMainnetSibling returns the Ethereum mainnet token sharing the same CrossChainID
+func EthereumMainnetSibling(token *Token, candidates []*Token) *Token {
+	if token == nil || token.CrossChainID == "" ||
+		token.ChainID == walletcommon.EthereumMainnet {
+		return nil
+	}
+
+	for _, candidate := range candidates {
+		if candidate != nil &&
+			candidate.ChainID == walletcommon.EthereumMainnet &&
+			candidate.CrossChainID == token.CrossChainID {
+			return candidate
+		}
+	}
+
+	return nil
 }
 
 func ParseCollectibleKey(tokenKey string) (chainID uint64, contractAddress common.Address, collectibleTokenID *big.Int, success bool) {


### PR DESCRIPTION
* When CoinGecko returns `ErrTokenNotMapped` it is classified as non-critical
* Chart history falls back to the Ethereum mainnet sibling

Closes status-im/status-app#21143
