### PR TITLE
fix(wallet): fix stuck balance shimmer on large token 

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -101,7 +101,7 @@ require (
 	github.com/prometheus/client_model v0.6.1
 	github.com/schollz/peerdiscovery v1.7.0
 	github.com/status-im/extkeys v1.4.0
-	github.com/status-im/go-wallet-sdk v0.0.0-20260428172609-d99313975e5c
+	github.com/status-im/go-wallet-sdk v0.0.0-20260612221124-9c7a9c043068
 	github.com/waku-org/go-waku v0.10.2-0.20260518064454-d6d39395ac48
 	github.com/waku-org/sds-go-bindings v0.0.0-20251222164514-d5b47a911904
 	github.com/wk8/go-ordered-map/v2 v2.1.7

--- a/go.sum
+++ b/go.sum
@@ -2286,8 +2286,8 @@ github.com/status-im/go-generate-fast v0.0.0-20250916164518-c78009bcfa9e h1:GV7a
 github.com/status-im/go-generate-fast v0.0.0-20250916164518-c78009bcfa9e/go.mod h1:iktiTcPdK+nuL47hn+7UL12uIkgJYyOAh99jdA6ruGw=
 github.com/status-im/go-sqlcipher/v4 v4.5.4-status.3 h1:/73h1w1hUfb3wVyTlNrUIwahZxatgesCHa6lwO57C2M=
 github.com/status-im/go-sqlcipher/v4 v4.5.4-status.3/go.mod h1:mF2UmIpBnzFeBdu/ypTDb/LdbS0nk0dfSN1WUsWTjMA=
-github.com/status-im/go-wallet-sdk v0.0.0-20260428172609-d99313975e5c h1:8lFggO3KQvtCX/nbNNtd+FVy8O2ZvpGwNKeodfvDtnc=
-github.com/status-im/go-wallet-sdk v0.0.0-20260428172609-d99313975e5c/go.mod h1:E4E1D0mflc2pcjsutZpvMYSjI+a231uBHQf8UjdT1Ug=
+github.com/status-im/go-wallet-sdk v0.0.0-20260612221124-9c7a9c043068 h1:P309M2KZxV+IcnRLJMkmPZm6nlQFV7i4tC1V7EtJ6Rg=
+github.com/status-im/go-wallet-sdk v0.0.0-20260612221124-9c7a9c043068/go.mod h1:E4E1D0mflc2pcjsutZpvMYSjI+a231uBHQf8UjdT1Ug=
 github.com/status-im/gomoji v1.1.3-0.20220213022530-e5ac4a8732d4 h1:CtobZoiNdHpx+xurFxnuJ1xsGm3oKMfcZkB3vmomJmA=
 github.com/status-im/gomoji v1.1.3-0.20220213022530-e5ac4a8732d4/go.mod h1:hmpnZzkzSZJbFYWAUkrPV8I36x7mdYiPhPqnALP4fKA=
 github.com/status-im/goroutine-defer-guard v0.3.1 h1:cZhcJ3gO6OgMYBOfEaAAUZaZgKZeSzMlGNEjMyejuRo=
@@ -2416,6 +2416,8 @@ github.com/waku-org/go-libp2p-pubsub v0.13.1-gowaku h1:ovXh1m76i0yPWXt95Z9ZRyEk0
 github.com/waku-org/go-libp2p-pubsub v0.13.1-gowaku/go.mod h1:MKPU5vMI8RRFyTP0HfdsF9cLmL1nHAeJm44AxJGJx44=
 github.com/waku-org/go-libp2p-rendezvous v0.0.0-20240110193335-a67d1cc760a0 h1:R4YYx2QamhBRl/moIxkDCNW+OP7AHbyWLBygDc/xIMo=
 github.com/waku-org/go-libp2p-rendezvous v0.0.0-20240110193335-a67d1cc760a0/go.mod h1:EhZP9fee0DYjKH/IOQvoNSy1tSHp2iZadsHGphcAJgY=
+github.com/waku-org/go-waku v0.10.2-0.20260518064454-d6d39395ac48 h1:a00GguapTGSRIN9ocw93WsrMOTD07TJ1iqCashttNwA=
+github.com/waku-org/go-waku v0.10.2-0.20260518064454-d6d39395ac48/go.mod h1:PDs4hlPbONeMQGsNyfArZV4R2Js1Zy5oqLBfw2VU278=
 github.com/waku-org/go-zerokit-rln v0.1.14-0.20240102145250-fa738c0bdf59 h1:jisj+OCI6QydLtFq3Pyhu49wl9ytPN7oAHjMfepHDrA=
 github.com/waku-org/go-zerokit-rln v0.1.14-0.20240102145250-fa738c0bdf59/go.mod h1:1PdBdPzyTaKt3VnpAHk3zj+r9dXPFOr3IHZP9nFle6E=
 github.com/waku-org/go-zerokit-rln-apple v0.0.0-20230916172309-ee0ee61dde2b h1:KgZVhsLkxsj5gb/FfndSCQu6VYwALrCOgYI3poR95yE=
@@ -2446,8 +2448,6 @@ github.com/wk8/go-ordered-map/v2 v2.1.7/go.mod h1:9Xvgm2mV2kSq2SAm0Y608tBmu8akTz
 github.com/wlynxg/anet v0.0.3/go.mod h1:eay5PRQr7fIVAMbTbchTnO9gG65Hg/uYGdc7mguHxoA=
 github.com/wlynxg/anet v0.0.5 h1:J3VJGi1gvo0JwZ/P1/Yc/8p63SoW98B5dHkYDmpgvvU=
 github.com/wlynxg/anet v0.0.5/go.mod h1:eay5PRQr7fIVAMbTbchTnO9gG65Hg/uYGdc7mguHxoA=
-github.com/waku-org/go-waku v0.10.2-0.20260518064454-d6d39395ac48 h1:a00GguapTGSRIN9ocw93WsrMOTD07TJ1iqCashttNwA=
-github.com/waku-org/go-waku v0.10.2-0.20260518064454-d6d39395ac48/go.mod h1:PDs4hlPbONeMQGsNyfArZV4R2Js1Zy5oqLBfw2VU278=
 github.com/xanzy/go-gitlab v0.15.0/go.mod h1:8zdQa/ri1dfn8eS3Ir1SyfvOKlw7WBJ8DVThkpGiXrs=
 github.com/xdg-go/pbkdf2 v1.0.0/go.mod h1:jrpuAogTd400dnrH08LKmI/xc1MbPOebTwRqcT5RDeI=
 github.com/xdg-go/scram v1.0.2/go.mod h1:1WAq6h33pAW+iRreB34OORO2Nf7qel3VV3fjBj+hCSs=

--- a/nix/pkgs/status-go/library/default.nix
+++ b/nix/pkgs/status-go/library/default.nix
@@ -11,7 +11,7 @@ let
 in pkgs.buildGoModule {
   pname = "status-go";
   src = builtins.path { path = ./../../../..; name = "status-go-library"; };
-  vendorHash = "sha256-itcTnM/Jm4shXuW38g6YlgNyLAHFs0CBlysqDwh4xXk=";
+  vendorHash = "sha256-bblnIanlRFp7MXO6yyjU0HY0tRgiyA6oLwmmoABXrqU=";
 
   inherit meta version;
 

--- a/services/wallet/multistandardbalance/controller.go
+++ b/services/wallet/multistandardbalance/controller.go
@@ -154,7 +154,7 @@ func (c *Controller) Stop() {
 	c.stopWalletEventsWatcher()
 }
 
-func (c *Controller) startChainFetch(chainID uint64) context.Context {
+func (c *Controller) startChainFetch(chainID uint64) (context.Context, context.CancelFunc) {
 	c.chainFetchMu.Lock()
 	defer c.chainFetchMu.Unlock()
 	if cancel, ok := c.chainFetchCancels[chainID]; ok {
@@ -162,7 +162,7 @@ func (c *Controller) startChainFetch(chainID uint64) context.Context {
 	}
 	ctx, cancel := context.WithCancel(context.Background())
 	c.chainFetchCancels[chainID] = cancel
-	return ctx
+	return ctx, cancel
 }
 
 func (c *Controller) cancelAllChainFetches() {
@@ -494,10 +494,11 @@ func (c *Controller) executeFetchConfigs(fetchConfigs map[uint64]multistandardfe
 			)
 		}
 
-		ctx := c.startChainFetch(chainID)
+		ctx, cancel := c.startChainFetch(chainID)
 
 		resultsCh, err := c.fetcher.FetchBalances(ctx, chainID, chainFetchConfig)
 		if err != nil {
+			cancel()
 			c.logger.Error("failed to fetch balances", zap.Uint64("chainID", chainID), zap.Error(err))
 			c.sendEventBalanceFetchFailedToStart(chainID, chainFetchConfig, err)
 			continue
@@ -506,8 +507,9 @@ func (c *Controller) executeFetchConfigs(fetchConfigs map[uint64]multistandardfe
 		c.logger.Debug("fetch started", zap.Uint64("chainID", chainID))
 		c.sendEventBalanceFetchStarted(chainID, chainFetchConfig)
 
-		go func(fetchChainID uint64) {
+		go func(fetchChainID uint64, ctx context.Context, cancel context.CancelFunc) {
 			defer gocommon.LogOnPanic()
+			defer cancel()
 			for {
 				select {
 				case <-c.stopCh:
@@ -519,7 +521,7 @@ func (c *Controller) executeFetchConfigs(fetchConfigs map[uint64]multistandardfe
 					c.handleFetchResult(ctx, fetchChainID, result)
 				}
 			}
-		}(chainID)
+		}(chainID, ctx, cancel)
 	}
 }
 

--- a/services/wallet/multistandardbalance/controller.go
+++ b/services/wallet/multistandardbalance/controller.go
@@ -93,6 +93,9 @@ type Controller struct {
 	pendingFullFetch   bool
 	pendingFetchConfig FetchConfig
 
+	chainFetchMu      sync.Mutex
+	chainFetchCancels map[uint64]context.CancelFunc
+
 	logger *zap.Logger
 }
 
@@ -122,6 +125,7 @@ func NewController(
 		publisher:               pubsub.NewPublisher(),
 		fetchDebounceFn:         debounce.New(config.FetchDebounceTime),
 		pendingFetchConfig:      make(FetchConfig),
+		chainFetchCancels:       make(map[uint64]context.CancelFunc),
 		walletFeed:              walletFeed,
 		logger:                  logger,
 	}
@@ -146,7 +150,28 @@ func (c *Controller) Stop() {
 		c.stopCh = nil
 	}
 
+	c.cancelAllChainFetches()
 	c.stopWalletEventsWatcher()
+}
+
+func (c *Controller) startChainFetch(chainID uint64) context.Context {
+	c.chainFetchMu.Lock()
+	defer c.chainFetchMu.Unlock()
+	if cancel, ok := c.chainFetchCancels[chainID]; ok {
+		cancel()
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	c.chainFetchCancels[chainID] = cancel
+	return ctx
+}
+
+func (c *Controller) cancelAllChainFetches() {
+	c.chainFetchMu.Lock()
+	defer c.chainFetchMu.Unlock()
+	for chainID, cancel := range c.chainFetchCancels {
+		cancel()
+		delete(c.chainFetchCancels, chainID)
+	}
 }
 
 func (c *Controller) GetPublisher() *pubsub.Publisher {
@@ -469,23 +494,20 @@ func (c *Controller) executeFetchConfigs(fetchConfigs map[uint64]multistandardfe
 			)
 		}
 
-		ctx, cancel := context.WithCancel(context.Background())
+		ctx := c.startChainFetch(chainID)
 
 		resultsCh, err := c.fetcher.FetchBalances(ctx, chainID, chainFetchConfig)
 		if err != nil {
 			c.logger.Error("failed to fetch balances", zap.Uint64("chainID", chainID), zap.Error(err))
 			c.sendEventBalanceFetchFailedToStart(chainID, chainFetchConfig, err)
-			cancel()
 			continue
 		}
 
 		c.logger.Debug("fetch started", zap.Uint64("chainID", chainID))
 		c.sendEventBalanceFetchStarted(chainID, chainFetchConfig)
 
-		go func() {
+		go func(fetchChainID uint64) {
 			defer gocommon.LogOnPanic()
-			defer cancel()
-
 			for {
 				select {
 				case <-c.stopCh:
@@ -494,10 +516,10 @@ func (c *Controller) executeFetchConfigs(fetchConfigs map[uint64]multistandardfe
 					if !ok {
 						return
 					}
-					c.handleFetchResult(ctx, chainID, result)
+					c.handleFetchResult(ctx, fetchChainID, result)
 				}
 			}
-		}()
+		}(chainID)
 	}
 }
 

--- a/services/wallet/multistandardbalance/test/controller_test.go
+++ b/services/wallet/multistandardbalance/test/controller_test.go
@@ -3,6 +3,7 @@ package multistandardbalance_test
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"math/big"
 	"sync"
@@ -1021,4 +1022,96 @@ func TestController_FetchImmediatelyWithConfig_IgnoresNonSuccessStatus(t *testin
 		require.Empty(t, getFetchCallsCopy(fetchCalls, fetchMutex),
 			"status %q should NOT trigger an immediate fetch", status)
 	}
+}
+
+func TestController_CancelsInFlightFetchWhenStartingNewFetchForSameChain(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	storage := mock_multistandardbalance.NewMockStorage(ctrl)
+	fetcher := mock_multistandardbalance.NewMockBalanceFetcher(ctrl)
+	accountsProvider := mock_multistandardbalance.NewMockAccountsProvider(ctrl)
+	accountsPublisher := pubsub.NewPublisher()
+	networksProvider := mock_multistandardbalance.NewMockNetworksProvider(ctrl)
+	tokenListProvider := mock_multistandardbalance.NewMockTokenListProvider(ctrl)
+	collectibleListProvider := mock_multistandardbalance.NewMockCollectiblesListProvider(ctrl)
+	lastBlockManager := mock_multistandardbalance.NewMockLastBlockManager(ctrl)
+	logger := zap.NewNop()
+
+	chainID := uint64(10)
+	address1 := types.Address{0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11}
+	key := multistandardbalance.BalancesKey{
+		Account: common.BytesToAddress(address1.Bytes()),
+		ChainID: chainID,
+	}
+	neverFetched := multistandardbalance.State{FetchedAt: multistandardbalance.NeverFetched}
+
+	accountsProvider.EXPECT().GetWalletAddresses().Return([]types.Address{address1}, nil).AnyTimes()
+	networksProvider.EXPECT().GetActiveNetworks().Return([]*params.Network{{ChainID: chainID}}, nil).AnyTimes()
+	networksProvider.EXPECT().GetPublisher().Return(pubsub.NewPublisher()).AnyTimes()
+	storage.EXPECT().GetNativeBalance(gomock.Any(), key).Return(big.NewInt(0), neverFetched, nil).AnyTimes()
+	storage.EXPECT().GetERC20Balances(gomock.Any(), key).Return(map[multistandardbalance.ContractAddress]*big.Int{}, neverFetched, nil).AnyTimes()
+	storage.EXPECT().GetERC721Balances(gomock.Any(), key).Return(map[multistandardbalance.ContractAddress]*big.Int{}, neverFetched, nil).AnyTimes()
+	storage.EXPECT().GetERC1155Balances(gomock.Any(), key).Return(map[multistandardbalance.HashableCollectibleID]*big.Int{}, neverFetched, nil).AnyTimes()
+	storage.EXPECT().ClearMissingAccounts(gomock.Any(), gomock.Any()).AnyTimes()
+	storage.EXPECT().ClearMissingChains(gomock.Any(), gomock.Any()).AnyTimes()
+	tokenListProvider.EXPECT().GetTokenContractAddresses(chainID).Return([]common.Address{}, nil).AnyTimes()
+	collectibleListProvider.EXPECT().GetCollectiblesList(chainID, gomock.Any()).Return([]multistandardbalance.CollectibleID{}, []multistandardbalance.CollectibleID{}, nil).AnyTimes()
+
+	var firstCtx context.Context
+	var ctxMu sync.Mutex
+	firstFetchStarted := make(chan struct{})
+	fetchCount := 0
+	var fetchMu sync.Mutex
+
+	fetcher.EXPECT().FetchBalances(gomock.Any(), chainID, gomock.Any()).DoAndReturn(
+		func(ctx context.Context, cid uint64, cfg multistandardfetcher.FetchConfig) (<-chan multistandardfetcher.FetchResult, error) {
+			fetchMu.Lock()
+			fetchCount++
+			callNumber := fetchCount
+			fetchMu.Unlock()
+
+			if callNumber == 1 {
+				ctxMu.Lock()
+				firstCtx = ctx
+				ctxMu.Unlock()
+				close(firstFetchStarted)
+				ch := make(chan multistandardfetcher.FetchResult)
+				return ch, nil
+			}
+
+			ch := make(chan multistandardfetcher.FetchResult)
+			close(ch)
+			return ch, nil
+		},
+	).Times(2)
+
+	controller := multistandardbalance.NewController(
+		multistandardbalance.ControllerConfig{
+			FetchDebounceTime: 0,
+			FetchPeriod:       time.Hour,
+		},
+		storage,
+		fetcher,
+		accountsProvider,
+		accountsPublisher,
+		networksProvider,
+		tokenListProvider,
+		collectibleListProvider,
+		lastBlockManager,
+		nil,
+		logger,
+	)
+
+	controller.Start()
+	defer controller.Stop()
+
+	<-firstFetchStarted
+	controller.TriggerFullFetch()
+
+	require.Eventually(t, func() bool {
+		ctxMu.Lock()
+		defer ctxMu.Unlock()
+		return firstCtx != nil && errors.Is(firstCtx.Err(), context.Canceled)
+	}, time.Second, 10*time.Millisecond, "expected in-flight fetch context to be canceled")
 }

--- a/services/wallet/reader.go
+++ b/services/wallet/reader.go
@@ -237,7 +237,13 @@ func (r *Reader) balancesToTokensByAddress(addresses []common.Address, allTokens
 		for _, token := range allTokens {
 			isMandatoryToken := slices.Contains(walletcommon.MandatoryTokens(), token.Key())
 			hasError := false
-			if _, ok := balances[token.ChainID][address][token.Address]; !ok {
+			if balances == nil {
+				hasError = true
+			} else if _, ok := balances[token.ChainID]; !ok {
+				hasError = true
+			} else if _, ok := balances[token.ChainID][address]; !ok {
+				hasError = true
+			} else if _, ok := balances[token.ChainID][address][token.Address]; !ok {
 				hasError = true
 			}
 

--- a/services/wallet/reader.go
+++ b/services/wallet/reader.go
@@ -139,7 +139,7 @@ func (r *Reader) startBalanceChangeWatcher() {
 				}
 				switch event.ResultType {
 				case multistandardfetcher.ResultTypeNative, multistandardfetcher.ResultTypeERC20:
-					if !event.BalanceChanged {
+					if !event.BalanceChanged && event.OldState.FetchedAt != multistandardbalance.NeverFetched {
 						continue
 					}
 
@@ -236,25 +236,15 @@ func (r *Reader) balancesToTokensByAddress(addresses []common.Address, allTokens
 	for _, address := range addresses {
 		for _, token := range allTokens {
 			isMandatoryToken := slices.Contains(walletcommon.MandatoryTokens(), token.Key())
-			hasError := false
-			if balances == nil {
-				hasError = true
-			} else if _, ok := balances[token.ChainID]; !ok {
-				hasError = true
-			} else if _, ok := balances[token.ChainID][address]; !ok {
-				hasError = true
-			} else if _, ok := balances[token.ChainID][address][token.Address]; !ok {
-				hasError = true
-			}
+
+			_, ok := balances[token.ChainID][address][token.Address]
+			hasError := !ok
 
 			hexBalance := &big.Int{}
-			if balances != nil {
-				tokenBalance := balances[token.ChainID][address][token.Address]
+			if tokenBalance := balances[token.ChainID][address][token.Address]; tokenBalance != nil && len(tokenBalance.Bytes()) <= 32 {
 				// Balances should be represented by a uint256 (32 bytes). Some spam tokens return
 				// fake values larger than that, so we ignore them.
-				if tokenBalance != nil && len(tokenBalance.Bytes()) <= 32 {
-					hexBalance = tokenBalance
-				}
+				hexBalance = tokenBalance
 			}
 
 			balance := big.NewFloat(0.0)
@@ -395,5 +385,34 @@ func (r *Reader) GetCachedBalances(chainIDs []uint64, addresses []common.Address
 		return nil, err
 	}
 
+	if storageBalances, storageErr := r.tokenBalancesStorage.GetBalances(context.Background(), allTokens, addresses); storageErr != nil {
+		logutils.ZapLogger().Error("failed to get live storage balances", zap.Error(storageErr))
+	} else {
+		balances = mergeFetchedBalances(balances, storageBalances)
+	}
+
 	return r.balancesToTokensByAddress(addresses, allTokens, balances, cachedTokens), nil
+}
+
+func mergeFetchedBalances(cached, fetched map[uint64]map[common.Address]map[common.Address]*big.Int) map[uint64]map[common.Address]map[common.Address]*big.Int {
+	if fetched == nil {
+		return cached
+	}
+	if cached == nil {
+		return fetched
+	}
+	for chainID, accounts := range fetched {
+		if cached[chainID] == nil {
+			cached[chainID] = make(map[common.Address]map[common.Address]*big.Int)
+		}
+		for account, tokens := range accounts {
+			if cached[chainID][account] == nil {
+				cached[chainID][account] = make(map[common.Address]*big.Int)
+			}
+			for tokenAddress, balance := range tokens {
+				cached[chainID][account][tokenAddress] = balance
+			}
+		}
+	}
+	return cached
 }

--- a/services/wallet/reader_impl_test.go
+++ b/services/wallet/reader_impl_test.go
@@ -18,12 +18,16 @@ import (
 	"github.com/status-im/go-wallet-sdk/pkg/tokens/types"
 	wsdktypes "github.com/status-im/go-wallet-sdk/pkg/tokens/types"
 
+	"github.com/status-im/go-wallet-sdk/pkg/balance/multistandardfetcher"
+
 	"github.com/status-im/status-go/internal/rpc/chain/ethclient"
 	"github.com/status-im/status-go/pkg/pubsub"
 	walletcommon "github.com/status-im/status-go/services/wallet/common"
+	"github.com/status-im/status-go/services/wallet/multistandardbalance"
 	"github.com/status-im/status-go/services/wallet/testutils"
 	mock_token "github.com/status-im/status-go/services/wallet/token/mock/token"
 	tokenTypes "github.com/status-im/status-go/services/wallet/token/types"
+	"github.com/status-im/status-go/services/wallet/tokenbalances"
 	mock_tokenbalances "github.com/status-im/status-go/services/wallet/tokenbalances/mock/storage"
 )
 
@@ -348,7 +352,7 @@ func TestBalancesToTokensByAddress(t *testing.T) {
 }
 
 func TestGetCachedBalancesInternal(t *testing.T) {
-	reader, tokenManager, _, mockCtrl := setupReader(t)
+	reader, tokenManager, tokenBalancesStorage, mockCtrl := setupReader(t)
 	defer mockCtrl.Finish()
 
 	addresses := []common.Address{
@@ -422,6 +426,9 @@ func TestGetCachedBalancesInternal(t *testing.T) {
 
 	tokenManager.EXPECT().GetCachedBalances().Return(cachedTokens, nil)
 	tokenManager.EXPECT().GetTokensByKeys(testutils.NewStringSliceElementsMatcher(tokensOfInterest)).Return(allTokens, nil)
+	tokenBalancesStorage.EXPECT().GetBalances(gomock.Any(), allTokens, addresses).Return(
+		map[uint64]map[common.Address]map[common.Address]*big.Int{}, nil,
+	)
 	tokens, err := reader.GetCachedBalances(chainIDs, addresses)
 	require.NoError(t, err)
 
@@ -462,4 +469,124 @@ func TestGetLastTokenUpdateTimestampsInternal(t *testing.T) {
 	// Verify that the retrieved timestamps match the stored values.
 	assert.Equal(t, timestamp1, timestamps[address1], "Timestamp for address1 does not match")
 	assert.Equal(t, timestamp2, timestamps[address2], "Timestamp for address2 does not match")
+}
+
+func TestGetCachedBalances_UsesStorageForMandatoryTokenWhenNotInUICache(t *testing.T) {
+	reader, tokenManager, tokenBalancesStorage, mockCtrl := setupReader(t)
+	defer mockCtrl.Finish()
+
+	account := common.HexToAddress("0x2a811F1E11636C144a2A062d3D402245A43D4074")
+	chainIDs := []uint64{walletcommon.OptimismMainnet}
+	addresses := []common.Address{account}
+
+	nativeToken := &tokenTypes.Token{
+		Token: &wsdktypes.Token{
+			Address:  tokenbalances.NativeTokenAddress,
+			Symbol:   "ETH",
+			Decimals: 18,
+			ChainID:  walletcommon.OptimismMainnet,
+		},
+	}
+	allTokens := []*tokenTypes.Token{nativeToken}
+	cachedTokens := map[common.Address][]tokenTypes.StorageToken{
+		account: {},
+	}
+	storageBalances := map[uint64]map[common.Address]map[common.Address]*big.Int{
+		walletcommon.OptimismMainnet: {
+			account: {
+				tokenbalances.NativeTokenAddress: big.NewInt(1_000_000_000_000_000_000),
+			},
+		},
+	}
+
+	tokenManager.EXPECT().GetCachedBalances().Return(cachedTokens, nil)
+	tokenManager.EXPECT().GetTokensByKeys(
+		testutils.NewStringSliceElementsMatcher(walletcommon.MandatoryTokensByChainID(walletcommon.OptimismMainnet)),
+	).Return(allTokens, nil)
+	tokenBalancesStorage.EXPECT().GetBalances(gomock.Any(), allTokens, addresses).Return(storageBalances, nil)
+
+	tokens, err := reader.GetCachedBalances(chainIDs, addresses)
+	require.NoError(t, err)
+
+	var nativeMandatory *tokenTypes.StorageToken
+	for i := range tokens[account] {
+		token := tokens[account][i]
+		if token.TokenChainID == walletcommon.OptimismMainnet &&
+			token.TokenAddress == tokenbalances.NativeTokenAddress {
+			nativeMandatory = &tokens[account][i]
+			break
+		}
+	}
+	require.NotNil(t, nativeMandatory, "expected mandatory native token in response")
+	assert.False(t, nativeMandatory.HasError, "mandatory token should not be loading when storage has balance")
+	assert.Equal(t, "1000000000000000000", nativeMandatory.RawBalance)
+}
+
+func TestReader_RefreshesUICacheWhenFirstFetchCompletesWithoutBalanceChange(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	tokenManager := mock_token.NewMockManagerInterface(mockCtrl)
+	tokenBalancesStorage := mock_tokenbalances.NewMockStorage(mockCtrl)
+	balancePublisher := pubsub.NewPublisher()
+	reader := NewReader(tokenManager, nil, &event.Feed{}, balancePublisher, tokenBalancesStorage, pubsub.NewPublisher())
+
+	require.NoError(t, reader.Start())
+	defer reader.Stop()
+
+	account := testAccAddress1
+	chainID := walletcommon.OptimismMainnet
+	key := multistandardbalance.BalancesKey{ChainID: chainID, Account: account}
+
+	tokenManager.EXPECT().GetCachedBalances().Return(map[common.Address][]tokenTypes.StorageToken{}, nil)
+	tokenManager.EXPECT().GetTokensByChains([]uint64{chainID}).Return([]*tokenTypes.Token{}, nil)
+	tokenBalancesStorage.EXPECT().GetBalances(gomock.Any(), gomock.Any(), []common.Address{account}).Return(
+		map[uint64]map[common.Address]map[common.Address]*big.Int{}, nil,
+	)
+	cacheSaved := make(chan struct{})
+	tokenManager.EXPECT().CacheBalances(gomock.Any()).DoAndReturn(func(_ map[common.Address][]tokenTypes.StorageToken) error {
+		close(cacheSaved)
+		return nil
+	})
+
+	pubsub.Publish(balancePublisher, multistandardbalance.EventBalanceFetchFinished{
+		Key:            key,
+		ResultType:     multistandardfetcher.ResultTypeERC20,
+		BalanceChanged: false,
+		OldState:       multistandardbalance.State{FetchedAt: multistandardbalance.NeverFetched},
+		NewState:       multistandardbalance.State{FetchedAt: time.Now().Unix()},
+	})
+
+	select {
+	case <-cacheSaved:
+	case <-time.After(time.Second):
+		t.Fatal("expected UI cache refresh after first fetch event")
+	}
+}
+
+func TestReader_SkipsUICacheRefreshWhenFetchUnchangedAndAlreadyFetched(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	tokenManager := mock_token.NewMockManagerInterface(mockCtrl)
+	tokenBalancesStorage := mock_tokenbalances.NewMockStorage(mockCtrl)
+	balancePublisher := pubsub.NewPublisher()
+	reader := NewReader(tokenManager, nil, &event.Feed{}, balancePublisher, tokenBalancesStorage, pubsub.NewPublisher())
+
+	require.NoError(t, reader.Start())
+	defer reader.Stop()
+
+	account := testAccAddress1
+	chainID := walletcommon.OptimismMainnet
+	key := multistandardbalance.BalancesKey{ChainID: chainID, Account: account}
+
+	pubsub.Publish(balancePublisher, multistandardbalance.EventBalanceFetchFinished{
+		Key:            key,
+		ResultType:     multistandardfetcher.ResultTypeERC20,
+		BalanceChanged: false,
+		OldState:       multistandardbalance.State{FetchedAt: time.Now().Unix()},
+		NewState:       multistandardbalance.State{FetchedAt: time.Now().Unix()},
+	})
+
+	time.Sleep(100 * time.Millisecond)
 }

--- a/services/wallet/reader_test.go
+++ b/services/wallet/reader_test.go
@@ -56,7 +56,7 @@ func setupReaderExported(t *testing.T) (*wallet.Reader, *mock_token.MockManagerI
 }
 
 func TestGetCachedBalances(t *testing.T) {
-	reader, tokenManager, _, mockCtrl := setupReaderExported(t)
+	reader, tokenManager, tokenBalancesStorage, mockCtrl := setupReaderExported(t)
 
 	defer mockCtrl.Finish()
 
@@ -132,6 +132,9 @@ func TestGetCachedBalances(t *testing.T) {
 
 	tokenManager.EXPECT().GetCachedBalances().Return(cachedTokens, nil)
 	tokenManager.EXPECT().GetTokensByKeys(testutils.NewStringSliceElementsMatcher(tokensOfInterest)).Return(allTokens, nil)
+	tokenBalancesStorage.EXPECT().GetBalances(gomock.Any(), allTokens, addresses).Return(
+		map[uint64]map[common.Address]map[common.Address]*big.Int{}, nil,
+	)
 	tokens, err := reader.GetCachedBalances(chainIDs, addresses)
 	require.NoError(t, err)
 
@@ -147,7 +150,7 @@ func TestGetCachedBalances(t *testing.T) {
 }
 
 func TestFetchBalances(t *testing.T) {
-	reader, tokenManager, _, mockCtrl := setupReaderExported(t)
+	reader, tokenManager, tokenBalancesStorage, mockCtrl := setupReaderExported(t)
 	defer mockCtrl.Finish()
 
 	addresses := []common.Address{
@@ -211,6 +214,9 @@ func TestFetchBalances(t *testing.T) {
 	// Test GetCachedBalances with cached data
 	tokenManager.EXPECT().GetCachedBalances().Return(cachedTokens, nil)
 	tokenManager.EXPECT().GetTokensByKeys(testutils.NewStringSliceElementsMatcher(tokensOfInterest)).Return(allTokens, nil)
+	tokenBalancesStorage.EXPECT().GetBalances(gomock.Any(), allTokens, addresses).Return(
+		map[uint64]map[common.Address]map[common.Address]*big.Int{}, nil,
+	)
 
 	tokens, err := reader.GetCachedBalances(chainIDs, addresses)
 	require.NoError(t, err)

--- a/services/wallet/tokenbalances/storage_multistandardbalance.go
+++ b/services/wallet/tokenbalances/storage_multistandardbalance.go
@@ -29,7 +29,7 @@ func (s *StorageMultistandardBalance) GetBalances(ctx context.Context, tokens []
 		ret[chainID] = make(map[AccountAddress]map[ContractAddress]*big.Int)
 		for _, account := range accountAddresses {
 			ret[chainID][account] = make(map[ContractAddress]*big.Int)
-			erc20balances, _, err := s.multistandardbalanceStorage.GetERC20Balances(ctx, multistandardbalance.BalancesKey{ChainID: chainID, Account: account})
+			erc20balances, erc20State, err := s.multistandardbalanceStorage.GetERC20Balances(ctx, multistandardbalance.BalancesKey{ChainID: chainID, Account: account})
 			if err != nil {
 				return nil, err
 			}
@@ -38,16 +38,20 @@ func (s *StorageMultistandardBalance) GetBalances(ctx context.Context, tokens []
 				if token.IsNative() {
 					needsNative = true
 				}
-				if _, exists := erc20balances[token.Address]; exists {
-					ret[chainID][account][token.Address] = erc20balances[token.Address]
+				if balance, exists := erc20balances[token.Address]; exists {
+					ret[chainID][account][token.Address] = balance
+				} else if erc20State.FetchedAt != multistandardbalance.NeverFetched {
+					ret[chainID][account][token.Address] = big.NewInt(0)
 				}
 			}
 			if needsNative {
-				nativeBalance, _, err := s.multistandardbalanceStorage.GetNativeBalance(ctx, multistandardbalance.BalancesKey{ChainID: chainID, Account: account})
+				nativeBalance, nativeState, err := s.multistandardbalanceStorage.GetNativeBalance(ctx, multistandardbalance.BalancesKey{ChainID: chainID, Account: account})
 				if err != nil {
 					return nil, err
 				}
-				ret[chainID][account][NativeTokenAddress] = nativeBalance
+				if nativeState.FetchedAt != multistandardbalance.NeverFetched {
+					ret[chainID][account][NativeTokenAddress] = nativeBalance
+				}
 			}
 		}
 	}

--- a/services/wallet/tokenbalances/storage_multistandardbalance_test.go
+++ b/services/wallet/tokenbalances/storage_multistandardbalance_test.go
@@ -13,8 +13,8 @@ import (
 	"github.com/status-im/go-wallet-sdk/pkg/tokens/types"
 
 	"github.com/status-im/status-go/services/wallet/multistandardbalance"
-	"github.com/status-im/status-go/services/wallet/tokenbalances"
 	tokentypes "github.com/status-im/status-go/services/wallet/token/types"
+	"github.com/status-im/status-go/services/wallet/tokenbalances"
 )
 
 func TestGetBalances_ERC20NeverFetched_MissingTokenNotInMap(t *testing.T) {

--- a/services/wallet/tokenbalances/storage_multistandardbalance_test.go
+++ b/services/wallet/tokenbalances/storage_multistandardbalance_test.go
@@ -1,0 +1,123 @@
+package tokenbalances_test
+
+import (
+	"context"
+	"math/big"
+	"testing"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/status-im/go-wallet-sdk/pkg/tokens/types"
+
+	"github.com/status-im/status-go/services/wallet/multistandardbalance"
+	"github.com/status-im/status-go/services/wallet/tokenbalances"
+	tokentypes "github.com/status-im/status-go/services/wallet/token/types"
+)
+
+func TestGetBalances_ERC20NeverFetched_MissingTokenNotInMap(t *testing.T) {
+	storage := multistandardbalance.NewStorageMemory()
+	adapter := tokenbalances.NewStorageMultistandardBalance(storage)
+
+	account := common.HexToAddress("0x2a811F1E11636C144a2A062d3D402245A43D4074")
+	chainID := uint64(8453)
+	token := erc20Token(chainID, "0x820C137fA9D5348B4B9B2E229CBeD970E8e7E360")
+
+	balances, err := adapter.GetBalances(context.Background(), []*tokentypes.Token{token}, []common.Address{account})
+	require.NoError(t, err)
+
+	_, ok := balances[chainID][account][token.Address]
+	assert.False(t, ok, "token should be absent when ERC20 balances were never fetched")
+}
+
+func TestGetBalances_ERC20Fetched_MissingTokenReturnsZero(t *testing.T) {
+	storage := multistandardbalance.NewStorageMemory()
+	adapter := tokenbalances.NewStorageMultistandardBalance(storage)
+
+	account := common.HexToAddress("0x2a811F1E11636C144a2A062d3D402245A43D4074")
+	chainID := uint64(8453)
+	key := multistandardbalance.BalancesKey{Account: account, ChainID: chainID}
+
+	knownToken := erc20Token(chainID, "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913")
+	missingToken := erc20Token(chainID, "0x820C137fA9D5348B4B9B2E229CBeD970E8e7E360")
+
+	_, _, err := storage.UpdateERC20Balances(context.Background(), key, map[common.Address]*big.Int{
+		knownToken.Address: big.NewInt(42),
+	}, fetchedState())
+	require.NoError(t, err)
+
+	balances, err := adapter.GetBalances(context.Background(), []*tokentypes.Token{knownToken, missingToken}, []common.Address{account})
+	require.NoError(t, err)
+
+	knownBalance, ok := balances[chainID][account][knownToken.Address]
+	require.True(t, ok)
+	assert.Equal(t, 0, knownBalance.Cmp(big.NewInt(42)))
+
+	missingBalance, ok := balances[chainID][account][missingToken.Address]
+	require.True(t, ok, "missing token should be present as zero after fetch")
+	assert.Equal(t, 0, missingBalance.Cmp(big.NewInt(0)))
+}
+
+func TestGetBalances_NativeNeverFetched_NotInMap(t *testing.T) {
+	storage := multistandardbalance.NewStorageMemory()
+	adapter := tokenbalances.NewStorageMultistandardBalance(storage)
+
+	account := common.HexToAddress("0x2a811F1E11636C144a2A062d3D402245A43D4074")
+	chainID := uint64(8453)
+	nativeToken := nativeToken(chainID)
+
+	balances, err := adapter.GetBalances(context.Background(), []*tokentypes.Token{nativeToken}, []common.Address{account})
+	require.NoError(t, err)
+
+	_, ok := balances[chainID][account][tokenbalances.NativeTokenAddress]
+	assert.False(t, ok, "native balance should be absent when never fetched")
+}
+
+func TestGetBalances_NativeFetched_InMap(t *testing.T) {
+	storage := multistandardbalance.NewStorageMemory()
+	adapter := tokenbalances.NewStorageMultistandardBalance(storage)
+
+	account := common.HexToAddress("0x2a811F1E11636C144a2A062d3D402245A43D4074")
+	chainID := uint64(8453)
+	key := multistandardbalance.BalancesKey{Account: account, ChainID: chainID}
+	nativeToken := nativeToken(chainID)
+
+	_, _, err := storage.UpdateNativeBalance(context.Background(), key, big.NewInt(1000), fetchedState())
+	require.NoError(t, err)
+
+	balances, err := adapter.GetBalances(context.Background(), []*tokentypes.Token{nativeToken}, []common.Address{account})
+	require.NoError(t, err)
+
+	nativeBalance, ok := balances[chainID][account][tokenbalances.NativeTokenAddress]
+	require.True(t, ok)
+	assert.Equal(t, 0, nativeBalance.Cmp(big.NewInt(1000)))
+}
+
+func erc20Token(chainID uint64, address string) *tokentypes.Token {
+	return &tokentypes.Token{
+		Token: &types.Token{
+			ChainID: chainID,
+			Address: common.HexToAddress(address),
+		},
+	}
+}
+
+func nativeToken(chainID uint64) *tokentypes.Token {
+	return &tokentypes.Token{
+		Token: &types.Token{
+			ChainID: chainID,
+			Address: common.HexToAddress("0x0000000000000000000000000000000000000000"),
+			Symbol:  "ETH",
+		},
+	}
+}
+
+func fetchedState() multistandardbalance.State {
+	return multistandardbalance.State{
+		AtBlockNumber: big.NewInt(100),
+		AtBlockHash:   common.HexToHash("0xabcdef"),
+		FetchedAt:     time.Now().Unix(),
+	}
+}


### PR DESCRIPTION
* bump go-wallet-sdk for multicall chunk retry when RPC body or gas limits the rpc
  * https://github.com/status-im/go-wallet-sdk/pull/43
* Treat fetched-but-missing ERC20 tokens as zero instead of errors

updated PR:
* refresh tokenManager cache on the first successful fetch even when balanceChanged=false (otherwise mandatory tokens never leave loading state)
* merge live multistandardbalance storage into GetCachedBalances so the UI can show balances before the UI cache catches up
* cancel in-flight per-chain fetches before starting a new one on the same chain (avoids overlapping multicall runs and context canceled errors)

fixes status-im/status-app#21224

https://github.com/status-im/status-app/pull/21241