### PR TITLE
Reduce crazy community fetches

### DIFF
--- a/protocol/messenger_communities.go
+++ b/protocol/messenger_communities.go
@@ -1173,9 +1173,6 @@ func (m *Messenger) SpectateCommunity(communityID types3.HexBytes) (*MessengerRe
 
 	response.AddCommunity(community)
 
-	// sync community
-	m.asyncRequestAllHistoricMessages()
-
 	return response, nil
 }
 

--- a/protocol/messenger_mailserver.go
+++ b/protocol/messenger_mailserver.go
@@ -29,6 +29,11 @@ const (
 	oneDayDuration   = 24 * time.Hour
 	oneMonthDuration = 31 * oneDayDuration
 
+	// Reduce historic backfill window on expensive networks (e.g. mobile data)
+	// to avoid excessive bandwidth/CPU usage.
+	// TODO remove or change this when implementing https://github.com/status-im/status-app/issues/18388
+	expensiveNetworkMaxSyncDuration = 1 * oneDayDuration
+
 	// historicSyncMinInterval is the minimum spacing between two historic
 	// syncs. The historic-sync worker enforces it by delaying the pending sync,
 	// never by dropping triggers (see startHistoricSyncWorker).
@@ -187,7 +192,31 @@ func (m *Messenger) defaultSyncPeriodFromNow() (uint32, error) {
 	if err != nil {
 		return 0, err
 	}
-	return uint32(m.getTimesource().GetCurrentTime()/1000) - defaultSyncPeriod, nil
+
+	syncPeriod := m.capSyncPeriodForNetwork(defaultSyncPeriod)
+	return syncPeriodFromNow(m.getTimesource().GetCurrentTime(), syncPeriod), nil
+}
+
+func syncPeriodFromNow(currentTimeMillis uint64, syncPeriod uint32) uint32 {
+	fromUnix := int64(currentTimeMillis/1000) - int64(syncPeriod)
+	if fromUnix < 0 {
+		return 0
+	}
+
+	return uint32(fromUnix)
+}
+
+func (m *Messenger) capSyncPeriodForNetwork(defaultSyncPeriod uint32) uint32 {
+	if !m.connectionState.IsExpensive() {
+		return defaultSyncPeriod
+	}
+
+	expensiveSeconds := uint32(expensiveNetworkMaxSyncDuration / time.Second)
+	if defaultSyncPeriod > expensiveSeconds {
+		return expensiveSeconds
+	}
+
+	return defaultSyncPeriod
 }
 
 // capToDefaultSyncPeriod caps the sync period to the default
@@ -615,10 +644,17 @@ func (m *Messenger) SyncChatFromSyncedFrom(chatID string) (uint32, error) {
 		return 0, err
 	}
 
+	syncPeriod := m.capSyncPeriodForNetwork(defaultSyncPeriod)
+
+	fromUnix := int64(chat.SyncedFrom) - int64(syncPeriod)
+	if fromUnix < 0 {
+		fromUnix = 0
+	}
+
 	batch := types2.StoreNodeBatch{
 		ChatIDs:     []string{chatID},
 		To:          time.Unix(int64(chat.SyncedFrom), 0),
-		From:        time.Unix(int64(chat.SyncedFrom-defaultSyncPeriod), 0),
+		From:        time.Unix(fromUnix, 0),
 		PubsubTopic: pubsubTopic,
 		Topics:      topics,
 	}

--- a/protocol/messenger_mailserver_sync_gate_test.go
+++ b/protocol/messenger_mailserver_sync_gate_test.go
@@ -3,7 +3,9 @@ package protocol
 import (
 	"errors"
 	"testing"
+	"time"
 
+	"github.com/status-im/status-go/internal/connection"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 )
@@ -53,4 +55,44 @@ func TestWithHistoricSyncInFlightRuns(t *testing.T) {
 	m.historicSyncMu.Lock()
 	require.False(t, m.historicSyncInFlight)
 	m.historicSyncMu.Unlock()
+}
+
+func TestCapSyncPeriodForNetwork(t *testing.T) {
+	t.Run("expensive network caps period", func(t *testing.T) {
+		m := &Messenger{connectionState: connection.State{Type: connection.NewType(connection.Cellular)}}
+
+		capped := m.capSyncPeriodForNetwork(uint32(30 * oneDayDuration / time.Second))
+
+		require.Equal(t, uint32(expensiveNetworkMaxSyncDuration/time.Second), capped)
+	})
+
+	t.Run("expensive network keeps shorter period", func(t *testing.T) {
+		m := &Messenger{connectionState: connection.State{Expensive: true}}
+
+		original := uint32(12 * time.Hour / time.Second)
+		capped := m.capSyncPeriodForNetwork(original)
+
+		require.Equal(t, original, capped)
+	})
+
+	t.Run("non expensive keeps period", func(t *testing.T) {
+		m := &Messenger{connectionState: connection.State{Type: connection.NewType(connection.Wifi)}}
+
+		original := uint32(30 * oneDayDuration / time.Second)
+		capped := m.capSyncPeriodForNetwork(original)
+
+		require.Equal(t, original, capped)
+	})
+}
+
+func TestSyncPeriodFromNow(t *testing.T) {
+	t.Run("clamps at zero when sync period is larger than current time", func(t *testing.T) {
+		from := syncPeriodFromNow(500, uint32(oneDayDuration/time.Second))
+		require.Zero(t, from)
+	})
+
+	t.Run("subtracts sync period from current time", func(t *testing.T) {
+		from := syncPeriodFromNow(90_000, 10)
+		require.Equal(t, uint32(80), from)
+	})
 }


### PR DESCRIPTION
Part of https://github.com/status-im/status-app/issues/21498

Removes the duplicated call to fetching the community messages.

Limits the duration of a fetch to 1 day on expensive networks, instead of the default 9 days.

The real fix will be to split the topics used to be per channel but requires discussions.
