### PR TITLE
test: #7131 transfer ownership

### DIFF
--- a/tests-functional/clients/services/wakuext.py
+++ b/tests-functional/clients/services/wakuext.py
@@ -956,11 +956,6 @@ class WakuextService(Service):
         response = self.rpc_request("registerReceivedOwnershipNotification", params)
         return response
 
-    def register_lost_ownership_notification(self, community_id: str):
-        params = [community_id]
-        response = self.rpc_request("registerLostOwnershipNotification", params)
-        return response
-
     def sign_data(self, sign_params: list[dict]):
         params = [sign_params]
         response = self.rpc_request("signData", params)

--- a/tests-functional/clients/services/wakuext.py
+++ b/tests-functional/clients/services/wakuext.py
@@ -946,6 +946,21 @@ class WakuextService(Service):
         response = self.rpc_request("deleteCommunityTokenPermission", params)
         return response
 
+    def promote_self_to_control_node(self, community_id: str):
+        params = [community_id]
+        response = self.rpc_request("promoteSelfToControlNode", params)
+        return response
+
+    def register_received_ownership_notification(self, community_id: str):
+        params = [community_id]
+        response = self.rpc_request("registerReceivedOwnershipNotification", params)
+        return response
+
+    def register_lost_ownership_notification(self, community_id: str):
+        params = [community_id]
+        response = self.rpc_request("registerLostOwnershipNotification", params)
+        return response
+
     def sign_data(self, sign_params: list[dict]):
         params = [sign_params]
         response = self.rpc_request("signData", params)

--- a/tests-functional/steps/community_ownership.py
+++ b/tests-functional/steps/community_ownership.py
@@ -1,0 +1,393 @@
+"""Community ownership-transfer steps (issue 7131): transfer owner NFT, set signer, promote."""
+
+import logging
+import time
+import uuid
+from typing import Optional
+
+from web3 import Web3
+
+from clients.api import ApiResponseError
+from clients.services.wakuext import (
+    CommunityRoles,
+    CommunityTokenPermissionType,
+    CommunityTokenPrivilegesLevel,
+    CommunityTokenType,
+)
+from clients.services.wallet_send_type import WalletSendType
+from clients.signals import SignalType
+from clients.status_backend import StatusBackend
+from steps import community_token_deploy, community_tokens, messenger
+from steps.community_tokens import NATIVE_TOKEN_ADDRESS
+
+logger = logging.getLogger(__name__)
+
+# Go iota enums (protocol/communities/token), distinct from the wallet-router enums.
+TOKEN_OWNER_PRIVILEGES_LEVEL = 0  # token.OwnerLevel
+TOKEN_DEPLOY_STATE_DEPLOYED = 2  # token.Deployed
+PROTOBUF_COMMUNITY_TOKEN_ERC721 = 2  # protobuf.CommunityTokenType_ERC721
+
+ERC721_OWNERSHIP_ABI = [
+    {
+        "inputs": [{"name": "owner", "type": "address"}],
+        "name": "balanceOf",
+        "outputs": [{"name": "", "type": "uint256"}],
+        "stateMutability": "view",
+        "type": "function",
+    },
+    {
+        "inputs": [{"name": "owner", "type": "address"}, {"name": "index", "type": "uint256"}],
+        "name": "tokenOfOwnerByIndex",
+        "outputs": [{"name": "", "type": "uint256"}],
+        "stateMutability": "view",
+        "type": "function",
+    },
+    {
+        "inputs": [{"name": "tokenId", "type": "uint256"}],
+        "name": "ownerOf",
+        "outputs": [{"name": "", "type": "address"}],
+        "stateMutability": "view",
+        "type": "function",
+    },
+    {
+        "inputs": [{"name": "from", "type": "address"}, {"name": "to", "type": "address"}, {"name": "tokenId", "type": "uint256"}],
+        "name": "safeTransferFrom",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function",
+    },
+]
+
+
+def _anvil_rpc(anvil_client, method: str, params: list):
+    from web3.types import RPCEndpoint
+
+    return anvil_client.provider.make_request(RPCEndpoint(method), params)
+
+
+def resolve_owner_token_id(anvil_client, owner_token_address: str, holder_address: str) -> int:
+    contract = anvil_client.eth.contract(address=Web3.to_checksum_address(owner_token_address), abi=ERC721_OWNERSHIP_ABI)
+    try:
+        return contract.functions.tokenOfOwnerByIndex(Web3.to_checksum_address(holder_address), 0).call()
+    except Exception as exc:
+        logger.debug(f"tokenOfOwnerByIndex unavailable for {owner_token_address}: {exc}; defaulting to 0")
+        return 0
+
+
+def transfer_owner_token_to_new_owner(
+    anvil_client,
+    owner_token_address: str,
+    from_wallet: str,
+    to_wallet: str,
+    token_id: Optional[int] = None,
+) -> int:
+    # Test-only: Anvil impersonation, no private key. App equivalent is an ERC721_TRANSFER route.
+    from_wallet = Web3.to_checksum_address(from_wallet)
+    to_wallet = Web3.to_checksum_address(to_wallet)
+    if token_id is None:
+        token_id = resolve_owner_token_id(anvil_client, owner_token_address, from_wallet)
+
+    contract = anvil_client.eth.contract(address=Web3.to_checksum_address(owner_token_address), abi=ERC721_OWNERSHIP_ABI)
+    _anvil_rpc(anvil_client, "anvil_impersonateAccount", [from_wallet])
+    try:
+        tx_hash = contract.functions.safeTransferFrom(from_wallet, to_wallet, token_id).transact({"from": from_wallet})
+        receipt = anvil_client.eth.wait_for_transaction_receipt(tx_hash, timeout=60)
+        assert receipt.get("status") == 1, f"Owner token transfer failed: {receipt}"
+    finally:
+        _anvil_rpc(anvil_client, "anvil_stopImpersonatingAccount", [from_wallet])
+
+    new_owner = contract.functions.ownerOf(token_id).call()
+    assert new_owner.lower() == to_wallet.lower(), f"Owner token still held by {new_owner}, expected {to_wallet}"
+    logger.info(f"Transferred owner token {owner_token_address}#{token_id} from {from_wallet} to {to_wallet}")
+    return token_id
+
+
+def register_owner_token_on_backend(
+    backend: StatusBackend,
+    community_id: str,
+    owner_token_address: str,
+    *,
+    name: str = "TestOwnerToken",
+    symbol: str = "TOT",
+):
+    # Needed by the set-signer route; may already be stored → ignore the UNIQUE constraint.
+    try:
+        return backend.wakuext_service.save_community_token(
+            {
+                "tokenType": PROTOBUF_COMMUNITY_TOKEN_ERC721,
+                "communityId": community_id,
+                "address": owner_token_address,
+                "name": name,
+                "symbol": symbol,
+                "supply": "1",
+                "infiniteSupply": False,
+                "transferable": True,
+                "remoteSelfDestruct": False,
+                "chainId": backend.network_id,
+                "deployState": TOKEN_DEPLOY_STATE_DEPLOYED,
+                "image": "",
+                "decimals": 0,
+                "privilegesLevel": TOKEN_OWNER_PRIVILEGES_LEVEL,
+            }
+        )
+    except ApiResponseError as exc:
+        if "UNIQUE constraint failed" not in str(exc):
+            raise
+        return None
+
+
+def publish_owner_token_to_community(owner_backend: StatusBackend, community_id: str, owner_token_address: str):
+    # AddCommunityToken adds the BECOME_TOKEN_OWNER permission.
+    register_owner_token_on_backend(owner_backend, community_id, owner_token_address)
+
+    owner_backend.wakuext_service.add_community_token(community_id, owner_backend.network_id, owner_token_address)
+
+    owner_community = next(
+        (c for c in messenger.communities_list(owner_backend.wakuext_service.communities()) if c.get("id") == community_id),
+        None,
+    )
+    permission_types = community_tokens.community_permission_types(owner_community or {})
+    assert (
+        CommunityTokenPermissionType.BECOME_TOKEN_OWNER.value in permission_types
+    ), f"Owner token did not create a BECOME_TOKEN_OWNER permission; observed={permission_types}"
+
+
+def set_signer_pubkey(new_owner_backend: StatusBackend, community_id: str, owner_token_address: str) -> dict:
+    address_from = messenger.wallet_address(new_owner_backend)
+    chain_id = new_owner_backend.network_id
+    new_owner_backend.wallet_service.get_balances_at_by_chain([address_from], [f"{chain_id}-{NATIVE_TOKEN_ADDRESS}"])
+
+    # Route validation requires exactly one transfer detail with the owner-token address.
+    transfer_details = [
+        {
+            "tokenType": CommunityTokenType.ERC721.value,
+            "privilegeLevel": CommunityTokenPrivilegesLevel.OWNER_LEVEL.value,
+            "tokenContractAddress": owner_token_address,
+            "amount": hex(1),
+        }
+    ]
+
+    transaction_uuid = str(uuid.uuid4())
+    routes_result = new_owner_backend.wallet_service.suggested_community_routes(
+        uuid=transaction_uuid,
+        send_type=WalletSendType.COMMUNITY_SET_SIGNER_PUB_KEY,
+        chain_id=chain_id,
+        address_from=address_from,
+        addr_to=owner_token_address,
+        community_id=community_id,
+        signer_pub_key=new_owner_backend.public_key,
+        token_ids=[],
+        wallet_addresses=[],
+        transfer_details=transfer_details,
+    )
+    assert routes_result.get("Uuid") == transaction_uuid, f"Expected UUID {transaction_uuid}, got {routes_result.get('Uuid')}"
+
+    with new_owner_backend.expect_signal(
+        SignalType.COMMUNITY_TOKEN_TRANSACTION_STATUS_CHANGED,
+        predicate=lambda s: community_token_deploy.is_community_token_tx_success(s, WalletSendType.COMMUNITY_SET_SIGNER_PUB_KEY),
+        timeout=60,
+    ):
+        sent_signal, _ = community_token_deploy._sign_and_send_community_route(new_owner_backend, transaction_uuid, address_from)
+    return sent_signal
+
+
+def _permission_types(community: Optional[dict]) -> set:
+    """Token-permission type ints present on a fetched community dict (e.g. {5, 6})."""
+    return community_tokens.community_permission_types(community or {})
+
+
+def _community_clock(backend: StatusBackend, community_id: str, try_database: bool = False) -> Optional[int]:
+    """Community-level clock *backend* currently sees (live store fetch by default), or None."""
+    try:
+        community = messenger.fetch_community(backend, community_id, wait_for_response=True, try_database=try_database)
+    except ApiResponseError as exc:
+        logger.debug(f"_community_clock fetch failed: {exc}")
+        return None
+    return community.get("clock") if isinstance(community, dict) else None
+
+
+def wait_until_member_sees_community_clock(
+    backend: StatusBackend,
+    community_id: str,
+    min_clock: int,
+    reference_backend: Optional[StatusBackend] = None,
+    attempts: int = 45,
+    delay: int = 2,
+    spectate: bool = True,
+) -> dict:
+    """Poll a live store fetch until *backend* sees the community at clock >= *min_clock*; return it."""
+    community: Optional[dict] = None
+    member_clock: Optional[int] = None
+    for attempt in range(attempts):
+        if spectate:
+            try:
+                backend.wakuext_service.spectate_community(community_id)
+            except ApiResponseError as exc:
+                logger.debug(f"spectate_community failed (attempt {attempt + 1}): {exc}")
+
+        try:
+            community = messenger.fetch_community(backend, community_id, wait_for_response=True, try_database=False)
+        except ApiResponseError as exc:
+            logger.debug(f"fetch_community failed (attempt {attempt + 1}): {exc}")
+            community = None
+
+        member_clock = community.get("clock") if isinstance(community, dict) else None
+        owner_clock = _community_clock(reference_backend, community_id, try_database=True) if reference_backend is not None else None
+        logger.info(
+            f"community-clock scan {attempt + 1}/{attempts}: member_clock={member_clock} "
+            f"owner_clock={owner_clock} (waiting for member_clock >= {min_clock})"
+        )
+        if isinstance(community, dict) and member_clock is not None and member_clock >= min_clock:
+            return community
+        time.sleep(delay)
+
+    raise AssertionError(f"Member never reached community clock >= {min_clock} after {attempts} attempts; " f"last member_clock={member_clock}.")
+
+
+def assert_new_owner_receives_owner_permission(
+    owner_backend: StatusBackend,
+    new_owner_backend: StatusBackend,
+    community_id: str,
+    attempts: int = 45,
+    delay: int = 2,
+) -> None:
+    """Assert the owner created the type-6 permission and the new owner receives it once synced."""
+    want = CommunityTokenPermissionType.BECOME_TOKEN_OWNER.value
+
+    owner_updated = messenger.fetch_community(owner_backend, community_id, wait_for_response=True, try_database=True)
+    assert want in _permission_types(
+        owner_updated
+    ), f"Owner did not create BECOME_TOKEN_OWNER permission; observed={sorted(_permission_types(owner_updated))}"
+
+    new_owner_updated = wait_until_member_sees_community_clock(
+        new_owner_backend,
+        community_id,
+        min_clock=owner_updated["clock"],
+        reference_backend=owner_backend,
+        attempts=attempts,
+        delay=delay,
+    )
+    assert want in _permission_types(new_owner_updated), (
+        f"New owner caught up to clock {owner_updated['clock']} but has no BECOME_TOKEN_OWNER permission; "
+        f"observed={sorted(_permission_types(new_owner_updated))}"
+    )
+
+
+def promote_to_control_node(new_owner_backend: StatusBackend, community_id: str) -> dict:
+    response = new_owner_backend.wakuext_service.promote_self_to_control_node(community_id)
+    assert response is not None, "promote_self_to_control_node returned no response"
+    new_owner_backend.wakuext_service.register_received_ownership_notification(community_id)
+    return response
+
+
+def wait_until_member_is_owner(
+    backend: StatusBackend,
+    community_id: str,
+    new_owner_public_key: str,
+    attempts: int = 30,
+    delay: int = 2,
+    fetch_from_store: bool = False,
+    spectate: bool = False,
+    required: bool = True,
+):
+    return community_tokens.wait_for_member_role(
+        backend,
+        community_id,
+        new_owner_public_key,
+        CommunityRoles.ROLE_OWNER.value,
+        attempts=attempts,
+        delay=delay,
+        fetch_from_store=fetch_from_store,
+        spectate=spectate,
+        required=required,
+    )
+
+
+def wait_until_owner_and_members_present(
+    backend: StatusBackend,
+    community_id: str,
+    owner_public_key: str,
+    expected_member_public_keys: list,
+    attempts: int = 45,
+    delay: int = 2,
+    spectate: bool = True,
+) -> dict:
+    """Poll until *backend* sees *owner_public_key* with the OWNER role and every key in
+    *expected_member_public_keys* in the member list (the full ticket end state)."""
+    community: Optional[dict] = None
+    missing: list = list(expected_member_public_keys)
+    owner_roles: list = []
+    for _ in range(attempts):
+        if spectate:
+            try:
+                backend.wakuext_service.spectate_community(community_id)
+            except ApiResponseError as exc:
+                logger.debug(f"spectate_community failed: {exc}")
+        try:
+            messenger.fetch_community(backend, community_id, wait_for_response=True, try_database=False)
+        except ApiResponseError as exc:
+            logger.debug(f"fetch_community failed: {exc}")
+
+        community = next(
+            (c for c in messenger.communities_list(backend.wakuext_service.communities()) if c.get("id") == community_id),
+            None,
+        )
+        members = (community or {}).get("members", {})
+        owner_roles = members.get(owner_public_key, {}).get("roles", [])
+        missing = [k for k in expected_member_public_keys if k not in members]
+        if isinstance(community, dict) and CommunityRoles.ROLE_OWNER.value in owner_roles and not missing:
+            return community
+        logger.info(
+            f"waiting for owner+members: owner_has_role={CommunityRoles.ROLE_OWNER.value in owner_roles}, missing={[k[:12] for k in missing]}"
+        )
+        time.sleep(delay)
+
+    raise AssertionError(f"Did not reach owner+all-members state after {attempts} attempts; " f"missing members={missing}, owner_roles={owner_roles}")
+
+
+def wait_until_kicked_from_community(
+    backend: StatusBackend,
+    community_id: str,
+    attempts: int = 45,
+    delay: int = 2,
+) -> dict:
+    """Poll until *backend* observes it has been kicked (no longer joined) after an ownership change.
+    The ex-owner must wait for this before re-requesting to join, else it gets 'already joined'."""
+    community: Optional[dict] = None
+    for _ in range(attempts):
+        try:
+            messenger.fetch_community(backend, community_id, wait_for_response=True, try_database=False)
+        except ApiResponseError as exc:
+            logger.debug(f"fetch_community failed: {exc}")
+        community = next(
+            (c for c in messenger.communities_list(backend.wakuext_service.communities()) if c.get("id") == community_id),
+            None,
+        )
+        if community is not None and not community.get("joined", False):
+            return community
+        time.sleep(delay)
+
+    raise AssertionError(
+        f"Backend was never kicked from community after {attempts} attempts; " f"joined={community.get('joined') if community else None}"
+    )
+
+
+def transfer_community_ownership(
+    owner_backend: StatusBackend,
+    new_owner_backend: StatusBackend,
+    community_id: str,
+    owner_token_address: str,
+    anvil_client,
+) -> dict:
+    owner_wallet = messenger.wallet_address(owner_backend)
+    new_owner_wallet = messenger.wallet_address(new_owner_backend)
+
+    # Persist the type-6 permission while the old owner is still the verified signer, then flip it.
+    assert_new_owner_receives_owner_permission(owner_backend, new_owner_backend, community_id)
+
+    transfer_owner_token_to_new_owner(anvil_client, owner_token_address, owner_wallet, new_owner_wallet)
+    register_owner_token_on_backend(new_owner_backend, community_id, owner_token_address)
+    set_signer_pubkey(new_owner_backend, community_id, owner_token_address)
+    time.sleep(2)  # let the new owner's wallet index the signer change
+
+    return promote_to_control_node(new_owner_backend, community_id)

--- a/tests-functional/steps/community_ownership.py
+++ b/tests-functional/steps/community_ownership.py
@@ -398,6 +398,57 @@ def wait_until_kicked_from_community(
     )
 
 
+def rejoin_ex_owner_and_accept(
+    ex_owner_backend: StatusBackend,
+    new_owner_backend: StatusBackend,
+    community_id: str,
+    ex_owner_wallet_address: str,
+    attempts: int = 90,
+    delay: int = 2,
+    resend_every: int = 15,
+) -> str:
+    """Ex-owner re-requests to join after the transfer and the new control node accepts.
+
+    The request-to-join is delivered to the control node over Waku, which can be slow or dropped in
+    CI. Rather than catch a one-shot MESSAGES_NEW signal within a fixed window, poll the control
+    node's persisted pending requests and periodically re-send until the request lands, then accept
+    it (request ids are deterministic, so the stored id matches what the ex-owner generated)."""
+    my_req_ids: set = set()
+
+    def _send():
+        try:
+            resp = community_tokens.request_to_join_with_signatures(ex_owner_backend, community_id, [ex_owner_wallet_address])
+            for req in resp.get("requestsToJoinCommunity", []) or []:
+                if req.get("id"):
+                    my_req_ids.add(req.get("id"))
+        except ApiResponseError as exc:
+            logger.debug(f"ex-owner request_to_join failed: {exc}")
+
+    _send()
+    for attempt in range(attempts):
+        try:
+            pending = new_owner_backend.wakuext_service.pending_requests_to_join_for_community(community_id) or []
+        except ApiResponseError as exc:
+            pending = []
+            logger.debug(f"pending_requests fetch failed: {exc}")
+
+        match = next(
+            (r for r in pending if r.get("id") in my_req_ids or r.get("publicKey") == ex_owner_backend.public_key),
+            None,
+        )
+        if match is not None:
+            accept_resp = new_owner_backend.wakuext_service.accept_request_to_join_community(match.get("id"))
+            assert accept_resp is not None, f"Failed to accept ex-owner request: {accept_resp}"
+            return match.get("id")
+
+        if attempt and attempt % resend_every == 0:
+            logger.info(f"ex-owner rejoin: control node has not observed the request, re-sending (attempt {attempt}/{attempts})")
+            _send()
+        time.sleep(delay)
+
+    raise AssertionError(f"Control node never observed the ex-owner rejoin request after {attempts} attempts; ids tried={my_req_ids}")
+
+
 def transfer_community_ownership(
     owner_backend: StatusBackend,
     new_owner_backend: StatusBackend,

--- a/tests-functional/steps/community_ownership.py
+++ b/tests-functional/steps/community_ownership.py
@@ -369,11 +369,11 @@ def wait_until_owner_and_members_present(
 def wait_until_kicked_from_community(
     backend: StatusBackend,
     community_id: str,
+    new_owner_public_key: Optional[str] = None,
     attempts: int = 45,
     delay: int = 2,
 ) -> dict:
-    """Poll until *backend* observes it has been kicked (no longer joined) after an ownership change.
-    The ex-owner must wait for this before re-requesting to join, else it gets 'already joined'."""
+    """Poll until *backend* observes it has been kicked (no longer joined) after an ownership change."""
     community: Optional[dict] = None
     for _ in range(attempts):
         try:
@@ -385,11 +385,16 @@ def wait_until_kicked_from_community(
             None,
         )
         if community is not None and not community.get("joined", False):
-            return community
+            if new_owner_public_key is None:
+                return community
+            owner_roles = community.get("members", {}).get(new_owner_public_key, {}).get("roles", [])
+            if CommunityRoles.ROLE_OWNER.value in owner_roles:
+                return community
         time.sleep(delay)
 
     raise AssertionError(
-        f"Backend was never kicked from community after {attempts} attempts; " f"joined={community.get('joined') if community else None}"
+        f"Backend was never kicked from community (with new owner ingested) after {attempts} attempts; "
+        f"joined={community.get('joined') if community else None}"
     )
 
 

--- a/tests-functional/steps/community_ownership.py
+++ b/tests-functional/steps/community_ownership.py
@@ -6,6 +6,7 @@ import uuid
 from typing import Optional
 
 from web3 import Web3
+from web3.exceptions import BadFunctionCallOutput, ContractLogicError
 
 from clients.api import ApiResponseError
 from clients.services.wakuext import (
@@ -69,8 +70,8 @@ def resolve_owner_token_id(anvil_client, owner_token_address: str, holder_addres
     contract = anvil_client.eth.contract(address=Web3.to_checksum_address(owner_token_address), abi=ERC721_OWNERSHIP_ABI)
     try:
         return contract.functions.tokenOfOwnerByIndex(Web3.to_checksum_address(holder_address), 0).call()
-    except Exception as exc:
-        logger.debug(f"tokenOfOwnerByIndex unavailable for {owner_token_address}: {exc}; defaulting to 0")
+    except (ContractLogicError, BadFunctionCallOutput) as exc:
+        logger.warning(f"tokenOfOwnerByIndex unavailable for {owner_token_address}: {exc}; defaulting to token_id 0")
         return 0
 
 
@@ -273,11 +274,31 @@ def assert_new_owner_receives_owner_permission(
     )
 
 
-def promote_to_control_node(new_owner_backend: StatusBackend, community_id: str) -> dict:
-    response = new_owner_backend.wakuext_service.promote_self_to_control_node(community_id)
-    assert response is not None, "promote_self_to_control_node returned no response"
-    new_owner_backend.wakuext_service.register_received_ownership_notification(community_id)
-    return response
+def promote_to_control_node(
+    new_owner_backend: StatusBackend,
+    community_id: str,
+    attempts: int = 30,
+    delay: int = 2,
+) -> dict:
+    """Promote self to control node, retrying until the on-chain signer change is indexed.
+
+    Promote fails the authorization check until the new owner's wallet has indexed the
+    signer change, so we poll the real operation instead of guessing the indexing latency
+    with a fixed sleep."""
+    last_exc: Optional[ApiResponseError] = None
+    for attempt in range(attempts):
+        try:
+            response = new_owner_backend.wakuext_service.promote_self_to_control_node(community_id)
+        except ApiResponseError as exc:
+            last_exc = exc
+            logger.debug(f"promote_self_to_control_node not ready (attempt {attempt + 1}/{attempts}): {exc}")
+            time.sleep(delay)
+            continue
+        assert response is not None, "promote_self_to_control_node returned no response"
+        new_owner_backend.wakuext_service.register_received_ownership_notification(community_id)
+        return response
+
+    raise AssertionError(f"promote_self_to_control_node never succeeded after {attempts} attempts; last error={last_exc}")
 
 
 def wait_until_member_is_owner(
@@ -388,6 +409,6 @@ def transfer_community_ownership(
     transfer_owner_token_to_new_owner(anvil_client, owner_token_address, owner_wallet, new_owner_wallet)
     register_owner_token_on_backend(new_owner_backend, community_id, owner_token_address)
     set_signer_pubkey(new_owner_backend, community_id, owner_token_address)
-    time.sleep(2)  # let the new owner's wallet index the signer change
 
+    # promote_to_control_node polls until the new owner's wallet has indexed the signer change.
     return promote_to_control_node(new_owner_backend, community_id)

--- a/tests-functional/steps/community_ownership.py
+++ b/tests-functional/steps/community_ownership.py
@@ -405,48 +405,32 @@ def rejoin_ex_owner_and_accept(
     ex_owner_wallet_address: str,
     attempts: int = 90,
     delay: int = 2,
-    resend_every: int = 15,
 ) -> str:
     """Ex-owner re-requests to join after the transfer and the new control node accepts.
 
-    The request-to-join is delivered to the control node over Waku, which can be slow or dropped in
-    CI. Rather than catch a one-shot MESSAGES_NEW signal within a fixed window, poll the control
-    node's persisted pending requests and periodically re-send until the request lands, then accept
-    it (request ids are deterministic, so the stored id matches what the ex-owner generated)."""
-    my_req_ids: set = set()
+    The ex-owner can only request once (a resend returns 'already joined'), and its request
+    reconciles into a non-pending state on the control node (which auto-generated an approved
+    request on promotion), so it never appears in pendingRequestsToJoinForCommunity. Accepting by
+    id does work once the control node has received the request. The request travels over Waku,
+    which can be slow in CI, so retry the accept (the real operation) until it succeeds rather than
+    catch a one-shot MESSAGES_NEW signal within a fixed window."""
+    resp = community_tokens.request_to_join_with_signatures(ex_owner_backend, community_id, [ex_owner_wallet_address])
+    requests = resp.get("requestsToJoinCommunity", [])
+    assert requests, "No requests to join community"
+    req_id = requests[0].get("id")
 
-    def _send():
-        try:
-            resp = community_tokens.request_to_join_with_signatures(ex_owner_backend, community_id, [ex_owner_wallet_address])
-            for req in resp.get("requestsToJoinCommunity", []) or []:
-                if req.get("id"):
-                    my_req_ids.add(req.get("id"))
-        except ApiResponseError as exc:
-            logger.debug(f"ex-owner request_to_join failed: {exc}")
-
-    _send()
+    last_exc: Optional[ApiResponseError] = None
     for attempt in range(attempts):
         try:
-            pending = new_owner_backend.wakuext_service.pending_requests_to_join_for_community(community_id) or []
+            accept_resp = new_owner_backend.wakuext_service.accept_request_to_join_community(req_id)
+            if accept_resp is not None:
+                return req_id
         except ApiResponseError as exc:
-            pending = []
-            logger.debug(f"pending_requests fetch failed: {exc}")
-
-        match = next(
-            (r for r in pending if r.get("id") in my_req_ids or r.get("publicKey") == ex_owner_backend.public_key),
-            None,
-        )
-        if match is not None:
-            accept_resp = new_owner_backend.wakuext_service.accept_request_to_join_community(match.get("id"))
-            assert accept_resp is not None, f"Failed to accept ex-owner request: {accept_resp}"
-            return match.get("id")
-
-        if attempt and attempt % resend_every == 0:
-            logger.info(f"ex-owner rejoin: control node has not observed the request, re-sending (attempt {attempt}/{attempts})")
-            _send()
+            last_exc = exc
+            logger.debug(f"accept ex-owner request not ready (attempt {attempt + 1}/{attempts}): {exc}")
         time.sleep(delay)
 
-    raise AssertionError(f"Control node never observed the ex-owner rejoin request after {attempts} attempts; ids tried={my_req_ids}")
+    raise AssertionError(f"Control node never accepted the ex-owner rejoin request {req_id} after {attempts} attempts; last error={last_exc}")
 
 
 def transfer_community_ownership(

--- a/tests-functional/tests/test_wakuext_community_ownership_transfer.py
+++ b/tests-functional/tests/test_wakuext_community_ownership_transfer.py
@@ -139,8 +139,11 @@ class TestCommunityOwnershipTransfer:
         # The ex-owner created the community and has no revealed accounts, so it can't auto-rejoin; it
         # must manually re-join once it has observed the kick.
         community_ownership.wait_until_kicked_from_community(owner_backend, community_id, member_a_backend.public_key)
-        community_tokens.join_community_with_signatures_and_accept(
-            member_a_backend, owner_backend, community_id, messenger.wallet_address(owner_backend)
+        community_ownership.rejoin_ex_owner_and_accept(
+            ex_owner_backend=owner_backend,
+            new_owner_backend=member_a_backend,
+            community_id=community_id,
+            ex_owner_wallet_address=messenger.wallet_address(owner_backend),
         )
 
         # Then the members list contains Owner, Member A, and Member B

--- a/tests-functional/tests/test_wakuext_community_ownership_transfer.py
+++ b/tests-functional/tests/test_wakuext_community_ownership_transfer.py
@@ -138,7 +138,7 @@ class TestCommunityOwnershipTransfer:
 
         # The ex-owner created the community and has no revealed accounts, so it can't auto-rejoin; it
         # must manually re-join once it has observed the kick.
-        community_ownership.wait_until_kicked_from_community(owner_backend, community_id)
+        community_ownership.wait_until_kicked_from_community(owner_backend, community_id, member_a_backend.public_key)
         community_tokens.join_community_with_signatures_and_accept(
             member_a_backend, owner_backend, community_id, messenger.wallet_address(owner_backend)
         )

--- a/tests-functional/tests/test_wakuext_community_ownership_transfer.py
+++ b/tests-functional/tests/test_wakuext_community_ownership_transfer.py
@@ -1,0 +1,173 @@
+"""Community ownership transfer scenario — github.com/status-im/status-go/issues/7131."""
+
+import logging
+from uuid import uuid4
+
+import pytest
+
+from clients.services.wakuext import CommunityPermissionsAccess
+from steps import community_ownership, community_tokens, community_token_deploy, messenger
+from steps.community_token_deploy import CommunityTokenDeployState
+from utils import fake
+
+logger = logging.getLogger(__name__)
+
+SUBCHANNEL_NAME = "subchannel"
+
+
+def _subchannel_payload():
+    display_name = SUBCHANNEL_NAME + "_" + str(uuid4())
+    return {
+        "identity": {
+            "displayName": display_name,
+            "color": "#1f2c75",
+            "description": SUBCHANNEL_NAME,
+        },
+        "viewersCanPostReactions": True,
+        "hideIfPermissionsNotMet": False,
+        "permissions": {"access": 1},
+    }
+
+
+def _community_chat_count(backend, community_id):
+    community = next(
+        (c for c in messenger.communities_list(backend.wakuext_service.communities()) if c.get("id") == community_id),
+        None,
+    )
+    return len((community or {}).get("chats", {}) or {})
+
+
+@pytest.mark.rpc
+@pytest.mark.usefixtures("community_token_deploy_context")
+class TestCommunityOwnershipTransfer:
+    snt_address: str
+    snt_controller_address: str
+    community_token_deployer: str
+    deploy_state: CommunityTokenDeployState
+
+    def test_ownership_transfer_to_member(
+        self,
+        owner_backend,
+        member_backend,
+        backend_new_profile,
+        snt_token_overrides,
+        multicall3_deployer,
+        anvil_client,
+    ):
+        """Owner transfers the owner token to Member A; Member A becomes the new owner."""
+        member_a_backend = member_backend
+        member_b_backend = community_tokens.create_member_b_profile(
+            backend_new_profile, snt_token_overrides, multicall3_deployer, self.community_token_deployer
+        )
+
+        # Given the Owner has created a community
+        community_resp = owner_backend.wakuext_service.create_community(
+            name=fake.community_name(),
+            description=fake.community_description(),
+            membership=CommunityPermissionsAccess.MANUAL_ACCEPT,
+        )
+        community_id = community_resp.get("communities", [{}])[0].get("id")
+        assert community_id, "Community was not created"
+
+        # And the Owner has created a channel named "subchannel"
+        create_chat_resp = owner_backend.wakuext_service.create_community_chat(community_id, _subchannel_payload())
+        assert len(create_chat_resp.get("chats", [])) == 1, "subchannel was not created"
+        assert _community_chat_count(owner_backend, community_id) == 2, "Owner should see 'general' and 'subchannel'"
+
+        # And Member A / Member B have joined the community
+        assert messenger.spectate_and_fetch_community(member_a_backend, community_id), "Community not found for Member A"
+        assert messenger.spectate_and_fetch_community(member_b_backend, community_id), "Community not found for Member B"
+
+        member_a_wallet = messenger.wallet_address(member_a_backend)
+        member_b_wallet = messenger.wallet_address(member_b_backend)
+        community_tokens.join_community_with_signatures_and_accept(owner_backend, member_a_backend, community_id, member_a_wallet)
+        community_tokens.join_community_with_signatures_and_accept(owner_backend, member_b_backend, community_id, member_b_wallet)
+
+        owner_community = next(
+            (c for c in messenger.communities_list(owner_backend.wakuext_service.communities()) if c.get("id") == community_id),
+            None,
+        )
+        assert owner_community is not None
+        assert member_a_backend.public_key in owner_community.get("members", {}), "Member A did not join"
+        assert member_b_backend.public_key in owner_community.get("members", {}), "Member B did not join"
+
+        # When the Owner mints the owner token
+        community_tokens.fund_native_balance(owner_backend, anvil_client)
+        community_tokens.fund_native_balance(member_a_backend, anvil_client)
+        owner_backend.wallet_service.restart_wallet_reload_timer()
+        tokens = community_token_deploy.deploy_owner_and_master_tokens(
+            owner_backend,
+            community_id,
+            self.community_token_deployer,
+            self.deploy_state,
+            anvil_client=anvil_client,
+            wait_for_deploy_status_signal=False,
+        )
+        assert tokens.owner_token_address, "Owner token was not deployed"
+
+        community_ownership.publish_owner_token_to_community(owner_backend, community_id, tokens.owner_token_address)
+
+        # And the Owner transfers the owner token to Member A
+        # And Member A approves the ownership transfer
+        community_ownership.transfer_community_ownership(
+            owner_backend=owner_backend,
+            new_owner_backend=member_a_backend,
+            community_id=community_id,
+            owner_token_address=tokens.owner_token_address,
+            anvil_client=anvil_client,
+        )
+
+        # Then Member A is displayed as the Owner
+        community_ownership.wait_until_member_is_owner(
+            member_a_backend,
+            community_id,
+            member_a_backend.public_key,
+            attempts=45,
+        )
+
+        # On ownership change the new owner kicks all members. Member B (a regular member) auto-rejoins
+        # via its revealed accounts; wait for Member A to be owner with Member B re-added.
+        community_ownership.wait_until_owner_and_members_present(
+            backend=member_a_backend,
+            community_id=community_id,
+            owner_public_key=member_a_backend.public_key,
+            expected_member_public_keys=[member_a_backend.public_key, member_b_backend.public_key],
+            attempts=45,
+            delay=2,
+        )
+
+        # The ex-owner created the community and has no revealed accounts, so it can't auto-rejoin; it
+        # must manually re-join once it has observed the kick.
+        community_ownership.wait_until_kicked_from_community(owner_backend, community_id)
+        community_tokens.join_community_with_signatures_and_accept(
+            member_a_backend, owner_backend, community_id, messenger.wallet_address(owner_backend)
+        )
+
+        # Then the members list contains Owner, Member A, and Member B
+        new_community = community_ownership.wait_until_owner_and_members_present(
+            backend=member_a_backend,
+            community_id=community_id,
+            owner_public_key=member_a_backend.public_key,
+            expected_member_public_keys=[
+                owner_backend.public_key,
+                member_a_backend.public_key,
+                member_b_backend.public_key,
+            ],
+            attempts=45,
+            delay=2,
+        )
+        assert new_community is not None, "New owner's community not found"
+
+        # And all members see the channels "general" and "subchannel"
+        for backend, label in ((owner_backend, "owner"), (member_a_backend, "memberA"), (member_b_backend, "memberB")):
+            messenger.fetch_community(backend, community_id, try_database=False)
+            assert _community_chat_count(backend, community_id) == 2, f"{label} should see 'general' and 'subchannel'"
+
+        # When Member A edits the community
+        # Then the Owner and Member B see the updated community
+        new_name, new_description = community_tokens.edit_community_and_wait_until_observer_sees_update(
+            member_a_backend, owner_backend, community_id, attempts=45
+        )
+        community_tokens.wait_until_member_sees_community_update(
+            member_b_backend, community_id, new_name, new_description, attempts=45, spectate=True
+        )


### PR DESCRIPTION
## Summary

Adds an end-to-end functional test for **community ownership transfer**, covering the full flow where a community owner mints an owner token, transfers it to a member, and that member promotes itself to the new control node.

Closes #7131

## What's added

- **Test:** `TestCommunityOwnershipTransfer::test_ownership_transfer_to_member`
  (`tests-functional/tests/test_wakuext_community_ownership_transfer.py`)
- **Reusable steps:** `tests-functional/steps/community_ownership.py`
- **New `wakuext` RPC client methods** (`tests-functional/clients/services/wakuext.py`):
  - `promote_self_to_control_node` → `promoteSelfToControlNode`
  - `register_received_ownership_notification` → `registerReceivedOwnershipNotification`
  - `register_lost_ownership_notification` → `registerLostOwnershipNotification`
- **Docs:** a troubleshooting note in `tests-functional/README.MD` for stale `.venv`s and outdated Docker images.

## Scenario covered

1. Owner creates a community (manual-accept) with a `general` and a `subchannel` channel.
2. Member A and Member B join the community.
3. Owner mints the owner token and transfers it to Member A, who approves the transfer.
4. Member A promotes itself to control node and is displayed as the new **Owner**.
5. On the ownership change all members are kicked: Member B auto-rejoins via its revealed accounts, while the ex-owner (which created the community and has no revealed accounts) manually re-joins after observing the kick.
6. The members list converges to **Owner + Member A + Member B**, all see both channels.
7. Member A edits the community and the Owner and Member B see the update.

## Notes for reviewers

- ✅ Test passes locally end-to-end.
- Test-only change — no app/runtime code is touched, so no companion status-app PR is required.