### PR TITLE
chore(messaging): remove missing message verification

### DIFF
--- a/internal/nodecfg/node_config.go
+++ b/internal/nodecfg/node_config.go
@@ -99,10 +99,8 @@ func insertWakuV2ConfigPreMigration(tx *sql.Tx, c *params.NodeConfig) error {
 func insertWakuV2ConfigPostMigration(tx *sql.Tx, c *params.NodeConfig) error {
 	_, err := tx.Exec(`
 	UPDATE wakuv2_config
-	SET enable_missing_message_verification = ?,
-		enable_store_confirmation_for_messages_sent = ?
+	SET enable_store_confirmation_for_messages_sent = ?
 	WHERE synthetic_id = 'id'`,
-		c.WakuV2Config.EnableMissingMessageVerification,
 		c.WakuV2Config.EnableStoreConfirmationForMessagesSent,
 	)
 
@@ -281,12 +279,10 @@ func loadNodeConfig(tx *sql.Tx) (*params.NodeConfig, error) {
 
 	err = tx.QueryRow(`
 	SELECT light_client,
-	       enable_missing_message_verification,
 	       enable_store_confirmation_for_messages_sent
 	FROM wakuv2_config WHERE synthetic_id = 'id'
 	`).Scan(
 		&nodecfg.WakuV2Config.LightClient,
-		&nodecfg.WakuV2Config.EnableMissingMessageVerification,
 		&nodecfg.WakuV2Config.EnableStoreConfirmationForMessagesSent,
 	)
 	if err != nil && err != sql.ErrNoRows {

--- a/params/config.go
+++ b/params/config.go
@@ -52,10 +52,7 @@ type WakuV2Config struct {
 	// AutoUpdate instructs the node to update their own ip address and port with the values seen by other nodes
 	AutoUpdate bool
 
-	// EnableMissingMessageVerification indicates whether the storenodes must be queried periodically to retrieve any missing message
-	EnableMissingMessageVerification bool
-
-	// EnableMissingMessageVerification indicates whether storenodes must be queried periodically to confirm if messages sent are actually propagated in the network
+	// EnableStoreConfirmationForMessagesSent indicates whether storenodes must be queried periodically to confirm if messages sent are actually propagated in the network
 	EnableStoreConfirmationForMessagesSent bool
 }
 

--- a/pkg/backend/defaults.go
+++ b/pkg/backend/defaults.go
@@ -139,7 +139,6 @@ func SetFleet(fleet string, nodeConfig *params.NodeConfig) error {
 		// mobile may need to override the following options
 		LightClient:                            specifiedWakuV2Config.LightClient,
 		EnableStoreConfirmationForMessagesSent: specifiedWakuV2Config.EnableStoreConfirmationForMessagesSent,
-		EnableMissingMessageVerification:       specifiedWakuV2Config.EnableMissingMessageVerification,
 		Nameserver:                             specifiedWakuV2Config.Nameserver,
 	}
 
@@ -328,10 +327,6 @@ func DefaultNodeConfig(installationID, keyUID string, request *requests.CreateAc
 
 	if request.WakuV2LightClient {
 		nodeConfig.WakuV2Config.LightClient = true
-	}
-
-	if request.WakuV2EnableMissingMessageVerification {
-		nodeConfig.WakuV2Config.EnableMissingMessageVerification = true
 	}
 
 	if request.WakuV2EnableStoreConfirmationForMessagesSent {

--- a/pkg/messaging/api_store_nodes.go
+++ b/pkg/messaging/api_store_nodes.go
@@ -53,7 +53,3 @@ func (a *API) Query(
 func (a *API) SetStorenodeConfigProvider(c history.StorenodeConfigProvider) {
 	a.core.stack.Transport.SetStorenodeConfigProvider(c)
 }
-
-func (a *API) SetCriteriaForMissingMessageVerification(peerInfo peer.AddrInfo, filters types.ChatFilters) {
-	a.core.stack.Transport.SetCriteriaForMissingMessageVerification(peerInfo, adapters.ToTransportFilters(filters))
-}

--- a/pkg/messaging/core.go
+++ b/pkg/messaging/core.go
@@ -232,7 +232,6 @@ func newWaku(params wakuParams) (*wakuv3.Waku, error) {
 		AutoUpdate:                             params.wakuConfig.AutoUpdate,
 		DefaultShardPubsubTopic:                wakuv3.DefaultShardPubsubTopic(),
 		ClusterID:                              params.clusterConfig.ClusterID,
-		EnableMissingMessageVerification:       params.wakuConfig.EnableMissingMessageVerification,
 		EnableStoreConfirmationForMessagesSent: params.wakuConfig.EnableStoreConfirmationForMessagesSent,
 		UseThrottledPublish:                    true,
 		MetricsEnabled:                         params.metricsEnabled,

--- a/pkg/messaging/layers/transport/transport.go
+++ b/pkg/messaging/layers/transport/transport.go
@@ -9,7 +9,6 @@ import (
 	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/pkg/errors"
 	"go.uber.org/zap"
-	"golang.org/x/exp/maps"
 
 	"github.com/waku-org/go-waku/waku/v2/api/history"
 
@@ -781,35 +780,6 @@ func (t *Transport) ConfirmMessageDelivered(messageID string) {
 		commHashes[i] = common.BytesToHash(h[:])
 	}
 	t.waku.ConfirmMessageDelivered(commHashes)
-}
-
-func (t *Transport) SetCriteriaForMissingMessageVerification(peerInfo peer.AddrInfo, filters []*Filter) {
-	topicMap := make(map[string]map[types.TopicType]struct{})
-	for _, f := range filters {
-		if !f.Listen || f.Ephemeral {
-			continue
-		}
-
-		_, ok := topicMap[f.PubsubTopic]
-		if !ok {
-			topicMap[f.PubsubTopic] = make(map[types.TopicType]struct{})
-		}
-
-		topicMap[f.PubsubTopic][f.ContentTopic] = struct{}{}
-	}
-
-	for pubsubTopic, contentTopics := range topicMap {
-		ctList := maps.Keys(contentTopics)
-		err := t.waku.SetCriteriaForMissingMessageVerification(peerInfo, pubsubTopic, ctList)
-		if err != nil {
-			t.logger.Error("could not check for missing messages",
-				zap.Error(err),
-				zap.Stringer("peerID", peerInfo.ID),
-				zap.String("pubsubTopic", pubsubTopic),
-				zap.Stringers("contentTopics", ctList))
-			return
-		}
-	}
 }
 
 func (t *Transport) GetActiveStorenode() peer.AddrInfo {

--- a/pkg/messaging/waku/config.go
+++ b/pkg/messaging/waku/config.go
@@ -57,7 +57,6 @@ type Config struct {
 	ClusterID                              uint16           `toml:",omitempty"`
 	EnableConfirmations                    bool             `toml:",omitempty"` // Enable sending message confirmations
 	SkipPublishToTopic                     bool             `toml:",omitempty"` // Used in testing
-	EnableMissingMessageVerification       bool             `toml:",omitempty"`
 	EnableStoreConfirmationForMessagesSent bool             `toml:",omitempty"` //Flag that enables checking with store node for sent message confimration
 	UseThrottledPublish                    bool             `toml:",omitempty"` // Flag that indicates whether a rate limited priority queue will be used to send messages or not
 }

--- a/pkg/messaging/waku/gowaku.go
+++ b/pkg/messaging/waku/gowaku.go
@@ -151,8 +151,6 @@ type Waku struct {
 
 	sendQueue *publish.MessageQueue
 
-	missingMsgVerifier *missing.MissingMessageVerifier
-
 	msgQueue chan *common.ReceivedMessage // Message queue for waku messages that havent been decoded
 
 	ctx    context.Context
@@ -974,34 +972,6 @@ func (w *Waku) Start() error {
 	w.wg.Add(1)
 	go w.runPeerExchangeLoop()
 
-	if w.cfg.EnableMissingMessageVerification {
-		w.missingMsgVerifier = missing.NewMissingMessageVerifier(
-			missing.NewDefaultStorenodeRequestor(w.node.Store()),
-			w,
-			w.node.Timesource(),
-			w.logger)
-
-		w.missingMsgVerifier.Start(w.ctx)
-		w.logger.Info("Started missing message verifier")
-
-		w.wg.Add(1)
-		go func() {
-			defer gocommon.LogOnPanic()
-			w.wg.Done()
-			for {
-				select {
-				case <-w.ctx.Done():
-					return
-				case envelope := <-w.missingMsgVerifier.C:
-					err = w.OnNewEnvelopes(envelope, common.MissingMessageType, false)
-					if err != nil {
-						w.logger.Error("OnNewEnvelopes error", zap.Error(err))
-					}
-				}
-			}
-		}()
-	}
-
 	if w.cfg.LightClient {
 		// Create FilterManager that will main peer connectivity
 		// for installed filters
@@ -1195,13 +1165,6 @@ func (w *Waku) MessageExists(mh pb.MessageHash) (bool, error) {
 	w.poolMu.Lock()
 	defer w.poolMu.Unlock()
 	return w.envelopeCache.Has(gethcommon.Hash(mh)), nil
-}
-
-func (w *Waku) SetTopicsToVerifyForMissingMessages(peerInfo peer.AddrInfo, pubsubTopic string, contentTopics []string) {
-	if !w.cfg.EnableMissingMessageVerification {
-		return
-	}
-	w.missingMsgVerifier.SetCriteriaInterest(peerInfo, protocol.NewContentFilter(pubsubTopic, contentTopics...))
 }
 
 func (w *Waku) setupRelaySubscriptions() error {
@@ -1466,10 +1429,6 @@ func (w *Waku) isGoingOnline(state connection.State) bool {
 	return !state.Offline && !w.onlineChecker.IsOnline()
 }
 
-func (w *Waku) isGoingOffline(state connection.State) bool {
-	return state.Offline && w.onlineChecker.IsOnline()
-}
-
 // shouldFireConnectionChanged reports whether next represents a change in
 // connectivity. The first observation (no state recorded yet) always fires so
 // downstream consumers like the LightClient FilterManager get initialized.
@@ -1492,12 +1451,6 @@ func (w *Waku) snapshotState() (connection.State, bool) {
 func (w *Waku) ConnectionChanged(state connection.State) {
 	if w.isGoingOnline(state) {
 		w.discoverAndConnectPeers()
-		if w.cfg.EnableMissingMessageVerification {
-			w.missingMsgVerifier.Start(w.ctx)
-		}
-	}
-	if w.isGoingOffline(state) && w.cfg.EnableMissingMessageVerification {
-		w.missingMsgVerifier.Stop()
 	}
 	isOnline := !state.Offline
 
@@ -1756,17 +1709,6 @@ func (w *Waku) DisconnectActiveStorenode(ctx context.Context, backoff time.Durat
 	if shouldCycle {
 		w.StorenodeCycle.Cycle(ctx)
 	}
-}
-
-func (w *Waku) SetCriteriaForMissingMessageVerification(peerInfo peer.AddrInfo, pubsubTopic string, contentTopics []types.TopicType) error {
-	var cTopics []string
-	for _, ct := range contentTopics {
-		cTopics = append(cTopics, common.BytesToTopic(ct.Bytes()).ContentTopic())
-	}
-	pubsubTopic = w.GetPubsubTopic(pubsubTopic)
-	w.SetTopicsToVerifyForMissingMessages(peerInfo, pubsubTopic, cTopics)
-
-	return nil
 }
 
 func (w *Waku) Metrics() string {

--- a/pkg/messaging/waku/types/waku.go
+++ b/pkg/messaging/waku/types/waku.go
@@ -118,8 +118,6 @@ type Waku interface {
 
 	SubscribeToConnStatusChanges() (*ConnStatusSubscription, error)
 
-	SetCriteriaForMissingMessageVerification(peerInfo peer.AddrInfo, pubsubTopic string, contentTopics []TopicType) error
-
 	SubscribeEnvelopeEvents(events chan<- EnvelopeEvent) Subscription
 
 	// Subscribe/Unsubscribe register and remove wire subscriptions for the

--- a/protocol/messenger.go
+++ b/protocol/messenger.go
@@ -669,9 +669,6 @@ func (m *Messenger) Start() (*MessengerResponse, error) {
 	m.messaging.SetStorenodeConfigProvider(m)
 
 	m.shutdownWaitGroup.Add(1)
-	go m.checkForMissingMessagesLoop()
-
-	m.shutdownWaitGroup.Add(1)
 	go m.checkForStorenodeCycleSignals()
 
 	controlledCommunities, err := m.communitiesManager.Controlled()

--- a/protocol/messenger_mailserver.go
+++ b/protocol/messenger_mailserver.go
@@ -310,39 +310,6 @@ func (m *Messenger) withHistoricSyncInFlight(now time.Time, fn func() (*Messenge
 	return fn()
 }
 
-const missingMessageCheckPeriod = 30 * time.Second
-
-func (m *Messenger) checkForMissingMessagesLoop() {
-	defer gocommon.LogOnPanic()
-	defer m.shutdownWaitGroup.Done()
-
-	t := time.NewTicker(missingMessageCheckPeriod)
-	defer t.Stop()
-
-	mailserverAvailableSignal := m.messaging.OnStorenodeAvailable()
-
-	for {
-		select {
-		case <-m.quit:
-			return
-
-		// Wait for mailserver available, also triggered on mailserver change
-		case <-mailserverAvailableSignal:
-
-		case <-t.C:
-
-		}
-
-		if m.isPaused() {
-			continue
-		}
-
-		filters := m.messaging.ChatFilters()
-		peerInfo := m.messaging.GetActiveStorenode()
-		m.messaging.SetCriteriaForMissingMessageVerification(peerInfo, filters)
-	}
-}
-
 func getPrioritizedBatches() []int {
 	return []int{1, 5, 10}
 }

--- a/protocol/requests/create_account.go
+++ b/protocol/requests/create_account.go
@@ -52,7 +52,6 @@ type CreateAccount struct {
 	WakuV2Nameserver                             *string `json:"wakuV2Nameserver"`
 	WakuV2LightClient                            bool    `json:"wakuV2LightClient"`
 	WakuV2EnableStoreConfirmationForMessagesSent bool    `json:"wakuV2EnableStoreConfirmationForMessagesSent"`
-	WakuV2EnableMissingMessageVerification       bool    `json:"wakuV2EnableMissingMessageVerification"`
 	WakuV2Fleet                                  string  `json:"wakuV2Fleet"`
 
 	LogLevel    *string `json:"logLevel"`


### PR DESCRIPTION
Closes https://github.com/status-im/status-go/issues/7569

## What

Removes the **missing-message verification** path from status-go:

- `MissingMessageVerifier`, its driving loop (`checkForMissingMessagesLoop`), and the full `SetCriteriaForMissingMessageVerification` call chain through the messaging API → transport → waku layers.
- The now-dead `EnableMissingMessageVerification` config flag and its plumbing (`params`, waku `Config`, create-account request field, node-config persistence). The `enable_missing_message_verification` DB column is left in the schema; the code simply stops reading/writing it.

## Why

logos-delivery's Messaging node already performs missed-message recovery (`RecvService`) against store nodes internally and selects store peers on its own. Re-implementing that verification in status-go is redundant once go-waku is replaced, so it is removed as part of the go-waku elimination.

Refs: logos-messaging/pm#380

## Notes

- **Sent-message store confirmation** (`MessageSentCheck` / `EnableStoreConfirmationForMessagesSent`) is intentionally left untouched.
- Store-node *selection* / cycle machinery is also untouched — this PR only removes the missing-message verification.
- Build/lint not run locally: this checkout lacks the native `libsds` dependency (requires the Nix dev shell). Changes were verified with `gofmt` and by confirming the net diff removes only the missing-message path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)