### PR TITLE
fix: bump go-waku to v0.10.2 (prefer connected peers) [backport #6943]

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -102,7 +102,7 @@ require (
 	github.com/schollz/peerdiscovery v1.7.0
 	github.com/status-im/extkeys v1.4.0
 	github.com/status-im/go-wallet-sdk v0.0.0-20260612221124-9c7a9c043068
-	github.com/waku-org/go-waku v0.10.2-0.20260518064454-d6d39395ac48
+	github.com/waku-org/go-waku v0.10.2
 	github.com/waku-org/sds-go-bindings v0.0.0-20251222164514-d5b47a911904
 	github.com/wk8/go-ordered-map/v2 v2.1.7
 	go.uber.org/atomic v1.11.0

--- a/go.sum
+++ b/go.sum
@@ -2416,8 +2416,8 @@ github.com/waku-org/go-libp2p-pubsub v0.13.1-gowaku h1:ovXh1m76i0yPWXt95Z9ZRyEk0
 github.com/waku-org/go-libp2p-pubsub v0.13.1-gowaku/go.mod h1:MKPU5vMI8RRFyTP0HfdsF9cLmL1nHAeJm44AxJGJx44=
 github.com/waku-org/go-libp2p-rendezvous v0.0.0-20240110193335-a67d1cc760a0 h1:R4YYx2QamhBRl/moIxkDCNW+OP7AHbyWLBygDc/xIMo=
 github.com/waku-org/go-libp2p-rendezvous v0.0.0-20240110193335-a67d1cc760a0/go.mod h1:EhZP9fee0DYjKH/IOQvoNSy1tSHp2iZadsHGphcAJgY=
-github.com/waku-org/go-waku v0.10.2-0.20260518064454-d6d39395ac48 h1:a00GguapTGSRIN9ocw93WsrMOTD07TJ1iqCashttNwA=
-github.com/waku-org/go-waku v0.10.2-0.20260518064454-d6d39395ac48/go.mod h1:PDs4hlPbONeMQGsNyfArZV4R2Js1Zy5oqLBfw2VU278=
+github.com/waku-org/go-waku v0.10.2 h1:Rjy9UhdXaeLSwcm8unMUiFM3HdLxyJvdtleREEMeyrg=
+github.com/waku-org/go-waku v0.10.2/go.mod h1:PDs4hlPbONeMQGsNyfArZV4R2Js1Zy5oqLBfw2VU278=
 github.com/waku-org/go-zerokit-rln v0.1.14-0.20240102145250-fa738c0bdf59 h1:jisj+OCI6QydLtFq3Pyhu49wl9ytPN7oAHjMfepHDrA=
 github.com/waku-org/go-zerokit-rln v0.1.14-0.20240102145250-fa738c0bdf59/go.mod h1:1PdBdPzyTaKt3VnpAHk3zj+r9dXPFOr3IHZP9nFle6E=
 github.com/waku-org/go-zerokit-rln-apple v0.0.0-20230916172309-ee0ee61dde2b h1:KgZVhsLkxsj5gb/FfndSCQu6VYwALrCOgYI3poR95yE=

--- a/nix/pkgs/status-go/library/default.nix
+++ b/nix/pkgs/status-go/library/default.nix
@@ -11,7 +11,7 @@ let
 in pkgs.buildGoModule {
   pname = "status-go";
   src = builtins.path { path = ./../../../..; name = "status-go-library"; };
-  vendorHash = "sha256-bblnIanlRFp7MXO6yyjU0HY0tRgiyA6oLwmmoABXrqU=";
+  vendorHash = "sha256-F8hMfPSun6gciHnx5uVZzXWQTc9yE2uiomREHq9mFkQ=";
 
   inherit meta version;
 


### PR DESCRIPTION
## What
Backports the go-waku dependency bump from #6943 (`v0.10.2-0.20260518…` → **v0.10.2**) onto `release/10.34.x`, so the next 10.34.x patch (v10.34.1) ships it.

## Why
go-waku v0.10.2 makes light-client **filter and lightpush** peer-selection prefer already-connected peers instead of churning on stale/unreachable peers learned via peer-exchange. Without it, a v10.34.x node running as a **light client** is flaky in the cross-version compatibility matrix (`test_chat_compatibility`).

The `tests-rpc-compat` matrix runs the build-under-test against the 2 latest release tags as both full and light clients. The `full-light` cell (peer = v10.34.0 as light receiver) flakes because v10.34.0 predates this fix. Local repro on a fresh fleet: with the **original v10.34.0** peer `full-light` **fails**; rebuilt with **go-waku v0.10.2** it **passes**.

## Scope / follow-ups
- Pure dependency bump (go.mod/go.sum only), identical to what's already on `develop` via #6943. Builds clean.
- `release/10.33.x` needs the same treatment (currently go-waku **v0.10.1**) for the matrix's other peer (v10.33.1) to behave as a light client — that's a larger bump (v0.10.1 → v0.10.2) and should be a separate, build-verified backport.
- After v10.34.1 (and a 10.33.x patch) are released, the compat matrix picks them up automatically.
- `light-light` (both nodes light) is the hardest cell and may need both peers fixed plus the lighter CI churn to be reliably green; tracked under status-im/status-go#7393.

Ref: #6943, #7393

🤖 Generated with [Claude Code](https://claude.com/claude-code)