### PR TITLE
fix: more robust clone targets for nim-sds and logos-storage native builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -171,9 +171,15 @@ endif
 clone-storage: ##@build Clone or update logos-storage-nim
 ifeq ($(LOGOS_STORAGE_BUILD_FROM_SOURCE),true)
 	@echo "Cloning or updating logos-storage-nim ..."
-	rm -rf "$(LOGOS_STORAGE_SOURCE_DIR)"
-	git clone https://github.com/logos-storage/logos-storage-nim.git $(LOGOS_STORAGE_SOURCE_DIR)
-	cd $(LOGOS_STORAGE_SOURCE_DIR) && git switch --force --detach $(LOGOS_STORAGE_VERSION) && git submodule update --init --recursive
+	if [ ! -d "$(LOGOS_STORAGE_SOURCE_DIR)" ]; then \
+		git clone --recurse-submodules https://github.com/logos-storage/logos-storage-nim.git "$(LOGOS_STORAGE_SOURCE_DIR)"; \
+	else \
+		cd "$(LOGOS_STORAGE_SOURCE_DIR)" && git fetch --tags; \
+	fi
+	cd "$(LOGOS_STORAGE_SOURCE_DIR)" && \
+		git switch --force --detach "$(LOGOS_STORAGE_VERSION)" && \
+		git clean -fdx && \
+		git submodule update --init --recursive --force
 endif
 
 $(LIBSTORAGE): clone-storage
@@ -299,9 +305,15 @@ USE_SYSTEM_NIM ?= 1
 clone-nim-sds: ##@build Clone or update nim-sds
 ifeq ($(NIM_SDS_BUILD_FROM_SOURCE),true)
 	@echo "Cloning or updating nim-sds ..."
-	rm -rf "$(NIM_SDS_SOURCE_DIR)"
-	git clone https://github.com/waku-org/nim-sds.git $(NIM_SDS_SOURCE_DIR)
-	cd $(NIM_SDS_SOURCE_DIR) && git switch --force --detach $(NIM_SDS_VERSION) && git submodule update --init --recursive
+	if [ ! -d "$(NIM_SDS_SOURCE_DIR)" ]; then \
+		git clone --recurse-submodules https://github.com/waku-org/nim-sds.git "$(NIM_SDS_SOURCE_DIR)"; \
+	else \
+		cd "$(NIM_SDS_SOURCE_DIR)" && git fetch --tags; \
+	fi
+	cd "$(NIM_SDS_SOURCE_DIR)" && \
+		git switch --force --detach "$(NIM_SDS_VERSION)" && \
+		git clean -fdx && \
+		git submodule update --init --recursive --force
 endif
 
 $(LIBSDS): clone-nim-sds

--- a/Makefile
+++ b/Makefile
@@ -107,7 +107,8 @@ BUILD_TAGS ?= gowaku_no_rln
 # Pin nim-sds revision here. Can be a tag (default) or commit hash.
 NIM_SDS_VERSION ?= v0.2.4
 
-# Option 1: Provide NIM_SDS_SOURCE_DIR. Make clones it if missing.
+# Option 1: Provide NIM_SDS_SOURCE_DIR. Make force-reclones a fresh copy (with submodules)
+# to guarantee a clean checkout on every build.
 NIM_SDS_SOURCE_DIR ?= $(GIT_ROOT)/../nim-sds
 # Normalize path separators for Windows (backslashes cause issues when passed through shells)
 ifeq ($(mkspecs),win32)
@@ -140,7 +141,8 @@ USE_LOGOS_STORAGE ?= false
 LOGOS_STORAGE_VERSION ?= 3c09f008bb5266a669fd19f18368f9e8b861b664
 LOGOS_STORAGE_SOURCE_DIR ?= $(GIT_ROOT)/../logos-storage-nim
 
-# Option 1: Provide LOGOS_STORAGE_SOURCE_DIR. Make clones it if missing.
+# Option 1: Provide LOGOS_STORAGE_SOURCE_DIR. Make force-reclones a fresh copy (with submodules)
+# to guarantee a clean checkout on every build.
 # Option 2: Provide LOGOS_STORAGE_LIB_DIR and LOGOS_STORAGE_INC_DIR.
 ifdef LOGOS_STORAGE_LIB_DIR
 ifdef LOGOS_STORAGE_INC_DIR
@@ -169,18 +171,18 @@ endif
 clone-storage: ##@build Clone or update logos-storage-nim
 ifeq ($(LOGOS_STORAGE_BUILD_FROM_SOURCE),true)
 	@echo "Cloning or updating logos-storage-nim ..."
-	if [ ! -d "$(LOGOS_STORAGE_SOURCE_DIR)" ]; then \
-		git clone --recurse-submodules https://github.com/logos-storage/logos-storage-nim.git $(LOGOS_STORAGE_SOURCE_DIR); \
-	else \
-		cd $(LOGOS_STORAGE_SOURCE_DIR) && git fetch --tags; \
-	fi
-	cd $(LOGOS_STORAGE_SOURCE_DIR) && git checkout $(LOGOS_STORAGE_VERSION) && git submodule update --init --recursive
+	rm -rf "$(LOGOS_STORAGE_SOURCE_DIR)"
+	git clone https://github.com/logos-storage/logos-storage-nim.git $(LOGOS_STORAGE_SOURCE_DIR)
+	cd $(LOGOS_STORAGE_SOURCE_DIR) && git switch --force --detach $(LOGOS_STORAGE_VERSION) && git submodule update --init --recursive
 endif
 
 $(LIBSTORAGE): clone-storage
 ifeq ($(LOGOS_STORAGE_BUILD_FROM_SOURCE),true)
 	@echo "Building logos-storage: $(LIBSTORAGE)"
-	$(MAKE) -C $(LOGOS_STORAGE_SOURCE_DIR) libstorage
+	$(MAKE) -C $(LOGOS_STORAGE_SOURCE_DIR) libstorage USE_SYSTEM_NIM=$(USE_SYSTEM_NIM) SHELL=$(MAKE_SHELL)
+	@test -f $(LIBSTORAGE) || (echo "Error: libstorage not found at $(LIBSTORAGE) after build" && exit 1)
+else
+	@test -f $(LIBSTORAGE) || (echo "Error: libstorage not found at $(LIBSTORAGE)" && exit 1)
 endif
 
 build-storage: $(LIBSTORAGE)
@@ -297,12 +299,9 @@ USE_SYSTEM_NIM ?= 1
 clone-nim-sds: ##@build Clone or update nim-sds
 ifeq ($(NIM_SDS_BUILD_FROM_SOURCE),true)
 	@echo "Cloning or updating nim-sds ..."
-	if [ ! -d "$(NIM_SDS_SOURCE_DIR)" ]; then \
-		git clone https://github.com/waku-org/nim-sds.git $(NIM_SDS_SOURCE_DIR); \
-	else \
-		cd $(NIM_SDS_SOURCE_DIR) && git fetch --tags; \
-	fi
-	cd $(NIM_SDS_SOURCE_DIR) && git checkout $(NIM_SDS_VERSION)
+	rm -rf "$(NIM_SDS_SOURCE_DIR)"
+	git clone https://github.com/waku-org/nim-sds.git $(NIM_SDS_SOURCE_DIR)
+	cd $(NIM_SDS_SOURCE_DIR) && git switch --force --detach $(NIM_SDS_VERSION) && git submodule update --init --recursive
 endif
 
 $(LIBSDS): clone-nim-sds
@@ -310,6 +309,7 @@ ifeq ($(NIM_SDS_BUILD_FROM_SOURCE),true)
 	@echo "Building nim-sds: $(LIBSDS)"
 	$(MAKE) -C $(NIM_SDS_SOURCE_DIR) update USE_SYSTEM_NIM=$(USE_SYSTEM_NIM)
 	$(MAKE) -C $(NIM_SDS_SOURCE_DIR) libsds USE_SYSTEM_NIM=$(USE_SYSTEM_NIM) NIMFLAGS=-d:noSignalHandler SHELL=$(MAKE_SHELL)
+	@test -f $(LIBSDS) || (echo "Error: libsds not found at $(LIBSDS) after build" && exit 1)
 else
 	@test -f $(LIBSDS) || (echo "Error: libsds not found at $(LIBSDS)" && exit 1)
 endif


### PR DESCRIPTION
status-app PR: https://github.com/status-im/status-app/pull/21319

## Summary

This PR makes the native dependency checkout logic more robust for `nim-sds` and `logos-storage-nim`.

Instead of blindly trusting the previous state of shared checkout directories, the Makefile now fetches updates, switches to the pinned revision, removes root-level untracked/ignored build artifacts, and force-updates submodules for that revision before building.

## Motivation

The previous logic reused native dependency checkouts:

```makefile
if [ ! -d "$(NIM_SDS_SOURCE_DIR)" ]; then
    git clone ...
else
    cd "$(NIM_SDS_SOURCE_DIR)" && git fetch --tags
fi

cd "$(NIM_SDS_SOURCE_DIR)" && git checkout/switch "$(NIM_SDS_VERSION)"
```

Fetching tags and switching to the pinned revision updates the Git revision, but it does not fully clean the reused working directory. State from previous CI jobs can remain in the checkout, including untracked files, ignored build outputs, stale artifacts, partially initialized submodules, or state inside submodule directories.

This was visible on Windows CI with `nim-sds`. The reused checkout entered the old `nimbus-build-system` flow, reported missing submodules and attempted to run `git submodule update --init --recursive`, but the subsequent `make libsds` still short-circuited with:

```text
Nothing to be done for 'libsds'
```

No `build/libsds.dll` was produced, and the final Go link step failed with:

```text
ld.exe: cannot find -lsds: No such file or directory
```

## Changes

- Keep reusing the existing `nim-sds` / `logos-storage-nim` checkout when present.
- Clone with `--recurse-submodules` only when the checkout directory is missing.
- Fetch tags before switching an existing checkout.
- Force-switch to the pinned revision with `git switch --force --detach`.
- Remove root-level untracked and ignored files with `git clean -fdx`.
- Force-update submodules with `git submodule update --init --recursive --force`.
- Keep both native dependency targets aligned on the same checkout/update behavior.

This avoids a full reclone on every source-built native dependency build, while still cleaning the most likely stale state from shared CI workspaces.

`git clean -fdx` and forced submodule updates are not as exhaustive as deleting the checkout and cloning from scratch, but they are a smaller and less network-heavy compromise. If this still proves insufficient, we can escalate to a full reclone or a more aggressive submodule cleanup sequence.
