### PR TITLE
chore(messaging): bump SDS stack (bindings v0.3.1, nim-sds v0.3.3)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -105,7 +105,12 @@ BUILD_TAGS ?= gowaku_no_rln
 # `nim-sds` variables
 
 # Pin nim-sds revision here. Can be a tag (default) or commit hash.
-NIM_SDS_VERSION ?= v0.2.5
+# v0.3.3 lives on the release/v0.3 branch: it carries the SDS retrieval-hint
+# provider required by the sds-go-bindings pin in go.mod, on the CamelCase FFI
+# ABI, with the causalHistory wire format kept backward-compatible with released
+# (v0.2.x) nodes. master/release-v0.4 moved to the snake_case CBOR ABI, which
+# these bindings do not link against, so we track release/v0.3.
+NIM_SDS_VERSION ?= v0.3.3
 
 # Option 1: Provide NIM_SDS_SOURCE_DIR. Make force-reclones a fresh copy (with submodules)
 # to guarantee a clean checkout on every build.

--- a/flake.lock
+++ b/flake.lock
@@ -75,17 +75,18 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1766504822,
-        "narHash": "sha256-tWVLbYoi8/xNzsbJmzMBnuc4GsB7/4oH05yCwuokKT8=",
-        "ref": "refs/heads/master",
-        "rev": "fb8039c5a56086ec7fb3e5e1a5a593bb3756ccb6",
-        "revCount": 76,
+        "lastModified": 1783637210,
+        "narHash": "sha256-O5M45RPTtaKVYeiyB6LSBawqcBuAHwyhYbvk5HMyh/M=",
+        "ref": "refs/tags/v0.3.3",
+        "rev": "259830c9cfa7dbad3bd2f792097ad3e180fb2e1c",
+        "revCount": 84,
         "submodules": true,
         "type": "git",
         "url": "https://github.com/logos-messaging/nim-sds"
       },
       "original": {
-        "rev": "fb8039c5a56086ec7fb3e5e1a5a593bb3756ccb6",
+        "ref": "refs/tags/v0.3.3",
+        "rev": "259830c9cfa7dbad3bd2f792097ad3e180fb2e1c",
         "submodules": true,
         "type": "git",
         "url": "https://github.com/logos-messaging/nim-sds"

--- a/flake.nix
+++ b/flake.nix
@@ -29,7 +29,7 @@
       inputs.circom-compat.url = "github:logos-storage/circom-compat-ffi/3cca4e91054a4d2bb5335feb19138362ce0fe417";
     };
     # We cannot do follows since the nim-unwrapped-2_0 doesn't exist in this nixpkgs version above
-    nim-sds.url = "git+https://github.com/logos-messaging/nim-sds?submodules=1&rev=fb8039c5a56086ec7fb3e5e1a5a593bb3756ccb6";
+    nim-sds.url = "git+https://github.com/logos-messaging/nim-sds?submodules=1&ref=refs/tags/v0.3.3&rev=259830c9cfa7dbad3bd2f792097ad3e180fb2e1c";
   };
 
   outputs = { self, nixpkgs, lmn, logos-storage-nim, nim-sds }:

--- a/go.mod
+++ b/go.mod
@@ -103,7 +103,7 @@ require (
 	github.com/status-im/extkeys v1.4.0
 	github.com/status-im/go-wallet-sdk v0.0.0-20260612221124-9c7a9c043068
 	github.com/waku-org/go-waku v0.10.3
-	github.com/waku-org/sds-go-bindings v0.0.0-20251222164514-d5b47a911904
+	github.com/waku-org/sds-go-bindings v0.3.1
 	github.com/wk8/go-ordered-map/v2 v2.1.7
 	go.uber.org/atomic v1.11.0
 	go.uber.org/mock v0.6.0

--- a/go.sum
+++ b/go.sum
@@ -2426,8 +2426,8 @@ github.com/waku-org/go-zerokit-rln-arm v0.0.0-20230916171929-1dd9494ff065 h1:Sd7
 github.com/waku-org/go-zerokit-rln-arm v0.0.0-20230916171929-1dd9494ff065/go.mod h1:7cSGUoGVIla1IpnChrLbkVjkYgdOcr7rcifEfh4ReR4=
 github.com/waku-org/go-zerokit-rln-x86_64 v0.0.0-20230916171518-2a77c3734dd1 h1:4HSdWMFMufpRo3ECTX6BrvA+VzKhXZf7mS0rTa5cCWU=
 github.com/waku-org/go-zerokit-rln-x86_64 v0.0.0-20230916171518-2a77c3734dd1/go.mod h1:+LeEYoW5/uBUTVjtBGLEVCUe9mOYAlu5ZPkIxLOSr5Y=
-github.com/waku-org/sds-go-bindings v0.0.0-20251222164514-d5b47a911904 h1:V6nJsnNpSl822Z013bYzh9lXnTfwBdQHptIOd3AVwXc=
-github.com/waku-org/sds-go-bindings v0.0.0-20251222164514-d5b47a911904/go.mod h1:GW6bN8Ski1GCOb2f5JbKKstH70wlPen1h8f1nzSDfSI=
+github.com/waku-org/sds-go-bindings v0.3.1 h1:u4k0XHxGnjLIwJsgtelSBA5GmN4YMiDfzpk2wfpexf4=
+github.com/waku-org/sds-go-bindings v0.3.1/go.mod h1:GW6bN8Ski1GCOb2f5JbKKstH70wlPen1h8f1nzSDfSI=
 github.com/wealdtech/go-ens/v3 v3.6.0 h1:EAByZlHRQ3vxqzzwNi0GvEq1AjVozfWO4DMldHcoVg8=
 github.com/wealdtech/go-ens/v3 v3.6.0/go.mod h1:hcmMr9qPoEgVSEXU2Bwzrn/9NczTWZ1rE53jIlqUpzw=
 github.com/wealdtech/go-multicodec v1.4.0 h1:iq5PgxwssxnXGGPTIK1srvt6U5bJwIp7k6kBrudIWxg=

--- a/nix/pkgs/status-go/library/default.nix
+++ b/nix/pkgs/status-go/library/default.nix
@@ -11,7 +11,7 @@ let
 in pkgs.buildGoModule {
   pname = "status-go";
   src = builtins.path { path = ./../../../..; name = "status-go-library"; };
-  vendorHash = "sha256-OoyiMXCy0pmD3642nmBUd0j9KGyjvdJvkFNKgdjvd5M=";
+  vendorHash = "sha256-0QqHYOfGHYevs6I4ZbO8Fr4umeadgYk4LA52pApbe34=";
 
   inherit meta version;
 

--- a/pkg/messaging/layers/reliability/sds.go
+++ b/pkg/messaging/layers/reliability/sds.go
@@ -20,7 +20,7 @@ func newSdsReliabilityManager(logger *zap.Logger) *sds.ReliabilityManager {
 		OnMessageSent: func(messageId sds.MessageID, channelId string) {
 			logger.Debug("message sent with sds", zap.String("messageId", string(messageId)), zap.String("channelId", channelId))
 		},
-		OnMissingDependencies: func(messageId sds.MessageID, missingDeps []sds.MessageID, channelId string) {
+		OnMissingDependencies: func(messageId sds.MessageID, missingDeps []sds.HistoryEntry, channelId string) {
 			logger.Debug("missing dependencies",
 				zap.String("messageId", string(messageId)),
 				zap.String("channelId", channelId),


### PR DESCRIPTION
## What

Moves status-go onto the **SDS retrieval-hint** line so store nodes can serve missing dependencies efficiently. It's a matched ABI bump across pins that must move together, so it lands as a single atomic commit (any subset fails to build):

| pin | version | notes |
|---|---|---|
| `sds-go-bindings` | **v0.3.1** | adds the `RetrievalHintProvider` callback + `HistoryEntry`-shaped `MissingDeps`; includes a one-line fix for a non-compiling `zap` log call on the tip commit |
| `nim-sds` (Makefile + flake) | **v0.3.3** | matching libsds on the CamelCase FFI ABI (`release/v0.3`) |
| `reliability` | — | `OnMissingDependencies` callback signature → `[]sds.HistoryEntry` (was `[]sds.MessageID`) |
| `nix` | — | refreshed Go-modules `vendorHash` for the bindings bump |

Upstream nim-sds `master`/`release-v0.4` moved to the snake_case CBOR ABI, which these bindings don't link against, so we track the `release/v0.3` line.

## Wire compatibility (important)

The retrieval-hint feature changed the SDS `causalHistory` protobuf. To stay compatible with **released (v0.2.x) nodes on the network**, the wire keeps:

- **field 3** = repeated *string* of message IDs (what every existing node reads)
- **field 8** = additive `HistoryEntry` metadata (hints), which old nodes skip

This was verified against the `tests-rpc-compat` suite (new build ⇄ `v10.34.1`/`v10.33.2` release peers). Field 8 is also chosen to align with the v0.4/SDS-R wire (which uses field 7 for `senderId`), so the v0.3.x and v0.4.x lines interoperate.

## What's in the nim-sds `v0.3.x` tags

- **v0.3.1** — retrieval-hint provider on the CamelCase ABI
- **v0.3.2** — hints moved to additive field 8 (backward-compatible; aligns with v0.4)
- **v0.3.3** — fixes a SIGSEGV where the malloc'd hint buffer (from the binding's `C.CBytes`) was freed with Nim's `deallocShared` instead of libc `free`

## Verification

- `pkg/messaging/layers/reliability` builds and its SDS tests pass against the v0.3.3 libsds
- `tests-rpc-compat` (new↔old interop) green on the rebased branch
- nim-sds wire-compat + reliability suites green upstream

🤖 Generated with [Claude Code](https://claude.com/claude-code)