### PR TITLE
test: skip light-client tests that are flaky under #7393

### DIFF
--- a/tests-functional/tests/conftest.py
+++ b/tests-functional/tests/conftest.py
@@ -132,6 +132,17 @@ def backend_factory(request):
     _parallel_teardown(tasks)
 
 
+def pytest_collection_modifyitems(config, items):
+    # Skip only the light-client leg of tests marked known-flaky under #7393, keeping the full-node
+    # (wakuV2LightClient_False) leg. Remove this hook and the marker when the issue is closed.
+    skip_flaky = pytest.mark.skip(
+        reason="known-flaky light-client test, tracked in https://github.com/status-im/status-go/issues/7393 (remove when the issue is closed)"
+    )
+    for item in items:
+        if item.get_closest_marker("light_client_7393") and "wakuV2LightClient_False" not in item.nodeid:
+            item.add_marker(skip_flaky)
+
+
 @pytest.fixture(scope="function", autouse=False)
 def waku_light_client(request) -> bool:
     return getattr(request, "param", False)

--- a/tests-functional/tests/test_wakuext_chats.py
+++ b/tests-functional/tests/test_wakuext_chats.py
@@ -20,6 +20,7 @@ class TestChatActions:
     def receiver(self, backend_new_profile, waku_light_client):
         return backend_new_profile("receiver", waku_light_client=waku_light_client)
 
+    @pytest.mark.light_client_7393
     def test_all_chats(self, sender, receiver):
         messenger.make_contacts(sender, receiver)
         private_group_id = messenger.join_private_group(admin=sender, member=receiver)
@@ -45,6 +46,7 @@ class TestChatActions:
         assert chat.get("chatType", 0) == ChatType.ONE_TO_ONE.value
         assert chat.get("lastMessage", {}).get("text", "") == sent_texts[0]
 
+    @pytest.mark.light_client_7393
     def test_chats_preview(self, sender, receiver):
         # One to one
         messenger.make_contacts(sender, receiver)
@@ -68,6 +70,7 @@ class TestChatActions:
         assert len(chats_previews) == 2
         assert {chat.get("id", "") for chat in chats_previews} == {one_to_one_chat_id, private_group_chat_id}
 
+    @pytest.mark.light_client_7393
     def test_active_chats(self, sender, receiver):
         messenger.make_contacts(sender, receiver)
         messenger.send_multiple_one_to_one_messages(1, sender=sender, receiver=receiver)

--- a/tests-functional/tests/test_wakuext_contact_requests.py
+++ b/tests-functional/tests/test_wakuext_contact_requests.py
@@ -52,6 +52,7 @@ class TestContactRequests:
         assert len(sent_request_messages) == 1, f"Expected one message with contentType {MessageContentType.SYSTEM_MESSAGE_MUTUAL_EVENT_SENT.value}"
         assert sent_request_messages[0].get("text") == f"You sent a contact request to @{receiver.public_key}"
 
+    @pytest.mark.light_client_7393
     async def test_accept_contact_request(self, sender, receiver):
         message_id = await async_messenger.send_contact_request_and_wait(sender, receiver)
         response = receiver.wakuext_service.accept_contact_request(message_id, sender.public_key)
@@ -71,6 +72,7 @@ class TestContactRequests:
         ), f"Expected one message with contentType {MessageContentType.SYSTEM_MESSAGE_MUTUAL_EVENT_ACCEPTED.value}"
         assert accept_request_messages[0].get("text") == f"You accepted @{sender.public_key}'s contact request"
 
+    @pytest.mark.light_client_7393
     async def test_decline_contact_request(self, sender, receiver):
         message_id = await async_messenger.send_contact_request_and_wait(sender, receiver)
         # Send without contact ID first and expect an error
@@ -87,6 +89,7 @@ class TestContactRequests:
         assert len(contact_request_messages) == 1, f"Expected one message with contentType {MessageContentType.CONTACT_REQUEST.value}"
         assert contact_request_messages[0].get("text") == "contact_request"
 
+    @pytest.mark.light_client_7393
     async def test_accept_latest_contact_request_for_contact(self, sender, receiver):
         await async_messenger.send_contact_request_and_wait(sender, receiver)
         response = receiver.wakuext_service.accept_latest_contact_request_for_contact(sender.public_key)
@@ -106,6 +109,7 @@ class TestContactRequests:
         ), f"Expected one message with contentType {MessageContentType.SYSTEM_MESSAGE_MUTUAL_EVENT_ACCEPTED.value}"
         assert accept_request_messages[0].get("text") == f"You accepted @{sender.public_key}'s contact request"
 
+    @pytest.mark.light_client_7393
     async def test_dismiss_latest_contact_request_for_contact(self, sender, receiver):
         await async_messenger.send_contact_request_and_wait(sender, receiver)
         response = receiver.wakuext_service.dismiss_latest_contact_request_for_contact(sender.public_key)
@@ -119,6 +123,7 @@ class TestContactRequests:
         assert len(contact_request_messages) == 1, f"Expected one message with contentType {MessageContentType.CONTACT_REQUEST.value}"
         assert contact_request_messages[0].get("text") == "contact_request"
 
+    @pytest.mark.light_client_7393
     async def test_get_latest_contact_request_for_contact(self, sender, receiver):
         await async_messenger.send_contact_request_and_wait(sender, receiver)
         response = receiver.wakuext_service.get_latest_contact_request_for_contact(sender.public_key)
@@ -128,6 +133,7 @@ class TestContactRequests:
         assert len(contact_request_message) == 1, f"Expected one message with contentType {MessageContentType.CONTACT_REQUEST.value}"
         assert contact_request_message[0].get("text") == "contact_request"
 
+    @pytest.mark.light_client_7393
     async def test_retract_contact_request(self, sender, receiver):
         await async_messenger.send_contact_request_and_wait(sender, receiver)
         response = sender.wakuext_service.retract_contact_request(receiver.public_key)
@@ -142,6 +148,7 @@ class TestContactRequests:
         ), f"Expected one message with contentType {MessageContentType.SYSTEM_MESSAGE_MUTUAL_EVENT_REMOVED.value}"
         assert retract_request_messages[0].get("text") == f"You removed @{receiver.public_key} as a contact"
 
+    @pytest.mark.light_client_7393
     async def test_remove_contact(self, sender, receiver):
         message_id = await async_messenger.send_contact_request_and_wait(sender, receiver)
         await async_messenger.accept_contact_request_and_wait(message_id, sender=sender, receiver=receiver)
@@ -157,6 +164,7 @@ class TestContactRequests:
         ), f"Expected one message with contentType {MessageContentType.SYSTEM_MESSAGE_MUTUAL_EVENT_REMOVED.value}"
         assert retract_request_messages[0].get("text") == f"You removed @{receiver.public_key} as a contact"
 
+    @pytest.mark.light_client_7393
     async def test_set_contact_local_nickname(self, sender, receiver):
         message_id = await async_messenger.send_contact_request_and_wait(sender, receiver)
         await async_messenger.accept_contact_request_and_wait(message_id, sender=sender, receiver=receiver)

--- a/tests-functional/tests/test_wakuext_message_reactions.py
+++ b/tests-functional/tests/test_wakuext_message_reactions.py
@@ -21,6 +21,7 @@ class TestMessageReactions:
     async def receiver(self, async_backend_new_profile, waku_light_client):
         return await async_backend_new_profile("receiver", waku_light_client=waku_light_client)
 
+    @pytest.mark.light_client_7393
     @parametrize_waku_light_client
     async def test_one_to_one_message_reactions(self, sender, receiver, waku_light_client):
         """Test message reactions with different wakuV2LightClient configurations"""

--- a/tests-functional/tests/test_wakuext_messages_fetching.py
+++ b/tests-functional/tests/test_wakuext_messages_fetching.py
@@ -82,6 +82,7 @@ class TestFetchingChatMessages:
         messages = response.get("messages", [])
         assert len(messages) == expected_count
 
+    @pytest.mark.light_client_7393
     def test_all_messages_from_chats_and_communities_which_match_term(self, sender, receiver):
         # One to one
         messenger.make_contacts(sender, receiver)
@@ -110,6 +111,7 @@ class TestFetchingChatMessages:
         assert text_group in actual_texts
         assert text_community in actual_texts
 
+    @pytest.mark.light_client_7393
     @pytest.mark.skip(reason="Skipped due to https://github.com/status-im/status-go/issues/6359")
     def test_all_messages_from_chats_and_communities_which_match_term_case_sensitive(self, sender, receiver):
         # One to one

--- a/tests-functional/tests/test_wakuext_messages_sending.py
+++ b/tests-functional/tests/test_wakuext_messages_sending.py
@@ -22,6 +22,7 @@ class TestSendingChatMessages:
     async def receiver(self, async_backend_new_profile, waku_light_client):
         return await async_backend_new_profile("receiver", waku_light_client=waku_light_client)
 
+    @pytest.mark.light_client_7393
     async def test_send_one_to_one_message(self, sender, receiver):
         # Generate unique message text BEFORE registering waiter for race-free waiting
         message_text = f"test_message_0_{uuid4()}"
@@ -52,6 +53,7 @@ class TestSendingChatMessages:
         actual_text = messages[0].get("text", "")
         assert actual_text == message_text
 
+    @pytest.mark.light_client_7393
     async def test_send_chat_message_community(self, sender, receiver):
         community_id = async_messenger.create_community(sender)
         community_chat_id = await async_messenger.join_community(member=receiver, admin=sender, community_id=community_id)
@@ -66,6 +68,7 @@ class TestSendingChatMessages:
         actual_text = messages[0].get("text", "")
         assert actual_text == text
 
+    @pytest.mark.light_client_7393
     async def test_send_chat_message_private_group(self, sender, receiver):
         await async_messenger.make_contacts(sender, receiver)
         private_group_id = await async_messenger.join_private_group(admin=sender, member=receiver)
@@ -78,6 +81,7 @@ class TestSendingChatMessages:
         actual_text = expected_message.get("text", "")
         assert actual_text == text
 
+    @pytest.mark.light_client_7393
     async def test_send_chat_messages_same_chat(self, sender, receiver):
         community_id = async_messenger.create_community(sender)
         community_chat_id = await async_messenger.join_community(member=receiver, admin=sender, community_id=community_id)
@@ -98,6 +102,7 @@ class TestSendingChatMessages:
         expected_texts.reverse()
         assert actual_texts == expected_texts
 
+    @pytest.mark.light_client_7393
     async def test_send_chat_messages_different_chats(self, sender, receiver):
         # Group
         await async_messenger.make_contacts(sender, receiver)
@@ -118,6 +123,7 @@ class TestSendingChatMessages:
         messages = response.get("messages", [])
         assert len(messages) == 2
 
+    @pytest.mark.light_client_7393
     async def test_send_group_message(self, sender, receiver):
         await async_messenger.make_contacts(sender, receiver)
         private_group_id = await async_messenger.join_private_group(admin=sender, member=receiver)
@@ -134,6 +140,7 @@ class TestSendingChatMessages:
     # Using delete_message is a workaround that might be considered an incorrect behaviour
     # TODO: create more realistic scenario where the message is intercepted in the network and not delivered,
     # use community messages to avoid 1-1 and group chats reliability mechanisms on protocol level
+    @pytest.mark.light_client_7393
     async def test_resend_one_to_one_message(self, sender, receiver):
         await async_messenger.make_contacts(sender, receiver)
 


### PR DESCRIPTION
Light-client (`wakuV2LightClient_True`) tests that need the light client to *receive*                                                                                                                                                                                                                                    a message from a peer flake because such messages can be silently dropped — and for                                                                                                                                                                                                                                       non-DataSync types (group membership, reactions) never recovered. This is a backend                                                                                                                                                                                                                                      issue tracked in #7393 and can't be fixed test-side.                                                                                                                                                                                                                                                                      
                                                                                                                                                                                                                                                                                                                            Marks the affected cross-node light-client-receive tests and adds a `pytest`                                                                                                                                                                                                                                              collection hook that skips **only** their `wakuV2LightClient_True` leg; the full-node                                                                                                                                                                                                                                     `wakuV2LightClient_False` leg still runs. Applies to both the rpc and nightly                                                                                                                                                                                                                                            reliability jobs.                                                                                                                                                                                                                                                                                                         
                                                                                                                                                                                                                                                                                                                           Important changes:                                                                                                                                                                                                                                                                                                        
 - [x] Skips only the light-client leg — full-node coverage is unchanged.                                                                                                                                                                                                                                                  
 - [x] Remove the marker, hook and skips when #7393 is fixed (`grep -rn light_client_7393 tests-functional/.github/`)
 
 Refs #7393  