### PR TITLE
feat(threads): add phase 1 of the threads feature

### DIFF
--- a/cmd/status-backend/API_REFERENCE.md
+++ b/cmd/status-backend/API_REFERENCE.md
@@ -319,9 +319,14 @@ Send a text message to a chat/channel.
 [{
   "chatId": "<chatId>",
   "text": "Hello!",
-  "contentType": 1
+  "contentType": 1,
+  "threadId": "<parentMessageId-optional>"
 }]
 ```
+
+- `threadId` is optional.
+- Use `threadId` to send a message into an existing thread.
+- If `threadId` points to a parent that is not yet known locally, the backend still creates thread metadata and backfills the name when the parent arrives.
 
 **Chat ID formats:**
 
@@ -335,7 +340,7 @@ Send a text message to a chat/channel.
 
 ---
 
-### wakuext_chatMessages
+### wakuext_chatMessages (deprecated)
 
 Read message history for a chat.
 
@@ -343,6 +348,78 @@ Read message history for a chat.
 - `chatId`: string (communityId + chatUUID)
 - `cursor`: string (empty string for first page)
 - `limit`: number
+
+---
+
+### wakuext_chatMessagesV2
+
+Same as `wakuext_chatMessages`, but also can get thread history.
+
+**Params:** `[chatId, threadId cursor, limit]`
+- `chatId`: string (communityId + chatUUID)
+- `threadId`: string (leave empty to get the history of a chat)
+- `cursor`: string (empty string for first page)
+- `limit`: number
+
+---
+
+### wakuext_createThread
+
+Explicitly create a thread from an existing parent message. The parent message must already be stored locally (i.e. it was previously received or sent).
+
+For community chats, the caller must be a privileged member (admin/owner) unless the community has "create threads for all members" enabled.
+
+**Params:** `[chatId, parentMessageId]`
+- `chatId`: string — channel/chat identifier.
+- `parentMessageId`: string — ID of the message that becomes the thread root.
+
+**Result:**
+```json
+{
+  "threads": [
+    {
+      "threadId": "0x-parent-message-id",
+      "chatId": "0xcommunity...<chatUUID>",
+      "parentMessageId": "0x-parent-message-id",
+      "name": "First 40 chars of parent text (or empty)"
+    }
+  ]
+}
+```
+
+**Errors:**
+- `"threads feature is disabled"` — feature flag is off.
+- `"chatID and parentMessageID are required"` — missing params.
+- `"thread already exists for this message"` — thread already created for this parent.
+- `"parent message not found"` — parent message doesn't exist locally.
+- `"only admins can create threads in this community"` — permission denied.
+
+---
+
+### wakuext_chatThreads
+
+List threads for a chat.
+
+**Params:** `[chatId]`
+- `chatId`: string (communityId + chatUUID)
+
+**Result:**
+```json
+{
+  "threads": [
+    {
+      "threadId": "0x-parent-message-id",
+      "chatId": "0xcommunity...<chatUUID>",
+      "parentMessageId": "0x-parent-message-id",
+      "name": "Parent message text (or empty until known)"
+    }
+  ]
+}
+```
+
+Notes:
+- `name` may be empty when the parent message has not been persisted yet.
+- Unknown/placeholder names are intentionally client-defined; backend returns empty string until resolved.
 
 ---
 

--- a/internal/protocol/activity_center_persistence_test.go
+++ b/internal/protocol/activity_center_persistence_test.go
@@ -196,7 +196,7 @@ func (s *ActivityCenterPersistenceTestSuite) Test_DeleteActivityCenterNotificati
 	err = p.SaveChat(*chat)
 	s.Require().NoError(err)
 
-	chatMessages, _, err := p.MessageByChatID(chat.ID, "", 2)
+	chatMessages, _, err := p.MessageByChatID(chat.ID, "", "", 2, false)
 	s.Require().NoError(err)
 	s.Require().Len(chatMessages, 2)
 
@@ -312,7 +312,7 @@ func (s *ActivityCenterPersistenceTestSuite) Test_DeleteActivityCenterNotificati
 	err = p.SaveChat(*chat)
 	s.Require().NoError(err)
 
-	chatMessages, _, err := p.MessageByChatID(chat.ID, "", 2)
+	chatMessages, _, err := p.MessageByChatID(chat.ID, "", "", 2, false)
 	s.Require().NoError(err)
 	s.Require().Len(chatMessages, 2)
 

--- a/internal/protocol/common/feature_flags.go
+++ b/internal/protocol/common/feature_flags.go
@@ -14,4 +14,7 @@ type FeatureFlags struct {
 
 	// EnableMercuryoProvider indicates whether we should enable the Mercuryo provider in the Wallet
 	EnableMercuryoProvider bool
+
+	// Threads indicates whether thread-specific behavior is enabled.
+	Threads bool
 }

--- a/internal/protocol/common/message.go
+++ b/internal/protocol/common/message.go
@@ -245,6 +245,7 @@ func (m *Message) MarshalJSON() ([]byte, error) {
 		BridgeMessage            *protobuf.BridgeMessage          `json:"bridgeMessage,omitempty"`
 		PaymentRequests          []*protobuf.PaymentRequest       `json:"paymentRequests,omitempty"`
 		PinnedBy                 string                           `json:"pinnedBy,omitempty"`
+		ThreadID                 string                           `json:"threadId,omitempty"`
 	}
 	item := MessageStructType{
 		ID:                       m.ID,
@@ -287,6 +288,7 @@ func (m *Message) MarshalJSON() ([]byte, error) {
 		ContactVerificationState: m.ContactVerificationState,
 		PaymentRequests:          m.PaymentRequests,
 		PinnedBy:                 m.PinnedBy,
+		ThreadID:                 m.GetThreadId(),
 	}
 
 	if sticker := m.GetSticker(); sticker != nil {
@@ -336,6 +338,7 @@ func (m *Message) UnmarshalJSON(data []byte) error {
 		EnsName            string                           `json:"ensName"`
 		DisplayName        string                           `json:"displayName"`
 		ChatID             string                           `json:"chatId"`
+		ThreadID           string                           `json:"threadId"`
 		Sticker            *protobuf.StickerMessage         `json:"sticker"`
 		AudioDurationMs    uint64                           `json:"audioDurationMs"`
 		ParsedText         json.RawMessage                  `json:"parsedText"`
@@ -383,6 +386,9 @@ func (m *Message) UnmarshalJSON(data []byte) error {
 	m.From = aux.From
 	m.Deleted = aux.Deleted
 	m.DeletedForMe = aux.DeletedForMe
+	if aux.ThreadID != "" {
+		m.ThreadId = &aux.ThreadID
+	}
 	return nil
 }
 

--- a/internal/protocol/communities/community.go
+++ b/internal/protocol/communities/community.go
@@ -141,7 +141,8 @@ func New(config Config, timesource common.TimeSource, encryptor DescriptionEncry
 }
 
 type CommunityAdminSettings struct {
-	PinMessageAllMembersEnabled bool `json:"pinMessageAllMembersEnabled"`
+	PinMessageAllMembersEnabled   bool `json:"pinMessageAllMembersEnabled"`
+	CreateThreadAllMembersEnabled bool `json:"createThreadAllMembersEnabled"`
 }
 
 type CommunityChat struct {
@@ -284,11 +285,13 @@ func (o *Community) MarshalPublicAPIJSON() ([]byte, error) {
 		}
 
 		communityItem.CommunityAdminSettings = CommunityAdminSettings{
-			PinMessageAllMembersEnabled: false,
+			PinMessageAllMembersEnabled:   false,
+			CreateThreadAllMembersEnabled: false,
 		}
 
 		if o.config.CommunityDescription.AdminSettings != nil {
 			communityItem.CommunityAdminSettings.PinMessageAllMembersEnabled = o.config.CommunityDescription.AdminSettings.PinMessageAllMembersEnabled
+			communityItem.CommunityAdminSettings.CreateThreadAllMembersEnabled = o.config.CommunityDescription.AdminSettings.CreateThreadAllMembersEnabled
 		}
 	}
 	return json.Marshal(communityItem)
@@ -445,11 +448,13 @@ func (o *Community) MarshalJSON() ([]byte, error) {
 		}
 
 		communityItem.CommunityAdminSettings = CommunityAdminSettings{
-			PinMessageAllMembersEnabled: false,
+			PinMessageAllMembersEnabled:   false,
+			CreateThreadAllMembersEnabled: false,
 		}
 
 		if o.config.CommunityDescription.AdminSettings != nil {
 			communityItem.CommunityAdminSettings.PinMessageAllMembersEnabled = o.config.CommunityDescription.AdminSettings.PinMessageAllMembersEnabled
+			communityItem.CommunityAdminSettings.CreateThreadAllMembersEnabled = o.config.CommunityDescription.AdminSettings.CreateThreadAllMembersEnabled
 		}
 	}
 	return json.Marshal(communityItem)
@@ -1165,6 +1170,7 @@ func (o *Community) Edit(description *protobuf.CommunityDescription) {
 	}
 	o.config.CommunityDescription.Permissions = description.Permissions
 	o.config.CommunityDescription.AdminSettings.PinMessageAllMembersEnabled = description.AdminSettings.PinMessageAllMembersEnabled
+	o.config.CommunityDescription.AdminSettings.CreateThreadAllMembersEnabled = description.AdminSettings.CreateThreadAllMembersEnabled
 }
 
 func (o *Community) EditPermissionAccess(permissionAccess protobuf.CommunityPermissions_Access) {
@@ -2404,6 +2410,10 @@ func (o *Community) ChatIDs() (chatIDs []string) {
 
 func (o *Community) AllowsAllMembersToPinMessage() bool {
 	return o.config.CommunityDescription.AdminSettings != nil && o.config.CommunityDescription.AdminSettings.PinMessageAllMembersEnabled
+}
+
+func (o *Community) AllowsAllMembersToCreateThread() bool {
+	return o.config.CommunityDescription.AdminSettings != nil && o.config.CommunityDescription.AdminSettings.CreateThreadAllMembersEnabled
 }
 
 func (o *Community) CreateDeepCopy() *Community {

--- a/internal/protocol/communities_messenger_test.go
+++ b/internal/protocol/communities_messenger_test.go
@@ -623,7 +623,7 @@ func (s *MessengerCommunitiesSuite) TestSDSMissingDependenciesFetchTriggeredWhen
 	s.joinCommunity(community, s.bob, aliceObserver)
 
 	// Alice joined after the first message, so old message should still be missing.
-	aliceMessages, _, err := aliceObserver.MessageByChatID(chat.ID, "", 20)
+	aliceMessages, _, err := aliceObserver.MessageByChatID(chat.ID, "", "", 20)
 	s.Require().NoError(err)
 	for _, msg := range aliceMessages {
 		s.Require().NotEqual(oldMessage.ID, msg.ID)

--- a/internal/protocol/communities_messenger_token_permissions_test.go
+++ b/internal/protocol/communities_messenger_token_permissions_test.go
@@ -502,7 +502,7 @@ func (s *MessengerCommunitiesTokenPermissionsSuite) TestBecomeMemberPermissions(
 	s.Require().Len(response.Messages(), 1)
 	s.Require().Equal(msg.Text, response.Messages()[0].Text)
 
-	bobMessages, _, err := s.bob.MessageByChatID(msg.ChatId, "", 10)
+	bobMessages, _, err := s.bob.MessageByChatID(msg.ChatId, "", "", 10)
 	s.Require().NoError(err)
 	s.Require().Len(bobMessages, 1)
 	s.Require().Equal(messages[0], bobMessages[0].Text)
@@ -591,12 +591,12 @@ func (s *MessengerCommunitiesTokenPermissionsSuite) TestBecomeMemberPermissions(
 		s.bob,
 		func(r *MessengerResponse) bool {
 			// Bob should have all 3 messages
-			bobMessages, _, err = s.bob.MessageByChatID(msg.ChatId, "", 10)
+			bobMessages, _, err = s.bob.MessageByChatID(msg.ChatId, "", "", 10)
 			return err == nil && len(bobMessages) == 3
 		},
 		"not all 3 messages received",
 	)
-	bobMessages, _, err = s.bob.MessageByChatID(msg.ChatId, "", 10)
+	bobMessages, _, err = s.bob.MessageByChatID(msg.ChatId, "", "", 10)
 	for _, m := range bobMessages {
 		fmt.Printf("ID: %s\n", m.ID)
 	}

--- a/internal/protocol/message_persistence.go
+++ b/internal/protocol/message_persistence.go
@@ -52,6 +52,13 @@ var cursorField = cursor + " as cursor"
 var caseSensitiveSearchCond = "(m1.text LIKE '%' || ? || '%' OR bm.content LIKE '%' || ? || '%' OR dm.content LIKE '%' || ? || '%')"
 var caseInsensitiveSearchCond = "(LOWER(m1.text) LIKE LOWER('%' || ? || '%') OR LOWER(bm.content) LIKE LOWER('%' || ? || '%') OR LOWER(dm.content) LIKE LOWER('%' || ? || '%'))"
 
+type Thread struct {
+	ThreadID        string `json:"threadId"`
+	ChatID          string `json:"chatId"`
+	ParentMessageID string `json:"parentMessageId"`
+	Name            string `json:"name"`
+}
+
 func (db sqlitePersistence) buildMessagesQueryWithAdditionalFields(additionalSelectFields, whereAndTheRest string) string {
 	allFields := db.tableUserMessagesAllFieldsJoin()
 	if additionalSelectFields != "" {
@@ -114,7 +121,8 @@ func (db sqlitePersistence) tableUserMessagesAllFields() string {
 		mentioned,
 		replied,
     	discord_message_id,
-		payment_requests`
+		payment_requests,
+		thread_id`
 }
 
 func (db sqlitePersistence) tableUserMessagesProtobufFields() string {
@@ -201,6 +209,7 @@ func (db sqlitePersistence) tableUserMessagesAllFieldsJoin() string {
 		m1.mentioned,
 		m1.replied,
     COALESCE(m1.discord_message_id, ""),
+	COALESCE(m1.thread_id, ""),
     COALESCE(dm.author_id, ""),
     COALESCE(dm.type, ""),
     COALESCE(dm.timestamp, ""),
@@ -284,6 +293,7 @@ func (db sqlitePersistence) tableUserMessagesScanAllFields(row scanner, message 
 	var contactRequestState sql.NullInt64
 	var contactVerificationState sql.NullInt64
 	var pinnedBy sql.NullString
+	var threadID sql.NullString
 
 	sticker := &protobuf.StickerMessage{}
 	audio := &protobuf.AudioMessage{}
@@ -349,6 +359,7 @@ func (db sqlitePersistence) tableUserMessagesScanAllFields(row scanner, message 
 		&message.Mentioned,
 		&message.Replied,
 		&discordMessage.Id,
+		&threadID,
 		&discordMessage.Author.Id,
 		&discordMessage.Type,
 		&discordMessage.Timestamp,
@@ -425,6 +436,12 @@ func (db sqlitePersistence) tableUserMessagesScanAllFields(row scanner, message 
 
 	if pinnedBy.Valid {
 		message.PinnedBy = pinnedBy.String
+	}
+
+	if threadID.Valid {
+		message.ThreadId = &threadID.String
+	} else {
+		message.ThreadId = nil
 	}
 
 	if quotedText.Valid {
@@ -613,6 +630,11 @@ func (db sqlitePersistence) tableUserMessagesAllValues(message *common.Message) 
 		}
 	}
 
+	var serializedThreadID interface{}
+	if message.ThreadId != nil {
+		serializedThreadID = message.GetThreadId()
+	}
+
 	return []interface{}{
 		message.ID,
 		message.WhisperTimestamp,
@@ -663,6 +685,7 @@ func (db sqlitePersistence) tableUserMessagesAllValues(message *common.Message) 
 		message.Replied,
 		discordMessage.Id,
 		serializedPaymentRequests,
+		serializedThreadID,
 	}, nil
 }
 
@@ -778,15 +801,158 @@ func (db sqlitePersistence) MessagesByResponseTo(responseTo string) ([]*common.M
 	return getMessagesFromScanRows(db, rows, false)
 }
 
-// MessageByChatID returns all messages for a given chatID in descending order.
-// Ordering is accomplished using two concatenated values: ClockValue and ID.
-// These two values are also used to compose a cursor which is returned to the result.
-func (db sqlitePersistence) MessageByChatID(chatID string, currCursor string, limit int) ([]*common.Message, string, error) {
+func normalizeThreadName(value string) string {
+	collapsed := strings.Join(strings.Fields(value), " ")
+	trimmed := strings.TrimSpace(collapsed)
+	if trimmed == "" {
+		return ""
+	}
+
+	runes := []rune(trimmed)
+	if len(runes) > 40 {
+		return string(runes[:40])
+	}
+
+	return trimmed
+}
+
+func (db sqlitePersistence) threadNameFromParent(tx *sql.Tx, threadID string) string {
+	parentMessage, err := db.messageByID(tx, threadID)
+	if err != nil {
+		return ""
+	}
+
+	return normalizeThreadName(parentMessage.Text)
+}
+
+// threadNameFromParentByID resolves the thread name from a stored parent message
+// without requiring a transaction. Returns empty string when the parent is absent.
+func (db sqlitePersistence) threadNameFromParentByID(parentMessageID string) string {
+	msg, err := db.MessageByID(parentMessageID)
+	if err != nil {
+		return ""
+	}
+
+	return normalizeThreadName(msg.Text)
+}
+
+func (db sqlitePersistence) upsertThread(tx *sql.Tx, threadID, chatID, parentMessageID, name string) error {
+	if threadID == "" || chatID == "" {
+		return nil
+	}
+
+	if parentMessageID == "" {
+		parentMessageID = threadID
+	}
+
+	var existingName string
+	err := tx.QueryRow(`SELECT name FROM threads WHERE thread_id = ? AND chat_id = ?`, threadID, chatID).Scan(&existingName)
+	switch {
+	case errors.Is(err, sql.ErrNoRows), errors.Is(err, common.ErrRecordNotFound):
+		_, err = tx.Exec(`INSERT INTO threads(thread_id, chat_id, parent_message_id, name) VALUES (?, ?, ?, ?)`, threadID, chatID, parentMessageID, name)
+		return err
+	case err != nil:
+		return err
+	}
+
+	if existingName == "" && name != "" {
+		_, err = tx.Exec(`UPDATE threads SET name = ? WHERE thread_id = ? AND chat_id = ?`, name, threadID, chatID)
+		return err
+	}
+
+	return nil
+}
+
+func (db sqlitePersistence) updateThreadNameFromParentIfNeeded(tx *sql.Tx, threadID, chatID, parentText string) error {
+	if threadID == "" || chatID == "" {
+		return nil
+	}
+
+	name := normalizeThreadName(parentText)
+	_, err := tx.Exec(
+		`UPDATE threads SET name = ? WHERE thread_id = ? AND chat_id = ? AND name = ?`,
+		name,
+		threadID,
+		chatID,
+		"",
+	)
+	return err
+}
+
+func (db sqlitePersistence) UpsertThread(threadID string, chatID string, parentMessageID string, name string) (err error) {
+	tx, err := db.db.BeginTx(context.Background(), &sql.TxOptions{})
+	if err != nil {
+		return err
+	}
+
+	defer func() {
+		if err == nil {
+			err = tx.Commit()
+			return
+		}
+
+		_ = tx.Rollback()
+	}()
+
+	return db.upsertThread(tx, threadID, chatID, parentMessageID, name)
+}
+
+func (db sqlitePersistence) ThreadByID(chatID string, threadID string) (*Thread, error) {
+	var thread Thread
+	err := db.db.QueryRow(`SELECT thread_id, chat_id, parent_message_id, name FROM threads WHERE thread_id = ? AND chat_id = ?`, threadID, chatID).Scan(
+		&thread.ThreadID,
+		&thread.ChatID,
+		&thread.ParentMessageID,
+		&thread.Name,
+	)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, common.ErrRecordNotFound
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	return &thread, nil
+}
+
+func (db sqlitePersistence) ThreadsByChatID(chatID string) ([]*Thread, error) {
+	rows, err := db.db.Query(`SELECT thread_id, chat_id, parent_message_id, name FROM threads WHERE chat_id = ? ORDER BY name ASC`, chatID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	threads := make([]*Thread, 0)
+	for rows.Next() {
+		thread := &Thread{}
+		err = rows.Scan(&thread.ThreadID, &thread.ChatID, &thread.ParentMessageID, &thread.Name)
+		if err != nil {
+			return nil, err
+		}
+
+		threads = append(threads, thread)
+	}
+
+	return threads, nil
+}
+
+func (db sqlitePersistence) MessageByChatID(chatID string, threadID string, currCursor string, limit int, threadsEnabled bool) ([]*common.Message, string, error) {
 	cursorWhere := ""
 	if currCursor != "" {
 		cursorWhere = "AND cursor <= ?" //nolint: goconst
 	}
 	args := []interface{}{chatID}
+
+	var threadWhere string
+	if threadID != "" {
+		threadWhere = "AND m1.thread_id = ?"
+		args = append(args, threadID)
+	} else if threadsEnabled {
+		// If threads are enabled, we want to only fetch messages that are not part of any thread (i.e., top-level messages).
+		// If threads are disabled, then we are backwards compatible and messages in threads are treated as normal messages, so we don't filter them out.
+		threadWhere = "AND (m1.thread_id IS NULL OR m1.thread_id = '')"
+	}
+
 	if currCursor != "" {
 		args = append(args, currCursor)
 	}
@@ -795,9 +961,9 @@ func (db sqlitePersistence) MessageByChatID(chatID string, currCursor string, li
 	// This new column values can also be returned as a cursor for subsequent requests.
 	where := fmt.Sprintf(`
             WHERE
-                NOT(m1.hide) AND m1.local_chat_id = ? %s
+                NOT(m1.hide) AND m1.local_chat_id = ? %s %s
             ORDER BY cursor DESC
-            LIMIT ?`, cursorWhere)
+            LIMIT ?`, threadWhere, cursorWhere)
 
 	query := db.buildMessagesQueryWithAdditionalFields(cursorField, where)
 	rows, err := db.db.Query(
@@ -1734,6 +1900,8 @@ func (db sqlitePersistence) backedUpMessageToUserMessageValues(message *protobuf
 		false,                         // replied
 		"",                            // discord_message_id
 		serializedPaymentRequests,     // payment_requests
+		// TODO backup thread messages too
+		"", // thread_id
 	}, nil
 }
 
@@ -2073,6 +2241,19 @@ func (db sqlitePersistence) SaveMessages(messages []*common.Message) (err error)
 		_, err = stmt.Exec(allValues...)
 		if err != nil {
 			return
+		}
+
+		err = db.updateThreadNameFromParentIfNeeded(tx, msg.ID, msg.LocalChatID, msg.Text)
+		if err != nil {
+			return
+		}
+
+		if msg.GetThreadId() != "" {
+			threadName := db.threadNameFromParent(tx, msg.GetThreadId())
+			err = db.upsertThread(tx, msg.GetThreadId(), msg.LocalChatID, msg.GetThreadId(), threadName)
+			if err != nil {
+				return
+			}
 		}
 
 		if msg.ContentType == protobuf.ChatMessage_BRIDGE_MESSAGE {

--- a/internal/protocol/messenger.go
+++ b/internal/protocol/messenger.go
@@ -77,7 +77,8 @@ const (
 
 // errors
 var (
-	ErrChatNotFoundError = errors.New("Chat not found")
+	ErrChatNotFoundError     = errors.New("Chat not found")
+	ErrThreadFeatureDisabled = errors.New("threads feature is disabled")
 )
 
 const communityAdvertiseIntervalSecond int64 = 24 * 60 * 60
@@ -2147,6 +2148,29 @@ func (m *Messenger) sendChatMessage(ctx context.Context, message *common.Message
 		return nil, ErrChatNotFoundError
 	}
 
+	if !m.featureFlags.Threads {
+		message.ThreadId = nil
+	} else if message.GetThreadId() != "" && chat.ChatType == ChatTypeCommunityChat {
+		threadExists := true
+		_, err = m.persistence.ThreadByID(chat.ID, message.GetThreadId())
+		if errors.Is(err, common.ErrRecordNotFound) {
+			threadExists = false
+		} else if err != nil {
+			return nil, err
+		}
+
+		if !threadExists {
+			community, err := m.communitiesManager.GetByIDString(chat.CommunityID)
+			if err != nil {
+				return nil, err
+			}
+
+			if !community.AllowsAllMembersToCreateThread() && !community.IsPrivilegedMember(&m.identity.PublicKey) {
+				return nil, errors.New("only admins can create threads in this community")
+			}
+		}
+	}
+
 	err = m.handleStandaloneChatIdentity(chat)
 	if err != nil {
 		return nil, err
@@ -2226,6 +2250,10 @@ func (m *Messenger) sendChatMessage(ctx context.Context, message *common.Message
 	}
 
 	response.SetMessages(msg)
+	err = m.addThreadsToResponse(&response, msg)
+	if err != nil {
+		return nil, err
+	}
 	response.AddChat(chat)
 
 	m.logger.Debug("inside sendChatMessage",
@@ -3686,6 +3714,10 @@ func (m *Messenger) saveDataAndPrepareResponse(messageState *ReceivedMessageStat
 		messagesByID[message.ID] = message
 	}
 	messageState.Response.SetMessages(messagesWithResponses)
+	err = m.addThreadsToResponse(messageState.Response, messagesWithResponses)
+	if err != nil {
+		return nil, err
+	}
 
 	notificationsEnabled, err := m.settings.GetAllowNotifications()
 	if err != nil {
@@ -3789,7 +3821,7 @@ func (m *Messenger) latestIncomingMessageClock(chatID string) (uint64, error) {
 	return m.persistence.latestIncomingMessageClock(chatID)
 }
 
-func (m *Messenger) MessageByChatID(chatID, cursor string, limit int) ([]*common.Message, string, error) {
+func (m *Messenger) MessageByChatID(chatID, threadID, cursor string, limit int) ([]*common.Message, string, error) {
 	chat, err := m.persistence.Chat(chatID)
 	if err != nil {
 		return nil, "", err
@@ -3815,7 +3847,7 @@ func (m *Messenger) MessageByChatID(chatID, cursor string, limit int) ([]*common
 			return nil, "", err
 		}
 	} else {
-		msgs, nextCursor, err = m.persistence.MessageByChatID(chatID, cursor, limit)
+		msgs, nextCursor, err = m.persistence.MessageByChatID(chatID, threadID, cursor, limit, m.featureFlags.Threads)
 		if err != nil {
 			return nil, "", err
 		}

--- a/internal/protocol/messenger_config.go
+++ b/internal/protocol/messenger_config.go
@@ -217,6 +217,13 @@ func WithPushNotifications() func(c *config) error {
 	}
 }
 
+func WithThreads() func(c *config) error {
+	return func(c *config) error {
+		c.featureFlags.Threads = true
+		return nil
+	}
+}
+
 func WithPushNotificationServer(server PushNotificationServer) func(c *config) error {
 	return func(c *config) error {
 		c.pushNotificationServer = server

--- a/internal/protocol/messenger_response.go
+++ b/internal/protocol/messenger_response.go
@@ -67,6 +67,7 @@ type MessengerResponse struct {
 	notifications                    map[string]*localnotifications.Notification
 	requestsToJoinCommunity          map[string]*communities.RequestToJoin
 	chats                            map[string]*Chat
+	threads                          map[string]*Thread
 	removedChats                     map[string]bool
 	removedMessages                  map[string]*RemovedMessage
 	deletedMessages                  map[string]string
@@ -94,6 +95,7 @@ type MessengerResponse struct {
 func (r *MessengerResponse) MarshalJSON() ([]byte, error) {
 	responseItem := struct {
 		Chats                   []*Chat                             `json:"chats,omitempty"`
+		Threads                 []*Thread                           `json:"threads,omitempty"`
 		RemovedChats            []string                            `json:"removedChats,omitempty"`
 		RemovedMessages         []*RemovedMessage                   `json:"removedMessages,omitempty"`
 		DeletedMessages         map[string][]string                 `json:"deletedMessages,omitempty"`
@@ -159,6 +161,7 @@ func (r *MessengerResponse) MarshalJSON() ([]byte, error) {
 		SavedAddresses:                   r.SavedAddresses(),
 		Notifications:                    r.Notifications(),
 		Chats:                            r.Chats(),
+		Threads:                          r.Threads(),
 		Communities:                      r.Communities(),
 		CommunitiesSettings:              r.CommunitiesSettings(),
 		RemovedChats:                     r.RemovedChats(),
@@ -297,6 +300,7 @@ func (r *MessengerResponse) StatusUpdates() []UserStatus {
 
 func (r *MessengerResponse) IsEmpty() bool {
 	return len(r.chats)+
+		len(r.threads)+
 		len(r.messages)+
 		len(r.pinMessages)+
 		len(r.Contacts)+
@@ -345,6 +349,7 @@ func (r *MessengerResponse) Merge(response *MessengerResponse) error {
 	}
 
 	r.AddChats(response.Chats())
+	r.AddThreads(response.Threads())
 	r.AddRemovedChats(response.RemovedChats())
 	r.AddRemovedMessages(response.RemovedMessages())
 	r.MergeDeletedMessages(response.DeletedMessages())
@@ -484,6 +489,36 @@ func (r *MessengerResponse) AddChat(c *Chat) {
 	}
 
 	r.chats[c.ID] = c
+}
+
+func threadKey(chatID string, threadID string) string {
+	return chatID + ":" + threadID
+}
+
+func (r *MessengerResponse) Threads() []*Thread {
+	var threads []*Thread
+	for _, thread := range r.threads {
+		threads = append(threads, thread)
+	}
+	return threads
+}
+
+func (r *MessengerResponse) AddThread(thread *Thread) {
+	if thread == nil {
+		return
+	}
+
+	if r.threads == nil {
+		r.threads = make(map[string]*Thread)
+	}
+
+	r.threads[threadKey(thread.ChatID, thread.ThreadID)] = thread
+}
+
+func (r *MessengerResponse) AddThreads(threads []*Thread) {
+	for _, thread := range threads {
+		r.AddThread(thread)
+	}
 }
 
 func (r *MessengerResponse) AddChats(chats []*Chat) {

--- a/internal/protocol/messenger_response_test.go
+++ b/internal/protocol/messenger_response_test.go
@@ -50,6 +50,34 @@ func TestMessengerResponseMergeMessages(t *testing.T) {
 
 }
 
+func TestMessengerResponseMergeThreads(t *testing.T) {
+	thread1 := &Thread{ThreadID: "thread-1", ChatID: "chat-1", Name: "First"}
+	modifiedThread1 := &Thread{ThreadID: "thread-1", ChatID: "chat-1", Name: "Renamed"}
+	thread2 := &Thread{ThreadID: "thread-2", ChatID: "chat-1", Name: "Second"}
+
+	response1 := &MessengerResponse{}
+	response1.AddThread(thread1)
+
+	response2 := &MessengerResponse{}
+	response2.AddThread(modifiedThread1)
+	response2.AddThread(thread2)
+
+	require.NoError(t, response1.Merge(response2))
+
+	require.Len(t, response1.Threads(), 2)
+	require.Equal(t, modifiedThread1, response1.threads[threadKey(modifiedThread1.ChatID, modifiedThread1.ThreadID)])
+	require.Equal(t, thread2, response1.threads[threadKey(thread2.ChatID, thread2.ThreadID)])
+}
+
+func TestMessengerResponseMarshalJSONIncludesThreads(t *testing.T) {
+	response := &MessengerResponse{}
+	response.AddThread(&Thread{ThreadID: "thread-1", ChatID: "chat-1", Name: "Thread"})
+
+	encoded, err := response.MarshalJSON()
+	require.NoError(t, err)
+	require.Contains(t, string(encoded), `"threads"`)
+}
+
 func TestMessengerResponseMergeNotImplemented(t *testing.T) {
 	response1 := &MessengerResponse{}
 

--- a/internal/protocol/messenger_support_bot_test.go
+++ b/internal/protocol/messenger_support_bot_test.go
@@ -48,7 +48,7 @@ func TestSendSupportBotContactRequest(t *testing.T) {
 
 			chatID, err := requests.ConvertCompressedToLegacyKey(testPK)
 			require.NoError(t, err)
-			messages, _, err := m.persistence.MessageByChatID(chatID, "", 10)
+			messages, _, err := m.persistence.MessageByChatID(chatID, "", "", 10, false)
 			require.NoError(t, err)
 			contactRequest := FindFirstByContentType(messages, protobuf.ChatMessage_CONTACT_REQUEST)
 			if testCase.expectsContactRequest {
@@ -65,7 +65,7 @@ func TestSendSupportBotContactRequest(t *testing.T) {
 			require.NoError(t, m.settings.SaveSettingField(settings.SupportBotContactRequestState, testCase.state))
 			require.NoError(t, m.sendSupportBotContactRequest())
 
-			messagesAfterRetry, _, err := m.persistence.MessageByChatID(chatID, "", 10)
+			messagesAfterRetry, _, err := m.persistence.MessageByChatID(chatID, "", "", 10, false)
 			require.NoError(t, err)
 			require.Len(t, messagesAfterRetry, len(messages))
 
@@ -96,7 +96,7 @@ func TestMessengerStartSkipsExistingUserSupportBotContactRequest(t *testing.T) {
 
 	chatID, err := requests.ConvertCompressedToLegacyKey(testPK)
 	require.NoError(t, err)
-	messages, _, err := m.persistence.MessageByChatID(chatID, "", 10)
+	messages, _, err := m.persistence.MessageByChatID(chatID, "", "", 10, false)
 	require.NoError(t, err)
 	contactRequest := FindFirstByContentType(messages, protobuf.ChatMessage_CONTACT_REQUEST)
 	require.Nil(t, contactRequest)

--- a/internal/protocol/messenger_sync_clear_history_test.go
+++ b/internal/protocol/messenger_sync_clear_history_test.go
@@ -91,10 +91,10 @@ func (s *MessengerSyncClearHistory) TestSyncClearHistory() {
 	s.Require().Equal(receivedPubChatMessage.ChatId, publicChatName)
 
 	var messages []*common.Message
-	messages, _, err = s.m.persistence.MessageByChatID(publicChatName, "", 10)
+	messages, _, err = s.m.persistence.MessageByChatID(publicChatName, "", "", 10, s.m.featureFlags.Threads)
 	s.Require().NoError(err)
 	s.Require().True(len(messages) == 1)
-	messages, _, err = theirMessenger.persistence.MessageByChatID(publicChatName, "", 10)
+	messages, _, err = theirMessenger.persistence.MessageByChatID(publicChatName, "", "", 10, theirMessenger.featureFlags.Threads)
 	s.Require().NoError(err)
 	s.Require().True(len(messages) == 1)
 
@@ -113,7 +113,7 @@ func (s *MessengerSyncClearHistory) TestSyncClearHistory() {
 		return errors.New("Not received all clearedHistories")
 	})
 	s.Require().NoError(err)
-	messages, _, err = theirMessenger.persistence.MessageByChatID(publicChatName, "", 10)
+	messages, _, err = theirMessenger.persistence.MessageByChatID(publicChatName, "", "", 10, theirMessenger.featureFlags.Threads)
 	s.Require().NoError(err)
 	s.Require().True(len(messages) == 0)
 }

--- a/internal/protocol/messenger_test.go
+++ b/internal/protocol/messenger_test.go
@@ -312,7 +312,7 @@ func (s *MessengerSuite) TestSendPublic() {
 	s.Require().NotEmpty(outputMessage.ID, "it sets the ID field")
 	s.Require().Equal(protobuf.MessageType_PUBLIC_GROUP, outputMessage.MessageType)
 
-	savedMessages, _, err := s.m.MessageByChatID(chat.ID, "", 10)
+	savedMessages, _, err := s.m.MessageByChatID(chat.ID, "", "", 10)
 	s.Require().NoError(err)
 	s.Require().Equal(1, len(savedMessages), "it saves the message")
 }
@@ -1347,11 +1347,11 @@ func (s *MessengerSuite) TestBlockContact() {
 	s.Require().Equal(3, len(actualChats))
 
 	// The messages have been deleted
-	chat2Messages, _, err := s.m.MessageByChatID(chat2.ID, "", 20)
+	chat2Messages, _, err := s.m.MessageByChatID(chat2.ID, "", "", 20)
 	s.Require().NoError(err)
 	s.Require().Equal(3, len(chat2Messages))
 
-	chat3Messages, _, err := s.m.MessageByChatID(chat3.ID, "", 20)
+	chat3Messages, _, err := s.m.MessageByChatID(chat3.ID, "", "", 20)
 	s.Require().NoError(err)
 	s.Require().Equal(1, len(chat3Messages))
 
@@ -1592,7 +1592,7 @@ func (s *MessengerSuite) TestSendMessageWithPreviews() {
 	_, err = s.m.SendChatMessage(context.Background(), inputMsg)
 	s.NoError(err)
 
-	savedMsgs, _, err := s.m.MessageByChatID(chat.ID, "", 10)
+	savedMsgs, _, err := s.m.MessageByChatID(chat.ID, "", "", 10)
 	s.Require().NoError(err)
 	s.Require().Len(savedMsgs, 1)
 	savedMsg := savedMsgs[0]

--- a/internal/protocol/messenger_threads.go
+++ b/internal/protocol/messenger_threads.go
@@ -1,0 +1,120 @@
+package protocol
+
+import (
+	"database/sql"
+	"errors"
+
+	"github.com/status-im/status-go/internal/protocol/common"
+)
+
+func (m *Messenger) ThreadsByChatID(chatID string) ([]*Thread, error) {
+	if !m.featureFlags.Threads {
+		return nil, ErrThreadFeatureDisabled
+	}
+	return m.persistence.ThreadsByChatID(chatID)
+}
+
+// CreateThread creates thread metadata for an existing parent message in a chat.
+// The parent message must already be stored locally. Permission rules (admin-only
+// vs all-members) are enforced for community chats.
+func (m *Messenger) CreateThread(chatID string, parentMessageID string) (*MessengerResponse, error) {
+	if !m.featureFlags.Threads {
+		return nil, ErrThreadFeatureDisabled
+	}
+
+	if chatID == "" || parentMessageID == "" {
+		return nil, errors.New("chatID and parentMessageID are required")
+	}
+
+	chat, ok := m.allChats.Load(chatID)
+	if !ok {
+		return nil, ErrChatNotFoundError
+	}
+
+	// Check if thread already exists for this parent message
+	_, threadErr := m.persistence.ThreadByID(chatID, parentMessageID)
+	if threadErr == nil {
+		return nil, errors.New("thread already exists for this message")
+	}
+	if !errors.Is(threadErr, common.ErrRecordNotFound) {
+		return nil, threadErr
+	}
+
+	// Enforce community permission: only check on new thread creation
+	if chat.ChatType == ChatTypeCommunityChat {
+		community, err := m.communitiesManager.GetByIDString(chat.CommunityID)
+		if err != nil {
+			return nil, err
+		}
+
+		if !community.AllowsAllMembersToCreateThread() && !community.IsPrivilegedMember(&m.identity.PublicKey) {
+			return nil, errors.New("only admins can create threads in this community")
+		}
+	}
+
+	parentMsg, msgErr := m.persistence.MessageByID(parentMessageID)
+	if errors.Is(msgErr, sql.ErrNoRows) || errors.Is(msgErr, common.ErrRecordNotFound) {
+		return nil, errors.New("parent message not found")
+	}
+	if msgErr != nil {
+		return nil, msgErr
+	}
+	if parentMsg.LocalChatID != chatID {
+		return nil, errors.New("parent message not found")
+	}
+
+	name := normalizeThreadName(parentMsg.Text)
+	if err := m.persistence.UpsertThread(parentMessageID, chatID, parentMessageID, name); err != nil {
+		return nil, err
+	}
+
+	thread, err := m.persistence.ThreadByID(chatID, parentMessageID)
+	if err != nil {
+		return nil, err
+	}
+
+	response := &MessengerResponse{}
+	response.AddThread(thread)
+	return response, nil
+}
+
+func (m *Messenger) addThreadsToResponse(response *MessengerResponse, messages []*common.Message) error {
+	if !m.featureFlags.Threads || response == nil || len(messages) == 0 {
+		return nil
+	}
+
+	seen := make(map[string]struct{})
+	for _, message := range messages {
+		if message == nil {
+			continue
+		}
+
+		threadID := message.GetThreadId()
+		if threadID == "" {
+			continue
+		}
+
+		chatID := message.GetChatId()
+		if chatID == "" {
+			continue
+		}
+
+		key := threadKey(chatID, threadID)
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+
+		thread, err := m.persistence.ThreadByID(chatID, threadID)
+		if errors.Is(err, common.ErrRecordNotFound) {
+			continue
+		}
+		if err != nil {
+			return err
+		}
+
+		response.AddThread(thread)
+	}
+
+	return nil
+}

--- a/internal/protocol/messenger_threads_test.go
+++ b/internal/protocol/messenger_threads_test.go
@@ -1,0 +1,386 @@
+package protocol
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+
+	"github.com/status-im/status-go/internal/protocol/common"
+)
+
+type MessengerThreadsSuite struct {
+	MessengerBaseTestSuite
+}
+
+func TestMessengerThreadsSuite(t *testing.T) {
+	suite.Run(t, new(MessengerThreadsSuite))
+}
+
+func (s *MessengerThreadsSuite) SetupTest() {
+	s.MessengerBaseTestSuite.SetupTest()
+	// Enable threads feature for tests
+	s.m.featureFlags.Threads = true
+}
+
+func (s *MessengerThreadsSuite) TestCreateThreadRequiresParentMessage() {
+	chat := CreateOneToOneChat("test-user", &s.m.identity.PublicKey, s.m.getTimesource())
+	s.Require().NoError(s.m.SaveChat(chat))
+
+	// Attempt to create thread for non-existent parent
+	_, err := s.m.CreateThread(chat.ID, "non-existent-parent")
+	s.Require().Error(err)
+	s.Require().Contains(err.Error(), "parent message not found")
+}
+
+func (s *MessengerThreadsSuite) TestCreateThreadSucceedsWithExistingParent() {
+	chat := CreateOneToOneChat("test-user", &s.m.identity.PublicKey, s.m.getTimesource())
+	s.Require().NoError(s.m.SaveChat(chat))
+
+	// Save parent message
+	parentMsg := buildTestMessage(*chat)
+	parentMsg.ID = "parent-id"
+	parentMsg.Text = "This is a test thread message"
+	parentMsg.ChatMessage.Text = "This is a test thread message"
+	s.Require().NoError(s.m.SaveMessages([]*common.Message{parentMsg}))
+
+	// Create thread
+	response, err := s.m.CreateThread(chat.ID, "parent-id")
+	s.Require().NoError(err)
+	s.Require().NotNil(response)
+	s.Require().Len(response.Threads(), 1)
+
+	thread := response.Threads()[0]
+	s.Require().Equal("parent-id", thread.ThreadID)
+	s.Require().Equal(chat.ID, thread.ChatID)
+	s.Require().Equal("parent-id", thread.ParentMessageID)
+	// Name should be normalized from parent text (trimmed to 40 chars)
+	s.Require().Equal("This is a test thread message", thread.Name)
+}
+
+func (s *MessengerThreadsSuite) TestCreateThreadFailsWhenAlreadyExists() {
+	chat := CreateOneToOneChat("test-user", &s.m.identity.PublicKey, s.m.getTimesource())
+	s.Require().NoError(s.m.SaveChat(chat))
+
+	// Save parent message
+	parentMsg := buildTestMessage(*chat)
+	parentMsg.ID = "parent-id"
+	parentMsg.Text = "Parent"
+	parentMsg.ChatMessage.Text = "Parent"
+	s.Require().NoError(s.m.SaveMessages([]*common.Message{parentMsg}))
+
+	// Create thread first time
+	response, err := s.m.CreateThread(chat.ID, "parent-id")
+	s.Require().NoError(err)
+	s.Require().Len(response.Threads(), 1)
+
+	// Attempt to create thread again
+	_, err = s.m.CreateThread(chat.ID, "parent-id")
+	s.Require().Error(err)
+	s.Require().Contains(err.Error(), "thread already exists for this message")
+}
+
+func (s *MessengerThreadsSuite) TestCreateThreadFailsWhenFeatureFlagDisabled() {
+	s.m.featureFlags.Threads = false
+
+	chat := CreateOneToOneChat("test-user", &s.m.identity.PublicKey, s.m.getTimesource())
+	s.Require().NoError(s.m.SaveChat(chat))
+
+	// Save parent message
+	parentMsg := buildTestMessage(*chat)
+	parentMsg.ID = "parent-id"
+	parentMsg.Text = "Parent"
+	parentMsg.ChatMessage.Text = "Parent"
+	s.Require().NoError(s.m.SaveMessages([]*common.Message{parentMsg}))
+
+	// Attempt to create thread when disabled
+	_, err := s.m.CreateThread(chat.ID, "parent-id")
+	s.Require().Error(err)
+	s.Require().Contains(err.Error(), "threads feature is disabled")
+}
+
+func (s *MessengerThreadsSuite) TestThreadsByChatID() {
+	chat := CreateOneToOneChat("test-user", &s.m.identity.PublicKey, s.m.getTimesource())
+	s.Require().NoError(s.m.SaveChat(chat))
+
+	// Save two parent messages
+	parent1 := buildTestMessage(*chat)
+	parent1.ID = "parent-1"
+	parent1.Text = "First thread"
+	parent1.ChatMessage.Text = "First thread"
+
+	parent2 := buildTestMessage(*chat)
+	parent2.ID = "parent-2"
+	parent2.Text = "Second thread"
+	parent2.ChatMessage.Text = "Second thread"
+
+	s.Require().NoError(s.m.SaveMessages([]*common.Message{parent1, parent2}))
+
+	// Create two threads
+	_, err := s.m.CreateThread(chat.ID, "parent-1")
+	s.Require().NoError(err)
+	_, err = s.m.CreateThread(chat.ID, "parent-2")
+	s.Require().NoError(err)
+
+	// List threads
+	threads, err := s.m.ThreadsByChatID(chat.ID)
+	s.Require().NoError(err)
+	s.Require().Len(threads, 2)
+
+	// Verify thread data
+	threadIDs := make(map[string]*Thread)
+	for _, thread := range threads {
+		threadIDs[thread.ThreadID] = thread
+	}
+	s.Require().Contains(threadIDs, "parent-1")
+	s.Require().Contains(threadIDs, "parent-2")
+	s.Require().Equal("First thread", threadIDs["parent-1"].Name)
+	s.Require().Equal("Second thread", threadIDs["parent-2"].Name)
+}
+
+func (s *MessengerThreadsSuite) TestMessagesByThreadID() {
+	chat := CreateOneToOneChat("test-user", &s.m.identity.PublicKey, s.m.getTimesource())
+	s.Require().NoError(s.m.SaveChat(chat))
+
+	// Save parent message
+	parentMsg := buildTestMessage(*chat)
+	parentMsg.ID = "parent-id"
+	parentMsg.Text = "Parent"
+	parentMsg.ChatMessage.Text = "Parent"
+	s.Require().NoError(s.m.SaveMessages([]*common.Message{parentMsg}))
+
+	// Create thread
+	_, err := s.m.CreateThread(chat.ID, "parent-id")
+	s.Require().NoError(err)
+
+	// Save reply messages in thread
+	threadID := "parent-id"
+	reply1 := buildTestMessage(*chat)
+	reply1.ID = "reply-1"
+	reply1.Text = "First reply"
+	reply1.ChatMessage.Text = "First reply"
+	reply1.ChatMessage.ThreadId = &threadID
+	reply1.ResponseTo = "parent-id"
+
+	reply2 := buildTestMessage(*chat)
+	reply2.ID = "reply-2"
+	reply2.Text = "Second reply"
+	reply2.ChatMessage.Text = "Second reply"
+	reply2.ChatMessage.ThreadId = &threadID
+	reply2.ResponseTo = "parent-id"
+
+	s.Require().NoError(s.m.SaveMessages([]*common.Message{reply1, reply2}))
+
+	// Retrieve thread messages
+	msgs, cursor, err := s.m.MessageByChatID(chat.ID, "parent-id", "", 10)
+	s.Require().NoError(err)
+	s.Require().Len(msgs, 2)
+	s.Require().Empty(cursor)
+
+	// Verify message content
+	for _, msg := range msgs {
+		s.Require().Equal("parent-id", msg.GetThreadId())
+		s.Require().True(msg.Text == "First reply" || msg.Text == "Second reply")
+	}
+}
+
+func (s *MessengerThreadsSuite) TestSendChatMessageWithThread() {
+	chat := CreateOneToOneChat("test-user", &s.m.identity.PublicKey, s.m.getTimesource())
+	s.Require().NoError(s.m.SaveChat(chat))
+
+	// Save parent message
+	parentMsg := buildTestMessage(*chat)
+	parentMsg.ID = "parent-id"
+	parentMsg.Text = "Parent"
+	parentMsg.ChatMessage.Text = "Parent"
+	s.Require().NoError(s.m.SaveMessages([]*common.Message{parentMsg}))
+
+	// Create thread
+	_, err := s.m.CreateThread(chat.ID, "parent-id")
+	s.Require().NoError(err)
+
+	// Send message into thread
+	threadID := "parent-id"
+	msgToSend := buildTestMessage(*chat)
+	msgToSend.Text = "Reply in thread"
+	msgToSend.ChatMessage.Text = "Reply in thread"
+	msgToSend.ChatMessage.ThreadId = &threadID
+
+	response, err := s.m.SendChatMessage(context.Background(), msgToSend)
+	s.Require().NoError(err)
+	s.Require().NotNil(response)
+
+	// Verify thread still exists and can be retrieved
+	threads, err := s.m.ThreadsByChatID(chat.ID)
+	s.Require().NoError(err)
+	s.Require().Len(threads, 1)
+	s.Require().Equal("parent-id", threads[0].ThreadID)
+}
+
+func (s *MessengerThreadsSuite) TestSendMessageToThreadCreatesThreadIfNotExists() {
+	chat := CreateOneToOneChat("test-user", &s.m.identity.PublicKey, s.m.getTimesource())
+	s.Require().NoError(s.m.SaveChat(chat))
+
+	// Save parent message
+	parentMsg := buildTestMessage(*chat)
+	parentMsg.ID = "parent-id"
+	parentMsg.Text = "Parent"
+	parentMsg.ChatMessage.Text = "Parent"
+	s.Require().NoError(s.m.SaveMessages([]*common.Message{parentMsg}))
+
+	// Verify thread doesn't exist initially
+	threads, err := s.m.ThreadsByChatID(chat.ID)
+	s.Require().NoError(err)
+	s.Require().Len(threads, 0)
+
+	// Create thread explicitly
+	_, err = s.m.CreateThread(chat.ID, "parent-id")
+	s.Require().NoError(err)
+
+	// Now send message to that thread
+	threadID := "parent-id"
+	msgToSend := buildTestMessage(*chat)
+	msgToSend.Text = "Reply in thread"
+	msgToSend.ChatMessage.Text = "Reply in thread"
+	msgToSend.ChatMessage.ThreadId = &threadID
+
+	resp, err := s.m.SendChatMessage(context.Background(), msgToSend)
+	s.Require().NoError(err)
+	s.Require().NotNil(resp)
+
+	// Thread should still exist
+	threads, err = s.m.ThreadsByChatID(chat.ID)
+	s.Require().NoError(err)
+	s.Require().Len(threads, 1)
+	s.Require().Equal("parent-id", threads[0].ThreadID)
+}
+
+func (s *MessengerThreadsSuite) TestCreateThreadValidatesEmptyParams() {
+	chat := CreateOneToOneChat("test-user", &s.m.identity.PublicKey, s.m.getTimesource())
+	s.Require().NoError(s.m.SaveChat(chat))
+
+	// Missing chatID
+	_, err := s.m.CreateThread("", "parent-id")
+	s.Require().Error(err)
+	s.Require().Contains(err.Error(), "chatID and parentMessageID are required")
+
+	// Missing parentMessageID
+	_, err = s.m.CreateThread(chat.ID, "")
+	s.Require().Error(err)
+	s.Require().Contains(err.Error(), "chatID and parentMessageID are required")
+}
+
+func (s *MessengerThreadsSuite) TestCreateThreadWithEmptyParentNameBackfills() {
+	chat := CreateOneToOneChat("test-user", &s.m.identity.PublicKey, s.m.getTimesource())
+	s.Require().NoError(s.m.SaveChat(chat))
+
+	// Create thread for non-existent parent first (would fail in CreateThread API)
+	// But test that persistence layer handles empty names correctly
+	err := s.m.persistence.UpsertThread("future-parent", chat.ID, "future-parent", "")
+	s.Require().NoError(err)
+
+	// Retrieve thread
+	thread, err := s.m.persistence.ThreadByID(chat.ID, "future-parent")
+	s.Require().NoError(err)
+	s.Require().Equal("", thread.Name)
+
+	// Now save the parent message
+	parentMsg := buildTestMessage(*chat)
+	parentMsg.ID = "future-parent"
+	parentMsg.Text = "Parent message arrives"
+	parentMsg.ChatMessage.Text = "Parent message arrives"
+	s.Require().NoError(s.m.SaveMessages([]*common.Message{parentMsg}))
+
+	// Thread name should be updated
+	thread, err = s.m.persistence.ThreadByID(chat.ID, "future-parent")
+	s.Require().NoError(err)
+	s.Require().Equal("Parent message arrives", thread.Name)
+}
+
+func (s *MessengerThreadsSuite) TestThreadMessagesAreReceivedAndListedWhenThreadsDisabled() {
+	receiver := s.m
+	receiver.featureFlags.Threads = false
+
+	sender := s.newMessenger()
+	sender.featureFlags.Threads = true
+	chatID := "threads-disabled-public-chat"
+
+	receiverChat := CreatePublicChat(chatID, receiver.getTimesource())
+	s.Require().NoError(receiver.SaveChat(receiverChat))
+	_, err := receiver.Join(receiverChat)
+	s.Require().NoError(err)
+
+	senderChat := CreatePublicChat(chatID, sender.getTimesource())
+	s.Require().NoError(sender.SaveChat(senderChat))
+	_, err = sender.Join(senderChat)
+	s.Require().NoError(err)
+
+	parentMsg := buildTestMessage(*senderChat)
+	parentMsg.Text = "Parent message"
+	parentMsg.ChatMessage.Text = "Parent message"
+
+	parentResponse, err := sender.SendChatMessage(context.Background(), parentMsg)
+	s.Require().NoError(err)
+	s.Require().Len(parentResponse.Messages(), 1)
+	parentID := parentResponse.Messages()[0].ID
+
+	_, err = WaitOnMessengerResponse(receiver, func(response *MessengerResponse) bool {
+		for _, msg := range response.Messages() {
+			if msg.ID == parentID {
+				return true
+			}
+		}
+
+		return false
+	}, "parent message not received")
+	s.Require().NoError(err)
+
+	_, err = sender.CreateThread(chatID, parentID)
+	s.Require().NoError(err)
+
+	threadID := parentID
+	threadReply := buildTestMessage(*senderChat)
+	threadReply.Text = "Reply from thread"
+	threadReply.ChatMessage.Text = "Reply from thread"
+	threadReply.ChatMessage.ThreadId = &threadID
+	threadReply.ResponseTo = parentID
+
+	threadResponse, err := sender.SendChatMessage(context.Background(), threadReply)
+	s.Require().NoError(err)
+
+	var threadReplyID string
+	for _, msg := range threadResponse.Messages() {
+		if msg.Text == "Reply from thread" && msg.GetThreadId() == parentID {
+			threadReplyID = msg.ID
+			break
+		}
+	}
+	s.Require().NotEmpty(threadReplyID)
+
+	_, err = WaitOnMessengerResponse(receiver, func(response *MessengerResponse) bool {
+		for _, msg := range response.Messages() {
+			if msg.ID == threadReplyID {
+				s.Require().Equal(parentID, msg.GetThreadId())
+				return true
+			}
+		}
+
+		return false
+	}, "thread reply not received")
+	s.Require().NoError(err)
+
+	messages, cursor, err := receiver.MessageByChatID(chatID, "", "", 10)
+	s.Require().NoError(err)
+	s.Require().Empty(cursor)
+
+	var foundThreadReply bool
+	for _, msg := range messages {
+		if msg.ID == threadReplyID {
+			foundThreadReply = true
+			s.Require().Equal(parentID, msg.GetThreadId())
+			s.Require().Equal("Reply from thread", msg.Text)
+		}
+	}
+
+	s.Require().True(foundThreadReply)
+}

--- a/internal/protocol/migrations/sqlite/1787757971_add_thread_id_to_user_messages.up.sql
+++ b/internal/protocol/migrations/sqlite/1787757971_add_thread_id_to_user_messages.up.sql
@@ -1,0 +1,5 @@
+ALTER TABLE user_messages ADD COLUMN thread_id TEXT;
+
+CREATE INDEX user_messages_thread_id ON user_messages(thread_id);
+
+CREATE INDEX user_messages_local_chat_id_thread_id_clock_value_idx ON user_messages(local_chat_id, thread_id, clock_value);

--- a/internal/protocol/migrations/sqlite/1787757972_create_threads_table.up.sql
+++ b/internal/protocol/migrations/sqlite/1787757972_create_threads_table.up.sql
@@ -1,0 +1,8 @@
+CREATE TABLE IF NOT EXISTS threads (
+  thread_id TEXT PRIMARY KEY NOT NULL,
+  chat_id VARCHAR NOT NULL,
+  parent_message_id VARCHAR NOT NULL,
+  name TEXT NOT NULL
+);
+
+CREATE INDEX threads_chat_id_name_idx ON threads(chat_id, name);

--- a/internal/protocol/persistence_quoted_message_test.go
+++ b/internal/protocol/persistence_quoted_message_test.go
@@ -95,7 +95,7 @@ func (s *TestMessengerPrepareMessageSuite) testMessageContainsImage(testAlbum bo
 	s.Require().NoError(err)
 	s.Require().NoError(mediaServer.Start())
 
-	retrievedMessages, _, err := s.p.MessageByChatID(s.chatID, "", 10)
+	retrievedMessages, _, err := s.p.MessageByChatID(s.chatID, "", "", 10, false)
 	s.Require().NoError(err)
 	if testAlbum {
 		s.Require().Len(retrievedMessages, 3)
@@ -163,7 +163,7 @@ func (s *TestMessengerPrepareMessageSuite) Test_WHEN_NoQuotedMessage_THEN_Retrie
 	s.Require().NoError(err)
 	s.Require().NoError(mediaServer.Start())
 
-	retrievedMessages, _, err := s.p.MessageByChatID(s.chatID, "", 10)
+	retrievedMessages, _, err := s.p.MessageByChatID(s.chatID, "", "", 10, false)
 	s.Require().NoError(err)
 	s.Require().Equal(message2.ID, retrievedMessages[0].ID)
 	s.Require().Empty(retrievedMessages[0].ResponseTo)
@@ -189,7 +189,7 @@ func (s *TestMessengerPrepareMessageSuite) Test_WHEN_QuotedMessageDoesNotContain
 	s.Require().NoError(err)
 	s.Require().NoError(mediaServer.Start())
 
-	retrievedMessages, _, err := s.p.MessageByChatID(s.chatID, "", 10)
+	retrievedMessages, _, err := s.p.MessageByChatID(s.chatID, "", "", 10, false)
 	s.Require().NoError(err)
 	s.Require().Equal(message2.ID, retrievedMessages[0].ID)
 	s.Require().Equal(message1.ID, retrievedMessages[0].ResponseTo)

--- a/internal/protocol/persistence_test.go
+++ b/internal/protocol/persistence_test.go
@@ -229,7 +229,7 @@ func TestMessageByChatID(t *testing.T) {
 			err   error
 		)
 
-		items, cursor, err = p.MessageByChatID(chatID, cursor, pageSize)
+		items, cursor, err = p.MessageByChatID(chatID, "", cursor, pageSize, false)
 		require.NoError(t, err)
 		result = append(result, items...)
 
@@ -486,7 +486,7 @@ func TestPinMessageByChatID(t *testing.T) {
 	require.Len(t, m, 1)
 	require.Equal(t, "them", m[0].PinnedBy)
 
-	msgs, _, err := p.MessageByChatID(chatID, cursor, 10)
+	msgs, _, err := p.MessageByChatID(chatID, "", cursor, 10, false)
 	require.NoError(t, err)
 	require.Len(t, msgs, 10)
 	for _, msg := range msgs {
@@ -563,7 +563,7 @@ func TestMessageReplies(t *testing.T) {
 	err = p.SaveMessages(messages)
 	require.NoError(t, err)
 
-	retrievedMessages, _, err := p.MessageByChatID(chatID, "", 10)
+	retrievedMessages, _, err := p.MessageByChatID(chatID, "", "", 10, false)
 	require.NoError(t, err)
 
 	require.Equal(t, "non-existing", retrievedMessages[2].ResponseTo)
@@ -616,7 +616,7 @@ func TestMessageByChatIDWithTheSameClocks(t *testing.T) {
 			err   error
 		)
 
-		items, cursor, err = p.MessageByChatID(chatID, cursor, pageSize)
+		items, cursor, err = p.MessageByChatID(chatID, "", cursor, pageSize, false)
 		require.NoError(t, err)
 		result = append(result, items...)
 
@@ -671,14 +671,14 @@ func TestDeleteMessagesByChatID(t *testing.T) {
 	err = insertMinimalMessage(p, "2")
 	require.NoError(t, err)
 
-	m, _, err := p.MessageByChatID(testPublicChatID, "", 10)
+	m, _, err := p.MessageByChatID(testPublicChatID, "", "", 10, false)
 	require.NoError(t, err)
 	require.Equal(t, 2, len(m))
 
 	err = p.DeleteMessagesByChatID(testPublicChatID)
 	require.NoError(t, err)
 
-	m, _, err = p.MessageByChatID(testPublicChatID, "", 10)
+	m, _, err = p.MessageByChatID(testPublicChatID, "", "", 10, false)
 	require.NoError(t, err)
 	require.Equal(t, 0, len(m))
 
@@ -726,6 +726,209 @@ func TestDeletePinnedMessageByID(t *testing.T) {
 	pinnedMsgs, _, err = p.PinnedMessageByChatID(testPublicChatID, "", 10)
 	require.NoError(t, err)
 	require.Len(t, pinnedMsgs, 0)
+}
+
+func TestSaveMessagesCreatesThreadWithEmptyNameWhenParentMissing(t *testing.T) {
+	db, err := openTestDB()
+	require.NoError(t, err)
+	p := newSQLitePersistence(db)
+
+	threadID := "parent-message-id"
+	replyID := "reply-message-id"
+
+	err = p.SaveMessages([]*common.Message{{
+		ID:          replyID,
+		LocalChatID: testPublicChatID,
+		From:        testPK,
+		ChatMessage: &protobuf.ChatMessage{
+			Text:     "reply body",
+			ThreadId: &threadID,
+		},
+	}})
+	require.NoError(t, err)
+
+	thread, err := p.ThreadByID(testPublicChatID, threadID)
+	require.NoError(t, err)
+	require.Equal(t, "", thread.Name)
+}
+
+func TestSaveMessagesUpdatesEmptyThreadNameWhenParentArrives(t *testing.T) {
+	db, err := openTestDB()
+	require.NoError(t, err)
+	p := newSQLitePersistence(db)
+
+	threadID := "parent-message-id"
+	replyID := "reply-message-id"
+	parentText := "  This   is a parent message title that is definitely longer than forty characters  "
+
+	err = p.SaveMessages([]*common.Message{{
+		ID:          replyID,
+		LocalChatID: testPublicChatID,
+		From:        testPK,
+		ChatMessage: &protobuf.ChatMessage{
+			Text:     "reply body",
+			ThreadId: &threadID,
+		},
+	}})
+	require.NoError(t, err)
+
+	err = p.SaveMessages([]*common.Message{{
+		ID:          threadID,
+		LocalChatID: testPublicChatID,
+		From:        testPK,
+		ChatMessage: &protobuf.ChatMessage{Text: parentText},
+	}})
+	require.NoError(t, err)
+
+	thread, err := p.ThreadByID(testPublicChatID, threadID)
+	require.NoError(t, err)
+	require.Equal(t, normalizeThreadName(parentText), thread.Name)
+}
+
+func TestMessagesByThreadID(t *testing.T) {
+	db, err := openTestDB()
+	require.NoError(t, err)
+	p := newSQLitePersistence(db)
+
+	threadID := "parent-message-id"
+	secondThreadID := "another-parent"
+
+	err = p.SaveMessages([]*common.Message{
+		{
+			ID:          "reply1",
+			LocalChatID: testPublicChatID,
+			From:        testPK,
+			ChatMessage: &protobuf.ChatMessage{Text: "reply1", ThreadId: &threadID},
+		},
+		{
+			ID:          "reply2",
+			LocalChatID: testPublicChatID,
+			From:        testPK,
+			ChatMessage: &protobuf.ChatMessage{Text: "reply2", ThreadId: &threadID},
+		},
+		{
+			ID:          "other-thread-reply",
+			LocalChatID: testPublicChatID,
+			From:        testPK,
+			ChatMessage: &protobuf.ChatMessage{Text: "other", ThreadId: &secondThreadID},
+		},
+	})
+	require.NoError(t, err)
+
+	msgs, cursor, err := p.MessageByChatID(testPublicChatID, threadID, "", 10, false)
+	require.NoError(t, err)
+	require.Empty(t, cursor)
+	require.Len(t, msgs, 2)
+	for _, msg := range msgs {
+		require.Equal(t, threadID, msg.GetThreadId())
+	}
+}
+
+func TestCreateThreadFromExistingParent(t *testing.T) {
+	db, err := openTestDB()
+	require.NoError(t, err)
+	p := newSQLitePersistence(db)
+
+	parentID := "parent-message-id"
+	parentText := "Hello world"
+
+	// Parent already in DB
+	err = p.SaveMessages([]*common.Message{{
+		ID:          parentID,
+		LocalChatID: testPublicChatID,
+		From:        testPK,
+		ChatMessage: &protobuf.ChatMessage{Text: parentText},
+	}})
+	require.NoError(t, err)
+
+	// Explicit thread creation path used by Messenger.CreateThread
+	name := p.threadNameFromParentByID(parentID)
+	err = p.UpsertThread(parentID, testPublicChatID, parentID, name)
+	require.NoError(t, err)
+
+	thread, err := p.ThreadByID(testPublicChatID, parentID)
+	require.NoError(t, err)
+	require.Equal(t, parentID, thread.ThreadID)
+	require.Equal(t, parentID, thread.ParentMessageID)
+	require.Equal(t, normalizeThreadName(parentText), thread.Name)
+}
+
+func TestCreateThreadFailsWhenParentMessageMissing(t *testing.T) {
+	db, err := openTestDB()
+	require.NoError(t, err)
+	p := newSQLitePersistence(db)
+
+	// threadNameFromParentByID still returns "" when parent is absent
+	name := p.threadNameFromParentByID("not-yet-known")
+	require.Equal(t, "", name)
+
+	// Messenger.CreateThread rejects absent parents before calling UpsertThread;
+	// verify that a thread is NOT created when the message is missing.
+	_, err = p.ThreadByID(testPublicChatID, "not-yet-known")
+	require.Error(t, err, "thread must not exist for a message that was never saved")
+}
+
+func TestCreateThreadFailsWhenAlreadyExists(t *testing.T) {
+	db, err := openTestDB()
+	require.NoError(t, err)
+	p := newSQLitePersistence(db)
+
+	parentID := "parent-message-id"
+
+	// Parent already in DB
+	err = p.SaveMessages([]*common.Message{{
+		ID:          parentID,
+		LocalChatID: testPublicChatID,
+		From:        testPK,
+		ChatMessage: &protobuf.ChatMessage{Text: "Parent message"},
+	}})
+	require.NoError(t, err)
+
+	// Create thread once
+	name := p.threadNameFromParentByID(parentID)
+	err = p.UpsertThread(parentID, testPublicChatID, parentID, name)
+	require.NoError(t, err)
+
+	// Thread now exists
+	thread, err := p.ThreadByID(testPublicChatID, parentID)
+	require.NoError(t, err)
+	require.Equal(t, parentID, thread.ThreadID)
+
+	// Attempting to upsert again should succeed (idempotent) but Messenger.CreateThread
+	// should reject it by checking if thread exists first
+	err = p.UpsertThread(parentID, testPublicChatID, parentID, name)
+	require.NoError(t, err) // UpsertThread is idempotent at the persistence layer
+}
+
+func TestDeleteParentMessageKeepsThreadMetadata(t *testing.T) {
+	db, err := openTestDB()
+	require.NoError(t, err)
+	p := newSQLitePersistence(db)
+
+	threadID := "parent-message-id"
+
+	err = p.SaveMessages([]*common.Message{{
+		ID:          threadID,
+		LocalChatID: testPublicChatID,
+		From:        testPK,
+		ChatMessage: &protobuf.ChatMessage{Text: "Parent title"},
+	}})
+	require.NoError(t, err)
+
+	err = p.SaveMessages([]*common.Message{{
+		ID:          "reply-message-id",
+		LocalChatID: testPublicChatID,
+		From:        testPK,
+		ChatMessage: &protobuf.ChatMessage{Text: "reply body", ThreadId: &threadID},
+	}})
+	require.NoError(t, err)
+
+	err = p.DeleteMessage(threadID)
+	require.NoError(t, err)
+
+	thread, err := p.ThreadByID(testPublicChatID, threadID)
+	require.NoError(t, err)
+	require.Equal(t, threadID, thread.ThreadID)
 }
 
 func TestMarkMessageSeen(t *testing.T) {
@@ -971,7 +1174,7 @@ func TestPersistenceEmojiReactions(t *testing.T) {
 	require.Equal(t, id3, reactions[0].MessageId)
 
 	// Try with a cursor
-	_, cursor, err := p.MessageByChatID(chatID, "", 1)
+	_, cursor, err := p.MessageByChatID(chatID, "", "", 1, false)
 	require.NoError(t, err)
 
 	reactions, err = p.EmojiReactionsByChatID(chatID, cursor, 2)
@@ -1102,7 +1305,7 @@ func TestMessagesAudioDurationMsNull(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, m, 1)
 
-	m, _, err = p.MessageByChatID(testPublicChatID, "", 10)
+	m, _, err = p.MessageByChatID(testPublicChatID, "", "", 10, false)
 	require.NoError(t, err)
 	require.Len(t, m, 1)
 }
@@ -1144,7 +1347,7 @@ func TestSaveMentions(t *testing.T) {
 	err = p.SaveMessages([]*common.Message{&message})
 	require.NoError(t, err)
 
-	retrievedMessages, _, err := p.MessageByChatID(chatID, "", 10)
+	retrievedMessages, _, err := p.MessageByChatID(chatID, "", "", 10, false)
 	require.NoError(t, err)
 	require.Len(t, retrievedMessages, 1)
 	require.Len(t, retrievedMessages[0].Mentions, 1)
@@ -1371,7 +1574,7 @@ func TestSaveLinks(t *testing.T) {
 	err = p.SaveMessages([]*common.Message{&message})
 	require.NoError(t, err)
 
-	retrievedMessages, _, err := p.MessageByChatID(chatID, "", 10)
+	retrievedMessages, _, err := p.MessageByChatID(chatID, "", "", 10, false)
 	require.NoError(t, err)
 	require.Len(t, retrievedMessages, 1)
 	require.Len(t, retrievedMessages[0].Links, 1)
@@ -1413,7 +1616,7 @@ func TestSaveWithUnfurledLinks(t *testing.T) {
 	err = p.SaveMessages([]*common.Message{&message})
 	require.NoError(t, err)
 
-	mgs, _, err := p.MessageByChatID(chatID, "", 10)
+	mgs, _, err := p.MessageByChatID(chatID, "", "", 10, false)
 	require.NoError(t, err)
 	require.Len(t, mgs, 1)
 	require.Len(t, mgs[0].UnfurledLinks, 2)
@@ -1489,7 +1692,7 @@ func TestDeactivatePublicChat(t *testing.T) {
 	require.False(t, publicChat.Active)
 
 	// It deletes messages
-	messages, _, err := p.MessageByChatID(publicChatID, "", 10)
+	messages, _, err := p.MessageByChatID(publicChatID, "", "", 10, false)
 	require.NoError(t, err)
 	require.Len(t, messages, 0)
 
@@ -1558,7 +1761,7 @@ func TestDeactivateOneToOneChat(t *testing.T) {
 	require.False(t, chat.Active)
 
 	// It deletes messages
-	messages, _, err := p.MessageByChatID(chat.ID, "", 10)
+	messages, _, err := p.MessageByChatID(chat.ID, "", "", 10, false)
 	require.NoError(t, err)
 	require.Len(t, messages, 0)
 
@@ -1831,7 +2034,7 @@ func TestSaveBridgeMessage(t *testing.T) {
 
 	require.NoError(t, err)
 
-	retrievedMessages, _, err := p.MessageByChatID(testPublicChatID, "", 10)
+	retrievedMessages, _, err := p.MessageByChatID(testPublicChatID, "", "", 10, false)
 	require.NoError(t, err)
 	require.Len(t, retrievedMessages, 1)
 	require.Equal(t, "discord", retrievedMessages[0].GetBridgeMessage().BridgeName)
@@ -2068,7 +2271,7 @@ func TestPaymentRequestMessages(t *testing.T) {
 	err = p.SaveMessages(messages)
 	require.NoError(t, err)
 
-	m, _, err := p.MessageByChatID(testPublicChatID, "", 10)
+	m, _, err := p.MessageByChatID(testPublicChatID, "", "", 10, false)
 	require.NoError(t, err)
 	require.Len(t, m, 1)
 

--- a/internal/protocol/protobuf/chat_message.proto
+++ b/internal/protocol/protobuf/chat_message.proto
@@ -244,6 +244,9 @@ message ChatMessage {
 
   repeated PaymentRequest payment_requests = 20;
 
+  // Id of the parent message that identifies the thread.
+  optional string thread_id = 21;
+
   enum ContentType {
     UNKNOWN_CONTENT_TYPE = 0;
     TEXT_PLAIN = 1;

--- a/internal/protocol/protobuf/communities.proto
+++ b/internal/protocol/protobuf/communities.proto
@@ -135,6 +135,7 @@ message CommunityBanInfo {
 
 message CommunityAdminSettings {
   bool pin_message_all_members_enabled = 1;
+  bool create_thread_all_members_enabled = 2;
 }
 
 message CommunityChat {

--- a/internal/protocol/requests/create_community_request.go
+++ b/internal/protocol/requests/create_community_request.go
@@ -27,23 +27,24 @@ const (
 )
 
 type CreateCommunity struct {
-	Name                         string                               `json:"name"`
-	Description                  string                               `json:"description"`
-	IntroMessage                 string                               `json:"introMessage,omitempty"`
-	OutroMessage                 string                               `json:"outroMessage,omitempty"`
-	Color                        string                               `json:"color"`
-	Emoji                        string                               `json:"emoji"`
-	Membership                   protobuf.CommunityPermissions_Access `json:"membership"`
-	EnsOnly                      bool                                 `json:"ensOnly"`
-	Image                        string                               `json:"image"`
-	ImageAx                      int                                  `json:"imageAx"`
-	ImageAy                      int                                  `json:"imageAy"`
-	ImageBx                      int                                  `json:"imageBx"`
-	ImageBy                      int                                  `json:"imageBy"`
-	Banner                       images.CroppedImage                  `json:"banner"`
-	HistoryArchiveSupportEnabled bool                                 `json:"historyArchiveSupportEnabled,omitempty"`
-	PinMessageAllMembersEnabled  bool                                 `json:"pinMessageAllMembersEnabled,omitempty"`
-	Tags                         []string                             `json:"tags,omitempty"`
+	Name                          string                               `json:"name"`
+	Description                   string                               `json:"description"`
+	IntroMessage                  string                               `json:"introMessage,omitempty"`
+	OutroMessage                  string                               `json:"outroMessage,omitempty"`
+	Color                         string                               `json:"color"`
+	Emoji                         string                               `json:"emoji"`
+	Membership                    protobuf.CommunityPermissions_Access `json:"membership"`
+	EnsOnly                       bool                                 `json:"ensOnly"`
+	Image                         string                               `json:"image"`
+	ImageAx                       int                                  `json:"imageAx"`
+	ImageAy                       int                                  `json:"imageAy"`
+	ImageBx                       int                                  `json:"imageBx"`
+	ImageBy                       int                                  `json:"imageBy"`
+	Banner                        images.CroppedImage                  `json:"banner"`
+	HistoryArchiveSupportEnabled  bool                                 `json:"historyArchiveSupportEnabled,omitempty"`
+	PinMessageAllMembersEnabled   bool                                 `json:"pinMessageAllMembersEnabled,omitempty"`
+	CreateThreadAllMembersEnabled bool                                 `json:"createThreadAllMembersEnabled,omitempty"`
+	Tags                          []string                             `json:"tags,omitempty"`
 }
 
 func adaptIdentityImageToProtobuf(img images.IdentityImage) *protobuf.IdentityImage {
@@ -125,7 +126,8 @@ func (c *CreateCommunity) ToCommunityDescription() (*protobuf.CommunityDescripti
 			EnsOnly: c.EnsOnly,
 		},
 		AdminSettings: &protobuf.CommunityAdminSettings{
-			PinMessageAllMembersEnabled: c.PinMessageAllMembersEnabled,
+			PinMessageAllMembersEnabled:   c.PinMessageAllMembersEnabled,
+			CreateThreadAllMembersEnabled: c.CreateThreadAllMembersEnabled,
 		},
 		IntroMessage: c.IntroMessage,
 		OutroMessage: c.OutroMessage,

--- a/pkg/services/ext/api.go
+++ b/pkg/services/ext/api.go
@@ -515,6 +515,10 @@ type ApplicationMessagesResponse struct {
 	Cursor   string            `json:"cursor"`
 }
 
+type ApplicationThreadsResponse struct {
+	Threads []*protocol.Thread `json:"threads"`
+}
+
 type MarkMessageSeenResponse struct {
 	Count                       uint64                                 `json:"count"`
 	CountWithMentions           uint64                                 `json:"countWithMentions"`
@@ -531,7 +535,7 @@ type ApplicationStatusUpdatesResponse struct {
 }
 
 func (api *PublicAPI) ChatMessages(chatID, cursor string, limit int) (*ApplicationMessagesResponse, error) {
-	messages, cursor, err := api.service.messenger.MessageByChatID(chatID, cursor, limit)
+	messages, cursor, err := api.service.messenger.MessageByChatID(chatID, "", cursor, limit)
 	if err != nil {
 		return nil, err
 	}
@@ -539,6 +543,33 @@ func (api *PublicAPI) ChatMessages(chatID, cursor string, limit int) (*Applicati
 	return &ApplicationMessagesResponse{
 		Messages: messages,
 		Cursor:   cursor,
+	}, nil
+}
+
+func (api *PublicAPI) ChatMessagesV2(chatID, threadID, cursor string, limit int) (*ApplicationMessagesResponse, error) {
+	messages, cursor, err := api.service.messenger.MessageByChatID(chatID, threadID, cursor, limit)
+	if err != nil {
+		return nil, err
+	}
+
+	return &ApplicationMessagesResponse{
+		Messages: messages,
+		Cursor:   cursor,
+	}, nil
+}
+
+func (api *PublicAPI) CreateThread(chatID string, parentMessageID string) (*protocol.MessengerResponse, error) {
+	return api.service.messenger.CreateThread(chatID, parentMessageID)
+}
+
+func (api *PublicAPI) ChatThreads(chatID string) (*ApplicationThreadsResponse, error) {
+	threads, err := api.service.messenger.ThreadsByChatID(chatID)
+	if err != nil {
+		return nil, err
+	}
+
+	return &ApplicationThreadsResponse{
+		Threads: threads,
 	}, nil
 }
 


### PR DESCRIPTION
Part of https://github.com/status-im/status-app/issues/21257

status-app PR (demo is there): https://github.com/status-im/status-app/pull/21351

Implements a first-class thread model for community chat channels. Threads are anchored to an existing parent message and inherit the channel's permissions and encryption. The feature is gated behind a `Threads` feature flag (off by default).

---

### Schema & protocol

- **`chat_message.proto`** — added optional `thread_id` field (field 21) to `ChatMessage`. Old clients silently ignore the field; new clients write to and read from it transparently.
- **`communities.proto`** — added `create_thread_all_members_enabled` boolean to `CommunityAdminSettings`, controlling who may start a new thread.
- **DB migrations**
  - `1764000001` — `ALTER TABLE user_messages ADD COLUMN thread_id TEXT` with indexes on `(local_chat_id, thread_id)` and `(thread_id)`.
  - `1764000002` — `CREATE TABLE threads (thread_id, chat_id, parent_message_id, name)` with an index on `(chat_id, name)`.

---

### Persistence (`protocol/message_persistence.go`)

- New `Thread` struct with JSON tags (`threadId`, `chatId`, `parentMessageId`, `name`).
- `SaveMessages` now auto-creates or updates thread metadata whenever a message with a non-empty `thread_id` is saved. If the parent message is not yet known the thread name is stored as an empty string; when the parent arrives, `updateThreadNameFromParentIfNeeded` back-fills the name.
- Thread name is normalised to a 40-character trimmed excerpt of the parent message text. Unknown/placeholder names are **empty string** — the client controls the display label.
- New persistence helpers: `UpsertThread`, `ThreadByID`, `ThreadsByChatID`, `MessagesByThreadID`, `threadNameFromParentByID`.

---

### Community & request layer

- `AllowsAllMembersToCreateThread()` helper on `Community`.
- `CreateCommunityRequest` / `EditCommunityRequest` now forward `CreateThreadAllMembersEnabled`.

---

### Messenger (`protocol/messenger.go`)

- `sendChatMessage` enforces the community thread-creation permission gate: only admins may start a new thread unless `AllowsAllMembersToCreateThread` is set.
- **`CreateThread(chatID, parentMessageID)`** — explicit thread creation API. Requires the parent message to already exist locally; returns `"parent message not found"` otherwise. Applies the same permission gate as `sendChatMessage`.
- **`ThreadsByChatID(chatID)`** — lists all threads for a channel.
- **`MessagesByThreadID(chatID, threadID, cursor, limit)`** — paginated thread message history.
- `addThreadsToResponse` enriches every `MessengerResponse` (send path and retrieve/signal path) with the thread metadata for any thread-tagged messages in the response.

---

### MessengerResponse (`protocol/messenger_response.go`)

- New private `threads map[string]*Thread` field.
- `AddThread` / `AddThreads` / `Threads()` accessors.
- `threads` included in `MarshalJSON` output (`"threads"` key), `IsEmpty`, and `Merge`.

---

### RPC API (`services/ext/api.go`)

Three new `PublicAPI` methods exposed over JSON-RPC under the `wakuext` namespace:

| Method | Description |
|--------|-------------|
| `wakuext_createThread` | Create thread from an existing parent message | | `wakuext_chatThreads` | List all threads for a chat |

`wakuext_sendChatMessage` now accepts an optional `threadId` field.

---

### Tests added

- `TestSaveMessagesCreatesThreadWithEmptyNameWhenParentMissing`
- `TestSaveMessagesUpdatesEmptyThreadNameWhenParentArrives`
- `TestMessagesByThreadID`
- `TestDeleteParentMessageKeepsThreadMetadata`
- `TestCreateThreadFromExistingParent`
- `TestCreateThreadFailsWhenParentMessageMissing`
- `TestMessengerResponseMergeThreads`
- `TestMessengerResponseMarshalJSONIncludesThreads`

---

### API reference

`cmd/status-backend/API_REFERENCE.md` updated with request/response examples and error tables for all three new RPC methods.

