### PR TITLE
refactor(messaging): build waku config from fleet+mode in newWaku

### DIFF
--- a/pkg/messaging/core.go
+++ b/pkg/messaging/core.go
@@ -23,7 +23,6 @@ import (
 	"github.com/status-im/status-go/pkg/messaging/layers/transport"
 	"github.com/status-im/status-go/pkg/messaging/types"
 	wakuv3 "github.com/status-im/status-go/pkg/messaging/waku"
-	wakuv2common "github.com/status-im/status-go/pkg/messaging/waku/common"
 	wakutypes "github.com/status-im/status-go/pkg/messaging/waku/types"
 	wakumetrics2 "github.com/status-im/status-go/pkg/messaging/wakumetrics"
 	"github.com/status-im/status-go/pkg/pubsub"
@@ -150,11 +149,12 @@ func NewCore(params CoreParams, options ...Options) (*Core, error) {
 	}
 
 	waku, err := newWaku(wakuParams{
-		identity:                        params.Identity,
 		nodeKey:                         params.NodeKey,
-		wakuConfig:                      params.WakuConfig,
 		fleet:                           params.Fleet,
 		mode:                            params.Mode,
+		port:                            params.WakuConfig.Port,
+		udpPort:                         params.WakuConfig.UDPPort,
+		nameserver:                      params.WakuConfig.Nameserver,
 		metricsEnabled:                  config.metricsEnabled,
 		onHistoricMessagesRequestFailed: config.onHistoricMessagesRequestFailed,
 		onPeerStats: func(status wakutypes.ConnStatus) {
@@ -224,12 +224,21 @@ func (c *Core) stop() error {
 }
 
 type wakuParams struct {
-	identity *ecdsa.PrivateKey
-	nodeKey  *ecdsa.PrivateKey
+	nodeKey *ecdsa.PrivateKey
 
-	wakuConfig     params.WakuV2Config
-	fleet          string
-	mode           wakuv3.Mode
+	// fleet + mode fully determine the peer configuration and the Core/Edge
+	// policy; the waku node builds the rest of its config from them.
+	fleet string
+	mode  wakuv3.Mode
+
+	// port / udpPort / nameserver are the only node settings a caller configures
+	// (zero/empty falls back to the waku defaults). Everything else — host,
+	// discovery limit, max message size, store-confirmation, etc. — is defaulted
+	// by the waku layer or derived from the mode.
+	port       int
+	udpPort    int
+	nameserver string
+
 	metricsEnabled bool
 
 	onHistoricMessagesRequestFailed func([]byte, peer.AddrInfo, error)
@@ -242,25 +251,19 @@ type wakuParams struct {
 
 func newWaku(params wakuParams) (*wakuv3.Waku, error) {
 	cfg := &wakuv3.Config{
-		MaxMessageSize: wakuv2common.DefaultMaxMessageSize,
-		Host:           params.wakuConfig.Host,
-		Port:           params.wakuConfig.Port,
 		// Fleet + Mode drive peer resolution and the peer-exchange/discv5/
-		// light-client policy inside the waku node (see wakuv2.setDefaults).
-		Fleet:                                  params.fleet,
-		Mode:                                   params.mode,
-		DiscoveryLimit:                         params.wakuConfig.DiscoveryLimit,
-		Nameserver:                             params.wakuConfig.Nameserver,
-		UDPPort:                                params.wakuConfig.UDPPort,
-		AutoUpdate:                             params.wakuConfig.AutoUpdate,
-		DefaultShardPubsubTopic:                wakuv3.DefaultShardPubsubTopic(),
-		EnableStoreConfirmationForMessagesSent: params.wakuConfig.EnableStoreConfirmationForMessagesSent,
-		UseThrottledPublish:                    true,
-		MetricsEnabled:                         params.metricsEnabled,
-	}
-
-	if params.wakuConfig.MaxMessageSize > 0 {
-		cfg.MaxMessageSize = params.wakuConfig.MaxMessageSize
+		// light-client policy inside the waku node (see wakuv2.setDefaults). The
+		// host, discovery limit, max message size and default shard topic are
+		// filled by the waku layer's setDefaults.
+		Fleet:      params.fleet,
+		Mode:       params.mode,
+		Port:       params.port,
+		UDPPort:    params.udpPort,
+		Nameserver: params.nameserver,
+		// Status nodes advertise the ip/port observed by their peers.
+		AutoUpdate:          true,
+		UseThrottledPublish: true,
+		MetricsEnabled:      params.metricsEnabled,
 	}
 
 	waku, err := wakuv3.New(


### PR DESCRIPTION
Exploratory refactor (per review of #7592): make `newWaku` build the waku node config from **fleet + mode** rather than threading most of `params.WakuV2Config` through it, and prune `wakuParams`.

Stacked on #7592 (base: `feat/waku-start-fleet-mode`). **Separate PR for now — decide later whether to fold into #7592.**

## What changed
`wakuParams` no longer carries `params.WakuV2Config`. It now holds only what a caller actually configures — `fleet` + `mode`, plus `port` / `udpPort` / `nameserver` — and `newWaku` builds the `wakuv3.Config` from those. Everything else is defaulted by the waku layer or derived from the mode.

### Removed from `wakuParams` / the config build
| Field | Why it's gone |
|---|---|
| `identity` | Dead — `newWaku` never read it (it uses `nodeKey`). |
| `Host` | Only ever `"0.0.0.0"` = the waku default; `setDefaults` fills it. |
| `DiscoveryLimit` | Only ever `20` = the waku default; `setDefaults` fills it. |
| `MaxMessageSize` | Never set by any caller; `setDefaults` fills it. |
| `DefaultShardPubsubTopic` | `setDefaults` fills it. |
| `EnableStoreConfirmationForMessagesSent` | **Unconditionally overridden by mode inside gowaku** (Core→true, Edge→false), so the passed value was already a no-op. |
| `AutoUpdate` | Now a fixed policy (`true`) — every caller already set it to `true`. |

### Kept (genuinely configured)
- `fleet`, `mode` — the core inputs.
- `port` / `udpPort` — only `cmd/push-notification-server` sets these (non-zero); the app leaves them 0 (random).
- `nameserver` — request-driven in the app (`request.WakuV2Nameserver`).

## Notes
- Backed by two reference audits: no production caller sets `Host`/`Port`/`UDPPort`/`DiscoveryLimit`/`MaxMessageSize` to a non-default (except cmd tooling for the ports), and `EnableStoreConfirmationForMessagesSent` is always overwritten by the mode branch in `gowaku.go`.
- **Public API unchanged:** `CoreParams.WakuConfig` stays; only the messaging-internal `newWaku` boundary is slimmed. `NewCore` reads `WakuConfig.Port/UDPPort/Nameserver` and passes them through.
- Behaviour-preserving: the resulting `wakuv3.Config` is equivalent for every real caller.
- Verification: `go build ./pkg/messaging/waku/` clean; `pkg/messaging` itself needs Nix (`libsds`) + `make generate` → CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)