### PR TITLE
refactor(messaging): replace go-waku verifier with StoreClient.FetchMissingMessages

### DIFF
--- a/pkg/messaging/layers/transport/transport.go
+++ b/pkg/messaging/layers/transport/transport.go
@@ -150,6 +150,12 @@ func NewTransport(
 		go t.receiveLoop()
 	}
 
+	// Back-fill messages that live delivery missed by periodically reconciling the
+	// listening topics against the store.
+	if waku != nil {
+		go t.reconcileMissingMessagesLoop()
+	}
+
 	return t, nil
 }
 

--- a/pkg/messaging/layers/transport/transport_missing.go
+++ b/pkg/messaging/layers/transport/transport_missing.go
@@ -1,0 +1,82 @@
+package transport
+
+import (
+	"context"
+	"time"
+
+	"go.uber.org/zap"
+
+	gocommon "github.com/status-im/status-go/common"
+	"github.com/status-im/status-go/pkg/messaging/waku/types"
+)
+
+// missingMessageReconcileInterval is how often the reconciler checks for messages
+// the store has but we don't.
+var missingMessageReconcileInterval = 30 * time.Second
+
+// missingMessageReconcileDelay holds the reconcile window's upper bound back from
+// now, so we don't query for messages that may still be propagating to the store.
+const missingMessageReconcileDelay = 20 * time.Second
+
+// reconcileMissingMessagesLoop periodically asks the store for messages on the
+// listening topics that we don't already have, back-filling gaps that live
+// delivery missed. It reads the listening filters directly (so there is no
+// criteria setter) and tracks the reconciled window per pubsub topic; the
+// StoreClient selects and pins a storenode per query, so this loop is unaware of
+// storenode selection.
+func (t *Transport) reconcileMissingMessagesLoop() {
+	defer gocommon.LogOnPanic()
+
+	ticker := time.NewTicker(missingMessageReconcileInterval)
+	defer ticker.Stop()
+
+	// lastReconciled records, per pubsub topic, the upper bound of the last
+	// successfully reconciled window, so each tick only covers new time.
+	lastReconciled := make(map[string]time.Time)
+
+	for {
+		select {
+		case <-t.quit:
+			return
+		case <-ticker.C:
+		}
+		t.reconcileMissingMessages(lastReconciled)
+	}
+}
+
+func (t *Transport) reconcileMissingMessages(lastReconciled map[string]time.Time) {
+	// Group the listening, non-ephemeral filters by pubsub topic.
+	contentTopicsByPubsub := make(map[string][]types.TopicType)
+	for _, f := range t.filters.Filters() {
+		if !f.Listen || f.Ephemeral {
+			continue
+		}
+		contentTopicsByPubsub[f.PubsubTopic] = append(contentTopicsByPubsub[f.PubsubTopic], f.ContentTopic)
+	}
+
+	to := time.Now().Add(-missingMessageReconcileDelay)
+	for pubsubTopic, contentTopics := range contentTopicsByPubsub {
+		from, seen := lastReconciled[pubsubTopic]
+		if !seen {
+			// First sighting of this topic: start from now. Older history is the
+			// job of explicit history sync, not the reconciler.
+			from = to
+		}
+		if !to.After(from) {
+			continue
+		}
+
+		err := t.waku.FetchMissingMessages(context.Background(), types.MailserverBatch{
+			From:        from,
+			To:          to,
+			PubsubTopic: pubsubTopic,
+			Topics:      contentTopics,
+		})
+		if err != nil {
+			t.logger.Debug("failed to reconcile missing messages",
+				zap.String("pubsubTopic", pubsubTopic), zap.Error(err))
+			continue // don't advance the window — retry it next tick
+		}
+		lastReconciled[pubsubTopic] = to
+	}
+}

--- a/pkg/messaging/waku/gowaku.go
+++ b/pkg/messaging/waku/gowaku.go
@@ -57,7 +57,6 @@ import (
 	"github.com/libp2p/go-libp2p/core/metrics"
 
 	filterapi "github.com/waku-org/go-waku/waku/v2/api/filter"
-	"github.com/waku-org/go-waku/waku/v2/api/missing"
 	"github.com/waku-org/go-waku/waku/v2/api/publish"
 	"github.com/waku-org/go-waku/waku/v2/dnsdisc"
 	"github.com/waku-org/go-waku/waku/v2/onlinechecker"
@@ -148,8 +147,6 @@ type Waku struct {
 	bandwidthCounter *metrics.BandwidthCounter
 
 	sendQueue *publish.MessageQueue
-
-	missingMsgVerifier *missing.MissingMessageVerifier
 
 	msgQueue chan *common.ReceivedMessage // Message queue for waku messages that havent been decoded
 
@@ -850,8 +847,7 @@ func (w *Waku) Start() error {
 	}
 
 	selector := newStoreSelector()
-	pager := newStorePager(wakuStoreRequestor{store: w.node.Store()}, NewHistoryProcessorWrapper(w), w.logger)
-	w.storeClient = NewStoreClient(selector, pager, w.GetPubsubTopic, w.logger)
+	w.storeClient = NewStoreClient(selector, wakuStoreRequestor{store: w.node.Store()}, NewHistoryProcessorWrapper(w), w.GetPubsubTopic, w.logger)
 
 	w.logger.Info("WakuV2 PeerID", zap.Stringer("id", w.node.Host().ID()))
 
@@ -967,34 +963,6 @@ func (w *Waku) Start() error {
 
 	w.wg.Add(1)
 	go w.runPeerExchangeLoop()
-
-	if w.cfg.EnableMissingMessageVerification {
-		w.missingMsgVerifier = missing.NewMissingMessageVerifier(
-			missing.NewDefaultStorenodeRequestor(w.node.Store()),
-			w,
-			w.node.Timesource(),
-			w.logger)
-
-		w.missingMsgVerifier.Start(w.ctx)
-		w.logger.Info("Started missing message verifier")
-
-		w.wg.Add(1)
-		go func() {
-			defer gocommon.LogOnPanic()
-			w.wg.Done()
-			for {
-				select {
-				case <-w.ctx.Done():
-					return
-				case envelope := <-w.missingMsgVerifier.C:
-					err = w.OnNewEnvelopes(envelope, common.MissingMessageType, false)
-					if err != nil {
-						w.logger.Error("OnNewEnvelopes error", zap.Error(err))
-					}
-				}
-			}
-		}()
-	}
 
 	if w.cfg.LightClient {
 		// Create FilterManager that will main peer connectivity
@@ -1159,13 +1127,6 @@ func (w *Waku) MessageExists(mh pb.MessageHash) (bool, error) {
 	w.poolMu.Lock()
 	defer w.poolMu.Unlock()
 	return w.envelopeCache.Has(gethcommon.Hash(mh)), nil
-}
-
-func (w *Waku) SetTopicsToVerifyForMissingMessages(peerInfo peer.AddrInfo, pubsubTopic string, contentTopics []string) {
-	if !w.cfg.EnableMissingMessageVerification {
-		return
-	}
-	w.missingMsgVerifier.SetCriteriaInterest(peerInfo, protocol.NewContentFilter(pubsubTopic, contentTopics...))
 }
 
 func (w *Waku) setupRelaySubscriptions() error {
@@ -1456,12 +1417,6 @@ func (w *Waku) snapshotState() (connection.State, bool) {
 func (w *Waku) ConnectionChanged(state connection.State) {
 	if w.isGoingOnline(state) {
 		w.discoverAndConnectPeers()
-		if w.cfg.EnableMissingMessageVerification {
-			w.missingMsgVerifier.Start(w.ctx)
-		}
-	}
-	if w.isGoingOffline(state) && w.cfg.EnableMissingMessageVerification {
-		w.missingMsgVerifier.Stop()
 	}
 	isOnline := !state.Offline
 
@@ -1693,15 +1648,17 @@ func (w *Waku) StoreQuery(
 	return w.storeClient.Query(ctx, batch, pageLimit, shouldProcessNextPage, processEnvelopes)
 }
 
-func (w *Waku) SetCriteriaForMissingMessageVerification(peerInfo peer.AddrInfo, pubsubTopic string, contentTopics []types.TopicType) error {
-	var cTopics []string
-	for _, ct := range contentTopics {
-		cTopics = append(cTopics, common.BytesToTopic(ct.Bytes()).ContentTopic())
+// FetchMissingMessages reconciles a window against the store for the batch's
+// topics via the StoreClient, fetching messages not already known locally and
+// feeding them into the receive pipeline tagged as missing messages. No-op when
+// missing-message verification is disabled.
+func (w *Waku) FetchMissingMessages(ctx context.Context, batch types.MailserverBatch) error {
+	if !w.cfg.EnableMissingMessageVerification {
+		return nil
 	}
-	pubsubTopic = w.GetPubsubTopic(pubsubTopic)
-	w.SetTopicsToVerifyForMissingMessages(peerInfo, pubsubTopic, cTopics)
-
-	return nil
+	return w.storeClient.FetchMissingMessages(ctx, batch, w.MessageExists, func(env *protocol.Envelope) error {
+		return w.OnNewEnvelopes(env, common.MissingMessageType, false)
+	})
 }
 
 func (w *Waku) Metrics() string {

--- a/pkg/messaging/waku/store_client.go
+++ b/pkg/messaging/waku/store_client.go
@@ -12,35 +12,38 @@ import (
 	types "github.com/status-im/status-go/pkg/messaging/waku/types"
 )
 
-// maxStoreQueryAttempts bounds how many storenodes Query tries before giving up.
+// maxStoreQueryAttempts bounds how many storenodes an operation tries before giving up.
 const maxStoreQueryAttempts = 3
 
 // ErrNoStorenodesReachable is returned when no configured storenode could serve
 // the query (none configured, or all attempts failed).
 var ErrNoStorenodesReachable = errors.New("no store node could serve the query")
 
-// StoreClient is the single status-go seam for historic-message retrieval: one
-// Query method, no peer argument. It selects a storenode on demand — no health
-// checks, no background cycle, no pinning — and fails over to another node if a
-// query fails. Phase 2 will swap the pager's wire call for the Logos Delivery
-// store FFI without touching callers.
+// StoreClient is the single status-go seam for store access: explicit history
+// retrieval (Query) and background missing-message reconciliation
+// (FetchMissingMessages). It selects a storenode on demand — no health checks, no
+// background cycle, no pinning — pinning one node for the duration of a single
+// operation and failing over to another only between operations. Phase 2 will swap
+// the wire call for the Logos Delivery store FFI without touching callers.
 type StoreClient struct {
 	selector           *storeSelector
+	requestor          storeRequestor
 	pager              *storePager
 	resolvePubsubTopic func(string) string
 	logger             *zap.Logger
 }
 
-func NewStoreClient(selector *storeSelector, pager *storePager, resolvePubsubTopic func(string) string, logger *zap.Logger) *StoreClient {
+func NewStoreClient(selector *storeSelector, requestor storeRequestor, processor envelopeProcessor, resolvePubsubTopic func(string) string, logger *zap.Logger) *StoreClient {
 	return &StoreClient{
 		selector:           selector,
-		pager:              pager,
+		requestor:          requestor,
+		pager:              newStorePager(requestor, processor, logger),
 		resolvePubsubTopic: resolvePubsubTopic,
 		logger:             logger.Named("store-client"),
 	}
 }
 
-// SetStorenodes sets the storenodes Query may use. Called once at startup.
+// SetStorenodes sets the storenodes operations may use. Called once at startup.
 func (sc *StoreClient) SetStorenodes(nodes []peer.AddrInfo) {
 	sc.selector.setStorenodes(nodes)
 }
@@ -50,33 +53,24 @@ func (sc *StoreClient) HasStorenodes() bool {
 	return sc.selector.hasStorenodes()
 }
 
-// Query retrieves historic messages for a single batch (one pubsub topic and its
-// content topics over [batch.From, batch.To]). It tries storenodes in turn until
-// one serves the whole query; on a mid-query failure it restarts on the next node
-// (a store cursor is bound to the node that issued it). pageLimit is the first
-// page size; shouldProcessNextPage (may be nil) is the per-page early-stop;
-// processEnvelopes controls synchronous handling of fetched envelopes.
-func (sc *StoreClient) Query(
-	ctx context.Context,
-	batch types.MailserverBatch,
-	pageLimit uint64,
-	shouldProcessNextPage func(int) (bool, uint64),
-	processEnvelopes bool,
-) error {
+// withStorenode runs fn against configured storenodes in turn, marking each
+// success/failure on the selector and stopping at the first success. fn receives a
+// single storenode and must run its whole operation against it — a store cursor is
+// bound to the node that issued it, so a mid-operation failure restarts fn on the
+// next node. Returns ErrNoStorenodesReachable if none is configured or every
+// bounded attempt failed.
+func (sc *StoreClient) withStorenode(ctx context.Context, fn func(ctx context.Context, node peer.AddrInfo) error) error {
 	candidates := sc.selector.candidates()
 	if len(candidates) == 0 {
 		return ErrNoStorenodesReachable
 	}
-
-	pubsubTopic := sc.resolvePubsubTopic(batch.PubsubTopic)
-	contentTopics := sc.contentTopics(batch)
 
 	var lastErr error
 	for i, node := range candidates {
 		if i >= maxStoreQueryAttempts {
 			break
 		}
-		err := sc.pager.run(ctx, node, pubsubTopic, contentTopics, batch.From, batch.To, pageLimit, shouldProcessNextPage, processEnvelopes)
+		err := fn(ctx, node)
 		if err == nil {
 			sc.selector.markSuccess(node.ID)
 			return nil
@@ -86,7 +80,7 @@ func (sc *StoreClient) Query(
 		}
 		sc.selector.markFailure(node.ID)
 		lastErr = err
-		sc.logger.Debug("store query failed, trying next storenode",
+		sc.logger.Debug("store operation failed, trying next storenode",
 			zap.Stringer("peerID", node.ID), zap.Error(err))
 	}
 
@@ -94,6 +88,25 @@ func (sc *StoreClient) Query(
 		lastErr = ErrNoStorenodesReachable
 	}
 	return lastErr
+}
+
+// Query retrieves historic messages for a single batch (one pubsub topic and its
+// content topics over [batch.From, batch.To]). It pins one storenode for the whole
+// query and fails over to another only if that node fails. pageLimit is the first
+// page size; shouldProcessNextPage (may be nil) is the per-page early-stop;
+// processEnvelopes controls synchronous handling of fetched envelopes.
+func (sc *StoreClient) Query(
+	ctx context.Context,
+	batch types.MailserverBatch,
+	pageLimit uint64,
+	shouldProcessNextPage func(int) (bool, uint64),
+	processEnvelopes bool,
+) error {
+	pubsubTopic := sc.resolvePubsubTopic(batch.PubsubTopic)
+	contentTopics := sc.contentTopics(batch)
+	return sc.withStorenode(ctx, func(ctx context.Context, node peer.AddrInfo) error {
+		return sc.pager.run(ctx, node, pubsubTopic, contentTopics, batch.From, batch.To, pageLimit, shouldProcessNextPage, processEnvelopes)
+	})
 }
 
 func (sc *StoreClient) contentTopics(batch types.MailserverBatch) []string {

--- a/pkg/messaging/waku/store_internals_test.go
+++ b/pkg/messaging/waku/store_internals_test.go
@@ -1,6 +1,7 @@
 package wakuv2
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"sync"
@@ -10,8 +11,10 @@ import (
 	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
+	"google.golang.org/protobuf/proto"
 
 	"github.com/waku-org/go-waku/waku/v2/protocol"
+	pb "github.com/waku-org/go-waku/waku/v2/protocol/pb"
 	storepb "github.com/waku-org/go-waku/waku/v2/protocol/store/pb"
 
 	types "github.com/status-im/status-go/pkg/messaging/waku/types"
@@ -185,7 +188,7 @@ func newClient(r storeRequestor, nodes []peer.AddrInfo) *StoreClient {
 		}
 		return s
 	}
-	return NewStoreClient(sel, newStorePager(r, &recordingProcessor{}, zap.NewNop()), resolve, zap.NewNop())
+	return NewStoreClient(sel, r, &recordingProcessor{}, resolve, zap.NewNop())
 }
 
 func batch() types.MailserverBatch {
@@ -226,4 +229,52 @@ func TestStoreClientNoStorenodes(t *testing.T) {
 
 	require.ErrorIs(t, sc.Query(context.Background(), batch(), 10, nil, false), ErrNoStorenodesReachable)
 	require.Empty(t, r.calls())
+}
+
+// --- FetchMissingMessages ---
+
+func TestStoreClientFetchMissingMessages(t *testing.T) {
+	known := make([]byte, 32)
+	known[0] = 1
+	missingHash := make([]byte, 32)
+	missingHash[0] = 2
+
+	r := &fakeRequestor{respond: func(req *storepb.StoreQueryRequest, _ int) ([]*storepb.WakuMessageKeyValue, []byte, error) {
+		if !req.IncludeData {
+			// hash-listing phase: return both hashes, no bodies.
+			return []*storepb.WakuMessageKeyValue{{MessageHash: known}, {MessageHash: missingHash}}, nil, nil
+		}
+		// by-hash fetch phase: return the body for the requested (missing) hash.
+		return []*storepb.WakuMessageKeyValue{{
+			MessageHash: missingHash,
+			Message:     &pb.WakuMessage{Payload: []byte("x")},
+			PubsubTopic: proto.String("pubsub"),
+		}}, nil, nil
+	}}
+	sc := newClient(r, []peer.AddrInfo{{ID: "n1"}})
+
+	exists := func(h pb.MessageHash) (bool, error) { return bytes.Equal(h[:], known), nil }
+	var delivered int
+	process := func(*protocol.Envelope) error { delivered++; return nil }
+
+	require.NoError(t, sc.FetchMissingMessages(context.Background(), batch(), exists, process))
+
+	calls := r.calls()
+	require.Len(t, calls, 2)
+	require.False(t, calls[0].IncludeData)                          // phase 1 lists hashes only
+	require.True(t, calls[1].IncludeData)                           // phase 2 fetches bodies
+	require.Equal(t, [][]byte{missingHash}, calls[1].MessageHashes) // only the unknown hash is fetched
+	require.Equal(t, 1, delivered)                                  // the missing message is delivered
+}
+
+func TestStoreClientFetchMissingMessagesNoneMissing(t *testing.T) {
+	hash := make([]byte, 32)
+	r := &fakeRequestor{respond: func(_ *storepb.StoreQueryRequest, _ int) ([]*storepb.WakuMessageKeyValue, []byte, error) {
+		return []*storepb.WakuMessageKeyValue{{MessageHash: hash}}, nil, nil
+	}}
+	sc := newClient(r, []peer.AddrInfo{{ID: "n1"}})
+
+	allExist := func(pb.MessageHash) (bool, error) { return true, nil }
+	require.NoError(t, sc.FetchMissingMessages(context.Background(), batch(), allExist, func(*protocol.Envelope) error { return nil }))
+	require.Len(t, r.calls(), 1) // only the hash listing; nothing to fetch
 }

--- a/pkg/messaging/waku/store_missing.go
+++ b/pkg/messaging/waku/store_missing.go
@@ -1,0 +1,162 @@
+package wakuv2
+
+import (
+	"context"
+	"encoding/hex"
+	"time"
+
+	"github.com/libp2p/go-libp2p/core/peer"
+	"google.golang.org/protobuf/proto"
+
+	"github.com/waku-org/go-waku/waku/v2/protocol"
+	"github.com/waku-org/go-waku/waku/v2/protocol/pb"
+	storepb "github.com/waku-org/go-waku/waku/v2/protocol/store/pb"
+
+	types "github.com/status-im/status-go/pkg/messaging/waku/types"
+)
+
+const (
+	// maxMessageHashesPerRequest is the store protocol's per-request hash limit for
+	// by-hash body fetches.
+	maxMessageHashesPerRequest = 50
+	// missingMessagePageSize is the pagination limit for missing-message queries.
+	missingMessagePageSize = 100
+)
+
+// FetchMissingMessages reconciles a window against the store: it lists the message
+// hashes the store holds for [batch.From, batch.To] on the batch's topics, fetches
+// the bodies of the ones not already known locally (messageExists), and pushes
+// them through process. It pins ONE storenode for the whole operation — hash
+// listing, body fetch, and all of their pagination — so every page comes from the
+// same node and cursors stay valid; it fails over to another node only if that one
+// fails the whole operation. messageExists and process are supplied by the waku
+// adapter (local dedup and the received-envelope sink, respectively).
+func (sc *StoreClient) FetchMissingMessages(
+	ctx context.Context,
+	batch types.MailserverBatch,
+	messageExists func(pb.MessageHash) (bool, error),
+	process func(*protocol.Envelope) error,
+) error {
+	pubsubTopic := sc.resolvePubsubTopic(batch.PubsubTopic)
+	contentTopics := sc.contentTopics(batch)
+	if len(contentTopics) == 0 {
+		return nil
+	}
+
+	return sc.withStorenode(ctx, func(ctx context.Context, node peer.AddrInfo) error {
+		missing, err := sc.listMissingHashes(ctx, node, pubsubTopic, contentTopics, batch.From, batch.To, messageExists)
+		if err != nil {
+			return err
+		}
+		if len(missing) == 0 {
+			return nil
+		}
+		return sc.fetchHashes(ctx, node, missing, process)
+	})
+}
+
+// listMissingHashes queries the store for the message hashes in [from,to] on the
+// given content topics (chunked) and returns the ones not already known locally.
+// It requests hashes only (IncludeData=false) to keep the diff cheap.
+func (sc *StoreClient) listMissingHashes(
+	ctx context.Context,
+	node peer.AddrInfo,
+	pubsubTopic string,
+	contentTopics []string,
+	from, to time.Time,
+	messageExists func(pb.MessageHash) (bool, error),
+) ([][]byte, error) {
+	var missing [][]byte
+	for _, chunk := range chunkContentTopics(contentTopics, maxContentTopicsPerRequest) {
+		var cursor []byte
+		for {
+			request := &storepb.StoreQueryRequest{
+				RequestId:        hex.EncodeToString(protocol.GenerateRequestID()),
+				IncludeData:      false,
+				PubsubTopic:      proto.String(pubsubTopic),
+				ContentTopics:    chunk,
+				TimeStart:        proto.Int64(from.UnixNano()),
+				TimeEnd:          proto.Int64(to.UnixNano()),
+				PaginationCursor: cursor,
+				PaginationLimit:  proto.Uint64(missingMessagePageSize),
+			}
+
+			reqCtx, cancel := context.WithTimeout(ctx, storeRequestTimeout)
+			messages, next, err := sc.requestor.query(reqCtx, node, request)
+			cancel()
+			if err != nil {
+				return nil, err
+			}
+
+			for _, mkv := range messages {
+				exists, err := messageExists(pb.ToMessageHash(mkv.MessageHash))
+				if err != nil {
+					return nil, err
+				}
+				if !exists {
+					missing = append(missing, mkv.MessageHash)
+				}
+			}
+
+			if next == nil {
+				break
+			}
+			cursor = next
+		}
+	}
+	return missing, nil
+}
+
+// fetchHashes fetches the bodies of the given message hashes (IncludeData=true)
+// and pushes each through process.
+func (sc *StoreClient) fetchHashes(
+	ctx context.Context,
+	node peer.AddrInfo,
+	hashes [][]byte,
+	process func(*protocol.Envelope) error,
+) error {
+	for _, chunk := range chunkHashes(hashes, maxMessageHashesPerRequest) {
+		var cursor []byte
+		for {
+			request := &storepb.StoreQueryRequest{
+				RequestId:        hex.EncodeToString(protocol.GenerateRequestID()),
+				IncludeData:      true,
+				MessageHashes:    chunk,
+				PaginationCursor: cursor,
+				PaginationLimit:  proto.Uint64(maxMessageHashesPerRequest),
+			}
+
+			reqCtx, cancel := context.WithTimeout(ctx, storeRequestTimeout)
+			messages, next, err := sc.requestor.query(reqCtx, node, request)
+			cancel()
+			if err != nil {
+				return err
+			}
+
+			for _, mkv := range messages {
+				env := protocol.NewEnvelope(mkv.Message, mkv.Message.GetTimestamp(), mkv.GetPubsubTopic())
+				if err := process(env); err != nil {
+					return err
+				}
+			}
+
+			if next == nil {
+				break
+			}
+			cursor = next
+		}
+	}
+	return nil
+}
+
+func chunkHashes(hashes [][]byte, size int) [][][]byte {
+	var chunks [][][]byte
+	for i := 0; i < len(hashes); i += size {
+		end := i + size
+		if end > len(hashes) {
+			end = len(hashes)
+		}
+		chunks = append(chunks, hashes[i:end])
+	}
+	return chunks
+}

--- a/pkg/messaging/waku/types/waku.go
+++ b/pkg/messaging/waku/types/waku.go
@@ -149,6 +149,11 @@ type Waku interface {
 		shouldProcessNextPage func(int) (bool, uint64),
 		processEnvelopes bool,
 	) error
+
+	// FetchMissingMessages reconciles a window against the store for the batch's
+	// topics, fetching messages not already known locally. No-op when
+	// missing-message verification is disabled. The storenode is selected internally.
+	FetchMissingMessages(ctx context.Context, batch MailserverBatch) error
 }
 
 type MailserverBatch struct {


### PR DESCRIPTION
Re-implements missing-message reconciliation in status-go as `StoreClient.FetchMissingMessages`, dropping the go-waku `MissingMessageVerifier`.

**Stacked on #7532** (StoreClient internals) — review/merge that first; this PR's base retargets to `develop` once it lands.

## Why
The go-waku verifier is wired to the active-storenode/cycle that #7532 removes. Adapting it via a `common.StorenodeRequestor` connector risked splitting one reconcile across storenodes (hash-listing on node A, body-fetch on node B) — and since the verifier advances `lastChecked` regardless, a message node B lacks would be dropped. Owning the logic lets us pin one node per reconcile and stay FFI-neutral (no go-waku `StoreRequestResult`/`StorenodeRequestor`).

## What
- `StoreClient.FetchMissingMessages` pins **one** storenode for the whole operation: list hashes for the window (`IncludeData=false`) → diff against `MessageExists` → fetch missing bodies (`IncludeData=true`), paginating both phases on that node; fails over only if the node fails the whole op. Advances the window only on success.
- A **Transport reconciler** drives it from the listening filters directly (no criteria setter, no messenger involvement), tracking the window per pubsub topic.
- Removes the go-waku `MissingMessageVerifier`, its envelope-channel consumer, and the `SetCriteria*` plumbing.

Gated by `EnableMissingMessageVerification`; storenode selection on demand, no active node or cycle.

## Test
- `go build` / `go vet` across messaging + protocol + downstream; `golangci-lint` 0 issues; goroutine-defer-guard clean.
- New unit tests for the hash-diff (`TestStoreClientFetchMissingMessages`, `…NoneMissing`); existing store tests pass under the `withStorenode` refactor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
