### PR TITLE
chore(params): drop dead peer fields from ClusterConfig (Phase 2c)

### DIFF
--- a/params/cluster.go
+++ b/params/cluster.go
@@ -78,14 +78,6 @@ func LoadPushFleetsFromFile(filepath string) error {
 	return nil
 }
 
-func DefaultWakuNodes(fleet string) []string {
-	return fleets.WakuNodes(fleet)
-}
-
-func DefaultDiscV5Nodes(fleet string) []string {
-	return fleets.DiscV5Nodes(fleet)
-}
-
 func DefaultClusterID(fleet string) uint16 {
 	return fleets.ClusterID(fleet)
 }
@@ -110,10 +102,8 @@ func DefaultPushNotificationServers() []*ecdsa.PublicKey {
 
 func DefaultClusterConfig(fleet string) ClusterConfig {
 	return ClusterConfig{
-		Enabled:              true,
-		Fleet:                fleet,
-		WakuNodes:            DefaultWakuNodes(fleet),
-		DiscV5BootstrapNodes: DefaultDiscV5Nodes(fleet),
-		ClusterID:            DefaultClusterID(fleet),
+		Enabled:   true,
+		Fleet:     fleet,
+		ClusterID: DefaultClusterID(fleet),
 	}
 }

--- a/params/config.go
+++ b/params/config.go
@@ -71,13 +71,10 @@ type ClusterConfig struct {
 	// An according fleet configuration is loaded from hard-coded lists.
 	Fleet string
 
-	// WakuNodes is a list of waku2 multiaddresses
-	WakuNodes []string
-
-	// DiscV5Nodes is a list of enr to be used for ambient discovery
-	DiscV5BootstrapNodes []string
-
-	//Waku network identifier
+	// ClusterID is the Waku network identifier. It is persisted for the selected
+	// fleet; the peer configuration (waku nodes, discv5 bootstrap nodes) is now
+	// resolved from the fleet name inside the messaging layer, so it is no longer
+	// carried here.
 	ClusterID uint16
 }
 

--- a/pkg/backend/backend_test.go
+++ b/pkg/backend/backend_test.go
@@ -1095,7 +1095,7 @@ func TestSetFleet(t *testing.T) {
 		t.FailNow()
 	}
 	// Check is using the right fleet
-	require.Equal(t, testContext.backend.config.ClusterConfig.WakuNodes, params.DefaultWakuNodes(params.FleetStatusProd))
+	require.Equal(t, params.FleetStatusProd, testContext.backend.config.ClusterConfig.Fleet)
 
 	require.NoError(t, testContext.backend.Logout())
 }


### PR DESCRIPTION
Phase 2c cleanup of status-go#7589 / logos-messaging/pm#380.

Stacked on #7592 (base: `feat/waku-start-fleet-mode`).

Now that the waku node resolves its peers from the fleet name internally (2b), most of `params.ClusterConfig` is dead. A reference audit found:

| Field | Verdict |
|---|---|
| `Fleet` | **keep** — drives fleet selection (`services/ext`, messenger mailserver cycle, DB) |
| `WakuNodes` | **remove** — no readers, never persisted |
| `DiscV5BootstrapNodes` | **remove** — zero readers, never persisted |
| `ClusterID` | keep — dead in logic but a DB column (avoid migration) |
| `Enabled` | keep — dead in logic but a DB column (avoid migration) |

## Changes
- Remove `WakuNodes` / `DiscV5BootstrapNodes` from `ClusterConfig`.
- Drop the now-orphaned `params.DefaultWakuNodes` / `DefaultDiscV5Nodes` re-exports; `DefaultClusterConfig` no longer populates the removed fields.
- Update one test assertion (`backend_test.go`) to check `ClusterConfig.Fleet` instead of the removed `WakuNodes`.

## Notes
- **Migration-free:** the removed fields were never in the `cluster_config` table (only `enabled`, `fleet`, `cluster_id` are). `ClusterID`/`Enabled` are left in place precisely to avoid a DB migration.
- The fields had no JSON tags, so a client could technically still send `WakuNodes`/`DiscV5BootstrapNodes` in the NodeConfig JSON — those keys are now simply ignored (they were unused anyway; a reloaded config never carried them since they weren't persisted).
- `fleets.WakuNodes` / `fleets.DiscV5Nodes` (the registry accessors used by the waku node) are untouched.
- Verification: `go build ./params/` clean; the rest needs Nix (`libsds`) + `make generate` → CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)