### PR TITLE
chore: bump nim-sds pin to v0.2.5

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -105,7 +105,7 @@ BUILD_TAGS ?= gowaku_no_rln
 # `nim-sds` variables
 
 # Pin nim-sds revision here. Can be a tag (default) or commit hash.
-NIM_SDS_VERSION ?= v0.2.4
+NIM_SDS_VERSION ?= v0.2.5
 
 # Option 1: Provide NIM_SDS_SOURCE_DIR. Make force-reclones a fresh copy (with submodules)
 # to guarantee a clean checkout on every build.


### PR DESCRIPTION
iOS symbol localization fixed in https://github.com/logos-messaging/nim-sds/pull/84 


refs https://github.com/status-im/status-app/pull/21356 
refs https://github.com/status-im/status-app/pull/21355