### PR TITLE
fix: publish numGoroutine expvar directly in status-backend

### DIFF
--- a/cmd/status-backend/server/server.go
+++ b/cmd/status-backend/server/server.go
@@ -27,6 +27,9 @@ func init() {
 		threadsCount, _ := runtime.ThreadCreateProfile([]runtime.StackRecord{})
 		return threadsCount
 	}))
+	expvar.Publish("numGoroutine", expvar.Func(func() any {
+		return runtime.NumGoroutine()
+	}))
 }
 
 type Server struct {

--- a/cmd/status-backend/server/server.go
+++ b/cmd/status-backend/server/server.go
@@ -27,9 +27,15 @@ func init() {
 		threadsCount, _ := runtime.ThreadCreateProfile([]runtime.StackRecord{})
 		return threadsCount
 	}))
-	expvar.Publish("numGoroutine", expvar.Func(func() any {
-		return runtime.NumGoroutine()
-	}))
+	// numGoroutine may already be published by github.com/anacrolix/envpprof
+	// when the torrent history-archive backend is compiled in (use_torrent).
+	// Publish it ourselves only when that dependency isn't linked, so the
+	// metric is always available at /debug/vars regardless of build tags.
+	if expvar.Get("numGoroutine") == nil {
+		expvar.Publish("numGoroutine", expvar.Func(func() any {
+			return runtime.NumGoroutine()
+		}))
+	}
 }
 
 type Server struct {


### PR DESCRIPTION
## What

Publish the `numGoroutine` metric to `/debug/vars` directly in `cmd/status-backend/server`, next to the existing `numThreads` publisher.

## Why

`numGoroutine` was never published by status-go itself — it came implicitly from `github.com/anacrolix/envpprof`'s `init()`, which is pulled in transitively by the BitTorrent history-archive backend.

#7486 moved the torrent backend behind the `use_torrent` build tag (default **off**), so `envpprof` is no longer linked into the default `status-backend` build. As a result `numGoroutine` vanished from `/debug/vars`, and the benchmark harness — which reads `data.get("numGoroutine", 0)` — has recorded **0 goroutines every run since 2026-06-24** (see [status-go-benchmarks](https://github.com/status-im/status-go-benchmarks)). `numThreads` kept working only because it's published here explicitly.

This makes the metric independent of whether the torrent backend is compiled in. The concurrent thread/RAM reductions in the benchmarks on the same day are real (torrent stack no longer linked) and are not addressed here.

## Test

`runtime.NumGoroutine()` mirrors the existing `numThreads` pattern; both `expvar` and `runtime` are already imported. Benchmark `num_goroutines_max` should report a non-zero count again once a build including this change is benchmarked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)