### PR TITLE
feat(links): add basic support for linking to messages

### DIFF
--- a/services/sharedurls/api.go
+++ b/services/sharedurls/api.go
@@ -39,3 +39,11 @@ func (api *PublicAPI) ShareUserURLWithData(pubKey string) (string, error) {
 func (api *PublicAPI) ParseSharedURL(url string) (*URLDataResponse, error) {
 	return ParseSharedURL(url)
 }
+
+func (api *PublicAPI) ShareMessageURL(chatID string, messageID string) (string, error) {
+	return ShareMessageURL(chatID, messageID)
+}
+
+func (api *PublicAPI) ParseMessageURL(url string) (*MessageURLData, error) {
+	return ParseMessageURL(url)
+}

--- a/services/sharedurls/service_test.go
+++ b/services/sharedurls/service_test.go
@@ -199,6 +199,47 @@ func (s *ShareUrlsSuite) TestIsStatusSharedUrl() {
 	}
 }
 
+func (s *ShareUrlsSuite) TestShareAndParseMessageURL() {
+	chatID := "0xabcdef1234567890fedcba9876543210003cdcd5-e065-48f9-b166-b1a94ac75a11"
+	messageID := "0xmessage-id-123"
+
+	link, err := ShareMessageURL(chatID, messageID)
+	s.Require().NoError(err)
+	s.Require().True(IsStatusSharedURL(link))
+	s.Require().Equal("https://status.app/m/0xabcdef1234567890fedcba9876543210003cdcd5-e065-48f9-b166-b1a94ac75a11?message-id=0xmessage-id-123", link)
+
+	parsed, err := ParseMessageURL(link)
+	s.Require().NoError(err)
+	s.Require().Equal(chatID, parsed.ChatID)
+	s.Require().Equal(messageID, parsed.MessageID)
+	s.Require().Equal("0xabcdef1234567890fedcba9876543210", parsed.CommunityID)
+}
+
+func (s *ShareUrlsSuite) TestParseMessageURLInternalScheme() {
+	link := "status-app://m/0xabcdef1234567890fedcba9876543210003cdcd5-e065-48f9-b166-b1a94ac75a11?message-id=0xmessage-id-123"
+
+	parsed, err := ParseMessageURL(link)
+	s.Require().NoError(err)
+	s.Require().Equal("0xabcdef1234567890fedcba9876543210003cdcd5-e065-48f9-b166-b1a94ac75a11", parsed.ChatID)
+	s.Require().Equal("0xmessage-id-123", parsed.MessageID)
+	s.Require().Equal("0xabcdef1234567890fedcba9876543210", parsed.CommunityID)
+}
+
+func (s *ShareUrlsSuite) TestParseMessageURLMissingMessageID() {
+	_, err := ParseMessageURL("https://status.app/m/chat-only")
+	s.Require().ErrorContains(err, "messageID is required")
+}
+
+func (s *ShareUrlsSuite) TestParseMessageURLLegacyRawChatID() {
+	link := "https://status.app/m/0xabcdef1234567890fedcba9876543210003cdcd5-e065-48f9-b166-b1a94ac75a11?message-id=0xmessage-id-123"
+
+	parsed, err := ParseMessageURL(link)
+	s.Require().NoError(err)
+	s.Require().Equal("0xabcdef1234567890fedcba9876543210003cdcd5-e065-48f9-b166-b1a94ac75a11", parsed.ChatID)
+	s.Require().Equal("0xmessage-id-123", parsed.MessageID)
+	s.Require().Equal("0xabcdef1234567890fedcba9876543210", parsed.CommunityID)
+}
+
 func (s *ShareUrlsSuite) TestShareCommunityURLWithChatKey() {
 	community := s.fakeCommunity()
 

--- a/services/sharedurls/types.go
+++ b/services/sharedurls/types.go
@@ -23,6 +23,12 @@ type ContactURLData struct {
 	PublicKey   string `json:"publicKey"`
 }
 
+type MessageURLData struct {
+	ChatID      string `json:"chatId"`
+	MessageID   string `json:"messageId"`
+	CommunityID string `json:"communityId"`
+}
+
 type URLDataResponse struct {
 	Community *CommunityURLData        `json:"community"`
 	Channel   *CommunityChannelURLData `json:"channel"`

--- a/services/sharedurls/utils.go
+++ b/services/sharedurls/utils.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/base64"
 	"fmt"
+	"net/url"
 	"strings"
 
 	"github.com/andybalholm/brotli"
@@ -11,6 +12,130 @@ import (
 
 	"github.com/status-im/status-go/protocol/protobuf"
 )
+
+const statusInternalBaseShareURL = "status-app://"
+const messagePath = "m/"
+const sharedURLMessagePrefix = baseShareURL + "/" + messagePath
+const sharedURLMessagePrefixHTTP = "http://status.app/" + messagePath
+const sharedURLMessagePrefixInternal = statusInternalBaseShareURL + messagePath
+const messageIDQueryParam = "message-id"
+
+func ShareMessageURL(chatID string, messageID string) (string, error) {
+	if strings.TrimSpace(chatID) == "" {
+		return "", fmt.Errorf("chatID is required")
+	}
+
+	if strings.TrimSpace(messageID) == "" {
+		return "", fmt.Errorf("messageID is required")
+	}
+
+	return fmt.Sprintf("%s%s?%s=%s",
+		sharedURLMessagePrefix,
+		url.PathEscape(chatID),
+		messageIDQueryParam,
+		url.QueryEscape(messageID),
+	), nil
+}
+
+func decodeMessageChatID(chatIDPathPart string) (string, error) {
+	chatID, unescapeErr := url.PathUnescape(chatIDPathPart)
+	if unescapeErr != nil {
+		return "", unescapeErr
+	}
+
+	if chatID == "" {
+		return "", fmt.Errorf("chatID is required")
+	}
+
+	return chatID, nil
+}
+
+func extractDeepLinkValueUntilSeparator(value string) string {
+	if value == "" {
+		return ""
+	}
+
+	endIdx := len(value)
+	for _, separator := range []string{"?", "#", "&"} {
+		idx := strings.Index(value, separator)
+		if idx != -1 && idx < endIdx {
+			endIdx = idx
+		}
+	}
+
+	return value[:endIdx]
+}
+
+func extractQueryParamFromLink(link string, paramName string) (string, error) {
+	parsedLink, err := url.Parse(link)
+	if err != nil {
+		return "", err
+	}
+
+	queryValues, err := url.ParseQuery(parsedLink.RawQuery)
+	if err != nil {
+		return "", err
+	}
+
+	return queryValues.Get(paramName), nil
+}
+
+func deriveCommunityIDFromChatID(chatID string) string {
+	if len(chatID) <= 36 {
+		return ""
+	}
+
+	channelID := chatID[len(chatID)-36:]
+	if !channelRegExp.MatchString(channelID) {
+		return ""
+	}
+
+	return chatID[:len(chatID)-36]
+}
+
+func ParseMessageURL(rawURL string) (*MessageURLData, error) {
+	trimmedURL := strings.TrimSpace(rawURL)
+	if trimmedURL == "" {
+		return nil, fmt.Errorf("not a status message url")
+	}
+
+	pathRemainder := ""
+	switch {
+	case strings.HasPrefix(trimmedURL, sharedURLMessagePrefix):
+		pathRemainder = strings.TrimPrefix(trimmedURL, sharedURLMessagePrefix)
+	case strings.HasPrefix(trimmedURL, sharedURLMessagePrefixHTTP):
+		pathRemainder = strings.TrimPrefix(trimmedURL, sharedURLMessagePrefixHTTP)
+	case strings.HasPrefix(trimmedURL, sharedURLMessagePrefixInternal):
+		pathRemainder = strings.TrimPrefix(trimmedURL, sharedURLMessagePrefixInternal)
+	default:
+		return nil, fmt.Errorf("not a status message url")
+	}
+
+	chatIDPathPart := extractDeepLinkValueUntilSeparator(pathRemainder)
+	if chatIDPathPart == "" {
+		return nil, fmt.Errorf("chatID is required")
+	}
+
+	chatID, err := decodeMessageChatID(chatIDPathPart)
+	if err != nil {
+		return nil, err
+	}
+
+	messageID, err := extractQueryParamFromLink(trimmedURL, messageIDQueryParam)
+	if err != nil {
+		return nil, err
+	}
+
+	if messageID == "" {
+		return nil, fmt.Errorf("messageID is required")
+	}
+
+	return &MessageURLData{
+		ChatID:      chatID,
+		MessageID:   messageID,
+		CommunityID: deriveCommunityIDFromChatID(chatID),
+	}, nil
+}
 
 func parseUserURLWithData(data string, chatKey string) (*URLDataResponse, error) {
 	if data == "" {
@@ -53,7 +178,10 @@ func IsStatusSharedURL(url string) bool {
 		strings.HasPrefix(url, sharedURLUserPrefixWithData) ||
 		strings.HasPrefix(url, sharedURLCommunityPrefix) ||
 		strings.HasPrefix(url, sharedURLCommunityPrefixWithData) ||
-		strings.HasPrefix(url, sharedURLChannelPrefixWithData)
+		strings.HasPrefix(url, sharedURLMessagePrefix) ||
+		strings.HasPrefix(url, sharedURLChannelPrefixWithData) ||
+		strings.HasPrefix(url, sharedURLMessagePrefixHTTP) ||
+		strings.HasPrefix(url, sharedURLMessagePrefixInternal)
 }
 
 func splitSharedURLData(data string) (string, string, error) {


### PR DESCRIPTION
Part of https://github.com/status-im/status-app/issues/21457

status-app PR: https://github.com/status-im/status-app/pull/21485

Implemented status-go support for message deep links end to end by adding new shared URL APIs to create and parse message links with chat ID and message ID payloads, extending shared URL type handling and tests for the new message-link format, and updating shared URL detection so message links are recognized consistently across the backend; we also updated link preview behavior to treat message links as navigational links (not unfurl targets) to avoid false preview failures, and finalized link generation to keep chat IDs readable in the URL path while preserving parser compatibility with previously generated encoded links.

