### PR TITLE
test(functional): observe light-client compat flakiness on CI [do not merge]

### DIFF
--- a/tests-functional/tests/test_chat_compatibility.py
+++ b/tests-functional/tests/test_chat_compatibility.py
@@ -3,6 +3,9 @@ import pytest
 from steps import messenger
 from utils.config import Config
 
+# NOTE (investigation, do not merge): dummy change to trigger a tests-rpc-compat CI
+# run while looking into light-client compat flakiness (full-light / light-light cells).
+
 
 def pytest_generate_tests(metafunc):
     if "peer_image" in metafunc.fixturenames:


### PR DESCRIPTION
**Investigation PR — do not merge.** Opened to capture a `tests-rpc-compat` CI run while diagnosing light-client compatibility flakiness.

## What
`test_community_compatibility[statusgo-peer-v10.34.0-full-light]` (and other light cells) flake intermittently on develop.

## Root cause (preliminary)
The compat matrix (#7542) runs vut (build-under-test) × peer in a full/light waku mode matrix. The peer images CI builds are the **2 latest release tags, v10.34.0 and v10.33.1**, and **neither contains the go-waku `preferConnectedPeers` fix (#6943, go-waku v0.10.2)** — both pin an older go-waku pseudo-version.

When the **peer** runs as a light client (the `full-light` and `light-light` cells), its filter peer-selection is connectedness-blind: it re-dials dead peer-exchange peers instead of the connected fleet node, so the filter subscription never establishes → pushed community messages never arrive → `MESSAGES_NEW` 60s timeout. This is an **old-peer-side bug that cannot be fixed from develop** (develop already has the fix; the released peer does not).

Expected matrix behavior:
- `full-full` ✅ stable
- `light-full` ✅ stable (vut is the light client and develop has the fix)
- `full-light` ⚠️ flaky (peer is light receiver, no fix)
- `light-light` ⚠️ flaky / often failing (peer light + light-light sender path)

## Next
Confirm via this CI run + local repro, then decide on mitigation (rerun/xfail the affected cells citing #7393, or ship a patched peer image).

🤖 Generated with [Claude Code](https://claude.com/claude-code)