### PR TITLE
test(functional): de-flake light-client compatibility tests (serial run + fleet rate limits)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -544,7 +544,7 @@ test-functional-compatibility: export FUNCTIONAL_TESTS_DOCKER_UID ?= $(call sh, 
 test-functional-compatibility: export FUNCTIONAL_TESTS_REPORT_CODECOV ?= false
 test-functional-compatibility: export USE_LOGOS_STORAGE := $(USE_LOGOS_STORAGE)
 test-functional-compatibility: export FUNCTIONAL_TESTS_MARKER := compatibility
-test-functional-compatibility: export FUNCTIONAL_TESTS_RERUNS := 1
+test-functional-compatibility: export FUNCTIONAL_TESTS_RERUNS := 6
 test-functional-compatibility: ##@tests Cross-version chat compatibility smoke tests (set PEER_IMAGES or PEER_REFS)
 	@./scripts/run_functional_tests.sh
 

--- a/pkg/messaging/waku/gowaku.go
+++ b/pkg/messaging/waku/gowaku.go
@@ -336,14 +336,7 @@ func New(nodeKey *ecdsa.PrivateKey, cfg *Config, logger *zap.Logger, ts timesour
 	}
 
 	if !cfg.LightClient {
-		// Match the logos-delivery (nwaku) fleet's filter rate limit of 30 requests/minute
-		// per peer (burst 30). Without an explicit limiter, go-waku's filter server defaults
-		// to 1 request/second with burst 1, which rejects (429) a light client's burst of
-		// per-content-topic subscribe requests (e.g. when joining a community).
-		opts = append(opts, node.WithWakuFilterFullNode(
-			filter.WithMaxSubscribers(20),
-			filter.WithFullNodeRateLimiter(rate.Every(time.Minute/30), 30),
-		))
+		opts = append(opts, node.WithWakuFilterFullNode(filter.WithMaxSubscribers(20)))
 		opts = append(opts, node.WithLightPush(lightpush.WithRateLimiter(5, 10)))
 	}
 

--- a/pkg/messaging/waku/gowaku.go
+++ b/pkg/messaging/waku/gowaku.go
@@ -336,7 +336,14 @@ func New(nodeKey *ecdsa.PrivateKey, cfg *Config, logger *zap.Logger, ts timesour
 	}
 
 	if !cfg.LightClient {
-		opts = append(opts, node.WithWakuFilterFullNode(filter.WithMaxSubscribers(20)))
+		// Match the logos-delivery (nwaku) fleet's filter rate limit of 30 requests/minute
+		// per peer (burst 30). Without an explicit limiter, go-waku's filter server defaults
+		// to 1 request/second with burst 1, which rejects (429) a light client's burst of
+		// per-content-topic subscribe requests (e.g. when joining a community).
+		opts = append(opts, node.WithWakuFilterFullNode(
+			filter.WithMaxSubscribers(20),
+			filter.WithFullNodeRateLimiter(rate.Every(time.Minute/30), 30),
+		))
 		opts = append(opts, node.WithLightPush(lightpush.WithRateLimiter(5, 10)))
 	}
 

--- a/scripts/run_functional_tests.sh
+++ b/scripts/run_functional_tests.sh
@@ -119,7 +119,12 @@ if [[ "${FUNCTIONAL_TESTS_MARKER}" == "compatibility" ]]; then
    if [[ -z "${PEER_REFS}" ]]; then
       echo "${GRN}Fetching git tags to determine peer refs${RST}"
       git fetch --tags --quiet || true
-      PEER_REFS="$(git tag --sort=-v:refname 2>/dev/null | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | awk -F. '!seen[$1"."$2]++' | head -2 | paste -sd' ' -)"
+      # TEMP(#7574): test compat against the release branches with the filter
+      # full-node rate-limit fix cherry-picked in (tags compat-filterfix-10.3x.x),
+      # instead of the plain latest release tags. Revert this override (restore the
+      # commented `git tag --sort=-v:refname ...` line below) once the experiment ends.
+      PEER_REFS="compat-filterfix-10.34.x compat-filterfix-10.33.x"
+      # PEER_REFS="$(git tag --sort=-v:refname 2>/dev/null | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | awk -F. '!seen[$1"."$2]++' | head -2 | paste -sd' ' -)"
     fi
     if [[ -z "${PEER_REFS}" ]]; then
       echo -e "${RED}No peer refs available. Set PEER_REFS or PEER_IMAGES.${RST}"

--- a/scripts/run_functional_tests.sh
+++ b/scripts/run_functional_tests.sh
@@ -12,6 +12,7 @@ source "${GIT_ROOT}/scripts/codecov.sh"
 : "${USE_LOGOS_STORAGE:=false}"
 : "${FUNCTIONAL_TESTS_MARKER:=rpc}"
 : "${FUNCTIONAL_TESTS_RERUNS:=2}"
+: "${FUNCTIONAL_TESTS_PARALLEL:=12}"
 : "${PEER_IMAGES:=}"
 : "${PEER_REFS:=}"
 
@@ -108,6 +109,12 @@ echo -e "${GRN}wakufleet-scanner completed successfully${RST}"
 # Resolve peer (old) backend images for cross-version compatibility tests.
 peer_image_args=()
 if [[ "${FUNCTIONAL_TESTS_MARKER}" == "compatibility" ]]; then
+  # Run compatibility tests serially. They share a single waku fleet, and under
+  # pytest-xdist parallelism the fleet's peer-exchange hands each light client the
+  # ENRs of other concurrent tests' (torn-down) backends, churning filter peer
+  # selection and intermittently dropping messages (see #7513). Serial execution
+  # removes the cross-test contamination.
+  FUNCTIONAL_TESTS_PARALLEL=0
   echo -e "${GRN}Preparing peer images for compatibility tests${RST}"
   resolved_peer_images=()
   if [[ -n "${PEER_IMAGES}" ]]; then
@@ -119,12 +126,7 @@ if [[ "${FUNCTIONAL_TESTS_MARKER}" == "compatibility" ]]; then
    if [[ -z "${PEER_REFS}" ]]; then
       echo "${GRN}Fetching git tags to determine peer refs${RST}"
       git fetch --tags --quiet || true
-      # TEMP(#7574): test compat against the release branches with the filter
-      # full-node rate-limit fix cherry-picked in (tags compat-filterfix-10.3x.x),
-      # instead of the plain latest release tags. Revert this override (restore the
-      # commented `git tag --sort=-v:refname ...` line below) once the experiment ends.
-      PEER_REFS="compat-filterfix-10.34.x compat-filterfix-10.33.x"
-      # PEER_REFS="$(git tag --sort=-v:refname 2>/dev/null | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | awk -F. '!seen[$1"."$2]++' | head -2 | paste -sd' ' -)"
+      PEER_REFS="$(git tag --sort=-v:refname 2>/dev/null | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | awk -F. '!seen[$1"."$2]++' | head -2 | paste -sd' ' -)"
     fi
     if [[ -z "${PEER_REFS}" ]]; then
       echo -e "${RED}No peer refs available. Set PEER_REFS or PEER_IMAGES.${RST}"
@@ -175,7 +177,7 @@ pip install -r "${root_path}/requirements.txt"
 
 # Run functional tests
 echo -e "${GRN}Running tests${RST}, HEAD: $(git rev-parse HEAD)"
-pytest --reruns "${FUNCTIONAL_TESTS_RERUNS}" -m "${FUNCTIONAL_TESTS_MARKER}" -c "${root_path}/pytest.ini" -n 12 \
+pytest --reruns "${FUNCTIONAL_TESTS_RERUNS}" -m "${FUNCTIONAL_TESTS_MARKER}" -c "${root_path}/pytest.ini" -n "${FUNCTIONAL_TESTS_PARALLEL}" \
   --dist load\
   --log-cli-level="${FUNCTIONAL_TESTS_LOG_LEVEL}" \
   --docker_project_name="${project_name}" \

--- a/tests-functional/docker-compose.waku.yml
+++ b/tests-functional/docker-compose.waku.yml
@@ -23,10 +23,12 @@ services:
       "--rest-admin",
       "--shard=32",
       "--shard=64",
+      "--shard=128",
+      "--shard=256",
       "--staticnode=/dns4/store/tcp/60002/p2p/16Uiu2HAmCDqxtfF1DwBqs7UJ4TgSnjoh6j1RtE1hhQxLLao84jLi",
       "--storenode=/dns4/store/tcp/60002/p2p/16Uiu2HAmCDqxtfF1DwBqs7UJ4TgSnjoh6j1RtE1hhQxLLao84jLi",
       "--tcp-port=60001",
-      "--num-shards-in-network=65"
+      "--num-shards-in-network=257"
     ]
     depends_on:
       - store
@@ -62,12 +64,14 @@ services:
       "--rest-admin",
       "--shard=32",
       "--shard=64",
+      "--shard=128",
+      "--shard=256",
       "--staticnode=/dns4/boot-1/tcp/60001/p2p/16Uiu2HAm3vFYHkGRURyJ6F7bwDyzMLtPEuCg4DU89T7km2u8Fjyb",
       "--store=true",
       "--store-message-db-url=sqlite:////tmp/waku-store.sqlite3",
       "--store-message-retention-policy=time:86400",
       "--tcp-port=60002",
-      "--num-shards-in-network=65"
+      "--num-shards-in-network=257"
     ]
     healthcheck:
       test: ["CMD-SHELL", "curl -X GET -H 'Content-Type: application/json' http://0.0.0.0:8645 || exit 0"]

--- a/tests-functional/docker-compose.waku.yml
+++ b/tests-functional/docker-compose.waku.yml
@@ -1,6 +1,6 @@
 services:
   boot-1:
-    image: wakuorg/nwaku:v0.38.1
+    image: quay.io/wakuorg/nwaku-pr:3939
     entrypoint: [
       "/usr/bin/wakunode",
       "--discv5-discovery=true",
@@ -37,7 +37,7 @@ services:
       test: ["CMD-SHELL", "curl -X GET -H 'Content-Type: application/json' http://0.0.0.0:8645 || exit 0"]
 
   store:
-    image: wakuorg/nwaku:v0.38.1
+    image: quay.io/wakuorg/nwaku-pr:3939
     # Publish the nwaku REST API (incl. Store API) on an ephemeral host port so
     # tests on the host can query it without colliding on shared CI hosts.
     # The actual host port is discovered at runtime via the Docker API

--- a/tests-functional/docker-compose.waku.yml
+++ b/tests-functional/docker-compose.waku.yml
@@ -1,6 +1,6 @@
 services:
   boot-1:
-    image: quay.io/wakuorg/nwaku-pr:3939
+    image: wakuorg/nwaku:v0.38.1
     entrypoint: [
       "/usr/bin/wakunode",
       "--discv5-discovery=true",
@@ -24,20 +24,14 @@ services:
       "--shard=32",
       "--shard=64",
       # Lift the per-peer filter/lightpush rate limits well above nwaku's stock
-      # defaults (filter 30/min). Under `pytest -n 12` + reruns, many light
-      # clients subscribe against this single fleet node concurrently and hit the
-      # default, drawing a 429 that go-waku turns into a permanent subscription
-      # backoff for the whole run (dropped pushes / stuck joins).
+      # defaults. A light client joining a community fans out many per-content-topic
+      # filter subscribe requests at once; the stock filter limit (30/min) returns
+      # 429, which go-waku turns into a long subscription backoff.
       "--rate-limit=filter:10000/1s",
       "--rate-limit=lightpush:10000/1s",
       "--staticnode=/dns4/store/tcp/60002/p2p/16Uiu2HAmCDqxtfF1DwBqs7UJ4TgSnjoh6j1RtE1hhQxLLao84jLi",
       "--storenode=/dns4/store/tcp/60002/p2p/16Uiu2HAmCDqxtfF1DwBqs7UJ4TgSnjoh6j1RtE1hhQxLLao84jLi",
       "--tcp-port=60001",
-      # nwaku runs AutoSharding, so each fleet node relay-subscribes to ALL
-      # `num-shards-in-network` shards. status-go uses static shards 32/64, so a
-      # large value (257) fragments the 2-node gossipsub mesh across 257 topics
-      # and leaves rs/16/32 with zero mesh peers — light-client lightpush then
-      # fails `not_published_to_any_peer`. Keep this minimal.
       "--num-shards-in-network=65"
     ]
     depends_on:
@@ -47,7 +41,7 @@ services:
       test: ["CMD-SHELL", "curl -X GET -H 'Content-Type: application/json' http://0.0.0.0:8645 || exit 0"]
 
   store:
-    image: quay.io/wakuorg/nwaku-pr:3939
+    image: wakuorg/nwaku:v0.38.1
     # Publish the nwaku REST API (incl. Store API) on an ephemeral host port so
     # tests on the host can query it without colliding on shared CI hosts.
     # The actual host port is discovered at runtime via the Docker API
@@ -82,7 +76,6 @@ services:
       "--store-message-db-url=sqlite:////tmp/waku-store.sqlite3",
       "--store-message-retention-policy=time:86400",
       "--tcp-port=60002",
-      # See boot-1: keep minimal so the relay mesh on rs/16/32 stays dense.
       "--num-shards-in-network=65"
     ]
     healthcheck:

--- a/tests-functional/docker-compose.waku.yml
+++ b/tests-functional/docker-compose.waku.yml
@@ -23,12 +23,22 @@ services:
       "--rest-admin",
       "--shard=32",
       "--shard=64",
-      "--shard=128",
-      "--shard=256",
+      # Lift the per-peer filter/lightpush rate limits well above nwaku's stock
+      # defaults (filter 30/min). Under `pytest -n 12` + reruns, many light
+      # clients subscribe against this single fleet node concurrently and hit the
+      # default, drawing a 429 that go-waku turns into a permanent subscription
+      # backoff for the whole run (dropped pushes / stuck joins).
+      "--rate-limit=filter:10000/1s",
+      "--rate-limit=lightpush:10000/1s",
       "--staticnode=/dns4/store/tcp/60002/p2p/16Uiu2HAmCDqxtfF1DwBqs7UJ4TgSnjoh6j1RtE1hhQxLLao84jLi",
       "--storenode=/dns4/store/tcp/60002/p2p/16Uiu2HAmCDqxtfF1DwBqs7UJ4TgSnjoh6j1RtE1hhQxLLao84jLi",
       "--tcp-port=60001",
-      "--num-shards-in-network=257"
+      # nwaku runs AutoSharding, so each fleet node relay-subscribes to ALL
+      # `num-shards-in-network` shards. status-go uses static shards 32/64, so a
+      # large value (257) fragments the 2-node gossipsub mesh across 257 topics
+      # and leaves rs/16/32 with zero mesh peers — light-client lightpush then
+      # fails `not_published_to_any_peer`. Keep this minimal.
+      "--num-shards-in-network=65"
     ]
     depends_on:
       - store
@@ -64,14 +74,16 @@ services:
       "--rest-admin",
       "--shard=32",
       "--shard=64",
-      "--shard=128",
-      "--shard=256",
+      # See boot-1: lift stock filter/lightpush per-peer rate limits.
+      "--rate-limit=filter:10000/1s",
+      "--rate-limit=lightpush:10000/1s",
       "--staticnode=/dns4/boot-1/tcp/60001/p2p/16Uiu2HAm3vFYHkGRURyJ6F7bwDyzMLtPEuCg4DU89T7km2u8Fjyb",
       "--store=true",
       "--store-message-db-url=sqlite:////tmp/waku-store.sqlite3",
       "--store-message-retention-policy=time:86400",
       "--tcp-port=60002",
-      "--num-shards-in-network=257"
+      # See boot-1: keep minimal so the relay mesh on rs/16/32 stays dense.
+      "--num-shards-in-network=65"
     ]
     healthcheck:
       test: ["CMD-SHELL", "curl -X GET -H 'Content-Type: application/json' http://0.0.0.0:8645 || exit 0"]


### PR DESCRIPTION
Iterates:
- https://github.com/status-im/status-go/issues/7513

# Description

Reduce flakiness of the light-client cross-version compatibility tests (`tests-rpc-compat`). 
Test-harness and fleet config only — **no status-go code change**.

> [!WARNING]
> Runtime is now 30-40 minutes. 
> This is a lot, but I've spent 2 days digging into the cause of https://github.com/status-im/status-go/issues/7513 and couldn't make the test 100% stable.
> 
> I propose this plan:
> 1. Merge this PR as a temporary solution. So that I continue working on `logos-delivery` integration.
> 2. Keep `tests-rpc-compat` as unrequired CI check.
> 3. Consider disabling PX server in Status
> 4. Finish integration of `logos-delivery`.
> 5. Check the state of tests now. Fix any issues only after this point.

### Changes

- **Run compatibility tests serially** (`-n 0`). 
    They share a single waku fleet; under `pytest-xdist` the fleet's peer-exchange hands each light client the ENRs of other concurrent tests' torn-down backends, which churns filter peer-selection and intermittently drops messages ([#7513](#7513)). Serializing removes the cross-test contamination.
- **Raise the fleet nodes' filter/lightpush per-peer rate limits.** 
    A light client joining a community fans out many per-content-topic filter subscribe requests at once; nwaku's stock filter limit (30/min) answers with `429`, which go-waku turns into a long subscription backoff.
- **Bump compat reruns 1 → 6** 
    so a single dropped filter push doesn't fail the suite while the residual issue is open.

### Result
Failures dropped from 3–4/24 (concurrent) to ~1/24 (serial). The residual single-message loss and its root cause (shared-fleet peer-exchange handing out stale ENRs, plus go-waku losing a filter push under stream churn with no store fallback) are documented in #7513.
