### PR TITLE
refactor(messaging): Status-owned MessageSentCheck (decoupled from StorenodeCycle)

### DIFF
--- a/pkg/messaging/waku/gowaku.go
+++ b/pkg/messaging/waku/gowaku.go
@@ -1116,7 +1116,7 @@ func (w *Waku) startMessageSender() error {
 	if w.cfg.EnableStoreConfirmationForMessagesSent {
 		msgStoredChan := make(chan gethcommon.Hash, 1000)
 		msgExpiredChan := make(chan gethcommon.Hash, 1000)
-		messageSentCheck := publish.NewMessageSentCheck(w.ctx, publish.NewDefaultStorenodeMessageVerifier(w.node.Store()), w.StorenodeCycle, w.node.Timesource(), msgStoredChan, msgExpiredChan, w.logger)
+		messageSentCheck := NewMessageSentCheck(w.ctx, publish.NewDefaultStorenodeMessageVerifier(w.node.Store()), w.StorenodeCycle, w.node.Timesource(), msgStoredChan, msgExpiredChan, w.logger)
 		sender.WithMessageSentCheck(messageSentCheck)
 
 		w.wg.Add(1)

--- a/pkg/messaging/waku/message_sent_check.go
+++ b/pkg/messaging/waku/message_sent_check.go
@@ -1,0 +1,242 @@
+package wakuv2
+
+import (
+	"bytes"
+	"context"
+	"sync"
+	"time"
+
+	gethcommon "github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/libp2p/go-libp2p/core/peer"
+	"go.uber.org/zap"
+
+	"github.com/waku-org/go-waku/waku/v2/api/publish"
+	"github.com/waku-org/go-waku/waku/v2/protocol"
+	"github.com/waku-org/go-waku/waku/v2/protocol/pb"
+
+	gocommon "github.com/status-im/status-go/common"
+)
+
+// Defaults mirror go-waku's publish.MessageSentCheck so behaviour is unchanged.
+const (
+	defaultMaxHashQueryLength   = 50
+	defaultHashQueryInterval    = 3 * time.Second
+	defaultMessageSentPeriod    = 3  // seconds after publish before a message is queried against the store
+	defaultMessageExpiredPeriod = 10 // seconds after publish before an unconfirmed message is considered expired
+	defaultStoreQueryTimeout    = 30 * time.Second
+)
+
+// storenodePeerProvider supplies the store node MessageSentCheck queries. It is
+// satisfied by the go-waku StorenodeCycle today; once the cycle is removed the
+// same seam can be backed by the on-demand StoreClient, so the check needs no
+// changes when that swap happens.
+type storenodePeerProvider interface {
+	GetActiveStorenodePeerInfo() peer.AddrInfo
+}
+
+// timeProvider is the subset of the node timesource MessageSentCheck needs.
+type timeProvider interface {
+	Now() time.Time
+}
+
+// MessageSentCheck is a Status-owned reimplementation of go-waku's
+// publish.MessageSentCheck (it implements publish.ISentCheck so it can be
+// plugged into the go-waku MessageSender). It tracks outgoing messages and,
+// once messageSentPeriod has elapsed since publish, asks a store node whether
+// each was stored: messages confirmed stored are reported on messageStoredChan,
+// messages still missing after messageExpiredPeriod on messageExpiredChan.
+//
+// Unlike go-waku's version it does not depend on the concrete StorenodeCycle —
+// the store node is supplied through the injectable storenodePeerProvider, so
+// the check is decoupled from the cycle's lifecycle.
+type MessageSentCheck struct {
+	messageIDs           map[string]map[gethcommon.Hash]uint32
+	messageIDsMu         sync.RWMutex
+	messageStoredChan    chan gethcommon.Hash
+	messageExpiredChan   chan gethcommon.Hash
+	ctx                  context.Context
+	messageVerifier      publish.StorenodeMessageVerifier
+	peerProvider         storenodePeerProvider
+	timesource           timeProvider
+	logger               *zap.Logger
+	maxHashQueryLength   uint64
+	hashQueryInterval    time.Duration
+	messageSentPeriod    uint32
+	messageExpiredPeriod uint32
+	storeQueryTimeout    time.Duration
+}
+
+var _ publish.ISentCheck = (*MessageSentCheck)(nil)
+
+// NewMessageSentCheck creates a MessageSentCheck with go-waku's default timings.
+func NewMessageSentCheck(
+	ctx context.Context,
+	messageVerifier publish.StorenodeMessageVerifier,
+	peerProvider storenodePeerProvider,
+	timesource timeProvider,
+	msgStoredChan chan gethcommon.Hash,
+	msgExpiredChan chan gethcommon.Hash,
+	logger *zap.Logger,
+) *MessageSentCheck {
+	return &MessageSentCheck{
+		messageIDs:           make(map[string]map[gethcommon.Hash]uint32),
+		messageStoredChan:    msgStoredChan,
+		messageExpiredChan:   msgExpiredChan,
+		ctx:                  ctx,
+		messageVerifier:      messageVerifier,
+		peerProvider:         peerProvider,
+		timesource:           timesource,
+		logger:               logger,
+		maxHashQueryLength:   defaultMaxHashQueryLength,
+		hashQueryInterval:    defaultHashQueryInterval,
+		messageSentPeriod:    defaultMessageSentPeriod,
+		messageExpiredPeriod: defaultMessageExpiredPeriod,
+		storeQueryTimeout:    defaultStoreQueryTimeout,
+	}
+}
+
+// Add registers a published message to be confirmed against the store.
+func (m *MessageSentCheck) Add(topic string, messageID gethcommon.Hash, sentTime uint32) {
+	m.messageIDsMu.Lock()
+	defer m.messageIDsMu.Unlock()
+
+	if _, ok := m.messageIDs[topic]; !ok {
+		m.messageIDs[topic] = make(map[gethcommon.Hash]uint32)
+	}
+	m.messageIDs[topic][messageID] = sentTime
+}
+
+// DeleteByMessageIDs stops tracking the given message ids, used by scenarios
+// like a message being acknowledged out-of-band via MVDS.
+func (m *MessageSentCheck) DeleteByMessageIDs(messageIDs []gethcommon.Hash) {
+	m.messageIDsMu.Lock()
+	defer m.messageIDsMu.Unlock()
+
+	for pubsubTopic, subMsgs := range m.messageIDs {
+		for _, hash := range messageIDs {
+			delete(subMsgs, hash)
+			if len(subMsgs) == 0 {
+				delete(m.messageIDs, pubsubTopic)
+			} else {
+				m.messageIDs[pubsubTopic] = subMsgs
+			}
+		}
+	}
+}
+
+// Start runs the periodic store-confirmation loop until the context is done. It
+// is meant to be invoked in its own goroutine (the MessageSender does so).
+func (m *MessageSentCheck) Start() {
+	defer gocommon.LogOnPanic()
+	ticker := time.NewTicker(m.hashQueryInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-m.ctx.Done():
+			return
+		case <-ticker.C:
+			m.messageIDsMu.Lock()
+			pubsubTopics := make([]string, 0, len(m.messageIDs))
+			pubsubMessageIds := make([][]gethcommon.Hash, 0, len(m.messageIDs))
+			pubsubMessageTime := make([][]uint32, 0, len(m.messageIDs))
+			for pubsubTopic, subMsgs := range m.messageIDs {
+				var queryMsgIds []gethcommon.Hash
+				var queryMsgTime []uint32
+				for msgID, sendTime := range subMsgs {
+					if uint64(len(queryMsgIds)) >= m.maxHashQueryLength {
+						break
+					}
+					// Only query messages whose sent grace period has elapsed.
+					if m.timesource.Now().Unix() > int64(sendTime)+int64(m.messageSentPeriod) {
+						queryMsgIds = append(queryMsgIds, msgID)
+						queryMsgTime = append(queryMsgTime, sendTime)
+					}
+				}
+				if len(queryMsgIds) > 0 {
+					pubsubTopics = append(pubsubTopics, pubsubTopic)
+					pubsubMessageIds = append(pubsubMessageIds, queryMsgIds)
+					pubsubMessageTime = append(pubsubMessageTime, queryMsgTime)
+				}
+			}
+			m.messageIDsMu.Unlock()
+
+			pubsubProcessedMessages := make([][]gethcommon.Hash, len(pubsubTopics))
+			for i, pubsubTopic := range pubsubTopics {
+				pubsubProcessedMessages[i] = m.messageHashBasedQuery(m.ctx, pubsubMessageIds[i], pubsubMessageTime[i], pubsubTopic)
+			}
+
+			m.messageIDsMu.Lock()
+			for i, pubsubTopic := range pubsubTopics {
+				subMsgs, ok := m.messageIDs[pubsubTopic]
+				if !ok {
+					continue
+				}
+				for _, hash := range pubsubProcessedMessages[i] {
+					delete(subMsgs, hash)
+					if len(subMsgs) == 0 {
+						delete(m.messageIDs, pubsubTopic)
+					} else {
+						m.messageIDs[pubsubTopic] = subMsgs
+					}
+				}
+			}
+			m.messageIDsMu.Unlock()
+		}
+	}
+}
+
+// messageHashBasedQuery asks the selected store node which of the given hashes it
+// holds. Hashes that are stored are reported on messageStoredChan; hashes still
+// missing past their expiry are reported on messageExpiredChan. Both sets are
+// returned so the caller can stop tracking them.
+func (m *MessageSentCheck) messageHashBasedQuery(ctx context.Context, hashes []gethcommon.Hash, relayTime []uint32, pubsubTopic string) []gethcommon.Hash {
+	selectedPeer := m.peerProvider.GetActiveStorenodePeerInfo()
+	if selectedPeer.ID == "" {
+		m.logger.Error("no store peer id available", zap.String("pubsubTopic", pubsubTopic))
+		return []gethcommon.Hash{}
+	}
+
+	requestID := protocol.GenerateRequestID()
+
+	messageHashes := make([]pb.MessageHash, len(hashes))
+	for i, hash := range hashes {
+		messageHashes[i] = pb.ToMessageHash(hash.Bytes())
+	}
+
+	m.logger.Debug("store.queryByHash request", zap.String("requestID", hexutil.Encode(requestID)), zap.Stringer("peerID", selectedPeer.ID), zap.Stringers("messageHashes", messageHashes))
+
+	queryCtx, cancel := context.WithTimeout(ctx, m.storeQueryTimeout)
+	defer cancel()
+	result, err := m.messageVerifier.MessageHashesExist(queryCtx, requestID, selectedPeer, m.maxHashQueryLength, messageHashes)
+	if err != nil {
+		m.logger.Error("store.queryByHash failed", zap.String("requestID", hexutil.Encode(requestID)), zap.Stringer("peerID", selectedPeer.ID), zap.Error(err))
+		return []gethcommon.Hash{}
+	}
+
+	m.logger.Debug("store.queryByHash result", zap.String("requestID", hexutil.Encode(requestID)), zap.Int("messages", len(result)))
+
+	var ackHashes []gethcommon.Hash
+	var missedHashes []gethcommon.Hash
+	for i, hash := range hashes {
+		found := false
+		for _, msgHash := range result {
+			if bytes.Equal(msgHash.Bytes(), hash.Bytes()) {
+				found = true
+				break
+			}
+		}
+
+		if found {
+			ackHashes = append(ackHashes, hash)
+			m.messageStoredChan <- hash
+		}
+
+		if !found && m.timesource.Now().Unix() > int64(relayTime[i])+int64(m.messageExpiredPeriod) {
+			missedHashes = append(missedHashes, hash)
+			m.messageExpiredChan <- hash
+		}
+	}
+
+	return append(ackHashes, missedHashes...)
+}

--- a/pkg/messaging/waku/message_sent_check_test.go
+++ b/pkg/messaging/waku/message_sent_check_test.go
@@ -1,0 +1,121 @@
+package wakuv2
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	gethcommon "github.com/ethereum/go-ethereum/common"
+	"github.com/libp2p/go-libp2p/core/peer"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"github.com/waku-org/go-waku/waku/v2/api/publish"
+	"github.com/waku-org/go-waku/waku/v2/protocol/pb"
+)
+
+type fakePeerProvider struct{ info peer.AddrInfo }
+
+func (f fakePeerProvider) GetActiveStorenodePeerInfo() peer.AddrInfo { return f.info }
+
+type fakeTime struct{ now int64 }
+
+func (f *fakeTime) Now() time.Time { return time.Unix(f.now, 0) }
+
+type fakeVerifier struct {
+	existing []pb.MessageHash
+	err      error
+	calls    int
+}
+
+func (f *fakeVerifier) MessageHashesExist(_ context.Context, _ []byte, _ peer.AddrInfo, _ uint64, _ []pb.MessageHash) ([]pb.MessageHash, error) {
+	f.calls++
+	return f.existing, f.err
+}
+
+func newTestCheck(verifier publish.StorenodeMessageVerifier, peerInfo peer.AddrInfo, now int64, stored, expired chan gethcommon.Hash) *MessageSentCheck {
+	return NewMessageSentCheck(context.Background(), verifier, fakePeerProvider{info: peerInfo}, &fakeTime{now: now}, stored, expired, zap.NewNop())
+}
+
+func existing(hashes ...gethcommon.Hash) []pb.MessageHash {
+	out := make([]pb.MessageHash, len(hashes))
+	for i, h := range hashes {
+		out[i] = pb.ToMessageHash(h.Bytes())
+	}
+	return out
+}
+
+func TestMessageSentCheckAddDelete(t *testing.T) {
+	msc := newTestCheck(&fakeVerifier{}, peer.AddrInfo{ID: "p"}, 1000, nil, nil)
+
+	h1, h2, h3 := gethcommon.HexToHash("0x1"), gethcommon.HexToHash("0x2"), gethcommon.HexToHash("0x3")
+	msc.Add("topic-a", h1, 100)
+	msc.Add("topic-a", h2, 100)
+	msc.Add("topic-b", h3, 100)
+	require.Len(t, msc.messageIDs["topic-a"], 2)
+	require.Len(t, msc.messageIDs["topic-b"], 1)
+
+	msc.DeleteByMessageIDs([]gethcommon.Hash{h1})
+	require.Len(t, msc.messageIDs["topic-a"], 1)
+
+	// removing the last id in a topic drops the topic entry entirely
+	msc.DeleteByMessageIDs([]gethcommon.Hash{h3})
+	_, ok := msc.messageIDs["topic-b"]
+	require.False(t, ok)
+}
+
+func TestMessageSentCheckQueryAcksStoredAndExpiresMissing(t *testing.T) {
+	stored := make(chan gethcommon.Hash, 4)
+	expired := make(chan gethcommon.Hash, 4)
+
+	h1 := gethcommon.HexToHash("0x01") // present in the store -> acked
+	h2 := gethcommon.HexToHash("0x02") // missing and past expiry -> expired
+
+	verifier := &fakeVerifier{existing: existing(h1)}
+	// now=1000, expiry = relayTime + 10; relayTime=980 -> 1000 > 990 -> expired
+	msc := newTestCheck(verifier, peer.AddrInfo{ID: "store"}, 1000, stored, expired)
+
+	processed := msc.messageHashBasedQuery(context.Background(), []gethcommon.Hash{h1, h2}, []uint32{980, 980}, "pubsub")
+
+	require.ElementsMatch(t, []gethcommon.Hash{h1, h2}, processed)
+	require.Equal(t, 1, verifier.calls)
+	require.Equal(t, h1, <-stored)
+	require.Equal(t, h2, <-expired)
+	require.Empty(t, stored)
+	require.Empty(t, expired)
+}
+
+func TestMessageSentCheckQueryKeepsRecentMissing(t *testing.T) {
+	stored := make(chan gethcommon.Hash, 4)
+	expired := make(chan gethcommon.Hash, 4)
+
+	h := gethcommon.HexToHash("0x05") // missing but not yet past expiry -> retried later
+
+	// now=1000, relayTime=995 -> 1000 > 1005 is false -> not expired
+	msc := newTestCheck(&fakeVerifier{existing: nil}, peer.AddrInfo{ID: "store"}, 1000, stored, expired)
+
+	processed := msc.messageHashBasedQuery(context.Background(), []gethcommon.Hash{h}, []uint32{995}, "pubsub")
+
+	require.Empty(t, processed)
+	require.Empty(t, stored)
+	require.Empty(t, expired)
+}
+
+func TestMessageSentCheckQueryNoPeer(t *testing.T) {
+	verifier := &fakeVerifier{existing: existing(gethcommon.HexToHash("0x1"))}
+	msc := newTestCheck(verifier, peer.AddrInfo{}, 1000, make(chan gethcommon.Hash, 1), make(chan gethcommon.Hash, 1))
+
+	processed := msc.messageHashBasedQuery(context.Background(), []gethcommon.Hash{gethcommon.HexToHash("0x1")}, []uint32{980}, "pubsub")
+
+	require.Empty(t, processed)
+	require.Equal(t, 0, verifier.calls) // no peer -> no store query attempted
+}
+
+func TestMessageSentCheckQueryVerifierError(t *testing.T) {
+	msc := newTestCheck(&fakeVerifier{err: errors.New("store down")}, peer.AddrInfo{ID: "store"}, 1000,
+		make(chan gethcommon.Hash, 1), make(chan gethcommon.Hash, 1))
+
+	processed := msc.messageHashBasedQuery(context.Background(), []gethcommon.Hash{gethcommon.HexToHash("0x1")}, []uint32{980}, "pubsub")
+	require.Empty(t, processed)
+}


### PR DESCRIPTION
Reimplements go-waku's `publish.MessageSentCheck` as a Status-owned type in `pkg/messaging/waku`. **No behaviour change** — prep for the storenode-cycle removal (#7567 / #7532).

## Why

go-waku's `MessageSentCheck` (store-based sent-confirmation) is wired to the concrete `*history.StorenodeCycle` — its only use is one line, `GetActiveStorenodePeerInfo()`. The store-client refactor removes that cycle, which would otherwise force us to drop store-confirmation. The `MessageSender` only depends on the `publish.ISentCheck` interface (`Start`/`Add`/`DeleteByMessageIDs`), so we can supply our own implementation and keep the feature **without forking go-waku**.

## What

- New `wakuv2.MessageSentCheck` — a faithful port of go-waku's logic: same default timings, same by-hash store query (reuses `publish.NewDefaultStorenodeMessageVerifier`), same `EventEnvelopeSent` / `EventEnvelopeExpired` events, still gated by `EnableStoreConfirmationForMessagesSent`. Implements `publish.ISentCheck`.
- The store node is supplied via an injectable `storenodePeerProvider` interface instead of `*history.StorenodeCycle`. Today it's still the `StorenodeCycle` (behaviour identical); once the cycle is gone the same seam can be backed by the on-demand `StoreClient` without touching this code.
- Time comparisons in `int64` (avoids the `uint32(Unix())` overflow / gosec footgun) — strictly not worse.
- Unit tests: ack / expiry / not-yet-expired / no-peer / verifier-error / add-delete.

`gowaku.go` now constructs `wakuv2.NewMessageSentCheck(...)` in place of `publish.NewMessageSentCheck(...)`; everything downstream (the `msgStored`/`msgExpired` consumer goroutine) is unchanged.

## Verification

`go build ./...`, `go vet ./pkg/messaging/...`, and `golangci-lint run --new-from-merge-base=origin/develop` all green; new unit tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
