### PR TITLE
fix: bump go-waku to v0.10.2 (prefer connected peers) [backport #6943]

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -102,7 +102,7 @@ require (
 	github.com/schollz/peerdiscovery v1.7.0
 	github.com/status-im/extkeys v1.4.0
 	github.com/status-im/go-wallet-sdk v0.0.0-20260126140800-7bb3ccf032ab
-	github.com/waku-org/go-waku v0.10.1
+	github.com/waku-org/go-waku v0.10.2
 	github.com/waku-org/sds-go-bindings v0.0.0-20251222164514-d5b47a911904
 	github.com/waku-org/waku-go-bindings v0.0.0-20251202095947-63b01b7d0ca9
 	github.com/wk8/go-ordered-map/v2 v2.1.7

--- a/go.sum
+++ b/go.sum
@@ -2411,8 +2411,6 @@ github.com/waku-org/go-libp2p-pubsub v0.13.1-gowaku h1:ovXh1m76i0yPWXt95Z9ZRyEk0
 github.com/waku-org/go-libp2p-pubsub v0.13.1-gowaku/go.mod h1:MKPU5vMI8RRFyTP0HfdsF9cLmL1nHAeJm44AxJGJx44=
 github.com/waku-org/go-libp2p-rendezvous v0.0.0-20240110193335-a67d1cc760a0 h1:R4YYx2QamhBRl/moIxkDCNW+OP7AHbyWLBygDc/xIMo=
 github.com/waku-org/go-libp2p-rendezvous v0.0.0-20240110193335-a67d1cc760a0/go.mod h1:EhZP9fee0DYjKH/IOQvoNSy1tSHp2iZadsHGphcAJgY=
-github.com/waku-org/go-waku v0.10.1 h1:05wNGVbUC4uP5JHPjBaHQywKvOgRkjJEcG8zL8/LKGo=
-github.com/waku-org/go-waku v0.10.1/go.mod h1:PDs4hlPbONeMQGsNyfArZV4R2Js1Zy5oqLBfw2VU278=
 github.com/waku-org/go-waku v0.10.2 h1:Rjy9UhdXaeLSwcm8unMUiFM3HdLxyJvdtleREEMeyrg=
 github.com/waku-org/go-waku v0.10.2/go.mod h1:PDs4hlPbONeMQGsNyfArZV4R2Js1Zy5oqLBfw2VU278=
 github.com/waku-org/go-zerokit-rln v0.1.14-0.20240102145250-fa738c0bdf59 h1:jisj+OCI6QydLtFq3Pyhu49wl9ytPN7oAHjMfepHDrA=

--- a/go.sum
+++ b/go.sum
@@ -2413,6 +2413,8 @@ github.com/waku-org/go-libp2p-rendezvous v0.0.0-20240110193335-a67d1cc760a0 h1:R
 github.com/waku-org/go-libp2p-rendezvous v0.0.0-20240110193335-a67d1cc760a0/go.mod h1:EhZP9fee0DYjKH/IOQvoNSy1tSHp2iZadsHGphcAJgY=
 github.com/waku-org/go-waku v0.10.1 h1:05wNGVbUC4uP5JHPjBaHQywKvOgRkjJEcG8zL8/LKGo=
 github.com/waku-org/go-waku v0.10.1/go.mod h1:PDs4hlPbONeMQGsNyfArZV4R2Js1Zy5oqLBfw2VU278=
+github.com/waku-org/go-waku v0.10.2 h1:Rjy9UhdXaeLSwcm8unMUiFM3HdLxyJvdtleREEMeyrg=
+github.com/waku-org/go-waku v0.10.2/go.mod h1:PDs4hlPbONeMQGsNyfArZV4R2Js1Zy5oqLBfw2VU278=
 github.com/waku-org/go-zerokit-rln v0.1.14-0.20240102145250-fa738c0bdf59 h1:jisj+OCI6QydLtFq3Pyhu49wl9ytPN7oAHjMfepHDrA=
 github.com/waku-org/go-zerokit-rln v0.1.14-0.20240102145250-fa738c0bdf59/go.mod h1:1PdBdPzyTaKt3VnpAHk3zj+r9dXPFOr3IHZP9nFle6E=
 github.com/waku-org/go-zerokit-rln-apple v0.0.0-20230916172309-ee0ee61dde2b h1:KgZVhsLkxsj5gb/FfndSCQu6VYwALrCOgYI3poR95yE=

--- a/nix/pkgs/status-go/library/default.nix
+++ b/nix/pkgs/status-go/library/default.nix
@@ -11,7 +11,7 @@ let
 in pkgs.buildGoModule {
   pname = "status-go";
   src = builtins.path { path = ./../../../..; name = "status-go-library"; };
-  vendorHash = "sha256-BuyGx8FPi2vK5m+F3MAgllOix/KNhQaE+9DB48cdxX8=";
+  vendorHash = "sha256-c+Kdz0tPkuT7bmhcmqFuANAuvhZAjo4PzoKV9E/gh+Y=";
 
   inherit meta version;
 


### PR DESCRIPTION
## What
Backports the go-waku peer-selection fix from #6943 onto `release/10.33.x` (**v0.10.1 → v0.10.2**), so the next 10.33.x patch ships it.

## Why
go-waku v0.10.2 makes light-client **filter and lightpush** peer-selection prefer already-connected peers instead of churning on stale/unreachable peers learned via peer-exchange. Without it, a v10.33.x node running as a **light client** is flaky in the cross-version compatibility matrix (`test_chat_compatibility`): the `tests-rpc-compat` job tests the build-under-test against the 2 latest release tags (v10.34.0 + v10.33.1) as both full and light clients, and the light cells flake because these peers predate the fix.

Companion to #7570 (same bump on `release/10.34.x`). Both patches are needed for the matrix's two peers to behave as light clients.

## Scope
- Minor go-waku bump (v0.10.1 → v0.10.2), go.mod/go.sum only — no transitive cascade, `waku-go-bindings` retained.
- **Build-verified**: compiles via the functional-test Dockerfile (CGO/libsds), no API breakage in v10.33.x code.

Ref: #6943, #7393, #7570

🤖 Generated with [Claude Code](https://claude.com/claude-code)