### PR TITLE
fix: broken logging into the app after syncing from desktop device

### DIFF
--- a/server/pairing/payload_management.go
+++ b/server/pairing/payload_management.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"strings"
 
-	"github.com/status-im/status-go/common"
 	accsmanagementtypes "github.com/status-im/status-go/internal/accounts-management/types"
 	"github.com/status-im/status-go/internal/db/multiaccounts"
 	"github.com/status-im/status-go/internal/db/multiaccounts/settings"
@@ -84,14 +83,11 @@ func (ppm *AccountPayloadMarshaller) UnmarshalProtobuf(data []byte) error {
 	}
 
 	// historically it so happened that on a mobile device a password without 0x is used, and on a desktop with it,
-	// so with local pairing we have a conflict that needs to be resolved
+	// so with local pairing we have a conflict that needs to be resolved, now, since we use the same codebase for both platforms,
+	// we don't need to trim the prefix anymore.
 	if ppm.multiaccount != nil && ppm.multiaccount.KeycardPairing != "" {
-		if common.IsMobilePlatform() {
-			pb.Password = strings.TrimPrefix(pb.Password, "0x")
-		} else {
-			if !strings.HasPrefix(pb.Password, "0x") {
-				pb.Password = "0x" + pb.Password
-			}
+		if !strings.HasPrefix(pb.Password, "0x") {
+			pb.Password = "0x" + pb.Password
 		}
 	}
 	ppm.password = pb.Password

--- a/server/pairing/payload_management_test.go
+++ b/server/pairing/payload_management_test.go
@@ -368,10 +368,10 @@ func (pms *PayloadMarshallerSuite) TestKeycardPairingPasswordAdjustments_Unmarsh
 		require.Equal(t, "0xABC", ppm.password)
 	})
 
-	// 2) KeycardPairing != "", IsMobilePlatform() == true => TrimPrefix("0x")
-	pms.T().Run("IsMobilePlatform => trim prefix 0x", func(t *testing.T) {
+	// 2) KeycardPairing != "", IsMobilePlatform() == true => keep/add "0x" (platform no longer matters, previously the prefix was trimmed on mobile).
+	pms.T().Run("IsMobilePlatform => add prefix 0x", func(t *testing.T) {
 		ap := &AccountPayload{
-			password:     "0xDEF",
+			password:     "DEF",
 			multiaccount: &multiaccounts.Account{},
 			keys:         make(map[string][]byte),
 		}
@@ -385,7 +385,7 @@ func (pms *PayloadMarshallerSuite) TestKeycardPairingPasswordAdjustments_Unmarsh
 		err = ppm.UnmarshalProtobuf(pb)
 		require.NoError(t, err)
 
-		require.Equal(t, "DEF", ppm.password)
+		require.Equal(t, "0xDEF", ppm.password)
 	})
 
 	// 3) KeycardPairing != "", IsMobilePlatform() == false, without "0x" => add "0x"


### PR DESCRIPTION
As the comment says, historically, on mobile devices a password was used without 0x, while on the desktop with it. Now, since we use the same codebase for both platforms, we don't need to trim the prefix anymore.