### PR TITLE
chore(messaging): drop unused Waku interface methods

### DIFF
--- a/pkg/messaging/api_communities.go
+++ b/pkg/messaging/api_communities.go
@@ -9,10 +9,6 @@ import (
 	types "github.com/status-im/status-go/pkg/messaging/types"
 )
 
-func (a *API) SubscribeToPubsubTopic(topic string) error {
-	return a.core.stack.Transport.SubscribeToPubsubTopic(topic)
-}
-
 func (a *API) GetKeysForGroup(groupID []byte) ([]*encryption.HashRatchetKeyCompatibility, error) {
 	return a.core.stack.Encryption.GetKeysForGroup(groupID)
 }

--- a/pkg/messaging/core_test_utils.go
+++ b/pkg/messaging/core_test_utils.go
@@ -55,15 +55,18 @@ func (f *TestMessagingEnvironment) SubscribePostEvents() chan *PostMessageSubscr
 }
 
 func (f *TestMessagingEnvironment) SimulateOffline() func() {
-	f.waku.Waku.(*wakuv3.Waku).SkipPublishToTopic(true)
+	f.waku.Waku.SkipPublishToTopic(true)
 	return func() {
-		f.waku.Waku.(*wakuv3.Waku).SkipPublishToTopic(false)
+		f.waku.Waku.SkipPublishToTopic(false)
 	}
 }
 
-// Wraps waku to provide ability to subscribe to post events.
+// Wraps waku to provide ability to subscribe to post events. It embeds the
+// concrete *wakuv3.Waku (not the types.Waku interface) so that the messaging
+// API methods that live on the backend — Send / Subscribe / Unsubscribe /
+// envelope events, i.e. transport.MessagingAPI — are promoted too.
 type testWakuWrapper struct {
-	types.Waku
+	*wakuv3.Waku
 	postSubscriptions []chan *PostMessageSubscription
 }
 

--- a/pkg/messaging/layers/transport/transport.go
+++ b/pkg/messaging/layers/transport/transport.go
@@ -118,9 +118,13 @@ func NewTransport(
 		envelopesMonitor.Start()
 	}
 
+	// The waku backend also satisfies MessagingAPI (Send / Subscribe /
+	// Unsubscribe / envelope events); those methods live on the concrete
+	// backend, not on the types.Waku lifecycle interface. Offline transports
+	// (tests) pass a nil waku and leave api nil.
 	var api MessagingAPI
 	if waku != nil {
-		api = waku
+		api, _ = waku.(MessagingAPI)
 	}
 	t := &Transport{
 		waku:             waku,
@@ -757,12 +761,6 @@ func PubkeyToHex(key *ecdsa.PublicKey) string {
 
 func (t *Transport) ConnectionChanged(state connection.State) {
 	t.waku.ConnectionChanged(state)
-}
-
-// Subscribe to a pubsub topic
-func (t *Transport) SubscribeToPubsubTopic(topic string) error {
-	t.logger.Debug("subscribing to pubsub topic", zap.String("pubsubtopic", topic))
-	return t.waku.SubscribeToPubsubTopic(topic)
 }
 
 func (t *Transport) ConfirmMessageDelivered(messageID string) {

--- a/pkg/messaging/waku/gowaku.go
+++ b/pkg/messaging/waku/gowaku.go
@@ -1173,6 +1173,14 @@ func (w *Waku) setupRelaySubscriptions() error {
 		return err
 	}
 
+	// Community control messages arrive on the non-protected pubsub topic.
+	// TODO remove once fully migrated to Global Community Control and Content Topic
+	// https://github.com/status-im/status-go/issues/6384
+	err = w.subscribeToPubsubTopicWithWakuRelay(DefaultNonProtectedPubsubTopic())
+	if err != nil {
+		return err
+	}
+
 	return nil
 }
 
@@ -1353,47 +1361,6 @@ func (w *Waku) ClearEnvelopesCache() {
 // it is not used by status-app.
 func (w *Waku) Peers() types.PeerStats {
 	return FormatPeerStats(w.node)
-}
-
-func (w *Waku) SubscribeToPubsubTopic(topic string) error {
-	topic = w.GetPubsubTopic(topic)
-
-	if !w.cfg.LightClient {
-		err := w.subscribeToPubsubTopicWithWakuRelay(topic)
-		if err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-func (w *Waku) UnsubscribeFromPubsubTopic(topic string) error {
-	topic = w.GetPubsubTopic(topic)
-
-	if !w.cfg.LightClient {
-		err := w.unsubscribeFromPubsubTopicWithWakuRelay(topic)
-		if err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-func (w *Waku) StartDiscV5() error {
-	if w.node.DiscV5() == nil {
-		return errors.New("discv5 is not setup")
-	}
-
-	return w.node.DiscV5().Start(w.ctx)
-}
-
-func (w *Waku) StopDiscV5() error {
-	if w.node.DiscV5() == nil {
-		return errors.New("discv5 is not setup")
-	}
-
-	w.node.DiscV5().Stop()
-	return nil
 }
 
 // isNetworkSwitchEvent reports whether next represents a genuine wifi <-> cellular

--- a/pkg/messaging/waku/types/waku.go
+++ b/pkg/messaging/waku/types/waku.go
@@ -106,22 +106,9 @@ type Waku interface {
 	// it is not used by status-app.
 	Peers() PeerStats
 
-	StartDiscV5() error
-
-	StopDiscV5() error
-
-	SubscribeToPubsubTopic(topic string) error
-
-	UnsubscribeFromPubsubTopic(topic string) error
-
 	SubscribeToConnStatusChanges() (*ConnStatusSubscription, error)
 
 	SubscribeEnvelopeEvents(events chan<- EnvelopeEvent) Subscription
-
-	// Subscribe/Unsubscribe register and remove wire subscriptions for the
-	// given content topics on a pubsub topic. See transport.MessagingAPI.
-	Subscribe(ctx context.Context, pubsubTopic string, contentTopics []TopicType) error
-	Unsubscribe(ctx context.Context, pubsubTopic string, contentTopics []TopicType) error
 
 	MaxMessageSize() uint32
 

--- a/protocol/messenger_filter_init.go
+++ b/protocol/messenger_filter_init.go
@@ -21,11 +21,8 @@ func (m *Messenger) InitFilters() error {
 	// Seed the for color generation
 	rand.Seed(time.Now().Unix())
 
-	// Community requests will arrive in this pubsub topic
-	// TODO remove once fully migrated to Global Community Control and Content Topic https://github.com/status-im/status-go/issues/6384
-	if err := m.messaging.SubscribeToPubsubTopic(types.DefaultNonProtectedPubsubTopic()); err != nil {
-		return err
-	}
+	// Subscription to the non-protected pubsub topic (community control
+	// messages) is now handled internally by the messaging backend on start.
 	filters, publicKeys, err := m.collectFiltersAndKeys()
 	if err != nil {
 		return err


### PR DESCRIPTION
Closes https://github.com/status-im/status-go/issues/7588
Iterates https://github.com/status-im/status-go/issues/7463

Based on:
- #7532

## What changed

Removes six methods from the `Waku` *lifecycle* interface (`pkg/messaging/waku/types/waku.go`), so callers no longer drive discovery or pubsub subscriptions manually:

- `StartDiscV5` / `StopDiscV5` — dead code; DiscV5 is already started/stopped inside `Waku.Start()`/`Stop()` via config.
- `UnsubscribeFromPubsubTopic` — had no callers.
- `SubscribeToPubsubTopic` — its single caller (`Messenger.InitFilters`, subscribing to the non-protected community-control topic) is now handled internally in `setupRelaySubscriptions()`.
- `Subscribe` / `Unsubscribe` (content-topic) — kept as concrete methods on the backend; they are the `transport.MessagingAPI` seam and were merely duplicated on the lifecycle interface.

## Notes

- **No behaviour change.** The non-protected topic (cluster 16 / index 64) is still subscribed in relay mode only; Edge/light-client remains a no-op, matching the old `SubscribeToPubsubTopic`.
- `transport` derives the `MessagingAPI` seam via a type assertion; the test wrapper embeds the concrete `*Waku` so it still satisfies it.
- Local verification: `go build` of the `waku`, `waku/types`, and `transport` packages passes. Full unit tests (`pkg/messaging`) require the Nix dev shell (`libsds`) and were not run locally — relying on CI.

Part of the larger effort to give status-go's `MessagingAPI` a `Start(fleet, mode)` shape (Phase 2, separate PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)