### PR TITLE
fix(messaging): periodically reconcile history while connectivity is unreliable

### DIFF
--- a/pkg/messaging/api.go
+++ b/pkg/messaging/api.go
@@ -51,6 +51,14 @@ func (a *API) ConnectionStatus() types.ConnectionStatus {
 	}
 }
 
+// OnHistoryReconcileNeeded returns a channel signalled whenever history should
+// be reconciled with the store nodes (#7568): periodically while connectivity
+// is not reliable (relay mesh not Connected on every default shard), and once
+// more when it recovers.
+func (a *API) OnHistoryReconcileNeeded() <-chan struct{} {
+	return a.core.stack.Transport.OnHistoryReconcileNeeded()
+}
+
 // SubscribeFilterMatched returns a channel that is notified whenever an incoming
 // envelope matches at least one installed filter. bufSize should be 1.
 // Callers must call UnsubscribeFilterMatched when done.

--- a/pkg/messaging/layers/transport/transport.go
+++ b/pkg/messaging/layers/transport/transport.go
@@ -727,6 +727,13 @@ func (t *Transport) ConnectionState() types.ConnectionState {
 	return t.waku.ConnectionState()
 }
 
+// OnHistoryReconcileNeeded returns the waku node's history-reconcile signal
+// (#7568): fired periodically while connectivity is not reliable and once when
+// it recovers.
+func (t *Transport) OnHistoryReconcileNeeded() <-chan struct{} {
+	return t.waku.OnHistoryReconcileNeeded()
+}
+
 // Peers is retained only for the Python functional tests (see tests-functional);
 // it is not used by status-app.
 func (t *Transport) Peers() types.PeerStats {

--- a/pkg/messaging/waku/gowaku.go
+++ b/pkg/messaging/waku/gowaku.go
@@ -174,6 +174,12 @@ type Waku struct {
 	// so it needs no lock of its own.
 	topicHealth   map[string]peermanager.TopicHealth
 	onlineChecker *onlinechecker.DefaultOnlineChecker
+	// historyReconcileNeeded is signalled by the history-reconcile loop (see
+	// history_reconcile.go) whenever the consumer should fetch history from the
+	// store nodes. Buffered (1) level-trigger: sends never block, a pending
+	// signal coalesces with later ones. Temporary until logos-delivery owns
+	// reconciliation end to end — see OnHistoryReconcileNeeded.
+	historyReconcileNeeded chan struct{}
 	// stateMu guards state and stateInitialized. ConnectionChanged is invoked
 	// from the OS/mobile path while checkForConnectionChanges and
 	// handleNetworkChangeFromApp run on the internal poller goroutine, so all
@@ -249,6 +255,7 @@ func New(nodeKey *ecdsa.PrivateKey, cfg *Config, logger *zap.Logger, ts timesour
 		connectionNotifChan:         make(chan node.PeerConnection, 20),
 		connStatusSubscriptions:     make(map[string]*types.ConnStatusSubscription),
 		topicHealth:                 make(map[string]peermanager.TopicHealth),
+		historyReconcileNeeded:      make(chan struct{}, 1),
 		ctx:                         ctx,
 		cancel:                      cancel,
 		wg:                          sync.WaitGroup{},
@@ -913,6 +920,8 @@ func (w *Waku) Start() error {
 			}
 		}
 	}()
+
+	w.startHistoryReconcileLoop()
 
 	if w.cfg.MetricsEnabled {
 		w.wg.Add(1)

--- a/pkg/messaging/waku/history_reconcile.go
+++ b/pkg/messaging/waku/history_reconcile.go
@@ -1,0 +1,117 @@
+package wakuv2
+
+import (
+	"time"
+
+	"go.uber.org/zap"
+
+	gocommon "github.com/status-im/status-go/common"
+	"github.com/status-im/status-go/pkg/messaging/waku/types"
+)
+
+const (
+	// History reconciliation (#7568): while the node cannot be confident it is
+	// receiving everything live, the consumer should periodically fetch history
+	// from the store nodes so silently missed messages are recovered. The node
+	// is confident only with a Connected relay mesh on every default shard.
+	historyReconcileCheckInterval = 10 * time.Second
+	historyReconcileMinInterval   = 30 * time.Second
+)
+
+// OnHistoryReconcileNeeded returns a channel signalled whenever history should
+// be reconciled with the store nodes: periodically while connectivity is not
+// reliable, and once more when it recovers (closing the unreliable window).
+// It is a buffered level-trigger; consumers that are slow or paused coalesce
+// pending signals instead of queueing them.
+//
+// Temporary: this channel exists because the Waku node cannot yet own the
+// fetch itself. It already has the subscription (filter) list, but lacks the
+// per-topic "when was it last fetched" watermark, which the Messenger persists
+// in the app DB (mailserver_topics). Eventually logos-delivery will own
+// reconciliation and history backfill entirely, including persisting
+// lastFetched per topic: its Messaging API already reconciles
+// (https://github.com/logos-messaging/logos-delivery/issues/3941) but does not
+// yet fetch history, and neither exposes nor persists lastFetched. That gap
+// should be closed in logos-delivery before integration — otherwise ownership
+// is split and persistence breaks, since we cannot persist lastFetched on its
+// behalf. Until then the fetch stays in the Messenger (Transport would be a
+// nicer interim home, but it is a stopgap either way), and this signal bridges
+// the two.
+func (w *Waku) OnHistoryReconcileNeeded() <-chan struct{} {
+	return w.historyReconcileNeeded
+}
+
+// startHistoryReconcileLoop runs the timing/decision half of history
+// reconciliation. The fetch itself lives with the consumer (the protocol
+// layer), which owns the topics and per-chat watermarks; this loop only owns
+// connectivity confidence and cadence. Suspended while the node is paused
+// (app backgrounded): SetPaused(false) triggers its own fetch on foreground.
+func (w *Waku) startHistoryReconcileLoop() {
+	w.wg.Add(1)
+	go func() {
+		defer gocommon.LogOnPanic()
+		defer w.wg.Done()
+		ticker := time.NewTicker(historyReconcileCheckInterval)
+		defer ticker.Stop()
+		sub := w.PauseBroadcaster.Subscribe()
+		defer sub.Unsubscribe()
+		paused := <-sub.C()
+		var tickerC <-chan time.Time
+		if !paused {
+			tickerC = ticker.C
+		}
+
+		reliable := w.reliablyConnected()
+		var lastReconcile time.Time
+
+		for {
+			select {
+			case <-w.ctx.Done():
+				return
+			case pausedState, ok := <-sub.C():
+				if !ok {
+					return
+				}
+				paused = pausedState
+				if paused {
+					tickerC = nil
+				} else {
+					tickerC = ticker.C
+				}
+			case <-tickerC:
+				wasReliable := reliable
+				reliable = w.reliablyConnected()
+				if !shouldReconcileHistory(reliable, wasReliable, lastReconcile, time.Now(), historyReconcileMinInterval) {
+					continue
+				}
+				lastReconcile = time.Now()
+				w.logger.Debug("history reconciliation needed", zap.Bool("reliable", reliable))
+				select {
+				case w.historyReconcileNeeded <- struct{}{}:
+				default: // a signal is already pending; coalesce
+				}
+			}
+		}
+	}()
+}
+
+// reliablyConnected reports whether connectivity is currently good enough to be
+// confident no live messages are being missed: a Connected relay mesh on every
+// default shard. Note that light (Edge) nodes report Connected on any
+// connectivity even though their filter-subscription health is not observable
+// yet (see deriveConnectionState); whether they should instead always
+// reconcile is a separate policy decision, deliberately not made here.
+func (w *Waku) reliablyConnected() bool {
+	return w.ConnectionState() == types.ConnectionStateConnected
+}
+
+// shouldReconcileHistory decides whether a reconciliation is due at a tick:
+// when the connection just recovered (an unreliable window closed, fetch what
+// it may have missed), or while it stays unreliable and minInterval has passed
+// since the last reconcile. While reliably connected, never.
+func shouldReconcileHistory(reliable, wasReliable bool, lastReconcile, now time.Time, minInterval time.Duration) bool {
+	if reliable {
+		return !wasReliable
+	}
+	return now.Sub(lastReconcile) >= minInterval
+}

--- a/pkg/messaging/waku/history_reconcile_test.go
+++ b/pkg/messaging/waku/history_reconcile_test.go
@@ -1,0 +1,68 @@
+package wakuv2
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestShouldReconcileHistory(t *testing.T) {
+	now := time.Now()
+
+	tests := []struct {
+		name          string
+		reliable      bool
+		wasReliable   bool
+		lastReconcile time.Time
+		want          bool
+	}{
+		{
+			name:        "reliably connected: no periodic reconciliation",
+			reliable:    true,
+			wasReliable: true,
+			want:        false,
+		},
+		{
+			name:        "unreliable window just closed: reconcile once",
+			reliable:    true,
+			wasReliable: false,
+			want:        true,
+		},
+		{
+			name:          "unreliable, never reconciled: due immediately",
+			reliable:      false,
+			wasReliable:   false,
+			lastReconcile: time.Time{},
+			want:          true,
+		},
+		{
+			name:          "unreliable, reconciled recently: not due yet",
+			reliable:      false,
+			wasReliable:   false,
+			lastReconcile: now.Add(-historyReconcileMinInterval / 2),
+			want:          false,
+		},
+		{
+			name:          "unreliable, min interval elapsed: due again",
+			reliable:      false,
+			wasReliable:   false,
+			lastReconcile: now.Add(-2 * historyReconcileMinInterval),
+			want:          true,
+		},
+		{
+			name:          "just turned unreliable after recent reconcile: waits for interval",
+			reliable:      false,
+			wasReliable:   true,
+			lastReconcile: now.Add(-historyReconcileMinInterval / 2),
+			want:          false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := shouldReconcileHistory(tt.reliable, tt.wasReliable, tt.lastReconcile, now, historyReconcileMinInterval)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/pkg/messaging/waku/types/waku.go
+++ b/pkg/messaging/waku/types/waku.go
@@ -113,6 +113,13 @@ type Waku interface {
 	// from it via ConnectionState.IsOnline().
 	ConnectionState() ConnectionState
 
+	// OnHistoryReconcileNeeded returns a channel signalled whenever history
+	// should be reconciled with the store nodes (#7568): periodically while
+	// connectivity is not reliable (relay mesh not Connected on every default
+	// shard), and once more when connectivity recovers. Buffered
+	// level-trigger; pending signals coalesce.
+	OnHistoryReconcileNeeded() <-chan struct{}
+
 	SubscribeEnvelopeEvents(events chan<- EnvelopeEvent) Subscription
 
 	MaxMessageSize() uint32

--- a/protocol/messenger.go
+++ b/protocol/messenger.go
@@ -644,6 +644,7 @@ func (m *Messenger) Start() (*MessengerResponse, error) {
 	m.schedulePublishGrantsForControlledCommunities()
 	m.handleENSVerificationSubscription(ensSubscription)
 	m.watchConnectionChange()
+	m.startHistoryReconciliationLoop()
 	m.watchChatsToUnmute()
 	m.watchCommunitiesToUnmute()
 	m.watchExpiredMessages()

--- a/protocol/messenger_mailserver_cycle.go
+++ b/protocol/messenger_mailserver_cycle.go
@@ -8,6 +8,45 @@ import (
 	gocommon "github.com/status-im/status-go/common"
 )
 
+// startHistoryReconciliationLoop fetches history from the store nodes whenever
+// the transport signals that reconciliation is needed — periodically while
+// connectivity is not reliable, and once more when it recovers. This is the
+// "unreliable" leg of the history-reconciliation policy (#7568), which the
+// offline→online and app-foreground triggers do not cover: without it, a
+// message that silently misses live delivery (degraded relay mesh) while the
+// client stays online is never recovered (see status-app#21405). The
+// transport owns the timing and the connectivity confidence; the fetch lives
+// here, for now, because the per-topic lastFetched watermark is persisted by
+// the Messenger in the app DB. This split is temporary until logos-delivery
+// owns reconciliation and backfill end to end — see the note on
+// Waku.OnHistoryReconcileNeeded.
+func (m *Messenger) startHistoryReconciliationLoop() {
+	if !m.config.codeControlFlags.AutoRequestHistoricMessages {
+		return
+	}
+
+	m.shutdownWaitGroup.Add(1)
+	go func() {
+		defer gocommon.LogOnPanic()
+		defer m.shutdownWaitGroup.Done()
+
+		// No isPaused check needed: the waku-side loop producing the signal is
+		// itself suspended while the transport is paused.
+		needed := m.messaging.OnHistoryReconcileNeeded()
+		for {
+			select {
+			case <-m.quit:
+				return
+			case <-needed:
+				m.logger.Debug("reconciling history with store nodes")
+				if _, err := m.requestAllHistoricMessages(true, false); err != nil {
+					m.logger.Warn("history reconciliation fetch failed", zap.Error(err))
+				}
+			}
+		}
+	}()
+}
+
 func (m *Messenger) asyncRequestAllHistoricMessages() {
 	if !m.config.codeControlFlags.AutoRequestHistoricMessages {
 		return


### PR DESCRIPTION
Companion PR: status-im/status-app#21408

Part of the fix for status-im/status-app#21405. Part of #7568.

#7532 implemented only the offline→online leg of the #7568 policy. A client that stays online never queries the store again after login, so a message that silently misses live delivery (degraded relay mesh) is lost until restart.

**Fix**: the Waku node runs a reconcile loop (`history_reconcile.go`). While the relay mesh is not `Connected` on every default shard it signals `OnHistoryReconcileNeeded()` every 30 seconds, and once more when connectivity recovers. The Messenger listens and runs the existing watermark-based fetch. Reliably connected clients issue no periodic store queries, preserving the #7568 goal.

**Deliberately out of scope**: light clients report `Connected` on any connectivity (their filter-subscription health is not observable yet), so they don't reconcile periodically here — whether they always should is a separate policy decision for a follow-up PR. Note the #21405 e2e failure involves light clients, so the e2e goes green only together with that follow-up.

The channel is a documented temporary seam: eventually logos-delivery owns reconciliation and backfill end to end, including per-topic `lastFetched` (gap tracked in logos-messaging/logos-delivery#3941); today that watermark is persisted by the Messenger in the app DB.

**Verification**: the loop was verified red→green end-to-end with a functional test on earlier commits of this branch (relay-isolated filter node; contact request persisted on the store node; receiver backfills within ~1 min — light clients were included in the unreliable set at the time). The test and its fleet topology were removed per review; `TestShouldReconcileHistory` covers the decision logic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Stacked follow-up: #7608 (coalescing historic-sync worker).
