### PR TITLE
refactor(messaging): drop ClearEnvelopesCache and dead envelope-cache state

### DIFF
--- a/pkg/messaging/layers/transport/transport.go
+++ b/pkg/messaging/layers/transport/transport.go
@@ -750,7 +750,6 @@ func (t *Transport) SetEnvelopeEventsHandler(handler EnvelopeEventsHandler) erro
 
 func (t *Transport) ClearProcessedMessageIDsCache() error {
 	t.logger.Debug("clearing processed messages cache")
-	t.waku.ClearEnvelopesCache()
 	return t.cache.Clear()
 }
 

--- a/pkg/messaging/waku/gowaku.go
+++ b/pkg/messaging/waku/gowaku.go
@@ -74,7 +74,6 @@ import (
 
 	gocommon "github.com/status-im/status-go/common"
 	"github.com/status-im/status-go/internal/connection"
-	cryptotypes "github.com/status-im/status-go/internal/crypto/types"
 	"github.com/status-im/status-go/internal/logutils"
 	"github.com/status-im/status-go/internal/timesource"
 	"github.com/status-im/status-go/pkg/messaging/waku/common"
@@ -142,8 +141,8 @@ type Waku struct {
 	subscriptionsMu sync.Mutex
 	subscriptions   map[types.TopicSubscription]string
 
-	envelopeCache *ttlcache.Cache[gethcommon.Hash, bool] // [Hash of envelope -> Processed] cache
-	poolMu        sync.RWMutex                           // Mutex to sync the message and expiration pools
+	envelopeCache *ttlcache.Cache[gethcommon.Hash, struct{}] // short-lived set of seen envelope hashes; feeds hit/miss metrics and self-send suppression only. De-duplication is owned by the transport's persistent processed-message cache (status-im/status-go#7464).
+	poolMu        sync.RWMutex                               // Mutex to sync the message and expiration pools
 
 	bandwidthCounter *metrics.BandwidthCounter
 
@@ -201,8 +200,8 @@ func (w *Waku) SetMetricsHandler(client IMetricsHandler) {
 	w.metricsHandler = client
 }
 
-func newTTLCache() *ttlcache.Cache[gethcommon.Hash, bool] {
-	cache := ttlcache.New(ttlcache.WithTTL[gethcommon.Hash, bool](cacheTTL))
+func newTTLCache() *ttlcache.Cache[gethcommon.Hash, struct{}] {
+	cache := ttlcache.New(ttlcache.WithTTL[gethcommon.Hash, struct{}](cacheTTL))
 	go func() {
 		defer gocommon.LogOnPanic()
 		cache.Start()
@@ -1248,8 +1247,7 @@ func (w *Waku) OnNewEnvelopes(envelope *protocol.Envelope, msgType common.Messag
 // addEnvelope adds an envelope to the envelope map, used for sending
 func (w *Waku) addEnvelope(envelope *common.ReceivedMessage) {
 	w.poolMu.Lock()
-	// Add the envelope to the cache with Processed set to false
-	w.envelopeCache.Set(envelope.Hash(), false, ttlcache.DefaultTTL)
+	w.envelopeCache.Set(envelope.Hash(), struct{}{}, ttlcache.DefaultTTL)
 	w.poolMu.Unlock()
 }
 
@@ -1258,14 +1256,7 @@ func (w *Waku) add(recvMessage *common.ReceivedMessage, processImmediately bool)
 
 	w.poolMu.Lock()
 	alreadyCached := w.envelopeCache.Has(recvMessage.Hash())
-	envelopeProcessed := false
 	w.poolMu.Unlock()
-
-	if !alreadyCached {
-		w.addEnvelope(recvMessage)
-	} else {
-		envelopeProcessed = w.envelopeCache.Get(recvMessage.Hash()).Value()
-	}
 
 	logger := w.logger.With(zap.String("envelopeHash", recvMessage.Hash().Hex()))
 
@@ -1273,19 +1264,21 @@ func (w *Waku) add(recvMessage *common.ReceivedMessage, processImmediately bool)
 		logger.Debug("w envelope already cached")
 		common.EnvelopesCachedCounter.WithLabelValues("hit").Inc()
 	} else {
+		w.addEnvelope(recvMessage)
 		logger.Debug("cached w envelope")
 		common.EnvelopesCachedCounter.WithLabelValues("miss").Inc()
 		common.EnvelopesSizeMeter.Observe(float64(len(recvMessage.Envelope.Message().Payload)))
 	}
 
-	if !envelopeProcessed {
-		if processImmediately {
-			logger.Debug("immediately processing envelope")
-			w.processMessage(recvMessage)
-		} else {
-			logger.Debug("posting event")
-			w.postEvent(recvMessage) // notify the local node about the new message
-		}
+	// De-duplication is owned by the transport's persistent processed-message
+	// cache (status-im/status-go#7464), so every received envelope is forwarded
+	// regardless of the in-memory cache above.
+	if processImmediately {
+		logger.Debug("immediately processing envelope")
+		w.processMessage(recvMessage)
+	} else {
+		logger.Debug("posting event")
+		w.postEvent(recvMessage) // notify the local node about the new message
 	}
 
 	return true, nil
@@ -1323,30 +1316,6 @@ func (w *Waku) processMessage(e *common.ReceivedMessage) {
 		Event: common.EventEnvelopeAvailable,
 		Data:  newReceivedMessage(e),
 	})
-}
-
-// HasEnvelope returns true if the envelope with the given hash is present in the cache.
-func (w *Waku) HasEnvelope(hash cryptotypes.Hash) bool {
-	w.poolMu.RLock()
-	defer w.poolMu.RUnlock()
-
-	return w.envelopeCache.Has(gethcommon.Hash(hash))
-}
-
-// isEnvelopeCached checks if envelope with specific hash has already been received and cached.
-func (w *Waku) IsEnvelopeCached(hash gethcommon.Hash) bool {
-	w.poolMu.Lock()
-	defer w.poolMu.Unlock()
-
-	return w.envelopeCache.Has(hash)
-}
-
-func (w *Waku) ClearEnvelopesCache() {
-	w.poolMu.Lock()
-	defer w.poolMu.Unlock()
-
-	w.envelopeCache.Stop()
-	w.envelopeCache = newTTLCache()
 }
 
 // Peers is retained only for the Python functional tests (see tests-functional);

--- a/pkg/messaging/waku/types/waku.go
+++ b/pkg/messaging/waku/types/waku.go
@@ -114,9 +114,6 @@ type Waku interface {
 	// ConnectionChanged is called whenever the client knows its connection status has changed
 	ConnectionChanged(connection.State)
 
-	// ClearEnvelopesCache clears waku envelopes cache
-	ClearEnvelopesCache()
-
 	// ConfirmMessageDelivered updates a message has been delivered in waku
 	ConfirmMessageDelivered(hash []common.Hash)
 


### PR DESCRIPTION
Iterates https://github.com/status-im/status-go/issues/7463

## What

Removes `ClearEnvelopesCache` from the `Waku` interface and cleans up the now-dead state in the in-memory `envelopeCache`.

Stacked on #7599 (shares the `Waku` interface + `gowaku.go`/`transport.go`). Review after that lands.

## Why

De-duplication of received messages moved **up into the transport** in #7464: `Transport.RetrieveRawAll` checks `t.cache.Hits(ids)` and `Transport.ConfirmMessagesProcessed` writes `t.cache.Add(ids)`, keyed by decoded message ID and backed by the persistent SQLite `transport_message_cache` table.

Since then, the waku-layer in-memory `envelopeCache` no longer participates in de-dup, but leftover scaffolding remained:

- The cache stored a `bool` "Processed" flag, but the only writer set it to `false` (`addEnvelope`). Nothing ever set it to `true` — that writer was removed when dedup moved to the transport (`processMessage` even documents it: *"nothing is marked processed here"*). So in `add()`, `envelopeProcessed` was **always false**, and every envelope was forwarded regardless of the cache. The `else { … Get().Value() }` branch was dead — and a latent nil-deref, since `Get()` ran outside `poolMu` (the entry could expire, or `ClearEnvelopesCache` could swap the whole cache, between the `Has` check and the `Get`).
- `ClearEnvelopesCache` (called only from `Transport.ClearProcessedMessageIDsCache`, on chat deletion) cleared this in-memory cache. Because the cache doesn't gate delivery, clearing it was a **no-op for re-delivery**: re-fetching a channel's history from store, or a relay duplicate, is forwarded either way — the persistent `t.cache.Clear()` is what actually decides re-processing. So the call was removed and the transport method keeps only `t.cache.Clear()`.

What the in-memory cache is still (legitimately) used for: hit/miss **metrics** and **self-send suppression** on publish (`message_publishing.go` checks `Has()` so a just-sent envelope already seen isn't self-notified twice). Both are presence checks, so the value type is narrowed `bool` → `struct{}`.

## Changes

- **`pkg/messaging/waku/types/waku.go`** — drop `ClearEnvelopesCache()` from the `Waku` interface.
- **`pkg/messaging/waku/gowaku.go`**
  - remove `ClearEnvelopesCache`, and the unused `HasEnvelope` / `IsEnvelopeCached` helpers (no callers);
  - simplify `add()` — drop the always-false `envelopeProcessed` branch (also removes the latent nil-deref);
  - narrow `envelopeCache` value `bool` → `struct{}` (a plain seen-set).
- **`pkg/messaging/layers/transport/transport.go`** — `ClearProcessedMessageIDsCache` drops the `t.waku.ClearEnvelopesCache()` call, keeps `t.cache.Clear()`.

## Behavior

No change in delivery/de-dup: envelopes were already always forwarded and de-duped by the transport's persistent cache. This only deletes dead code and one no-op call. `MessageExists` (still reads the cache as a presence-set) is left untouched.

## Verification

`goimports` clean; `go vet ./pkg/messaging/waku/...` passes (the `var _ types.Waku = (*Waku)(nil)` assertion still holds). No test references the removed methods. Full `pkg/messaging`/`protocol` build needs Nix (`libsds`) + `make generate` → CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
