### PR TITLE
fix: logos_storage_config migration timestamp

### DIFF
--- a/internal/db/appdatabase/migrations/sql/1782243470_add_logos_storage_config.up.sql
+++ b/internal/db/appdatabase/migrations/sql/1782243470_add_logos_storage_config.up.sql
@@ -1,4 +1,4 @@
-CREATE TABLE logos_storage_config (
+CREATE TABLE IF NOT EXISTS logos_storage_config (
   enabled BOOLEAN DEFAULT false,
   log_level TEXT DEFAULT 'info',
   log_format TEXT DEFAULT 'auto',


### PR DESCRIPTION
## Summary

Fixes the Logos Storage config migration timestamp so accounts already migrated past newer `develop` migrations still create `logos_storage_config` on login.