### PR TITLE
feat(messaging): add three-state ConnectionStatus; derive Online() from it

### DIFF
--- a/pkg/messaging/adapters/connection_status.go
+++ b/pkg/messaging/adapters/connection_status.go
@@ -17,6 +17,7 @@ func NewConnectionStatusSubscription(s *wakutypes.ConnStatusSubscription) *Conne
 		c: utils.BridgeChannels(s.C, func(status wakutypes.ConnStatus) types.ConnectionStatus {
 			return types.ConnectionStatus{
 				IsOnline: status.IsOnline,
+				State:    status.State,
 			}
 		}),
 	}

--- a/pkg/messaging/api.go
+++ b/pkg/messaging/api.go
@@ -3,6 +3,7 @@ package messaging
 import (
 	"time"
 
+	"github.com/status-im/status-go/pkg/messaging/types"
 	"github.com/status-im/status-go/pkg/pubsub"
 )
 
@@ -33,9 +34,21 @@ func (a *API) GetCurrentTime() uint64 {
 	return uint64(a.core.timeSource.Now().UnixNano() / int64(time.Millisecond))
 }
 
-// Online reports whether the transport currently has at least one connected peer.
+// Online reports whether the transport currently has connectivity. It derives
+// from the three-state ConnectionStatus (online == status != Disconnected),
+// matching the logos-delivery Messaging API's online semantics.
 func (a *API) Online() bool {
-	return a.core.stack.Transport.PeerCount() > 0
+	return a.core.stack.Transport.ConnectionState().IsOnline()
+}
+
+// ConnectionStatus returns the transport's current three-state connection status
+// (Disconnected / PartiallyConnected / Connected).
+func (a *API) ConnectionStatus() types.ConnectionStatus {
+	state := a.core.stack.Transport.ConnectionState()
+	return types.ConnectionStatus{
+		IsOnline: state.IsOnline(),
+		State:    state,
+	}
 }
 
 // SubscribeFilterMatched returns a channel that is notified whenever an incoming

--- a/pkg/messaging/layers/transport/transport.go
+++ b/pkg/messaging/layers/transport/transport.go
@@ -722,6 +722,11 @@ func (t *Transport) PeerCount() int {
 	return len(t.waku.Peers())
 }
 
+// ConnectionState returns the waku node's current three-state connection status.
+func (t *Transport) ConnectionState() types.ConnectionState {
+	return t.waku.ConnectionState()
+}
+
 // Peers is retained only for the Python functional tests (see tests-functional);
 // it is not used by status-app.
 func (t *Transport) Peers() types.PeerStats {

--- a/pkg/messaging/types/connection_status.go
+++ b/pkg/messaging/types/connection_status.go
@@ -1,7 +1,23 @@
 package types
 
+import (
+	wakutypes "github.com/status-im/status-go/pkg/messaging/waku/types"
+)
+
+// ConnectionState is the three-state connection status (Disconnected /
+// PartiallyConnected / Connected) surfaced to the Messaging API, re-exported
+// from the waku layer that produces it.
+type ConnectionState = wakutypes.ConnectionState
+
+const (
+	ConnectionStateDisconnected       = wakutypes.ConnectionStateDisconnected
+	ConnectionStatePartiallyConnected = wakutypes.ConnectionStatePartiallyConnected
+	ConnectionStateConnected          = wakutypes.ConnectionStateConnected
+)
+
 type ConnectionStatus struct {
-	IsOnline bool `json:"isOnline"`
+	IsOnline bool            `json:"isOnline"`
+	State    ConnectionState `json:"state"`
 }
 
 type ConnectionStatusSubscription interface {

--- a/pkg/messaging/waku/gowaku.go
+++ b/pkg/messaging/waku/gowaku.go
@@ -166,7 +166,15 @@ type Waku struct {
 	connectionNotifChan     chan node.PeerConnection
 	connStatusSubscriptions map[string]*types.ConnStatusSubscription
 	connStatusMu            sync.Mutex
-	onlineChecker           *onlinechecker.DefaultOnlineChecker
+	// connState is the latest derived three-state connection status, guarded by
+	// connStatusMu. ConnectionState() reads it; checkForConnectionChanges writes it.
+	connState types.ConnectionState
+	// topicHealth caches the most recent per-pubsub-topic mesh health reported by
+	// go-waku on topicHealthStatusChan. Accessed only from the connection poller
+	// goroutine (the topicHealthStatusChan/ticker/connectionNotifChan select loop),
+	// so it needs no lock of its own.
+	topicHealth   map[string]peermanager.TopicHealth
+	onlineChecker *onlinechecker.DefaultOnlineChecker
 	// stateMu guards state and stateInitialized. ConnectionChanged is invoked
 	// from the OS/mobile path while checkForConnectionChanges and
 	// handleNetworkChangeFromApp run on the internal poller goroutine, so all
@@ -241,6 +249,7 @@ func New(nodeKey *ecdsa.PrivateKey, cfg *Config, logger *zap.Logger, ts timesour
 		topicHealthStatusChan:       make(chan peermanager.TopicHealthStatus, 100),
 		connectionNotifChan:         make(chan node.PeerConnection, 20),
 		connStatusSubscriptions:     make(map[string]*types.ConnStatusSubscription),
+		topicHealth:                 make(map[string]peermanager.TopicHealth),
 		ctx:                         ctx,
 		cancel:                      cancel,
 		wg:                          sync.WaitGroup{},
@@ -889,8 +898,15 @@ func (w *Waku) Start() error {
 				}
 			case <-tickerC:
 				w.checkForConnectionChanges()
-			case <-w.topicHealthStatusChan:
-				// TODO: https://github.com/status-im/status-go/issues/4628
+			case topicHealth := <-w.topicHealthStatusChan:
+				// go-waku reports per-shard mesh health (UnHealthy / MinimallyHealthy
+				// / SufficientlyHealthy); cache it so checkForConnectionChanges can
+				// tell PartiallyConnected from Connected. Supersedes the old no-op
+				// (status-im/status-go#4628).
+				w.topicHealth[topicHealth.Topic] = topicHealth.Health
+				if !paused {
+					w.checkForConnectionChanges()
+				}
 			case <-w.connectionNotifChan:
 				if !paused {
 					w.checkForConnectionChanges()
@@ -1008,17 +1024,54 @@ func (w *Waku) Start() error {
 	return nil
 }
 
+// deriveConnectionState maps the node's current connectivity onto the three-state
+// ConnectionState, mirroring logos-delivery's health monitor
+// (node_health_monitor.nim calculateConnectionState):
+//
+//   - no peers                     -> Disconnected
+//   - relay mesh SufficientlyHealthy on every default shard -> Connected
+//   - peers, but a degraded mesh   -> PartiallyConnected
+//
+// Light (Edge) nodes have no relay mesh, so per-shard mesh health is not
+// meaningful for them; any connectivity is reported as Connected until
+// per-protocol (filter/lightpush/store) health is exposed. Runs on the
+// connection poller goroutine, so topicHealth is read without a lock.
+func (w *Waku) deriveConnectionState() types.ConnectionState {
+	if len(w.node.Host().Network().Peers()) == 0 {
+		return types.ConnectionStateDisconnected
+	}
+	if w.cfg.IsLightClient() {
+		return types.ConnectionStateConnected
+	}
+	for _, topic := range w.cfg.DefaultShardedPubsubTopics {
+		if w.topicHealth[topic] < peermanager.SufficientlyHealthy {
+			return types.ConnectionStatePartiallyConnected
+		}
+	}
+	return types.ConnectionStateConnected
+}
+
+// ConnectionState returns the latest derived three-state connection status.
+func (w *Waku) ConnectionState() types.ConnectionState {
+	w.connStatusMu.Lock()
+	defer w.connStatusMu.Unlock()
+	return w.connState
+}
+
 func (w *Waku) checkForConnectionChanges() {
 
-	isOnline := len(w.node.Host().Network().Peers()) > 0
+	state := w.deriveConnectionState()
+	isOnline := state.IsOnline()
 
 	w.connStatusMu.Lock()
 
+	w.connState = state
 	latestConnStatus := types.ConnStatus{
 		IsOnline: isOnline,
+		State:    state,
 	}
 
-	w.logger.Debug("connection status", zap.Bool("isOnline", isOnline))
+	w.logger.Debug("connection status", zap.Bool("isOnline", isOnline), zap.Stringer("state", state))
 	for k, subs := range w.connStatusSubscriptions {
 		if !subs.Send(latestConnStatus) {
 			delete(w.connStatusSubscriptions, k)
@@ -1034,7 +1087,7 @@ func (w *Waku) checkForConnectionChanges() {
 	prevState, _ := w.snapshotState()
 	next := connection.State{
 		Type:    prevState.Type, //setting state type as previous one since there won't be a change here
-		Offline: !latestConnStatus.IsOnline,
+		Offline: !isOnline,
 	}
 	if w.shouldFireConnectionChanged(next) {
 		w.ConnectionChanged(next)

--- a/pkg/messaging/waku/types/connection.go
+++ b/pkg/messaging/waku/types/connection.go
@@ -1,0 +1,37 @@
+package types
+
+// ConnectionState mirrors the logos-delivery Messaging API's three-state
+// connection status (see logos-delivery waku/api/types.nim `ConnectionStatus`).
+// It lets status-go speak the same vocabulary as the Messaging API:
+//
+//   - Disconnected:        no connectivity.
+//   - PartiallyConnected:  some peers, but the mesh is not yet healthy.
+//   - Connected:           a healthy mesh.
+//
+// Online detection derives from it: a node is online whenever it is not
+// Disconnected (both PartiallyConnected and Connected count as online), matching
+// logos-delivery's `status != Disconnected` semantics.
+type ConnectionState int
+
+const (
+	ConnectionStateDisconnected ConnectionState = iota
+	ConnectionStatePartiallyConnected
+	ConnectionStateConnected
+)
+
+// IsOnline reports whether the node has any connectivity.
+func (s ConnectionState) IsOnline() bool {
+	return s != ConnectionStateDisconnected
+}
+
+// String returns a stable, host-facing label (also used as the signal payload).
+func (s ConnectionState) String() string {
+	switch s {
+	case ConnectionStatePartiallyConnected:
+		return "partiallyConnected"
+	case ConnectionStateConnected:
+		return "connected"
+	default:
+		return "disconnected"
+	}
+}

--- a/pkg/messaging/waku/types/waku.go
+++ b/pkg/messaging/waku/types/waku.go
@@ -17,7 +17,8 @@ import (
 )
 
 type ConnStatus struct {
-	IsOnline bool `json:"isOnline"`
+	IsOnline bool            `json:"isOnline"`
+	State    ConnectionState `json:"state"`
 }
 
 type PeerStats map[peer.ID]WakuV2Peer
@@ -106,6 +107,11 @@ type Waku interface {
 	Peers() PeerStats
 
 	SubscribeToConnStatusChanges() (*ConnStatusSubscription, error)
+
+	// ConnectionState returns the node's current three-state connection status
+	// (Disconnected / PartiallyConnected / Connected). Online detection derives
+	// from it via ConnectionState.IsOnline().
+	ConnectionState() ConnectionState
 
 	SubscribeEnvelopeEvents(events chan<- EnvelopeEvent) Subscription
 

--- a/protocol/messenger.go
+++ b/protocol/messenger.go
@@ -1353,9 +1353,15 @@ func (m *Messenger) watchConnectionChange() {
 		defer subscription.Unsubscribe()
 		ticker := time.NewTicker(keepAlivePeriod)
 		defer ticker.Stop()
+		// Sentinel outside the valid enum range so the first event always emits.
+		lastConnState := types2.ConnectionState(-1)
 		for {
 			select {
 			case status := <-subscription.C():
+				if status.State != lastConnState {
+					lastConnState = status.State
+					signal.SendConnectionStatusChange(status)
+				}
 				processNewState(status.IsOnline)
 			case <-ticker.C:
 				if m.isPaused() {

--- a/signal/events_connection_status.go
+++ b/signal/events_connection_status.go
@@ -1,0 +1,28 @@
+package signal
+
+import (
+	messagingtypes "github.com/status-im/status-go/pkg/messaging/types"
+)
+
+// EventConnectionStatusChange is emitted when the waku node's three-state
+// connection status changes. It mirrors the logos-delivery Messaging API's
+// connection-status-change event (Disconnected / PartiallyConnected /
+// Connected), superseding the removed peer-stats signal.
+const EventConnectionStatusChange = "waku.connection.status.change"
+
+// ConnectionStatusSignal is the payload of EventConnectionStatusChange.
+type ConnectionStatusSignal struct {
+	// Status is the connection state as a stable label:
+	// "disconnected" | "partiallyConnected" | "connected".
+	Status string `json:"status"`
+	// IsOnline is a convenience flag (status != disconnected).
+	IsOnline bool `json:"isOnline"`
+}
+
+// SendConnectionStatusChange emits the connection-status-change signal.
+func SendConnectionStatusChange(status messagingtypes.ConnectionStatus) {
+	send(EventConnectionStatusChange, ConnectionStatusSignal{
+		Status:   status.State.String(),
+		IsOnline: status.IsOnline,
+	})
+}


### PR DESCRIPTION
Closes https://github.com/status-im/status-go/issues/7466

## What

Prepares status-go for the logos-delivery Messaging API's **three-state connection status** and switches online detection to derive from it.

`Peers()` RPC is **kept** — the discovery functional tests need it.

## Why

The logos-delivery Messaging API exposes connection status as `ConnectionStatus = {Disconnected, PartiallyConnected, Connected}` (`waku/api/types.nim`) with the semantic **`online == status != Disconnected`** (`recv_service.nim`). status-go only had a boolean (`ConnStatus.IsOnline`, `Online() = peerCount > 0`). This introduces the same three-state vocabulary so status-go can speak it when logos-delivery's richer status lands.

## Changes

**Three-state type (waku → messaging):**
- New `wakutypes.ConnectionState` enum (`Disconnected`/`PartiallyConnected`/`Connected`) with `IsOnline()` (`!= Disconnected`) and a stable `String()`. Re-exported as `messaging/types.ConnectionState`.
- `ConnStatus` / `messaging.ConnectionStatus` now carry the state; surfaced on the interfaces via `Waku.ConnectionState()`, `Transport.ConnectionState()`, and `API.ConnectionStatus()`.

**Faithful derivation** (`gowaku.deriveConnectionState`, mirroring logos-delivery's `calculateConnectionState`):
- no peers → **Disconnected**
- relay mesh `SufficientlyHealthy` on every default shard → **Connected**
- peers but a degraded mesh → **PartiallyConnected**

This **activates the go-waku `TopicHealth` channel that was previously a no-op** (`topicHealthStatusChan`, TODO #4628): the 3-level `UnHealthy`/`MinimallyHealthy`/`SufficientlyHealthy` health is now cached and used to tell Partial from Connected. Light (Edge) nodes have no relay mesh, so they report `Connected` on any connectivity (per-protocol filter/lightpush/store health is left for a follow-up).

**`Online()` switch:** `API.Online()` now returns `Transport.ConnectionState().IsOnline()` instead of `PeerCount() > 0`. Because `Disconnected == zero peers`, **online detection is behaviourally unchanged** for all 8 `Messenger.Online()` callers (sync gate, mailserver cycle, resend, community advertisement, contact-code publish); the new states only subdivide the existing "online" case.

**Host-app signal:** new `EventConnectionStatusChange` (`waku.connection.status.change`, payload `{status, isOnline}`), emitted from `Messenger.watchConnectionChange` on state transitions — mirroring logos-delivery's connection-status-change event and replacing the removed `wakuv2.peerstats` signal.

**Kept:** `Peers()` (+ `PeerCount()`) for the discovery functional tests.

## Design notes
- The enum lives in the waku layer (where it's produced) and is re-exported upward, so both the `Waku` and messaging-API interfaces speak the same type without duplication/mapping.
- Signal emission is deduped by state (a transition, not every event), so it isn't chatty.

## Verification
`goimports` clean on all 9 files. Built clean (unfiltered): `pkg/messaging/waku/types`, `pkg/messaging/waku`, `pkg/messaging/types`, `pkg/messaging/layers/transport`, `pkg/messaging/adapters` — this covers the enum, the derivation + topic-health wiring, `*Waku`'s new interface method (the `var _ types.Waku` assertion holds), and the adapter/type re-export. `signal` / `pkg/messaging` / `protocol` can't fully link locally (pre-existing `libsds` CGO + un-generated segmentation protobuf), so those (`API.Online/ConnectionStatus`, the signal, the messenger emission) go to CI — they type-check against the clean packages above.

## Follow-ups (not in scope)
- Per-protocol (filter/lightpush/store) health for light-node PartiallyConnected.
- Optional `EventShardTopicHealthChange` signal (logos-delivery also exposes it).

Issue: #7466

🤖 Generated with [Claude Code](https://claude.com/claude-code)
