### PR TITLE
fix(backup): switch order of import so that pending CR get the message

### DIFF
--- a/protocol/messenger_backup_handler.go
+++ b/protocol/messenger_backup_handler.go
@@ -37,6 +37,15 @@ func (m *Messenger) handleLocalBackup(ctx context.Context, state *ReceivedMessag
 		errors = append(errors, err)
 	}
 
+	if len(backup.Messages) > 0 {
+		err := m.persistence.SaveBackedUpMessages(backup.Messages)
+		if err != nil {
+			errors = append(errors, err)
+		}
+
+		signal.LocalMessageBackupDone()
+	}
+
 	for _, contact := range backup.Contacts {
 		err = m.HandleSyncInstallationContactV2(ctx, state, contact, nil)
 		if err != nil {
@@ -52,15 +61,6 @@ func (m *Messenger) handleLocalBackup(ctx context.Context, state *ReceivedMessag
 	communityErrors := m.handleLocalBackupCommunities(state, backup.Communities)
 	if len(communityErrors) > 0 {
 		errors = append(errors, communityErrors...)
-	}
-
-	if len(backup.Messages) > 0 {
-		err := m.persistence.SaveBackedUpMessages(backup.Messages)
-		if err != nil {
-			errors = append(errors, err)
-		}
-
-		signal.LocalMessageBackupDone()
 	}
 
 	return errors

--- a/protocol/messenger_handler.go
+++ b/protocol/messenger_handler.go
@@ -411,8 +411,34 @@ func (m *Messenger) syncContactRequestForInstallationContact(contact *contacts.C
 	}
 
 	if contactRequestID != "" {
-		m.logger.Warn("syncContactRequestForInstallationContact: skipping as contact request found", zap.String("contactRequestID", contactRequestID))
-		return nil
+		m.logger.Warn("syncContactRequestForInstallationContact: using existing contact request", zap.String("contactRequestID", contactRequestID))
+
+		existingContactRequest, err := m.persistence.MessageByID(contactRequestID)
+		if err != nil {
+			if err != common.ErrRecordNotFound {
+				return err
+			}
+
+			// The ID was returned by lookup but the message is missing. Fall back to
+			// synthesizing a default request to keep contact-request actions available.
+			m.logger.Warn("syncContactRequestForInstallationContact: contact request id found but message missing", zap.String("contactRequestID", contactRequestID))
+		} else {
+			if outgoing {
+				notification := m.generateOutgoingContactRequestNotification(contact, existingContactRequest)
+				notification.Timestamp = existingContactRequest.WhisperTimestamp
+				err = m.addActivityCenterNotification(state.Response, notification, nil)
+				if err != nil {
+					return err
+				}
+			} else {
+				err = m.createIncomingContactRequestNotification(contact, state, existingContactRequest, true)
+				if err != nil {
+					return err
+				}
+			}
+
+			return nil
+		}
 	}
 
 	clock, timestamp := chat.NextClockAndTimestamp(m.getTimesource())

--- a/protocol/messenger_local_backup_test.go
+++ b/protocol/messenger_local_backup_test.go
@@ -34,6 +34,63 @@ func makeMutualContacts(lhs *Messenger, rhs *Messenger) error {
 	return makeMutualContact(rhs, &lhs.identity.PublicKey)
 }
 
+func (s *MessengerLocalBackupSuite) TestLocalBackupRestoresContactRequestText() {
+	bob1 := s.anotherMessenger()
+	bob2 := s.anotherMessenger()
+	alice := s.newMessenger()
+
+	err := bob1.settings.SaveSetting(settings.MessagesBackupEnabled.GetReactName(), true)
+	s.Require().NoError(err)
+
+	aliceID := types.EncodeHex(crypto.FromECDSAPub(&alice.identity.PublicKey))
+	bobID := types.EncodeHex(crypto.FromECDSAPub(&bob1.identity.PublicKey))
+	contactRequestText := "hello from backup"
+
+	_, err = alice.SendContactRequest(context.Background(), &requests.SendContactRequest{
+		ID:      bobID,
+		Message: contactRequestText,
+	})
+	s.Require().NoError(err)
+
+	_, err = WaitOnMessengerResponse(
+		bob1,
+		func(r *MessengerResponse) bool {
+			for _, msg := range r.Messages() {
+				if msg.ContentType == protobuf.ChatMessage_CONTACT_REQUEST && msg.From == aliceID && msg.Text == contactRequestText {
+					return true
+				}
+			}
+			return false
+		},
+		"contact request not received",
+	)
+	s.Require().NoError(err)
+
+	marshalledBackup, err := bob1.ExportBackup()
+	s.Require().NoError(err)
+
+	err = bob2.ImportBackup(marshalledBackup)
+	s.Require().NoError(err)
+
+	restoredContactRequestID, err := bob2.persistence.LatestPendingContactRequestIDForContact(aliceID)
+	s.Require().NoError(err)
+	s.Require().NotEmpty(restoredContactRequestID)
+	s.Require().NotEqual(defaultContactRequestID(aliceID), restoredContactRequestID)
+
+	restoredContactRequest, err := bob2.persistence.MessageByID(restoredContactRequestID)
+	s.Require().NoError(err)
+	s.Require().Equal(protobuf.ChatMessage_CONTACT_REQUEST, restoredContactRequest.ContentType)
+	s.Require().Equal(contactRequestText, restoredContactRequest.Text)
+	s.Require().NotEqual(defaultContactRequestText(), restoredContactRequest.Text)
+
+	notification, err := bob2.PendingNotificationContactRequest(aliceID)
+	s.Require().NoError(err)
+	s.Require().NotNil(notification)
+	s.Require().NotNil(notification.Message)
+	s.Require().Equal(restoredContactRequestID, notification.Message.ID)
+	s.Require().Equal(contactRequestText, notification.Message.Text)
+}
+
 func (s *MessengerLocalBackupSuite) TestLocalBackup() {
 	// Create bob1
 	bob1 := s.anotherMessenger()
@@ -353,7 +410,7 @@ func (s *MessengerLocalBackupSuite) TestLocalBackup() {
 	// Validate messages
 	messages, err := bob2.persistence.AllMessagesForBackup()
 	s.Require().NoError(err)
-	s.Require().Len(messages, 15)
+	s.Require().Len(messages, 13)
 
 	// Build a map for easier assertions
 	messageMap := make(map[string]*protobuf.BackedUpMessage)


### PR DESCRIPTION
Fixes https://github.com/status-im/status-app/issues/19591

The problem was that we imported contacts and requests before the messages, meaning that when the contact was parsed, it assumed it lost the contact request message, so it generated the default one.

Switch the order of import solves that.

This caused one small issue, that no AC notif was generated with the new order. This was solved by correctly checking if there is an existing message existed for the request.

Now the imported profile has the right pending contact request with the message and  an AC notification, also with the message.

<img width="394" height="224" alt="image" src="https://github.com/user-attachments/assets/b64895ba-4149-42be-96fe-ee907ab0700f" />

<img width="898" height="688" alt="image" src="https://github.com/user-attachments/assets/823ec40e-e779-401d-a75f-4b5c9d41cafe" />
