### PR TITLE
chore(deps): bump go-waku to v0.10.3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -102,7 +102,7 @@ require (
 	github.com/schollz/peerdiscovery v1.7.0
 	github.com/status-im/extkeys v1.4.0
 	github.com/status-im/go-wallet-sdk v0.0.0-20260612221124-9c7a9c043068
-	github.com/waku-org/go-waku v0.10.2
+	github.com/waku-org/go-waku v0.10.3
 	github.com/waku-org/sds-go-bindings v0.0.0-20251222164514-d5b47a911904
 	github.com/wk8/go-ordered-map/v2 v2.1.7
 	go.uber.org/atomic v1.11.0

--- a/go.sum
+++ b/go.sum
@@ -2416,8 +2416,8 @@ github.com/waku-org/go-libp2p-pubsub v0.13.1-gowaku h1:ovXh1m76i0yPWXt95Z9ZRyEk0
 github.com/waku-org/go-libp2p-pubsub v0.13.1-gowaku/go.mod h1:MKPU5vMI8RRFyTP0HfdsF9cLmL1nHAeJm44AxJGJx44=
 github.com/waku-org/go-libp2p-rendezvous v0.0.0-20240110193335-a67d1cc760a0 h1:R4YYx2QamhBRl/moIxkDCNW+OP7AHbyWLBygDc/xIMo=
 github.com/waku-org/go-libp2p-rendezvous v0.0.0-20240110193335-a67d1cc760a0/go.mod h1:EhZP9fee0DYjKH/IOQvoNSy1tSHp2iZadsHGphcAJgY=
-github.com/waku-org/go-waku v0.10.2 h1:Rjy9UhdXaeLSwcm8unMUiFM3HdLxyJvdtleREEMeyrg=
-github.com/waku-org/go-waku v0.10.2/go.mod h1:PDs4hlPbONeMQGsNyfArZV4R2Js1Zy5oqLBfw2VU278=
+github.com/waku-org/go-waku v0.10.3 h1:6BpsnM+kwfGNCJo3KrSqe7+zLTK3Tw9xLZrxJJbfHmQ=
+github.com/waku-org/go-waku v0.10.3/go.mod h1:PDs4hlPbONeMQGsNyfArZV4R2Js1Zy5oqLBfw2VU278=
 github.com/waku-org/go-zerokit-rln v0.1.14-0.20240102145250-fa738c0bdf59 h1:jisj+OCI6QydLtFq3Pyhu49wl9ytPN7oAHjMfepHDrA=
 github.com/waku-org/go-zerokit-rln v0.1.14-0.20240102145250-fa738c0bdf59/go.mod h1:1PdBdPzyTaKt3VnpAHk3zj+r9dXPFOr3IHZP9nFle6E=
 github.com/waku-org/go-zerokit-rln-apple v0.0.0-20230916172309-ee0ee61dde2b h1:KgZVhsLkxsj5gb/FfndSCQu6VYwALrCOgYI3poR95yE=

--- a/nix/pkgs/status-go/library/default.nix
+++ b/nix/pkgs/status-go/library/default.nix
@@ -11,7 +11,7 @@ let
 in pkgs.buildGoModule {
   pname = "status-go";
   src = builtins.path { path = ./../../../..; name = "status-go-library"; };
-  vendorHash = "sha256-p3NQemuslvRFSmSZHS9fcklXEec+QC6N4LxFfGamE+U=";
+  vendorHash = "sha256-OoyiMXCy0pmD3642nmBUd0j9KGyjvdJvkFNKgdjvd5M=";
 
   inherit meta version;
 


### PR DESCRIPTION
Requires:
- https://github.com/logos-messaging/logos-delivery-go/pull/1314

Companion status-app PR: https://github.com/status-im/status-app/pull/21431
 
## Summary

Bumps `github.com/waku-org/go-waku` from **v0.10.2 → v0.10.3**.

v0.10.3 contains the fix for an inverted idle-subscription cleanup check in the filter protocol (`waku/v2/protocol/filter/subscribers_map.go`). The previous code deleted **recently-active** filter subscribers and never reaped **idle** ones (the `<`/`>` comparison was backwards), causing intermittent filter message-delivery loss on service/full nodes and a slow leak of the subscribers map.

## Changes

- `go.mod` / `go.sum`: `waku-org/go-waku` → `v0.10.3`
- `nix/pkgs/status-go/library/default.nix`: updated `vendorHash` to match the new module set (via `make vendor`)

## Verification

- `go.sum` completeness confirmed: the full dependency tree resolves and compiles past module loading with no "missing go.sum entry" errors (remaining local build steps only need build-time-generated files that CI/nix produce).
- New `vendorHash` (`sha256-OoyiMXCy0pmD3642nmBUd0j9KGyjvdJvkFNKgdjvd5M=`) obtained from the nix build's fixed-output-derivation hash, i.e. the value `make vendor` writes.

- 🤖 Generated with [Claude Code](https://claude.com/claude-code)