### PR TITLE
fix(community): prevent nil pointer panic when generating channel bloom filters

### DIFF
--- a/protocol/communities/community_bloom_filter.go
+++ b/protocol/communities/community_bloom_filter.go
@@ -13,6 +13,13 @@ import (
 )
 
 func generateBloomFiltersForChannels(description *protobuf.CommunityDescription, privateKey *ecdsa.PrivateKey) error {
+	// Bloom filters for encrypted channels require the community private key to
+	// derive the shared secret. Without it (e.g. we're not the control node) we
+	// can't and shouldn't generate them, so skip to avoid a nil pointer panic.
+	if privateKey == nil {
+		return nil
+	}
+
 	for channelID, channel := range description.Chats {
 		if !channelEncrypted(ChatID(description.ID, channelID), description.TokenPermissions) {
 			continue

--- a/protocol/communities/community_bloom_filter_test.go
+++ b/protocol/communities/community_bloom_filter_test.go
@@ -65,3 +65,37 @@ func (s *CommunityBloomFilterSuite) TestBasic() {
 	s.Require().True(verifyMembershipWithBloomFilter(filter, memberIdentity, &ownerIdentity.PublicKey, encryptedChannelID, description.Clock))
 	s.Require().False(verifyMembershipWithBloomFilter(filter, nonMemberIdentity, &ownerIdentity.PublicKey, encryptedChannelID, description.Clock))
 }
+
+func (s *CommunityBloomFilterSuite) TestNilPrivateKey() {
+	memberIdentity, err := crypto.GenerateKey()
+	s.Require().NoError(err)
+
+	communityID := "cid"
+	encryptedChannelID := "enc"
+
+	description := &protobuf.CommunityDescription{
+		ID:    communityID,
+		Clock: 1,
+		Chats: map[string]*protobuf.CommunityChat{
+			encryptedChannelID: {
+				Members: map[string]*protobuf.CommunityMember{
+					crypto.PubkeyToHex(&memberIdentity.PublicKey): {},
+				},
+			},
+		},
+		TokenPermissions: map[string]*protobuf.CommunityTokenPermission{
+			"permissionID": {
+				Id:            "permissionID",
+				Type:          protobuf.CommunityTokenPermission_CAN_VIEW_CHANNEL,
+				TokenCriteria: []*protobuf.TokenCriteria{{}},
+				ChatIds:       []string{ChatID(communityID, encryptedChannelID)},
+			},
+		},
+	}
+
+	// Without the community private key we can't derive the shared secret, so
+	// bloom filter generation must be skipped instead of panicking.
+	err = generateBloomFiltersForChannels(description, nil)
+	s.Require().NoError(err)
+	s.Require().Nil(description.Chats[encryptedChannelID].MembersList)
+}


### PR DESCRIPTION
Fixes #7620
companion PR: https://github.com/status-im/status-app/pull/21484

Community.marshaledDescription() generates bloom filters for encrypted channels by deriving a shared secret from the community private key. When publishing a community we don't control, the private key is nil, which flowed through GenerateSharedKey into ecies.ImportECDSA and caused a SIGSEGV nil pointer dereference that crashed the process (issue #7620). This adds an early guard in generateBloomFiltersForChannels to skip bloom filter generation when no private key is available, since it can only be produced by the control node anyway, and adds a regression test covering the nil private key case.