### PR TITLE
fix(curated): pause curated communities loop on expensive networks + improve grafana download graphs

### DIFF
--- a/pkg/messaging/waku/gowaku.go
+++ b/pkg/messaging/waku/gowaku.go
@@ -101,12 +101,18 @@ type ErrorSendingEnvelope struct {
 	SentEnvelope SentEnvelope
 }
 
+type StatsSummary struct {
+	DownloadRate uint64
+	UploadRate   uint64
+}
+
 type IMetricsHandler interface {
 	PushSentEnvelope(sentEnvelope SentEnvelope)
 	PushErrorSendingEnvelope(errorSendingEnvelope ErrorSendingEnvelope)
 	PushPeerConnFailures(peerConnFailures map[string]int)
 	PushMessageCheckSuccess()
 	PushMessageCheckFailure()
+	PushBandwidthStats(downloadRate uint64, uploadRate uint64)
 	PushPeerCountByShard(peerCountByShard map[uint16]uint)
 	PushPeerCountByOrigin(peerCountByOrigin map[wps.Origin]uint)
 	PushDialFailure(dialFailure common.DialError)
@@ -1140,6 +1146,20 @@ func (w *Waku) reportPeerMetrics() {
 		}
 		w.metricsHandler.PushPeerCountByShard(peerCountByShard)
 		w.metricsHandler.PushPeerCountByOrigin(peerCountByOrigin)
+		stats := w.GetStats()
+		w.metricsHandler.PushBandwidthStats(stats.DownloadRate, stats.UploadRate)
+	}
+}
+
+func (w *Waku) GetStats() StatsSummary {
+	if w.bandwidthCounter == nil {
+		return StatsSummary{}
+	}
+
+	totals := w.bandwidthCounter.GetBandwidthTotals()
+	return StatsSummary{
+		DownloadRate: uint64(math.Max(0, totals.RateIn)),
+		UploadRate:   uint64(math.Max(0, totals.RateOut)),
 	}
 }
 

--- a/pkg/messaging/wakumetrics/client.go
+++ b/pkg/messaging/wakumetrics/client.go
@@ -94,6 +94,11 @@ func (c *Client) PushMessageCheckFailure() {
 	metrics.StoreQueryFailures.Inc()
 }
 
+func (c *Client) PushBandwidthStats(downloadRate uint64, uploadRate uint64) {
+	metrics.BandwidthDownloadBytesRate.Set(float64(downloadRate))
+	metrics.BandwidthUploadBytesRate.Set(float64(uploadRate))
+}
+
 func (c *Client) PushPeerCountByShard(peerCountByShard map[uint16]uint) {
 	for shard, count := range peerCountByShard {
 		metrics.PeersByShard.WithLabelValues(strconv.FormatUint(uint64(shard), 10)).Set(float64(count))

--- a/pkg/messaging/wakumetrics/client_test.go
+++ b/pkg/messaging/wakumetrics/client_test.go
@@ -61,6 +61,15 @@ func getGaugeVecValue(metric *prometheus.GaugeVec, labels ...string) float64 {
 	return pb.Gauge.GetValue()
 }
 
+func getGaugeValue(metric prometheus.Gauge) float64 {
+	pb := &dto.Metric{}
+	err := metric.Write(pb)
+	if err != nil {
+		return 0
+	}
+	return pb.Gauge.GetValue()
+}
+
 func TestClient_DoubleRegister(t *testing.T) {
 	client := createTestClient(t)
 	require.Error(t, client.RegisterWithRegistry())
@@ -134,6 +143,15 @@ func TestClient_PushPeerCountByShard(t *testing.T) {
 		value := getGaugeVecValue(metrics.PeersByShard, strconv.FormatUint(uint64(shard), 10))
 		require.Equal(t, float64(expectedCount), value)
 	}
+}
+
+func TestClient_PushBandwidthStats(t *testing.T) {
+	client := createTestClient(t)
+
+	client.PushBandwidthStats(2048, 1024)
+
+	require.Equal(t, float64(2048), getGaugeValue(metrics.BandwidthDownloadBytesRate))
+	require.Equal(t, float64(1024), getGaugeValue(metrics.BandwidthUploadBytesRate))
 }
 
 func TestClient_PushErrorSendingEnvelope(t *testing.T) {

--- a/pkg/messaging/wakumetrics/metrics.go
+++ b/pkg/messaging/wakumetrics/metrics.go
@@ -9,6 +9,8 @@ type MetricsCollection struct {
 	EnvelopeSentTotal            *prometheus.CounterVec
 	MessagesReceivedTotal        *prometheus.CounterVec
 	WakuMessagesSizeBytes        *prometheus.CounterVec
+	BandwidthDownloadBytesRate   prometheus.Gauge
+	BandwidthUploadBytesRate     prometheus.Gauge
 	EnvelopeSentErrors           *prometheus.CounterVec
 	PeerDialFailures             *prometheus.CounterVec
 	MissedMessages               *prometheus.CounterVec
@@ -54,6 +56,20 @@ var metrics = MetricsCollection{
 			Help: "Size of each Waku message in bytes sent by this node",
 		},
 		[]string{"publish_method"},
+	),
+
+	BandwidthDownloadBytesRate: prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Name: "waku_bandwidth_download_bytes_per_second",
+			Help: "Current Waku/libp2p download bandwidth in bytes per second",
+		},
+	),
+
+	BandwidthUploadBytesRate: prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Name: "waku_bandwidth_upload_bytes_per_second",
+			Help: "Current Waku/libp2p upload bandwidth in bytes per second",
+		},
 	),
 
 	EnvelopeSentErrors: prometheus.NewCounterVec(
@@ -153,6 +169,8 @@ var collectors = []prometheus.Collector{
 	metrics.MessagesSentTotal,
 	metrics.MessagesReceivedTotal,
 	metrics.WakuMessagesSizeBytes,
+	metrics.BandwidthDownloadBytesRate,
+	metrics.BandwidthUploadBytesRate,
 	metrics.EnvelopeSentErrors,
 	metrics.MessageDeliveryConfirmations,
 	metrics.PeersByOrigin,

--- a/protocol/messenger.go
+++ b/protocol/messenger.go
@@ -155,6 +155,7 @@ type Messenger struct {
 	historicSyncTrigger  chan struct{}
 	ratchetNotFoundDelay time.Duration
 
+	connectionStateMutex  sync.RWMutex
 	connectionState       connection.State
 	contractMaker         *contracts.ContractMaker
 	verificationDatabase  *verification.Persistence

--- a/protocol/messenger_curated_communities.go
+++ b/protocol/messenger_curated_communities.go
@@ -44,7 +44,7 @@ func (m *Messenger) startCuratedCommunitiesUpdateLoop() {
 		for {
 			select {
 			case <-time.After(interval):
-				if m.isPaused() {
+				if m.shouldPauseCuratedCommunitiesUpdateLoop() {
 					interval = curatedCommunitiesUpdateInterval
 					continue
 				}
@@ -86,6 +86,13 @@ func (m *Messenger) startCuratedCommunitiesUpdateLoop() {
 			}
 		}
 	}()
+}
+
+func (m *Messenger) shouldPauseCuratedCommunitiesUpdateLoop() bool {
+	// TODO when we implement back the setting for the user to select if they want to
+	// fetch on expensive networks, use canSyncWithStoreNodes()
+	// https://github.com/status-im/status-app/issues/18388
+	return m.isPaused() || m.getConnectionState().IsExpensive()
 }
 
 func (m *Messenger) getCuratedCommunitiesFromContract() (*communities.CuratedCommunities, error) {

--- a/protocol/messenger_curated_communities_test.go
+++ b/protocol/messenger_curated_communities_test.go
@@ -1,0 +1,18 @@
+package protocol
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/status-im/status-go/internal/connection"
+)
+
+func TestShouldPauseCuratedCommunitiesUpdateLoop(t *testing.T) {
+	m := &Messenger{}
+
+	require.False(t, m.shouldPauseCuratedCommunitiesUpdateLoop())
+
+	m.setConnectionState(connection.State{Expensive: true})
+	require.True(t, m.shouldPauseCuratedCommunitiesUpdateLoop())
+}

--- a/protocol/messenger_mailserver.go
+++ b/protocol/messenger_mailserver.go
@@ -553,15 +553,29 @@ func (m *Messenger) calculateGapForChat(chat *Chat, from uint32) (*common.Messag
 }
 
 func (m *Messenger) canSyncWithStoreNodes() (bool, error) {
-	if m.connectionState.IsExpensive() {
+	if m.getConnectionState().IsExpensive() {
 		return m.settings.CanSyncOnMobileNetwork()
 	}
 	return true, nil
 }
 
+func (m *Messenger) getConnectionState() connection.State {
+	m.connectionStateMutex.RLock()
+	defer m.connectionStateMutex.RUnlock()
+
+	return m.connectionState
+}
+
+func (m *Messenger) setConnectionState(state connection.State) {
+	m.connectionStateMutex.Lock()
+	defer m.connectionStateMutex.Unlock()
+
+	m.connectionState = state
+}
+
 func (m *Messenger) ConnectionChanged(state connection.State) {
 	m.messaging.ConnectionChanged(state)
-	m.connectionState = state
+	m.setConnectionState(state)
 }
 
 // processMailserverBatch queries the store for a single batch, applying the

--- a/services/ext/service.go
+++ b/services/ext/service.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"time"
 
 	"go.opentelemetry.io/otel"
@@ -83,6 +84,10 @@ type Service struct {
 	accountsDB      *accounts.Database
 	multiAccountsDB *multiaccounts.Database
 	account         *multiaccounts.Account
+
+	connectionStateMu      sync.Mutex
+	lastConnectionState    connection.State
+	hasLastConnectionState bool
 
 	logger *zap.Logger
 }
@@ -247,6 +252,17 @@ func (s *Service) StartMessenger() (*protocol.MessengerResponse, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	// Android can report connectivity before login; apply the latest known state
+	// now that messenger exists so expensive/offline gates are correct from start.
+	s.connectionStateMu.Lock()
+	hasLastState := s.hasLastConnectionState
+	lastState := s.lastConnectionState
+	s.connectionStateMu.Unlock()
+	if hasLastState {
+		s.messenger.ConnectionChanged(lastState)
+	}
+
 	s.MarkStarted()
 	s.messenger.StartRetrieveMessagesLoop(time.Second, s.cancelMessenger)
 
@@ -783,7 +799,13 @@ func obtainNodeKey(nodeConfig *params.NodeConfig) (*ecdsa.PrivateKey, error) {
 }
 
 func (s *Service) ConnectionChanged(state connection.State) {
-	if s.messenger != nil {
-		s.messenger.ConnectionChanged(state)
+	s.connectionStateMu.Lock()
+	s.lastConnectionState = state
+	s.hasLastConnectionState = true
+	messenger := s.messenger
+	s.connectionStateMu.Unlock()
+
+	if messenger != nil {
+		messenger.ConnectionChanged(state)
 	}
 }

--- a/tools/metrics/grafana/provisioning/dashboards/status-go.json
+++ b/tools/metrics/grafana/provisioning/dashboards/status-go.json
@@ -1577,6 +1577,180 @@
       ],
       "title": "Average messages sent every 10 min",
       "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "description": "Current libp2p/Waku transport bandwidth reported by status-go.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "Bps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 71
+      },
+      "id": 20,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.5.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "editorMode": "code",
+          "expr": "waku_bandwidth_download_bytes_per_second",
+          "instant": false,
+          "legendFormat": "Download",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "editorMode": "code",
+          "expr": "waku_bandwidth_upload_bytes_per_second",
+          "instant": false,
+          "legendFormat": "Upload",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "Waku Bandwidth",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "description": "Approximate total download over the selected dashboard time range, derived from the bandwidth rate gauge.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "decbytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 0,
+        "y": 79
+      },
+      "id": 21,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "11.5.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "editorMode": "code",
+          "expr": "avg_over_time(waku_bandwidth_download_bytes_per_second[$__range]) * $__range_s",
+          "instant": true,
+          "legendFormat": "Approx Download",
+          "range": false,
+          "refId": "A"
+        }
+      ],
+      "title": "Approx Download Over Range",
+      "type": "stat"
     }
   ],
   "preload": false,


### PR DESCRIPTION
Needed for https://github.com/status-im/status-go/issues/7614

Companion PR: https://github.com/status-im/status-app/pull/21469

Skips curated community fetch on expensive network, since they cost about 100 MB of download.

I also added some more data to the grafana, to monitor the bandwidth and estimated download: 
<img width="1598" height="586" alt="image" src="https://github.com/user-attachments/assets/08bed860-04e2-42e2-af93-2fd0d1d0f37c" />
