### PR TITLE
fix(curated): pause curated communities loop on expensive networks

### DIFF
--- a/protocol/messenger.go
+++ b/protocol/messenger.go
@@ -153,6 +153,7 @@ type Messenger struct {
 	historicSyncInFlight      bool
 	lastHistoricSyncRequestAt time.Time
 
+	connectionStateMutex  sync.RWMutex
 	connectionState       connection.State
 	contractMaker         *contracts.ContractMaker
 	verificationDatabase  *verification.Persistence

--- a/protocol/messenger_curated_communities.go
+++ b/protocol/messenger_curated_communities.go
@@ -44,7 +44,7 @@ func (m *Messenger) startCuratedCommunitiesUpdateLoop() {
 		for {
 			select {
 			case <-time.After(interval):
-				if m.isPaused() {
+				if m.shouldPauseCuratedCommunitiesUpdateLoop() {
 					interval = curatedCommunitiesUpdateInterval
 					continue
 				}
@@ -86,6 +86,13 @@ func (m *Messenger) startCuratedCommunitiesUpdateLoop() {
 			}
 		}
 	}()
+}
+
+func (m *Messenger) shouldPauseCuratedCommunitiesUpdateLoop() bool {
+	// TODO when we implement back the setting for the user to select if they want to
+	// fetch on expensive networks, use canSyncWithStoreNodes()
+	// https://github.com/status-im/status-app/issues/18388
+	return m.isPaused() || m.getConnectionState().IsExpensive()
 }
 
 func (m *Messenger) getCuratedCommunitiesFromContract() (*communities.CuratedCommunities, error) {

--- a/protocol/messenger_curated_communities_test.go
+++ b/protocol/messenger_curated_communities_test.go
@@ -1,0 +1,18 @@
+package protocol
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/status-im/status-go/internal/connection"
+)
+
+func TestShouldPauseCuratedCommunitiesUpdateLoop(t *testing.T) {
+	m := &Messenger{}
+
+	require.False(t, m.shouldPauseCuratedCommunitiesUpdateLoop())
+
+	m.setConnectionState(connection.State{Expensive: true})
+	require.True(t, m.shouldPauseCuratedCommunitiesUpdateLoop())
+}

--- a/protocol/messenger_mailserver.go
+++ b/protocol/messenger_mailserver.go
@@ -658,15 +658,29 @@ func (m *Messenger) calculateGapForChat(chat *Chat, from uint32) (*common.Messag
 }
 
 func (m *Messenger) canSyncWithStoreNodes() (bool, error) {
-	if m.connectionState.IsExpensive() {
+	if m.getConnectionState().IsExpensive() {
 		return m.settings.CanSyncOnMobileNetwork()
 	}
 	return true, nil
 }
 
+func (m *Messenger) getConnectionState() connection.State {
+	m.connectionStateMutex.RLock()
+	defer m.connectionStateMutex.RUnlock()
+
+	return m.connectionState
+}
+
+func (m *Messenger) setConnectionState(state connection.State) {
+	m.connectionStateMutex.Lock()
+	defer m.connectionStateMutex.Unlock()
+
+	m.connectionState = state
+}
+
 func (m *Messenger) ConnectionChanged(state connection.State) {
 	m.messaging.ConnectionChanged(state)
-	m.connectionState = state
+	m.setConnectionState(state)
 }
 
 func (m *Messenger) processMailserverBatch(peerInfo peer.AddrInfo, batch types2.StoreNodeBatch) error {


### PR DESCRIPTION
Part of #7614

Companion PR: https://github.com/status-im/status-app/pull/21461

The easiest step to avoid big downloads on mobile on data. They will still be fetched when the user does to the portal