### PR TITLE
fix: mediaserver reinitialization 

### DIFF
--- a/pkg/backend/geth_backend.go
+++ b/pkg/backend/geth_backend.go
@@ -2093,7 +2093,12 @@ func (b *StatusBackend) Logout() error {
 	b.account = nil
 
 	if b.statusNode != nil {
-		if err := b.statusNode.Stop(); err != nil {
+		if b.statusNode.IsRunning() {
+			if err := b.statusNode.Stop(); err != nil {
+				return err
+			}
+		}
+		if err := b.statusNode.StopMediaServer(); err != nil {
 			return err
 		}
 		b.statusNode = nil

--- a/pkg/backend/geth_backend_media_server_test.go
+++ b/pkg/backend/geth_backend_media_server_test.go
@@ -1,0 +1,74 @@
+package backend
+
+import (
+	"fmt"
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/status-im/status-go/internal/testutils"
+	"github.com/status-im/status-go/protocol/requests"
+)
+
+func reserveLocalhostPort(t *testing.T) int {
+	t.Helper()
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	port := ln.Addr().(*net.TCPAddr).Port
+	require.NoError(t, ln.Close())
+
+	return port
+}
+
+// TestMediaServerPortIgnoredOnRepeatedInitialize reproduces the client flow:
+// login -> logout -> InitializeApplication -> login again.
+//
+// Without restarting the media server when InitializeApplication re-applies its
+// options, the second login serves images on a random port even though
+// InitializeApplication passes the same port.
+func TestMediaServerPortIgnoredOnRepeatedInitialize(t *testing.T) {
+	tmpdir := t.TempDir()
+	b := NewStatusBackend(testutils.MustCreateTestLogger())
+	b.UpdateRootDataDir(tmpdir)
+
+	port := reserveLocalhostPort(t)
+
+	// InitializeApplication #1 + first login
+	initializeApplicationWithMediaServerPortHelper(t, b, port)
+
+	acc, err := b.CreateAccountAndLogin(&requests.CreateAccount{
+		DisplayName:        "media-server-test",
+		CustomizationColor: "#ffffff",
+		Password:           testPassword,
+		RootDataDir:        tmpdir,
+		LogFilePath:        tmpdir + "/log",
+		KdfIterations:      1,
+	})
+	require.NoError(t, err)
+	require.Contains(t, b.StatusNode().MediaServer().GetListeningAddrPort(), fmt.Sprintf(":%d", port))
+
+	// "login again": logout then InitializeApplication then login
+	require.NoError(t, b.Logout())
+
+	initializeApplicationWithMediaServerPortHelper(t, b, port)
+
+	require.NoError(t, b.LoginAccount(&requests.Login{
+		KeyUID:        acc.KeyUID,
+		Password:      testPassword,
+		KdfIterations: 1,
+	}))
+
+	require.Contains(t, b.StatusNode().MediaServer().GetListeningAddrPort(), fmt.Sprintf(":%d", port),
+		"media server should keep the configured port after logout + re-initialize + login")
+}
+
+func initializeApplicationWithMediaServerPortHelper(t *testing.T, b *StatusBackend, port int) {
+	t.Helper()
+
+	addr := fmt.Sprintf("127.0.0.1:%d", port)
+	enableTLS := false
+	b.StatusNode().SetMediaServerOptions(&addr, &enableTLS, "localhost", port)
+	require.NoError(t, b.OpenAccounts())
+}

--- a/pkg/backend/node/get_status_node.go
+++ b/pkg/backend/node/get_status_node.go
@@ -319,6 +319,9 @@ func (n *StatusNode) LoadLocalBackup(filePath string) error {
 }
 
 func (n *StatusNode) SetMediaServerOptions(address *string, enableTLS *bool, advertizeHost string, advertizePort int) {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+
 	n.mediaServerAddress = address
 	n.mediaServerEnableTLS = enableTLS
 	n.mediaServerAdvertizeHost = advertizeHost
@@ -332,6 +335,9 @@ func (n *StatusNode) SetMediaServerOptions(address *string, enableTLS *bool, adv
 }
 
 func (n *StatusNode) StopMediaServer() error {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+
 	if n.mediaServer == nil {
 		return nil
 	}

--- a/pkg/backend/node/get_status_node.go
+++ b/pkg/backend/node/get_status_node.go
@@ -323,6 +323,22 @@ func (n *StatusNode) SetMediaServerOptions(address *string, enableTLS *bool, adv
 	n.mediaServerEnableTLS = enableTLS
 	n.mediaServerAdvertizeHost = advertizeHost
 	n.mediaServerAdvertizePort = advertizePort
+
+	if n.mediaServer != nil {
+		if err := n.startMediaServer(); err != nil {
+			n.logger.Error("failed to restart media server with updated options", zap.Error(err))
+		}
+	}
+}
+
+func (n *StatusNode) StopMediaServer() error {
+	if n.mediaServer == nil {
+		return nil
+	}
+
+	err := n.mediaServer.Stop()
+	n.mediaServer = nil
+	return err
 }
 
 func (n *StatusNode) startWithDB(config *params.NodeConfig) error {
@@ -500,7 +516,9 @@ func (n *StatusNode) Stop() error {
 	n.rpcClient = nil
 	n.config = nil
 
-	n.mediaServer.SetDataProviders(nil, nil, nil)
+	if n.mediaServer != nil {
+		n.mediaServer.SetDataProviders(nil, nil, nil)
+	}
 
 	n.downloader.Stop()
 	n.downloader = nil

--- a/tests-functional/tests/test_media_server.py
+++ b/tests-functional/tests/test_media_server.py
@@ -1,4 +1,5 @@
 import asyncio
+import os
 import tempfile
 
 import pytest
@@ -10,7 +11,10 @@ def _media_server_health(port, certificate):
         cert_file.write(certificate)
         cert_file_path = cert_file.name
 
-    return requests.get(f"https://localhost:{port}/health", timeout=10, verify=cert_file_path)
+    try:
+        return requests.get(f"https://localhost:{port}/health", timeout=10, verify=cert_file_path)
+    finally:
+        os.unlink(cert_file_path)
 
 
 @pytest.mark.rpc
@@ -20,16 +24,7 @@ class TestMediaServer:
     async def test_media_server_health(self, async_backend_new_profile):
         backend = await async_backend_new_profile("sender")
 
-        media_server_url = f"https://localhost:{backend.backend.media_server_port}"
-        certificate = backend.backend.image_server_tls_cert()
-
-        with tempfile.NamedTemporaryFile(mode="w", suffix=".crt", delete=False) as cert_file:
-            # Save the certificate to a temporary file
-            cert_file.write(certificate)
-            cert_file_path = cert_file.name
-
-        # Make a health request to the media server with the loaded certificate
-        response = requests.get(media_server_url + "/health", timeout=10, verify=cert_file_path)
+        response = _media_server_health(backend.backend.media_server_port, backend.backend.image_server_tls_cert())
         assert response.status_code == 200
 
     async def test_multiple_media_servers(self, async_backend_new_profile):
@@ -41,18 +36,10 @@ class TestMediaServer:
         # Media server ports are available directly - no need to wait for signals
         # (signals arrive before async signal client connects, so they're always missed)
 
-        with tempfile.NamedTemporaryFile(mode="w", suffix=".crt", delete=False) as cert_file:
-            cert_file.write(backend_1.backend.image_server_tls_cert())
-            cert_file_path_1 = cert_file.name
-
-        with tempfile.NamedTemporaryFile(mode="w", suffix=".crt", delete=False) as cert_file:
-            cert_file.write(backend_2.backend.image_server_tls_cert())
-            cert_file_path_2 = cert_file.name
-
-        response = requests.get(f"https://localhost:{backend_1.backend.media_server_port}/health", timeout=10, verify=cert_file_path_1)
+        response = _media_server_health(backend_1.backend.media_server_port, backend_1.backend.image_server_tls_cert())
         assert response.status_code == 200
 
-        response = requests.get(f"https://localhost:{backend_2.backend.media_server_port}/health", timeout=10, verify=cert_file_path_2)
+        response = _media_server_health(backend_2.backend.media_server_port, backend_2.backend.image_server_tls_cert())
         assert response.status_code == 200
 
     async def test_media_server_port_stable_after_reinitialize(self, async_backend_new_profile):

--- a/tests-functional/tests/test_media_server.py
+++ b/tests-functional/tests/test_media_server.py
@@ -5,6 +5,14 @@ import pytest
 import requests
 
 
+def _media_server_health(port, certificate):
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".crt", delete=False) as cert_file:
+        cert_file.write(certificate)
+        cert_file_path = cert_file.name
+
+    return requests.get(f"https://localhost:{port}/health", timeout=10, verify=cert_file_path)
+
+
 @pytest.mark.rpc
 @pytest.mark.asyncio
 class TestMediaServer:
@@ -46,3 +54,14 @@ class TestMediaServer:
 
         response = requests.get(f"https://localhost:{backend_2.backend.media_server_port}/health", timeout=10, verify=cert_file_path_2)
         assert response.status_code == 200
+
+    async def test_media_server_port_stable_after_reinitialize(self, async_backend_new_profile):
+        backend = await async_backend_new_profile("sender")
+
+        port = backend.backend.media_server_port
+        assert _media_server_health(port, backend.backend.image_server_tls_cert()).status_code == 200
+
+        backend.backend.logout()
+        backend.backend.init_status_backend()  # re-Initialize with the same port
+
+        assert _media_server_health(port, backend.backend.image_server_tls_cert()).status_code == 200


### PR DESCRIPTION
Fix media server port not being re-applied on repeated InitializeApplication after logout.

* Restart media server in `SetMediaServerOptions` when a listener is already running
* Stop media server on logout so the configured port can be rebound

fixes #7602 