### PR TITLE
refactor(waku): drop Version/PeerCount and move GetCurrentTime to transport

### DIFF
--- a/pkg/messaging/api.go
+++ b/pkg/messaging/api.go
@@ -1,6 +1,8 @@
 package messaging
 
 import (
+	"time"
+
 	"github.com/status-im/status-go/pkg/pubsub"
 )
 
@@ -28,7 +30,7 @@ func (a *API) Publisher() *pubsub.Publisher {
 
 // GetCurrentTime satisfies the common.TimeSource interface.
 func (a *API) GetCurrentTime() uint64 {
-	return a.core.stack.Transport.GetCurrentTime()
+	return uint64(a.core.timeSource.Now().UnixNano() / int64(time.Millisecond))
 }
 
 // Online reports whether the transport currently has at least one connected peer.

--- a/pkg/messaging/core.go
+++ b/pkg/messaging/core.go
@@ -34,6 +34,7 @@ type Core struct {
 
 	identity   *ecdsa.PrivateKey
 	waku       wakutypes.Waku
+	timeSource timesource.Provider
 	stack      *common.MessagingStack
 	controller *controller.Controller
 
@@ -104,10 +105,16 @@ func newCore(waku wakutypes.Waku, params CoreParams, config *config) (*Core, err
 		config.tracer,
 	)
 
+	timeSource := params.TimeSource
+	if timeSource == nil {
+		timeSource = timesource.DefaultService()
+	}
+
 	return &Core{
 		config:     *config,
 		identity:   params.Identity,
 		waku:       waku,
+		timeSource: timeSource,
 		stack:      stack,
 		controller: controller,
 		publisher:  publisher,

--- a/pkg/messaging/layers/transport/envelopes_monitor.go
+++ b/pkg/messaging/layers/transport/envelopes_monitor.go
@@ -181,7 +181,7 @@ func (m *EnvelopesMonitor) handleEvent(event types.EnvelopeEvent) {
 
 func (m *EnvelopesMonitor) handleEventEnvelopeSent(event types.EnvelopeEvent) {
 	// Mailserver confirmations for WakuV2 are disabled
-	if (m.w == nil || m.w.Version() < 2) && m.awaitOnlyMailServerConfirmations {
+	if m.w == nil && m.awaitOnlyMailServerConfirmations {
 		if !m.isMailserver(event.Peer) {
 			return
 		}

--- a/pkg/messaging/layers/transport/transport.go
+++ b/pkg/messaging/layers/transport/transport.go
@@ -672,11 +672,6 @@ func (t *Transport) TrackMany(identifiers [][]byte, hashes [][]byte, newMessages
 	}
 }
 
-// GetCurrentTime returns the current unix timestamp in milliseconds
-func (t *Transport) GetCurrentTime() uint64 {
-	return t.waku.GetCurrentTime()
-}
-
 func (t *Transport) MaxMessageSize() uint32 {
 	return t.waku.MaxMessageSize()
 }
@@ -724,7 +719,7 @@ func (t *Transport) cleanFiltersLoop() {
 }
 
 func (t *Transport) PeerCount() int {
-	return t.waku.PeerCount()
+	return len(t.waku.Peers())
 }
 
 // Peers is retained only for the Python functional tests (see tests-functional);

--- a/pkg/messaging/waku/gowaku.go
+++ b/pkg/messaging/waku/gowaku.go
@@ -731,11 +731,6 @@ func (w *Waku) MaxMessageSize() uint32 {
 	return w.cfg.MaxMessageSize
 }
 
-// CurrentTime returns current time.
-func (w *Waku) CurrentTime() time.Time {
-	return w.timesource.Now()
-}
-
 func (w *Waku) SendEnvelopeEvent(event common.EnvelopeEvent) int {
 	return w.envelopeFeed.Send(event)
 }
@@ -1395,10 +1390,6 @@ func (w *Waku) ClearEnvelopesCache() {
 	w.envelopeCache = newTTLCache()
 }
 
-func (w *Waku) PeerCount() int {
-	return w.node.PeerCount()
-}
-
 // Peers is retained only for the Python functional tests (see tests-functional);
 // it is not used by status-app.
 func (w *Waku) Peers() types.PeerStats {
@@ -1721,12 +1712,6 @@ func FormatPeerConnFailures(wakuNode *node.WakuNode) map[string]int {
 	return p
 }
 
-// GetCurrentTime returns current time.
-// Implements protocol/common.TimeSource
-func (w *Waku) GetCurrentTime() uint64 {
-	return uint64(w.CurrentTime().UnixNano() / int64(time.Millisecond))
-}
-
 func (w *Waku) GetActiveStorenode() peer.AddrInfo {
 	return w.StorenodeCycle.GetActiveStorenodePeerInfo()
 }
@@ -1782,10 +1767,6 @@ func (w *Waku) SetCriteriaForMissingMessageVerification(peerInfo peer.AddrInfo, 
 	w.SetTopicsToVerifyForMissingMessages(peerInfo, pubsubTopic, cTopics)
 
 	return nil
-}
-
-func (w *Waku) Version() uint {
-	return 2
 }
 
 func (w *Waku) Metrics() string {

--- a/pkg/messaging/waku/types/waku.go
+++ b/pkg/messaging/waku/types/waku.go
@@ -104,12 +104,6 @@ type Waku interface {
 	// Resume re-arms goroutines suspended by Pause. Idempotent.
 	Resume() error
 
-	// Waku protocol version
-	Version() uint
-
-	// PeerCount
-	PeerCount() int
-
 	// Peers is retained only for the Python functional tests (see tests-functional);
 	// it is not used by status-app.
 	Peers() PeerStats
@@ -125,9 +119,6 @@ type Waku interface {
 	SubscribeToConnStatusChanges() (*ConnStatusSubscription, error)
 
 	SetCriteriaForMissingMessageVerification(peerInfo peer.AddrInfo, pubsubTopic string, contentTopics []TopicType) error
-
-	// GetCurrentTime returns current time.
-	GetCurrentTime() uint64
 
 	SubscribeEnvelopeEvents(events chan<- EnvelopeEvent) Subscription
 

--- a/pkg/messaging/waku/waku_test.go
+++ b/pkg/messaging/waku/waku_test.go
@@ -58,7 +58,7 @@ func TestDiscoveryV5(t *testing.T) {
 	require.NoError(t, w.Start())
 
 	err = testutils.RetryWithBackOff(func() error {
-		if w.PeerCount() == 0 {
+		if len(w.Peers()) == 0 {
 			return errors.New("no peers discovered")
 		}
 		return nil
@@ -66,7 +66,7 @@ func TestDiscoveryV5(t *testing.T) {
 
 	require.NoError(t, err)
 
-	require.NotEqual(t, 0, w.PeerCount())
+	require.NotEqual(t, 0, len(w.Peers()))
 	require.NoError(t, w.Stop())
 }
 
@@ -90,7 +90,7 @@ func TestRestartDiscoveryV5(t *testing.T) {
 
 	// Sanity check, not great, but it's probably helpful
 	err = testutils.RetryWithBackOff(func() error {
-		if w.PeerCount() == 0 {
+		if len(w.Peers()) == 0 {
 			return errors.New("no peers discovered")
 		}
 		return nil
@@ -105,7 +105,7 @@ func TestRestartDiscoveryV5(t *testing.T) {
 	}
 
 	err = testutils.RetryWithBackOff(func() error {
-		if w.PeerCount() == 0 {
+		if len(w.Peers()) == 0 {
 			return errors.New("no peers discovered")
 		}
 		return nil
@@ -113,7 +113,7 @@ func TestRestartDiscoveryV5(t *testing.T) {
 	require.NoError(t, err)
 
 	require.True(t, w.seededBootnodesForDiscV5)
-	require.NotEqual(t, 0, w.PeerCount())
+	require.NotEqual(t, 0, len(w.Peers()))
 	require.NoError(t, w.Stop())
 }
 


### PR DESCRIPTION
Continues the cleanup of the `types.Waku` interface with three small, independent simplifications.

- **`Version()`** — only ever returned `2`. Removed from the interface and adapter. Its sole consumer in `EnvelopesMonitor` had a statically-dead `Version() < 2` guard, now reduced to the `m.w == nil` check (behavior preserved).
- **`GetCurrentTime()`** — was a pure pass-through: the waku adapter never used it itself, and `Transport.GetCurrentTime()` only forwarded it (its single caller is the messaging API). Since the messaging `API` *is* the messenger's `common.TimeSource`, ownership now sits at `Core`: it holds the `timesource.Provider` and `API.GetCurrentTime` computes the millisecond timestamp directly — no hop through `Transport` or the waku adapter. The now-dead `Waku.CurrentTime()` is removed as well. (Note: this timesource is status-go's own; it is **not** passed into go-waku, which keeps its own internal timesource. The waku adapter retains its `timesource` solely for outgoing message timestamps via `timestamp()`.)
- **`PeerCount()`** — duplicated `len(Peers())`. Removed; callers now use `len(Peers())`.

Build + vet pass on the messaging packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)