### PR TITLE
[DRAFT] fix: Android overheating on community spectate (status-app#21470)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -416,7 +416,7 @@ endif
 statusgo-android-library: generate statusgo-c-bindings build-libsds-android ##@cross-compile Build status-go as Android mobile library
 	@echo "Building Android mobile library..."
 	$(ANDROID_BUILD_FLAGS) CGO_LDFLAGS="$(CGO_LDFLAGS)" CGO_CFLAGS="$(CGO_CFLAGS)" \
-	go build -buildmode=c-shared -tags 'gowaku_no_rln nowatchdog disable_torrent' \
+	go build -buildmode=c-shared -tags 'gowaku_no_rln nowatchdog disable_torrent $(EXTRA_BUILD_TAGS)' \
 		-ldflags="-checklinkname=0 -X github.com/status-im/status-go/vendor/github.com/ethereum/go-ethereum/metrics.EnabledStr=true" \
 		-o "build/bin/libstatus.so" ./build/bin/statusgo-lib
 	@echo "Android library built"

--- a/mobile/pprof_listener.go
+++ b/mobile/pprof_listener.go
@@ -1,0 +1,25 @@
+//go:build mobile_pprof
+
+package statusgo
+
+import (
+	"net/http"
+	_ "net/http/pprof" // registers pprof handlers on http.DefaultServeMux
+
+	"go.uber.org/zap"
+
+	"github.com/status-im/status-go/common"
+	logutils "github.com/status-im/status-go/internal/logutils"
+)
+
+// When built with the `mobile_pprof` tag, expose Go's net/http/pprof endpoints
+// on a loopback-only listener so the Android service process can be CPU-profiled
+// on a device (e.g. via `adb forward tcp:6060 tcp:6060`).
+func init() {
+	go func() {
+		defer common.LogOnPanic()
+		if err := http.ListenAndServe("127.0.0.1:6060", nil); err != nil {
+			logutils.ZapLogger().Error("mobile pprof listener stopped", zap.Error(err))
+		}
+	}()
+}

--- a/pkg/backend/geth_backend.go
+++ b/pkg/backend/geth_backend.go
@@ -125,7 +125,15 @@ func NewStatusBackend(logger *zap.Logger) *StatusBackend {
 		zap.String("IpfsGatewayURL", gocommon.IpfsGatewayURL))
 
 	if gocommon.IsMobilePlatform() {
-		debug.SetMemoryLimit(1024 * 1024 * 150) // 150MB
+		// #21470: the previous 150MB soft limit sat ~3x below the measured
+		// working set (350-620MB while syncing a large community), which forces
+		// the Go GC into permanent maximum-aggression mode. Measured on a
+		// Samsung S21FE (identical 9-day community sync, ~1.7GB ingested):
+		// with 150MB the GC was 61% of service CPU and the process ran at
+		// 150-390% CPU; with the limit lifted the same walk ran at 46-127%
+		// CPU with GC no longer in the profile's top consumers. 1GB keeps an
+		// OOM guard well above the working set without starving the GC.
+		debug.SetMemoryLimit(1024 * 1024 * 1024) // 1GB
 	}
 
 	return backend

--- a/pkg/messaging/api_store_nodes.go
+++ b/pkg/messaging/api_store_nodes.go
@@ -63,8 +63,9 @@ func (a *API) ProcessMailserverBatchHashFirst(
 	batch types.StoreNodeBatch,
 	storenode peer.AddrInfo,
 	processEnvelopes bool,
+	skipBodies bool,
 ) (wakutypes.HashFirstStats, error) {
-	return a.core.stack.Transport.ProcessMailserverBatchHashFirst(ctx, *adapters.ToWakuBatch(&batch), storenode, processEnvelopes)
+	return a.core.stack.Transport.ProcessMailserverBatchHashFirst(ctx, *adapters.ToWakuBatch(&batch), storenode, processEnvelopes, skipBodies)
 }
 
 func (a *API) SetStorenodeConfigProvider(c history.StorenodeConfigProvider) {

--- a/pkg/messaging/api_store_nodes.go
+++ b/pkg/messaging/api_store_nodes.go
@@ -9,6 +9,7 @@ import (
 
 	adapters "github.com/status-im/status-go/pkg/messaging/adapters"
 	types "github.com/status-im/status-go/pkg/messaging/types"
+	wakutypes "github.com/status-im/status-go/pkg/messaging/waku/types"
 )
 
 // These methods ideally shouldn't be exposed as they reveal implementation details
@@ -52,6 +53,18 @@ func (a *API) ProcessMailserverBatch(
 	processEnvelopes bool,
 ) error {
 	return a.core.stack.Transport.ProcessMailserverBatch(ctx, *adapters.ToWakuBatch(&batch), storenode, pageLimit, shouldProcessNextPage, processEnvelopes)
+}
+
+// ProcessMailserverBatchHashFirst runs a hash-first store-node backfill of the batch,
+// fetching full bodies only for hashes not already held locally (issue #21470-hf). It
+// returns per-batch stats for the caller's once-per-backfill log.
+func (a *API) ProcessMailserverBatchHashFirst(
+	ctx context.Context,
+	batch types.StoreNodeBatch,
+	storenode peer.AddrInfo,
+	processEnvelopes bool,
+) (wakutypes.HashFirstStats, error) {
+	return a.core.stack.Transport.ProcessMailserverBatchHashFirst(ctx, *adapters.ToWakuBatch(&batch), storenode, processEnvelopes)
 }
 
 func (a *API) SetStorenodeConfigProvider(c history.StorenodeConfigProvider) {

--- a/pkg/messaging/controller/controller.go
+++ b/pkg/messaging/controller/controller.go
@@ -46,11 +46,19 @@ func NewController(
 	logger *zap.Logger,
 	tracer trace.Tracer,
 ) *Controller {
+	proc := processor.NewProcessor(identity, stack, messageConfirmationStorage, hashRatchetStorage, logger, tracer)
+	// #21470 gate #2: drop undecryptable hash-ratchet messages instead of
+	// parking them in SQLite for replay. Device-validated (Samsung S21FE,
+	// spectating the Status community): service RSS 876MB -> 480MB, data dir
+	// 144MB after ~3GB ingested (previously grew by gigabytes of parked
+	// blobs); key distribution (SeqNo==0) and plaintext channels unaffected.
+	// Dropped content remains on the store node and is re-fetched after join.
+	proc.SetDropUndecryptableWithoutKeys(true)
 	return &Controller{
 		identity:                   identity,
 		stack:                      stack,
 		sender:                     sender.NewSender(identity, stack, logger, tracer),
-		processor:                  processor.NewProcessor(identity, stack, messageConfirmationStorage, hashRatchetStorage, logger, tracer),
+		processor:                  proc,
 		messageConfirmationStorage: messageConfirmationStorage,
 		hashRatchetStorage:         hashRatchetStorage,
 		publisher:                  publisher,

--- a/pkg/messaging/controller/processor/keyless_drop.go
+++ b/pkg/messaging/controller/processor/keyless_drop.go
@@ -1,0 +1,17 @@
+package processor
+
+// shouldDropUndecryptableHashRatchetMessage reports whether an incoming
+// hash-ratchet message that could not be decrypted (ErrHashRatchetGroupIDNotFound)
+// should be dropped instead of parked for retroactive replay.
+//
+// It drops only when the feature is enabled AND the node holds no key material at
+// all for the message's group — i.e. a keyless spectator receiving a community
+// channel's encrypted data plane (issue #21470). A member missing only this
+// rotation's key still holds other keys for the group, so the message is kept so
+// it can be replayed once the newer key arrives.
+//
+// Key-exchange messages (HR header SeqNo == 0) decrypt successfully and never
+// reach this branch, so a drop can never discard key-distribution traffic.
+func shouldDropUndecryptableHashRatchetMessage(enabled, holdsKeys bool) bool {
+	return enabled && !holdsKeys
+}

--- a/pkg/messaging/controller/processor/keyless_drop_test.go
+++ b/pkg/messaging/controller/processor/keyless_drop_test.go
@@ -1,0 +1,19 @@
+package processor
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestShouldDropUndecryptableHashRatchetMessage(t *testing.T) {
+	// Disabled: never drop, regardless of key material (default-off behaviour).
+	require.False(t, shouldDropUndecryptableHashRatchetMessage(false, false))
+	require.False(t, shouldDropUndecryptableHashRatchetMessage(false, true))
+
+	// Enabled: drop only when the node holds no key material for the group
+	// (keyless spectator). A member missing this rotation's key still holds
+	// other keys, so the message is kept for retroactive replay.
+	require.True(t, shouldDropUndecryptableHashRatchetMessage(true, false))
+	require.False(t, shouldDropUndecryptableHashRatchetMessage(true, true))
+}

--- a/pkg/messaging/controller/processor/processor.go
+++ b/pkg/messaging/controller/processor/processor.go
@@ -43,6 +43,30 @@ type Processor struct {
 	logger    *zap.Logger
 
 	tracer trace.Tracer
+
+	// dropUndecryptableWithoutKeys enables the keyless early-drop of undecryptable
+	// hash-ratchet messages (issue #21470, gate #2). Default off pending on-device
+	// validation of this shared processing path; toggle via
+	// SetDropUndecryptableWithoutKeys.
+	dropUndecryptableWithoutKeys bool
+}
+
+// SetDropUndecryptableWithoutKeys toggles gate #2 (#21470): when enabled, an
+// incoming hash-ratchet message the node cannot decrypt AND holds no key material
+// for is dropped instead of parked in the DB for retroactive replay. Default off.
+func (r *Processor) SetDropUndecryptableWithoutKeys(enabled bool) {
+	r.dropUndecryptableWithoutKeys = enabled
+}
+
+// holdsKeysForGroup reports whether the node holds any hash-ratchet key material
+// for groupID. Fails open (true) on lookup error so a transient DB issue never
+// causes a message to be dropped.
+func (r *Processor) holdsKeysForGroup(groupID []byte) bool {
+	keys, err := r.stack.Encryption.GetKeysForGroup(groupID)
+	if err != nil {
+		return true
+	}
+	return len(keys) > 0
 }
 
 func NewProcessor(
@@ -157,6 +181,15 @@ func (r *Processor) processMessage(m *messagingtypes.ReceivedMessage) (*processM
 			span.AddEvent("hash ratchet with group id not found yet", oteltrace.WithAttributes(
 				otelattribute.String("groupID", types.ToHex(info.GroupID)),
 			))
+			// #21470 gate #2: a keyless spectator receiving a community channel's
+			// encrypted data plane will never obtain this group's key, so parking
+			// the message for replay only grows the DB. Drop it; the store node
+			// retains it for post-join backfill/MMV recovery.
+			if r.dropUndecryptableWithoutKeys &&
+				shouldDropUndecryptableHashRatchetMessage(true, r.holdsKeysForGroup(info.GroupID)) {
+				span.AddEvent("dropping undecryptable hash ratchet message (no keys held)")
+				return nil, nil
+			}
 			return nil, r.hashRatchetStorage.SaveMessage(info.GroupID, info.KeyID, m)
 		} else {
 			span.AddEvent("encryption layer not processed", oteltrace.WithAttributes(

--- a/pkg/messaging/layers/segmentation/persistence.go
+++ b/pkg/messaging/layers/segmentation/persistence.go
@@ -7,6 +7,12 @@ import (
 type Persistence interface {
 	IsMessageAlreadyCompleted(hash []byte) (bool, error)
 	SaveMessageSegment(segment *Message, sigPubKey *ecdsa.PublicKey, timestamp int64) error
+	// GetMessageSegmentsCompletionInfo returns the number of stored segments for a
+	// message and the SegmentsCount its data segments advertise (0 if none stored
+	// yet). It is a cheap aggregate (COUNT + MAX, no payload blobs copied) used to
+	// avoid loading every stored segment via GetMessageSegments until the message
+	// can actually be reassembled (issue #21470-hf).
+	GetMessageSegmentsCompletionInfo(hash []byte, sigPubKey *ecdsa.PublicKey) (storedCount int, segmentsCount uint32, err error)
 	GetMessageSegments(hash []byte, sigPubKey *ecdsa.PublicKey) ([]*Message, error)
 	CompleteMessageSegments(hash []byte, sigPubKey *ecdsa.PublicKey, timestamp int64) error
 	RemoveMessageSegmentsOlderThan(timestamp int64) error

--- a/pkg/messaging/layers/segmentation/segmenter.go
+++ b/pkg/messaging/layers/segmentation/segmenter.go
@@ -153,6 +153,21 @@ func (s *Segmenter) Reconstruct(payload []byte, sigPubKey *ecdsa.PublicKey, tran
 		return nil, nil, err
 	}
 
+	// Cheap completion precheck (issue #21470-hf): a message can only be reassembled
+	// once at least SegmentsCount segments (data + parity) are stored. Until then,
+	// skip the expensive GetMessageSegments below, which copies every stored payload
+	// blob out of sqlcipher — for an N-segment message arriving one segment at a time
+	// that full read would otherwise run on every arrival (O(N^2) blob copies).
+	// This is a NECESSARY-condition filter only; the authoritative completeness and
+	// hash checks still run on the fully loaded segments below.
+	storedCount, expectedCount, err := s.persistence.GetMessageSegmentsCompletionInfo(segmentMessage.EntireMessageHash, sigPubKey)
+	if err != nil {
+		return nil, nil, err
+	}
+	if expectedCount == 0 || storedCount < int(expectedCount) {
+		return nil, nil, ErrIncomplete
+	}
+
 	segments, err := s.persistence.GetMessageSegments(segmentMessage.EntireMessageHash, sigPubKey)
 	if err != nil {
 		return nil, nil, err

--- a/pkg/messaging/layers/segmentation/segmenter_test.go
+++ b/pkg/messaging/layers/segmentation/segmenter_test.go
@@ -1,6 +1,7 @@
 package segmentation
 
 import (
+	"crypto/ecdsa"
 	_ "embed"
 	"testing"
 
@@ -185,4 +186,137 @@ func (s *MessageSegmentationSuite) TestProtobufMissDecoding() {
 
 	// Ensure that the sanity check for the segmented message fails, as expected.
 	s.Require().False(segmentedMessage.IsValid())
+}
+
+// countingPersistence wraps a real Persistence and counts GetMessageSegments
+// calls, so tests can assert the expensive full-segment read (which copies every
+// stored payload blob out of sqlcipher) happens only once, on completion —
+// instead of on every arriving segment (the O(N^2) behavior, issue #21470-hf).
+type countingPersistence struct {
+	Persistence
+	getSegmentsCalls int
+}
+
+func (c *countingPersistence) GetMessageSegments(hash []byte, sigPubKey *ecdsa.PublicKey) ([]*Message, error) {
+	c.getSegmentsCalls++
+	return c.Persistence.GetMessageSegments(hash, sigPubKey)
+}
+
+func (s *MessageSegmentationSuite) newCountingSegmenter() (*Segmenter, *countingPersistence) {
+	db, err := testutils.SetupTestMemorySQLDB(testutils.NewTestDBInitializer([]*bindata.AssetSource{
+		{
+			Names:     migrations.AssetNames(),
+			AssetFunc: migrations.Asset,
+		},
+	}))
+	s.Require().NoError(err)
+	counting := &countingPersistence{Persistence: NewSQLitePersistence(db)}
+	return NewSegmenter(counting, zap.Must(zap.NewDevelopment())), counting
+}
+
+// TestReadsAllSegmentsOnlyOnCompletion (no parity) verifies that arriving segments
+// before the last do NOT trigger a full read of every stored segment, and the last
+// one triggers exactly one such read (issue #21470-hf: O(N) instead of O(N^2)).
+func (s *MessageSegmentationSuite) TestReadsAllSegmentsOnlyOnCompletion() {
+	segmenter, counting := s.newCountingSegmenter()
+
+	signer, err := crypto.GenerateKey()
+	s.Require().NoError(err)
+
+	segmentsCount := 5 // floor(5*0.125)=0 parity segments
+	segSize := (len(s.testPayload) + segmentsCount - 1) / segmentsCount
+	segs, err := segmenter.Segment(s.testPayload, segSize)
+	s.Require().NoError(err)
+	s.Require().Len(segs, segmentsCount)
+
+	for i := 0; i < segmentsCount-1; i++ {
+		_, _, err := segmenter.Reconstruct(segs[i], &signer.PublicKey, nil)
+		s.Require().ErrorIs(err, ErrIncomplete)
+	}
+	s.Require().Equal(0, counting.getSegmentsCalls, "must not read all segments before completion")
+
+	payload, _, err := segmenter.Reconstruct(segs[segmentsCount-1], &signer.PublicKey, nil)
+	s.Require().NoError(err)
+	s.Require().ElementsMatch(s.testPayload, payload)
+	s.Require().Equal(1, counting.getSegmentsCalls, "reads all segments exactly once, on completion")
+}
+
+// TestReadsAllSegmentsOnlyOnCompletionOutOfOrder verifies the completion precheck
+// is order-independent: the full read still fires exactly once, on the arrival that
+// brings the stored count up to SegmentsCount.
+func (s *MessageSegmentationSuite) TestReadsAllSegmentsOnlyOnCompletionOutOfOrder() {
+	segmenter, counting := s.newCountingSegmenter()
+
+	signer, err := crypto.GenerateKey()
+	s.Require().NoError(err)
+
+	segmentsCount := 5
+	segSize := (len(s.testPayload) + segmentsCount - 1) / segmentsCount
+	segs, err := segmenter.Segment(s.testPayload, segSize)
+	s.Require().NoError(err)
+
+	order := []int{3, 0, 4, 1, 2}
+	for i, idx := range order {
+		payload, _, err := segmenter.Reconstruct(segs[idx], &signer.PublicKey, nil)
+		if i < segmentsCount-1 {
+			s.Require().ErrorIs(err, ErrIncomplete)
+			s.Require().Equal(0, counting.getSegmentsCalls)
+		} else {
+			s.Require().NoError(err)
+			s.Require().ElementsMatch(s.testPayload, payload)
+			s.Require().Equal(1, counting.getSegmentsCalls)
+		}
+	}
+}
+
+// TestDuplicateSegmentDoesNotTriggerRead verifies a duplicate arrival (which
+// REPLACEs its row and leaves the stored count unchanged) neither completes the
+// message nor triggers a full read.
+func (s *MessageSegmentationSuite) TestDuplicateSegmentDoesNotTriggerRead() {
+	segmenter, counting := s.newCountingSegmenter()
+
+	signer, err := crypto.GenerateKey()
+	s.Require().NoError(err)
+
+	segmentsCount := 5
+	segSize := (len(s.testPayload) + segmentsCount - 1) / segmentsCount
+	segs, err := segmenter.Segment(s.testPayload, segSize)
+	s.Require().NoError(err)
+
+	_, _, err = segmenter.Reconstruct(segs[0], &signer.PublicKey, nil)
+	s.Require().ErrorIs(err, ErrIncomplete)
+	_, _, err = segmenter.Reconstruct(segs[0], &signer.PublicKey, nil) // duplicate
+	s.Require().ErrorIs(err, ErrIncomplete)
+	s.Require().Equal(0, counting.getSegmentsCalls, "duplicate must not trigger a full read")
+}
+
+// TestParityCompletionReadsOnce verifies the completion precheck fires the single
+// full read even when the completing segment is a parity segment (reedsolomon
+// reconstruction with one data segment missing).
+func (s *MessageSegmentationSuite) TestParityCompletionReadsOnce() {
+	segmenter, counting := s.newCountingSegmenter()
+
+	signer, err := crypto.GenerateKey()
+	s.Require().NoError(err)
+
+	segmentsCount := 8 // floor(8*0.125)=1 parity segment
+	segSize := (len(s.testPayload) + segmentsCount - 1) / segmentsCount
+	segs, err := segmenter.Segment(s.testPayload, segSize)
+	s.Require().NoError(err)
+	s.Require().Len(segs, segmentsCount+1) // 8 data + 1 parity
+
+	// Deliver 7 of the 8 data segments (index 0..6), then the parity segment
+	// (index 8) which brings the stored count to 8 and completes via parity.
+	arrival := []int{0, 1, 2, 3, 4, 5, 6, 8}
+	for i, idx := range arrival {
+		payload, _, err := segmenter.Reconstruct(segs[idx], &signer.PublicKey, nil)
+		if i < segmentsCount-1 {
+			s.Require().ErrorIs(err, ErrIncomplete)
+			s.Require().Equal(0, counting.getSegmentsCalls)
+		} else {
+			s.Require().NoError(err)
+			s.Require().ElementsMatch(s.testPayload, payload)
+			s.Require().Equal(1, counting.getSegmentsCalls)
+		}
+	}
 }

--- a/pkg/messaging/layers/segmentation/sqlite_persistence.go
+++ b/pkg/messaging/layers/segmentation/sqlite_persistence.go
@@ -36,6 +36,26 @@ func (s *SQLitePersistence) SaveMessageSegment(segment *Message, sigPubKey *ecds
 	return err
 }
 
+// GetMessageSegmentsCompletionInfo returns how many segments are stored for the
+// message and the SegmentsCount its data segments advertise. Data segments carry
+// segments_count = N (> 0); parity segments carry 0, so MAX(segments_count) is N
+// once any data segment is stored, and 0 while only parity has arrived. This is a
+// cheap aggregate over just this message's rows (via the primary-key prefix
+// hash+sig_pub_key) that copies no payload blobs (issue #21470-hf).
+func (s *SQLitePersistence) GetMessageSegmentsCompletionInfo(hash []byte, sigPubKey *ecdsa.PublicKey) (int, uint32, error) {
+	sigPubKeyBlob := crypto.CompressPubkey(sigPubKey)
+
+	var storedCount int
+	var segmentsCount uint32
+	err := s.db.QueryRow(
+		"SELECT COUNT(*), COALESCE(MAX(segments_count), 0) FROM message_segments WHERE hash = ? AND sig_pub_key = ?",
+		hash, sigPubKeyBlob).Scan(&storedCount, &segmentsCount)
+	if err != nil {
+		return 0, 0, err
+	}
+	return storedCount, segmentsCount, nil
+}
+
 // Get ordered message segments for given hash
 func (s *SQLitePersistence) GetMessageSegments(hash []byte, sigPubKey *ecdsa.PublicKey) ([]*Message, error) {
 	sigPubKeyBlob := crypto.CompressPubkey(sigPubKey)

--- a/pkg/messaging/layers/transport/transport.go
+++ b/pkg/messaging/layers/transport/transport.go
@@ -664,6 +664,18 @@ func (t *Transport) ProcessMailserverBatch(
 	return t.waku.ProcessMailserverBatch(ctx, batch, storenode, pageLimit, shouldProcessNextPage, processEnvelopes)
 }
 
+// ProcessMailserverBatchHashFirst runs a hash-first store-node backfill of the batch:
+// it fetches only the hashes in the window, then full bodies for the hashes not already
+// held locally (issue #21470-hf). Bodies are ingested exactly as the classic path.
+func (t *Transport) ProcessMailserverBatchHashFirst(
+	ctx context.Context,
+	batch types.MailserverBatch,
+	storenode peer.AddrInfo,
+	processEnvelopes bool,
+) (types.HashFirstStats, error) {
+	return t.waku.ProcessMailserverBatchHashFirst(ctx, batch, storenode, processEnvelopes)
+}
+
 func (t *Transport) SetStorenodeConfigProvider(c history.StorenodeConfigProvider) {
 	t.waku.SetStorenodeConfigProvider(c)
 }

--- a/pkg/messaging/layers/transport/transport.go
+++ b/pkg/messaging/layers/transport/transport.go
@@ -672,8 +672,9 @@ func (t *Transport) ProcessMailserverBatchHashFirst(
 	batch types.MailserverBatch,
 	storenode peer.AddrInfo,
 	processEnvelopes bool,
+	skipBodies bool,
 ) (types.HashFirstStats, error) {
-	return t.waku.ProcessMailserverBatchHashFirst(ctx, batch, storenode, processEnvelopes)
+	return t.waku.ProcessMailserverBatchHashFirst(ctx, batch, storenode, processEnvelopes, skipBodies)
 }
 
 func (t *Transport) SetStorenodeConfigProvider(c history.StorenodeConfigProvider) {

--- a/pkg/messaging/waku/common/filter.go
+++ b/pkg/messaging/waku/common/filter.go
@@ -85,6 +85,23 @@ func NewFilters(defaultPubsubTopic string, logger *zap.Logger) *Filters {
 	}
 }
 
+// PendingMessageCount returns the total number of decrypted messages waiting across all
+// installed filter stores for the retrieve loop to consume. It is the backpressure signal
+// for the hash-first body fetch: fetched envelopes are decrypted (ReceivedMessage.Open)
+// and handed to these unbounded per-filter stores, so this count is what balloons when the
+// fetch outpaces the (slow) consumer (issue #21470-hf).
+func (fs *Filters) PendingMessageCount() int {
+	fs.RLock()
+	defer fs.RUnlock()
+	total := 0
+	for _, watcher := range fs.watchers {
+		if watcher.Messages != nil {
+			total += watcher.Messages.Count()
+		}
+	}
+	return total
+}
+
 // Install will add a new filter to the filter collection
 func (fs *Filters) Install(watcher *Filter) (string, error) {
 	if watcher.KeySym != nil && watcher.KeyAsym != nil {

--- a/pkg/messaging/waku/common/filter_test.go
+++ b/pkg/messaging/waku/common/filter_test.go
@@ -354,3 +354,78 @@ func TestWatchers(t *testing.T) {
 		require.Equal(t, tst[i].msgCnt, count[i])
 	}
 }
+
+// newCountTestMessage builds a distinct ReceivedMessage on the given content topic;
+// distinct seeds yield distinct envelope hashes (issue #21470-hf backpressure signal).
+func newCountTestMessage(t *testing.T, contentTopic string, seed byte) *ReceivedMessage {
+	data := make([]byte, 8)
+	data[0] = seed
+	msg := &pb.WakuMessage{
+		Payload:      data,
+		ContentTopic: contentTopic,
+		Timestamp:    proto.Int64(time.Now().UnixNano() + int64(seed)),
+		Meta:         []byte{},
+	}
+	envelope := protocol.NewEnvelope(msg, msg.GetTimestamp(), testShard)
+	rm := NewReceivedMessage(envelope, "test")
+	require.NotNil(t, rm)
+	return rm
+}
+
+// TestMemoryMessageStoreCount verifies the store reports its pending size, does not
+// double-count duplicate hashes, and returns to zero after Pop — the primitive the
+// hash-first body-fetch backpressure signal is built on (issue #21470-hf).
+func TestMemoryMessageStoreCount(t *testing.T) {
+	filter, err := generateFilter(t, true)
+	require.NoError(t, err)
+	ct := maps.Keys(filter.ContentTopics)[0].ContentTopic()
+
+	store := NewMemoryMessageStore()
+	require.Equal(t, 0, store.Count())
+
+	for i := 0; i < 3; i++ {
+		require.NoError(t, store.Add(newCountTestMessage(t, ct, byte(i))))
+	}
+	require.Equal(t, 3, store.Count())
+
+	// Same message added twice is stored (and counted) once.
+	dup := newCountTestMessage(t, ct, 9)
+	require.NoError(t, store.Add(dup))
+	require.NoError(t, store.Add(dup))
+	require.Equal(t, 4, store.Count())
+
+	popped, err := store.Pop()
+	require.NoError(t, err)
+	require.Len(t, popped, 4)
+	require.Equal(t, 0, store.Count())
+}
+
+// TestFiltersPendingMessageCount verifies the aggregate backpressure signal sums the
+// pending messages across every installed filter store and drops as they are consumed
+// (issue #21470-hf).
+func TestFiltersPendingMessageCount(t *testing.T) {
+	filters := NewFilters(testShard, createLogger(t))
+
+	f1, err := generateFilter(t, true)
+	require.NoError(t, err)
+	f2, err := generateFilter(t, true)
+	require.NoError(t, err)
+	_, err = filters.Install(f1)
+	require.NoError(t, err)
+	_, err = filters.Install(f2)
+	require.NoError(t, err)
+
+	require.Equal(t, 0, filters.PendingMessageCount())
+
+	ct1 := maps.Keys(f1.ContentTopics)[0].ContentTopic()
+	require.NoError(t, f1.Messages.Add(newCountTestMessage(t, ct1, 1)))
+	require.NoError(t, f1.Messages.Add(newCountTestMessage(t, ct1, 2)))
+	ct2 := maps.Keys(f2.ContentTopics)[0].ContentTopic()
+	require.NoError(t, f2.Messages.Add(newCountTestMessage(t, ct2, 3)))
+
+	require.Equal(t, 3, filters.PendingMessageCount())
+
+	_, err = f1.Messages.Pop()
+	require.NoError(t, err)
+	require.Equal(t, 1, filters.PendingMessageCount())
+}

--- a/pkg/messaging/waku/common/message.go
+++ b/pkg/messaging/waku/common/message.go
@@ -88,6 +88,10 @@ func (msg *ReceivedMessage) isAsymmetricEncryption() bool {
 type MessageStore interface {
 	Add(*ReceivedMessage) error
 	Pop() ([]*ReceivedMessage, error)
+	// Count reports how many messages are currently held (added but not yet popped).
+	// It is the per-filter contribution to the hash-first body-fetch backpressure
+	// signal (issue #21470-hf).
+	Count() int
 }
 
 // NewMemoryMessageStore returns pointer to an instance of the MemoryMessageStore.
@@ -138,6 +142,13 @@ func (store *MemoryMessageStore) Add(msg *ReceivedMessage) error {
 		store.messages[msg.Hash()] = msg
 	}
 	return nil
+}
+
+// Count returns how many messages are currently held in the store.
+func (store *MemoryMessageStore) Count() int {
+	store.mu.Lock()
+	defer store.mu.Unlock()
+	return len(store.messages)
 }
 
 // Pop returns all available messages and cleans the store.

--- a/pkg/messaging/waku/hash_first_backfill.go
+++ b/pkg/messaging/waku/hash_first_backfill.go
@@ -3,6 +3,7 @@ package wakuv2
 import (
 	"context"
 	"encoding/hex"
+	"time"
 
 	"github.com/libp2p/go-libp2p/core/peer"
 	"google.golang.org/protobuf/proto"
@@ -42,7 +43,77 @@ const (
 	// may carry. Mirrors the verifier's maxMsgHashesPerRequest — the store node caps the
 	// number of message_hashes keys per request.
 	hashFirstMaxHashesPerRequest = 50
+
+	// hashFirstMaxContentTopicsPerRequest bounds how many content topics a single metadata
+	// store query may carry. Mirrors the classic HistoryRetriever's maxTopicsPerRequest and
+	// the verifier's maxContentTopicsPerRequest — the store node caps the number of content
+	// topics per request. The general (all-filters) history sync batches many more topics
+	// than the spectate path, so the metadata walk must chunk them (issue #21470-hf).
+	hashFirstMaxContentTopicsPerRequest = 10
 )
+
+// hashFirstMaxWindow caps the duration of a single metadata store query. The classic
+// HistoryRetriever caps each query to 24h and walks a longer range backward (see
+// history.go's exceeds24h handling); the general history sync can span the ~9-day default
+// sync period, so the metadata walk is split into <=24h sub-windows to match (issue
+// #21470-hf).
+const hashFirstMaxWindow = 24 * time.Hour
+
+// hashFirstTimeWindow is one <=24h sub-window of the metadata walk, in unix nanoseconds.
+type hashFirstTimeWindow struct {
+	fromNano int64
+	toNano   int64
+}
+
+// partitionContentTopics splits content topics into chunks of at most maxPerRequest, so
+// each metadata store query stays within the store node's per-request content-topic limit.
+// A non-positive maxPerRequest yields a single chunk (defensive: never emit an unbounded
+// or infinite split). Order is preserved.
+func partitionContentTopics(topics []string, maxPerRequest int) [][]string {
+	if len(topics) == 0 {
+		return nil
+	}
+	if maxPerRequest <= 0 {
+		return [][]string{topics}
+	}
+	var chunks [][]string
+	for i := 0; i < len(topics); i += maxPerRequest {
+		j := i + maxPerRequest
+		if j > len(topics) {
+			j = len(topics)
+		}
+		chunks = append(chunks, topics[i:j])
+	}
+	return chunks
+}
+
+// splitWindowNewestFirst splits [fromNano, toNano) into consecutive sub-windows of at most
+// maxWindowNano, ordered NEWEST-FIRST (the first window ends at toNano). This mirrors the
+// classic HistoryRetriever, which caps each store query to 24h and walks a longer range
+// backward: a single metadata query over a multi-day range would silently cover only the
+// newest window while the watermark still advances to `to`, losing the older days.
+// Newest-first ordering keeps bodies fetched most-recent-first (matching aa9fa29b5). An
+// empty or inverted range yields no windows; a non-positive maxWindowNano yields a single
+// window spanning the range (defensive: never loop forever).
+func splitWindowNewestFirst(fromNano, toNano, maxWindowNano int64) []hashFirstTimeWindow {
+	if toNano <= fromNano {
+		return nil
+	}
+	if maxWindowNano <= 0 {
+		return []hashFirstTimeWindow{{fromNano: fromNano, toNano: toNano}}
+	}
+	var windows []hashFirstTimeWindow
+	end := toNano
+	for end > fromNano {
+		start := end - maxWindowNano
+		if start < fromNano {
+			start = fromNano
+		}
+		windows = append(windows, hashFirstTimeWindow{fromNano: start, toNano: end})
+		end = start
+	}
+	return windows
+}
 
 // partitionMessageHashes splits hashes into batches of at most maxPerRequest, so each
 // body-fetch store query stays within the store node's per-request hash-key limit. A
@@ -127,9 +198,15 @@ func planBodyFetch(unknown []wpb.MessageHash, skipBodies bool) (toFetch []wpb.Me
 // normal ingest path (OnNewEnvelopes), exactly as the classic full-body path does. It
 // returns per-batch stats for the once-per-backfill INFO log.
 //
+// The metadata walk generalizes to the general (all-filters) history sync's batch shapes
+// (issue #21470-hf): content topics are chunked to at most hashFirstMaxContentTopicsPerRequest
+// per store query, and a multi-day window is split into <=24h sub-windows walked
+// newest-first, both mirroring the classic HistoryRetriever so coverage is identical and no
+// day is silently dropped from a range wider than 24h.
+//
 // Cancellation: the caller's ctx is threaded into every store query and checked between
-// pages and between body-fetch partitions, so leave/background aborts promptly. As with
-// the classic path, watermark bookkeeping lives in the caller and advances only after
+// chunks, windows, pages and body-fetch partitions, so leave/background aborts promptly. As
+// with the classic path, watermark bookkeeping lives in the caller and advances only after
 // this returns without error, so a cancelled batch marks nothing fetched.
 func (w *Waku) ProcessMailserverBatchHashFirst(
 	ctx context.Context,
@@ -149,43 +226,27 @@ func (w *Waku) ProcessMailserverBatchHashFirst(
 	requestor := missing.NewDefaultStorenodeRequestor(w.node.Store())
 
 	// Phase 1 — metadata-only page walk (newest-first): collect every hash in the window,
-	// skipping those already held locally.
+	// skipping those already held locally. The general sync batches many topics over a
+	// multi-day window, so the walk is chunked by content topic (store per-request cap) and
+	// by <=24h sub-window (query duration cap), exactly as the classic HistoryRetriever does.
+	windows := splitWindowNewestFirst(batch.From.UnixNano(), batch.To.UnixNano(), hashFirstMaxWindow.Nanoseconds())
 	var unknownHashes []wpb.MessageHash
-	metadataQuery := buildMetadataQuery(
-		hex.EncodeToString(protocol.GenerateRequestID()),
-		pubsubTopic, contentTopics, batch.From.UnixNano(), batch.To.UnixNano())
-
-	result, err := requestor.Query(ctx, storenode, metadataQuery)
-	if err != nil {
-		return stats, err
-	}
-	for {
-		pageHashes := make([]wpb.MessageHash, 0, len(result.Messages()))
-		for _, mkv := range result.Messages() {
-			stats.HashesSeen++
-			pageHashes = append(pageHashes, wpb.ToMessageHash(mkv.MessageHash))
-		}
-		pageUnknown, known, err := filterUnknownHashes(pageHashes, w.MessageExists)
-		if err != nil {
-			return stats, err
-		}
-		stats.HashesKnown += known
-		unknownHashes = append(unknownHashes, pageUnknown...)
-
-		if result.IsComplete() {
-			break
-		}
-		if err := ctx.Err(); err != nil {
-			return stats, err
-		}
-		if err := result.Next(ctx); err != nil {
-			return stats, err
+	for _, topicChunk := range partitionContentTopics(contentTopics, hashFirstMaxContentTopicsPerRequest) {
+		for _, window := range windows {
+			if err := ctx.Err(); err != nil {
+				return stats, err
+			}
+			chunkUnknown, err := w.walkMetadataWindow(ctx, requestor, storenode, pubsubTopic, topicChunk, window, &stats)
+			if err != nil {
+				return stats, err
+			}
+			unknownHashes = append(unknownHashes, chunkUnknown...)
 		}
 	}
 
-	// De-duplicate across pages as well: a hash unknown on one page must not be fetched
-	// twice if the store repeats it.
-	unknownHashes, _, err = filterUnknownHashes(unknownHashes, func(wpb.MessageHash) (bool, error) { return false, nil })
+	// De-duplicate across chunks, windows and pages: a hash unknown in one place must not be
+	// fetched twice if the store repeats it.
+	unknownHashes, _, err := filterUnknownHashes(unknownHashes, func(wpb.MessageHash) (bool, error) { return false, nil })
 	if err != nil {
 		return stats, err
 	}
@@ -235,6 +296,56 @@ func (w *Waku) ProcessMailserverBatchHashFirst(
 	}
 
 	return stats, nil
+}
+
+// walkMetadataWindow runs the metadata-only page walk for one content-topic chunk over one
+// <=24h sub-window: it pages newest-first pulling only hashes, accumulates HashesSeen /
+// HashesKnown into stats, and returns the hashes not already held locally (per-page
+// de-duplicated; the caller de-duplicates across chunks/windows). The ctx is checked
+// between pages so a cancel aborts promptly.
+func (w *Waku) walkMetadataWindow(
+	ctx context.Context,
+	requestor commonapi.StorenodeRequestor,
+	storenode peer.AddrInfo,
+	pubsubTopic string,
+	contentTopics []string,
+	window hashFirstTimeWindow,
+	stats *types.HashFirstStats,
+) ([]wpb.MessageHash, error) {
+	metadataQuery := buildMetadataQuery(
+		hex.EncodeToString(protocol.GenerateRequestID()),
+		pubsubTopic, contentTopics, window.fromNano, window.toNano)
+
+	result, err := requestor.Query(ctx, storenode, metadataQuery)
+	if err != nil {
+		return nil, err
+	}
+
+	var unknownHashes []wpb.MessageHash
+	for {
+		pageHashes := make([]wpb.MessageHash, 0, len(result.Messages()))
+		for _, mkv := range result.Messages() {
+			stats.HashesSeen++
+			pageHashes = append(pageHashes, wpb.ToMessageHash(mkv.MessageHash))
+		}
+		pageUnknown, known, err := filterUnknownHashes(pageHashes, w.MessageExists)
+		if err != nil {
+			return nil, err
+		}
+		stats.HashesKnown += known
+		unknownHashes = append(unknownHashes, pageUnknown...)
+
+		if result.IsComplete() {
+			break
+		}
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		if err := result.Next(ctx); err != nil {
+			return nil, err
+		}
+	}
+	return unknownHashes, nil
 }
 
 // ingestBodyPage feeds one page of fetched full-body envelopes into the normal ingest

--- a/pkg/messaging/waku/hash_first_backfill.go
+++ b/pkg/messaging/waku/hash_first_backfill.go
@@ -91,6 +91,24 @@ func filterUnknownHashes(hashes []wpb.MessageHash, exists func(wpb.MessageHash) 
 	return unknown, known, nil
 }
 
+// buildMetadataQuery builds the metadata-only (hash) store query that walks the window.
+// It requests NO bodies (IncludeData:false) and NEWEST-FIRST pagination
+// (PaginationForward:false) so bodies are later fetched most-recent-first — for a keyed
+// fetch that means a cancellation (leave/background) keeps the most useful (newest)
+// history rather than the oldest (issue #21470-hf enhancement).
+func buildMetadataQuery(requestID string, pubsubTopic string, contentTopics []string, fromNano, toNano int64) *storepb.StoreQueryRequest {
+	return &storepb.StoreQueryRequest{
+		RequestId:         requestID,
+		IncludeData:       false,
+		PubsubTopic:       &pubsubTopic,
+		ContentTopics:     contentTopics,
+		TimeStart:         proto.Int64(fromNano),
+		TimeEnd:           proto.Int64(toNano),
+		PaginationForward: false,
+		PaginationLimit:   proto.Uint64(hashFirstMetadataPageSize),
+	}
+}
+
 // planBodyFetch decides which unknown-hash bodies to actually fetch. When skipBodies is
 // set (keyless spectator with a resolved description — every body here is undecryptable),
 // nothing is fetched and all unknowns are counted as skipped; the hashes were still
@@ -130,18 +148,12 @@ func (w *Waku) ProcessMailserverBatchHashFirst(
 
 	requestor := missing.NewDefaultStorenodeRequestor(w.node.Store())
 
-	// Phase 1 — metadata-only page walk: collect every hash in the window, skipping those
-	// already held locally.
+	// Phase 1 — metadata-only page walk (newest-first): collect every hash in the window,
+	// skipping those already held locally.
 	var unknownHashes []wpb.MessageHash
-	metadataQuery := &storepb.StoreQueryRequest{
-		RequestId:       hex.EncodeToString(protocol.GenerateRequestID()),
-		IncludeData:     false,
-		PubsubTopic:     &pubsubTopic,
-		ContentTopics:   contentTopics,
-		TimeStart:       proto.Int64(batch.From.UnixNano()),
-		TimeEnd:         proto.Int64(batch.To.UnixNano()),
-		PaginationLimit: proto.Uint64(hashFirstMetadataPageSize),
-	}
+	metadataQuery := buildMetadataQuery(
+		hex.EncodeToString(protocol.GenerateRequestID()),
+		pubsubTopic, contentTopics, batch.From.UnixNano(), batch.To.UnixNano())
 
 	result, err := requestor.Query(ctx, storenode, metadataQuery)
 	if err != nil {

--- a/pkg/messaging/waku/hash_first_backfill.go
+++ b/pkg/messaging/waku/hash_first_backfill.go
@@ -1,0 +1,224 @@
+package wakuv2
+
+import (
+	"context"
+	"encoding/hex"
+
+	"github.com/libp2p/go-libp2p/core/peer"
+	"google.golang.org/protobuf/proto"
+
+	commonapi "github.com/waku-org/go-waku/waku/v2/api/common"
+	"github.com/waku-org/go-waku/waku/v2/api/missing"
+	"github.com/waku-org/go-waku/waku/v2/protocol"
+	wpb "github.com/waku-org/go-waku/waku/v2/protocol/pb"
+	storepb "github.com/waku-org/go-waku/waku/v2/protocol/store/pb"
+
+	common "github.com/status-im/status-go/pkg/messaging/waku/common"
+	types "github.com/status-im/status-go/pkg/messaging/waku/types"
+)
+
+// Hash-first spectate backfill (issue #21470-hf).
+//
+// A keyless spectator's store-node backfill of a community's single universal content
+// topic re-downloads the same 1.4MB community description dozens of times: each
+// heartbeat republish is a fresh ciphertext with a unique envelope hash, so post-download
+// dedup cannot collapse them. Device measurement (Samsung S21FE) put the useful content
+// at ~1/1000th of the bytes ingested.
+//
+// go-waku's own missing-message verifier already solves the shape of this: it queries the
+// store for hashes+metadata ONLY (no bodies), checks each hash against what it already
+// holds, and fetches full bodies for the unknown hashes alone
+// (go-waku waku/v2/api/missing/missing_messages.go). We apply the same hash-first shape
+// to the spectate backfill so bodies are fetched only for envelopes we have not already
+// seen. HistoryRetriever.Query cannot be reused because it hardcodes IncludeData:true
+// (go-waku waku/v2/api/history/history.go), so this path drives the store client directly
+// via the same requestor/message-tracker the verifier uses.
+const (
+	// hashFirstMetadataPageSize bounds the metadata-only (hash) page walk. Mirrors the
+	// verifier's messageFetchPageSize.
+	hashFirstMetadataPageSize = 100
+
+	// hashFirstMaxHashesPerRequest bounds how many hashes a single body-fetch store query
+	// may carry. Mirrors the verifier's maxMsgHashesPerRequest — the store node caps the
+	// number of message_hashes keys per request.
+	hashFirstMaxHashesPerRequest = 50
+)
+
+// partitionMessageHashes splits hashes into batches of at most maxPerRequest, so each
+// body-fetch store query stays within the store node's per-request hash-key limit. A
+// non-positive maxPerRequest yields a single batch (defensive: never emit an unbounded
+// or infinite split).
+func partitionMessageHashes(hashes []wpb.MessageHash, maxPerRequest int) [][]wpb.MessageHash {
+	if len(hashes) == 0 {
+		return nil
+	}
+	if maxPerRequest <= 0 {
+		return [][]wpb.MessageHash{hashes}
+	}
+	var batches [][]wpb.MessageHash
+	for i := 0; i < len(hashes); i += maxPerRequest {
+		j := i + maxPerRequest
+		if j > len(hashes) {
+			j = len(hashes)
+		}
+		batches = append(batches, hashes[i:j])
+	}
+	return batches
+}
+
+// filterUnknownHashes returns the hashes not already held locally, in first-seen order
+// and de-duplicated, together with how many inputs were already known. exists is the
+// local "already processed this envelope" authority (the verifier's message tracker).
+// A duplicate hash within the input is counted once and, if unknown, fetched once.
+func filterUnknownHashes(hashes []wpb.MessageHash, exists func(wpb.MessageHash) (bool, error)) (unknown []wpb.MessageHash, known int, err error) {
+	seen := make(map[wpb.MessageHash]struct{}, len(hashes))
+	for _, h := range hashes {
+		if _, ok := seen[h]; ok {
+			continue
+		}
+		seen[h] = struct{}{}
+
+		has, err := exists(h)
+		if err != nil {
+			return nil, 0, err
+		}
+		if has {
+			known++
+			continue
+		}
+		unknown = append(unknown, h)
+	}
+	return unknown, known, nil
+}
+
+// ProcessMailserverBatchHashFirst backfills a store-node batch hash-first: it walks the
+// window pulling only message hashes+metadata, filters out envelopes already held
+// locally, then fetches full bodies only for the unknown hashes and feeds them into the
+// normal ingest path (OnNewEnvelopes), exactly as the classic full-body path does. It
+// returns per-batch stats for the once-per-backfill INFO log.
+//
+// Cancellation: the caller's ctx is threaded into every store query and checked between
+// pages and between body-fetch partitions, so leave/background aborts promptly. As with
+// the classic path, watermark bookkeeping lives in the caller and advances only after
+// this returns without error, so a cancelled batch marks nothing fetched.
+func (w *Waku) ProcessMailserverBatchHashFirst(
+	ctx context.Context,
+	batch types.MailserverBatch,
+	storenode peer.AddrInfo,
+	processEnvelopes bool,
+) (types.HashFirstStats, error) {
+	var stats types.HashFirstStats
+
+	pubsubTopic := w.GetPubsubTopic(batch.PubsubTopic)
+	contentTopics := make([]string, 0, len(batch.Topics))
+	for _, topic := range batch.Topics {
+		contentTopics = append(contentTopics, common.BytesToTopic(topic.Bytes()).ContentTopic())
+	}
+
+	requestor := missing.NewDefaultStorenodeRequestor(w.node.Store())
+
+	// Phase 1 — metadata-only page walk: collect every hash in the window, skipping those
+	// already held locally.
+	var unknownHashes []wpb.MessageHash
+	metadataQuery := &storepb.StoreQueryRequest{
+		RequestId:       hex.EncodeToString(protocol.GenerateRequestID()),
+		IncludeData:     false,
+		PubsubTopic:     &pubsubTopic,
+		ContentTopics:   contentTopics,
+		TimeStart:       proto.Int64(batch.From.UnixNano()),
+		TimeEnd:         proto.Int64(batch.To.UnixNano()),
+		PaginationLimit: proto.Uint64(hashFirstMetadataPageSize),
+	}
+
+	result, err := requestor.Query(ctx, storenode, metadataQuery)
+	if err != nil {
+		return stats, err
+	}
+	for {
+		pageHashes := make([]wpb.MessageHash, 0, len(result.Messages()))
+		for _, mkv := range result.Messages() {
+			stats.HashesSeen++
+			pageHashes = append(pageHashes, wpb.ToMessageHash(mkv.MessageHash))
+		}
+		pageUnknown, known, err := filterUnknownHashes(pageHashes, w.MessageExists)
+		if err != nil {
+			return stats, err
+		}
+		stats.HashesKnown += known
+		unknownHashes = append(unknownHashes, pageUnknown...)
+
+		if result.IsComplete() {
+			break
+		}
+		if err := ctx.Err(); err != nil {
+			return stats, err
+		}
+		if err := result.Next(ctx); err != nil {
+			return stats, err
+		}
+	}
+
+	// De-duplicate across pages as well: a hash unknown on one page must not be fetched
+	// twice if the store repeats it.
+	unknownHashes, _, err = filterUnknownHashes(unknownHashes, func(wpb.MessageHash) (bool, error) { return false, nil })
+	if err != nil {
+		return stats, err
+	}
+
+	// Phase 2 — body fetch: pull full bodies ONLY for the unknown hashes, in store-capped
+	// batches, and feed them into the normal ingest path.
+	for _, part := range partitionMessageHashes(unknownHashes, hashFirstMaxHashesPerRequest) {
+		if err := ctx.Err(); err != nil {
+			return stats, err
+		}
+
+		hashBytes := make([][]byte, 0, len(part))
+		for _, h := range part {
+			hashBytes = append(hashBytes, h.Bytes())
+		}
+		bodyQuery := &storepb.StoreQueryRequest{
+			RequestId:       hex.EncodeToString(protocol.GenerateRequestID()),
+			IncludeData:     true,
+			MessageHashes:   hashBytes,
+			PaginationLimit: proto.Uint64(hashFirstMaxHashesPerRequest),
+		}
+
+		bodyResult, err := requestor.Query(ctx, storenode, bodyQuery)
+		if err != nil {
+			return stats, err
+		}
+		for {
+			if err := w.ingestBodyPage(bodyResult, processEnvelopes, &stats); err != nil {
+				return stats, err
+			}
+			if bodyResult.IsComplete() {
+				break
+			}
+			if err := ctx.Err(); err != nil {
+				return stats, err
+			}
+			if err := bodyResult.Next(ctx); err != nil {
+				return stats, err
+			}
+		}
+	}
+
+	return stats, nil
+}
+
+// ingestBodyPage feeds one page of fetched full-body envelopes into the normal ingest
+// path (OnNewEnvelopes, StoreMessageType) and accumulates fetched-body stats.
+func (w *Waku) ingestBodyPage(result commonapi.StoreRequestResult, processEnvelopes bool, stats *types.HashFirstStats) error {
+	for _, mkv := range result.Messages() {
+		if mkv.Message == nil {
+			continue
+		}
+		envelope := protocol.NewEnvelope(mkv.Message, mkv.Message.GetTimestamp(), mkv.GetPubsubTopic())
+		if err := w.OnNewEnvelopes(envelope, common.StoreMessageType, processEnvelopes); err != nil {
+			return err
+		}
+		stats.BodiesFetched++
+		stats.BytesEstimate += int64(proto.Size(mkv.Message))
+	}
+	return nil
+}

--- a/pkg/messaging/waku/hash_first_backfill.go
+++ b/pkg/messaging/waku/hash_first_backfill.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/libp2p/go-libp2p/core/peer"
+	"go.uber.org/zap"
 	"google.golang.org/protobuf/proto"
 
 	commonapi "github.com/waku-org/go-waku/waku/v2/api/common"
@@ -50,7 +51,21 @@ const (
 	// topics per request. The general (all-filters) history sync batches many more topics
 	// than the spectate path, so the metadata walk must chunk them (issue #21470-hf).
 	hashFirstMaxContentTopicsPerRequest = 10
+
+	// hashFirstIngestHighWater bounds how many fetched-but-not-yet-consumed envelopes
+	// (decrypted messages sitting in the per-filter stores awaiting the retrieve loop) the
+	// body fetch lets accumulate before pausing. Without this the fetch outruns the slow
+	// per-description consumer and the backlog balloons memory: at ~1.4MB per
+	// community-description envelope, letting the msgQueue fill to its 1024 cap is ~1.4GB.
+	// Capping the in-flight backlog here keeps the transient peak an order of magnitude
+	// lower while still pipelining fetch and ingest (issue #21470-hf).
+	hashFirstIngestHighWater = 128
 )
+
+// hashFirstBackpressurePoll is how often a paused body fetch re-checks the ingest backlog.
+// This is flow control, not a hot path, so a coarse interval keeps the poll cost negligible
+// while still resuming promptly once the consumer drains (issue #21470-hf).
+const hashFirstBackpressurePoll = 100 * time.Millisecond
 
 // hashFirstMaxWindow caps the duration of a single metadata store query. The classic
 // HistoryRetriever caps each query to 24h and walks a longer range backward (see
@@ -192,6 +207,39 @@ func planBodyFetch(unknown []wpb.MessageHash, skipBodies bool) (toFetch []wpb.Me
 	return unknown, 0
 }
 
+// waitForIngestCapacity blocks the body fetch until the ingest backlog reported by depth
+// drops below highWater, polling every poll. It returns immediately (paused=false) when
+// highWater <= 0 (disabled) or the backlog is already below it. While paused it honours
+// ctx cancellation, returning the ctx error so leave/background aborts promptly. This is
+// pure flow control: it holds no locks while sleeping, so the (separate) retrieve-loop and
+// decrypt goroutines keep draining the backlog and it always makes progress unless the
+// caller is cancelled (issue #21470-hf).
+func waitForIngestCapacity(ctx context.Context, depth func() int, highWater int, poll time.Duration) (paused bool, err error) {
+	if highWater <= 0 || depth() < highWater {
+		return false, nil
+	}
+	paused = true
+	for {
+		if err := ctx.Err(); err != nil {
+			return paused, err
+		}
+		select {
+		case <-ctx.Done():
+			return paused, ctx.Err()
+		case <-time.After(poll):
+		}
+		if depth() < highWater {
+			return paused, nil
+		}
+	}
+}
+
+// pendingIngestCount is the body-fetch backpressure signal: the number of decrypted
+// envelopes waiting in the filter stores for the retrieve loop to consume (issue #21470-hf).
+func (w *Waku) pendingIngestCount() int {
+	return w.filters.PendingMessageCount()
+}
+
 // ProcessMailserverBatchHashFirst backfills a store-node batch hash-first: it walks the
 // window pulling only message hashes+metadata, filters out envelopes already held
 // locally, then fetches full bodies only for the unknown hashes and feeds them into the
@@ -280,6 +328,20 @@ func (w *Waku) ProcessMailserverBatchHashFirst(
 			return stats, err
 		}
 		for {
+			// Backpressure: before enqueuing another page of (large) decrypted bodies,
+			// wait for the ingest backlog to fall below the high-water mark so fetched
+			// envelopes cannot pile up faster than the slow per-description consumer
+			// drains them (issue #21470-hf).
+			paused, err := waitForIngestCapacity(ctx, w.pendingIngestCount, hashFirstIngestHighWater, hashFirstBackpressurePoll)
+			if err != nil {
+				return stats, err
+			}
+			if paused {
+				stats.BodyFetchThrottled++
+				w.logger.Debug("hash-first body fetch throttled: ingest backlog above high-water",
+					zap.Int("highWater", hashFirstIngestHighWater),
+					zap.Int("pending", w.pendingIngestCount()))
+			}
 			if err := w.ingestBodyPage(bodyResult, processEnvelopes, &stats); err != nil {
 				return stats, err
 			}

--- a/pkg/messaging/waku/hash_first_backfill.go
+++ b/pkg/messaging/waku/hash_first_backfill.go
@@ -91,6 +91,18 @@ func filterUnknownHashes(hashes []wpb.MessageHash, exists func(wpb.MessageHash) 
 	return unknown, known, nil
 }
 
+// planBodyFetch decides which unknown-hash bodies to actually fetch. When skipBodies is
+// set (keyless spectator with a resolved description — every body here is undecryptable),
+// nothing is fetched and all unknowns are counted as skipped; the hashes were still
+// walked, so the watermark advances and the skip is measurable. Otherwise every unknown
+// hash is fetched (issue #21470-hf enhancement).
+func planBodyFetch(unknown []wpb.MessageHash, skipBodies bool) (toFetch []wpb.MessageHash, skippedKeyless int) {
+	if skipBodies {
+		return nil, len(unknown)
+	}
+	return unknown, 0
+}
+
 // ProcessMailserverBatchHashFirst backfills a store-node batch hash-first: it walks the
 // window pulling only message hashes+metadata, filters out envelopes already held
 // locally, then fetches full bodies only for the unknown hashes and feeds them into the
@@ -106,6 +118,7 @@ func (w *Waku) ProcessMailserverBatchHashFirst(
 	batch types.MailserverBatch,
 	storenode peer.AddrInfo,
 	processEnvelopes bool,
+	skipBodies bool,
 ) (types.HashFirstStats, error) {
 	var stats types.HashFirstStats
 
@@ -165,9 +178,15 @@ func (w *Waku) ProcessMailserverBatchHashFirst(
 		return stats, err
 	}
 
+	// Keyless spectator with a resolved description: every remaining body on the shared
+	// community content topic is undecryptable, so skip the body fetch entirely (the
+	// hashes were still walked, so the watermark advances and the skip is measured).
+	toFetch, skippedKeyless := planBodyFetch(unknownHashes, skipBodies)
+	stats.BodiesSkippedKeyless += skippedKeyless
+
 	// Phase 2 — body fetch: pull full bodies ONLY for the unknown hashes, in store-capped
 	// batches, and feed them into the normal ingest path.
-	for _, part := range partitionMessageHashes(unknownHashes, hashFirstMaxHashesPerRequest) {
+	for _, part := range partitionMessageHashes(toFetch, hashFirstMaxHashesPerRequest) {
 		if err := ctx.Err(); err != nil {
 			return stats, err
 		}

--- a/pkg/messaging/waku/hash_first_backfill_test.go
+++ b/pkg/messaging/waku/hash_first_backfill_test.go
@@ -1,0 +1,131 @@
+package wakuv2
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	wpb "github.com/waku-org/go-waku/waku/v2/protocol/pb"
+
+	types "github.com/status-im/status-go/pkg/messaging/waku/types"
+)
+
+// hashN builds a distinct, deterministic message hash from n.
+func hashN(n byte) wpb.MessageHash {
+	var h wpb.MessageHash
+	h[0] = n
+	return h
+}
+
+func hashesN(ns ...byte) []wpb.MessageHash {
+	out := make([]wpb.MessageHash, 0, len(ns))
+	for _, n := range ns {
+		out = append(out, hashN(n))
+	}
+	return out
+}
+
+// TestPartitionMessageHashes covers the body-fetch batching limit: unknown hashes must
+// be split into store queries of at most maxPerRequest keys (issue #21470-hf). The
+// verifier caps this at maxMsgHashesPerRequest; exceeding it would have the store node
+// reject or truncate the query.
+func TestPartitionMessageHashes(t *testing.T) {
+	require.Equal(t, hashFirstMaxHashesPerRequest, 50, "must mirror the verifier's per-request cap")
+
+	// empty -> no batches (nothing to fetch)
+	require.Empty(t, partitionMessageHashes(nil, 50))
+	require.Empty(t, partitionMessageHashes([]wpb.MessageHash{}, 50))
+
+	// fewer than the cap -> a single batch
+	got := partitionMessageHashes(hashesN(1, 2, 3), 50)
+	require.Len(t, got, 1)
+	require.Equal(t, hashesN(1, 2, 3), got[0])
+
+	// exactly the cap -> a single full batch
+	got = partitionMessageHashes(hashesN(1, 2, 3, 4), 4)
+	require.Len(t, got, 1)
+	require.Len(t, got[0], 4)
+
+	// one over the cap -> two batches, remainder in the second
+	got = partitionMessageHashes(hashesN(1, 2, 3, 4, 5), 4)
+	require.Len(t, got, 2)
+	require.Equal(t, hashesN(1, 2, 3, 4), got[0])
+	require.Equal(t, hashesN(5), got[1])
+
+	// several full batches plus a remainder
+	got = partitionMessageHashes(hashesN(1, 2, 3, 4, 5, 6, 7), 3)
+	require.Len(t, got, 3)
+	require.Equal(t, hashesN(1, 2, 3), got[0])
+	require.Equal(t, hashesN(4, 5, 6), got[1])
+	require.Equal(t, hashesN(7), got[2])
+
+	// defensive: a non-positive cap must not divide-by-zero or loop forever; one batch
+	require.Len(t, partitionMessageHashes(hashesN(1, 2), 0), 1)
+	require.Len(t, partitionMessageHashes(hashesN(1, 2), -1), 1)
+}
+
+// TestFilterUnknownHashes covers known-hash filtering: bodies are fetched ONLY for
+// hashes not already held locally, so a hash the node already processed must be dropped
+// (issue #21470-hf). This is what turns off the redundant re-download of the
+// heartbeat-republished community description.
+func TestFilterUnknownHashes(t *testing.T) {
+	// known set: hashes 2 and 4 are already held locally
+	knownSet := map[wpb.MessageHash]bool{hashN(2): true, hashN(4): true}
+	exists := func(h wpb.MessageHash) (bool, error) { return knownSet[h], nil }
+
+	// mixed: 1,3,5 unknown (kept, in order); 2,4 known (dropped, counted)
+	unknown, known, err := filterUnknownHashes(hashesN(1, 2, 3, 4, 5), exists)
+	require.NoError(t, err)
+	require.Equal(t, hashesN(1, 3, 5), unknown)
+	require.Equal(t, 2, known)
+
+	// all known -> nothing to fetch
+	unknown, known, err = filterUnknownHashes(hashesN(2, 4), exists)
+	require.NoError(t, err)
+	require.Empty(t, unknown)
+	require.Equal(t, 2, known)
+
+	// all unknown -> all fetched
+	unknown, known, err = filterUnknownHashes(hashesN(7, 8, 9), exists)
+	require.NoError(t, err)
+	require.Equal(t, hashesN(7, 8, 9), unknown)
+	require.Equal(t, 0, known)
+}
+
+// TestFilterUnknownHashes_Dedup verifies a hash repeated in the input is fetched at most
+// once (the store node can return the same hash across pages; fetching its 1.4MB body
+// twice is exactly the waste we are removing).
+func TestFilterUnknownHashes_Dedup(t *testing.T) {
+	exists := func(wpb.MessageHash) (bool, error) { return false, nil }
+
+	unknown, known, err := filterUnknownHashes(hashesN(1, 1, 2, 1, 2), exists)
+	require.NoError(t, err)
+	require.Equal(t, hashesN(1, 2), unknown, "each distinct unknown hash fetched once, first-seen order")
+	require.Equal(t, 0, known)
+}
+
+// TestFilterUnknownHashes_ExistsError verifies an existence-check error aborts (we must
+// not silently treat an unreadable local state as "unknown" and refetch everything).
+func TestFilterUnknownHashes_ExistsError(t *testing.T) {
+	boom := errors.New("boom")
+	exists := func(wpb.MessageHash) (bool, error) { return false, boom }
+
+	_, _, err := filterUnknownHashes(hashesN(1), exists)
+	require.ErrorIs(t, err, boom)
+}
+
+// TestHashFirstStatsAdd covers the window bookkeeping: a backfill spans several batches,
+// and the once-per-backfill INFO log needs their sum (issue #21470-hf).
+func TestHashFirstStatsAdd(t *testing.T) {
+	var total types.HashFirstStats
+	total.Add(types.HashFirstStats{HashesSeen: 100, HashesKnown: 90, BodiesFetched: 10, BytesEstimate: 1000})
+	total.Add(types.HashFirstStats{HashesSeen: 40, HashesKnown: 39, BodiesFetched: 1, BytesEstimate: 1400})
+
+	require.Equal(t, types.HashFirstStats{
+		HashesSeen:    140,
+		HashesKnown:   129,
+		BodiesFetched: 11,
+		BytesEstimate: 2400,
+	}, total)
+}

--- a/pkg/messaging/waku/hash_first_backfill_test.go
+++ b/pkg/messaging/waku/hash_first_backfill_test.go
@@ -115,17 +115,41 @@ func TestFilterUnknownHashes_ExistsError(t *testing.T) {
 	require.ErrorIs(t, err, boom)
 }
 
+// TestPlanBodyFetch covers the keyless body-skip decision (issue #21470-hf
+// enhancement): a keyless spectator whose community description is already resolved must
+// fetch NO bodies (every body on the shared community topic is an undecryptable channel
+// message or a description already held), while a keyed user fetches everything.
+func TestPlanBodyFetch(t *testing.T) {
+	unknown := hashesN(1, 2, 3)
+
+	// skip: fetch nothing, count all as keyless-skipped
+	toFetch, skipped := planBodyFetch(unknown, true)
+	require.Empty(t, toFetch, "keyless + resolved description fetches no bodies")
+	require.Equal(t, 3, skipped)
+
+	// no-skip: fetch everything, skip nothing
+	toFetch, skipped = planBodyFetch(unknown, false)
+	require.Equal(t, unknown, toFetch)
+	require.Equal(t, 0, skipped)
+
+	// skip with nothing unknown: no bodies, no skips
+	toFetch, skipped = planBodyFetch(nil, true)
+	require.Empty(t, toFetch)
+	require.Equal(t, 0, skipped)
+}
+
 // TestHashFirstStatsAdd covers the window bookkeeping: a backfill spans several batches,
 // and the once-per-backfill INFO log needs their sum (issue #21470-hf).
 func TestHashFirstStatsAdd(t *testing.T) {
 	var total types.HashFirstStats
-	total.Add(types.HashFirstStats{HashesSeen: 100, HashesKnown: 90, BodiesFetched: 10, BytesEstimate: 1000})
-	total.Add(types.HashFirstStats{HashesSeen: 40, HashesKnown: 39, BodiesFetched: 1, BytesEstimate: 1400})
+	total.Add(types.HashFirstStats{HashesSeen: 100, HashesKnown: 90, BodiesFetched: 10, BytesEstimate: 1000, BodiesSkippedKeyless: 0})
+	total.Add(types.HashFirstStats{HashesSeen: 40, HashesKnown: 9, BodiesFetched: 0, BytesEstimate: 0, BodiesSkippedKeyless: 31})
 
 	require.Equal(t, types.HashFirstStats{
-		HashesSeen:    140,
-		HashesKnown:   129,
-		BodiesFetched: 11,
-		BytesEstimate: 2400,
+		HashesSeen:           140,
+		HashesKnown:          99,
+		BodiesFetched:        10,
+		BytesEstimate:        1000,
+		BodiesSkippedKeyless: 31,
 	}, total)
 }

--- a/pkg/messaging/waku/hash_first_backfill_test.go
+++ b/pkg/messaging/waku/hash_first_backfill_test.go
@@ -1,6 +1,7 @@
 package wakuv2
 
 import (
+	"context"
 	"errors"
 	"testing"
 	"time"
@@ -11,6 +12,50 @@ import (
 
 	types "github.com/status-im/status-go/pkg/messaging/waku/types"
 )
+
+// TestWaitForIngestCapacity covers the pure flow-control decision that backpressures the
+// hash-first body fetch against the ingest backlog (issue #21470-hf): it does not pause
+// when disabled or below the high-water mark, pauses until the backlog drains, and honours
+// context cancellation while paused.
+func TestWaitForIngestCapacity(t *testing.T) {
+	const poll = time.Millisecond
+
+	t.Run("disabled high-water never pauses", func(t *testing.T) {
+		paused, err := waitForIngestCapacity(context.Background(), func() int { return 10000 }, 0, poll)
+		require.NoError(t, err)
+		require.False(t, paused)
+	})
+
+	t.Run("below high-water does not pause", func(t *testing.T) {
+		paused, err := waitForIngestCapacity(context.Background(), func() int { return 10 }, 100, poll)
+		require.NoError(t, err)
+		require.False(t, paused)
+	})
+
+	t.Run("pauses until the backlog drains", func(t *testing.T) {
+		depth := 145
+		calls := 0
+		depthFn := func() int {
+			calls++
+			d := depth
+			depth -= 20 // consumer drains ~20 per poll
+			return d
+		}
+		paused, err := waitForIngestCapacity(context.Background(), depthFn, 100, poll)
+		require.NoError(t, err)
+		require.True(t, paused)
+		// Initial over-threshold check + at least one re-check after a poll.
+		require.GreaterOrEqual(t, calls, 2)
+	})
+
+	t.Run("respects context cancellation while paused", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		paused, err := waitForIngestCapacity(ctx, func() int { return 10000 }, 100, poll)
+		require.ErrorIs(t, err, context.Canceled)
+		require.True(t, paused)
+	})
+}
 
 // hashN builds a distinct, deterministic message hash from n.
 func hashN(n byte) wpb.MessageHash {

--- a/pkg/messaging/waku/hash_first_backfill_test.go
+++ b/pkg/messaging/waku/hash_first_backfill_test.go
@@ -115,6 +115,21 @@ func TestFilterUnknownHashes_ExistsError(t *testing.T) {
 	require.ErrorIs(t, err, boom)
 }
 
+// TestBuildMetadataQuery covers the two behavioral contracts of the hash-walk query
+// (issue #21470-hf): it must request NO bodies (the whole point — metadata only) and it
+// must page NEWEST-FIRST so bodies are fetched most-recent-first.
+func TestBuildMetadataQuery(t *testing.T) {
+	q := buildMetadataQuery("req-1", "pub-a", []string{"0x01", "0x02"}, 1000, 2000)
+
+	require.False(t, q.IncludeData, "metadata walk must NOT fetch bodies")
+	require.False(t, q.PaginationForward, "must page newest-first so bodies are fetched most-recent-first")
+	require.Equal(t, uint64(hashFirstMetadataPageSize), q.GetPaginationLimit())
+	require.Equal(t, "pub-a", q.GetPubsubTopic())
+	require.Equal(t, []string{"0x01", "0x02"}, q.ContentTopics)
+	require.Equal(t, int64(1000), q.GetTimeStart())
+	require.Equal(t, int64(2000), q.GetTimeEnd())
+}
+
 // TestPlanBodyFetch covers the keyless body-skip decision (issue #21470-hf
 // enhancement): a keyless spectator whose community description is already resolved must
 // fetch NO bodies (every body on the shared community topic is an undecryptable channel

--- a/pkg/messaging/waku/hash_first_backfill_test.go
+++ b/pkg/messaging/waku/hash_first_backfill_test.go
@@ -3,6 +3,7 @@ package wakuv2
 import (
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
@@ -63,6 +64,102 @@ func TestPartitionMessageHashes(t *testing.T) {
 	// defensive: a non-positive cap must not divide-by-zero or loop forever; one batch
 	require.Len(t, partitionMessageHashes(hashesN(1, 2), 0), 1)
 	require.Len(t, partitionMessageHashes(hashesN(1, 2), -1), 1)
+}
+
+// TestPartitionContentTopics covers the metadata-query topic chunking that generalizes
+// the hash-first walk to the general (all-filters) history sync (issue #21470-hf): the
+// global sync batches MANY content topics, and a single store query may carry at most
+// maxContentTopicsPerRequest (mirrors the classic HistoryRetriever's maxTopicsPerRequest
+// and the verifier's maxContentTopicsPerRequest). Chunking wrong would have the store node
+// reject or silently truncate the query, dropping whole topics from the walk.
+func TestPartitionContentTopics(t *testing.T) {
+	require.Equal(t, 10, hashFirstMaxContentTopicsPerRequest,
+		"must mirror the classic HistoryRetriever maxTopicsPerRequest / verifier maxContentTopicsPerRequest")
+
+	// empty -> no chunks
+	require.Empty(t, partitionContentTopics(nil, 10))
+	require.Empty(t, partitionContentTopics([]string{}, 10))
+
+	// fewer than the cap -> a single chunk, order preserved
+	got := partitionContentTopics([]string{"a", "b", "c"}, 10)
+	require.Len(t, got, 1)
+	require.Equal(t, []string{"a", "b", "c"}, got[0])
+
+	// exactly the cap -> a single full chunk
+	got = partitionContentTopics([]string{"a", "b", "c", "d"}, 4)
+	require.Len(t, got, 1)
+	require.Len(t, got[0], 4)
+
+	// one over the cap -> two chunks, remainder in the second
+	got = partitionContentTopics([]string{"a", "b", "c", "d", "e"}, 4)
+	require.Len(t, got, 2)
+	require.Equal(t, []string{"a", "b", "c", "d"}, got[0])
+	require.Equal(t, []string{"e"}, got[1])
+
+	// several full chunks plus a remainder
+	got = partitionContentTopics([]string{"a", "b", "c", "d", "e", "f", "g"}, 3)
+	require.Len(t, got, 3)
+	require.Equal(t, []string{"a", "b", "c"}, got[0])
+	require.Equal(t, []string{"d", "e", "f"}, got[1])
+	require.Equal(t, []string{"g"}, got[2])
+
+	// defensive: a non-positive cap must not divide-by-zero or loop forever; one chunk
+	require.Len(t, partitionContentTopics([]string{"a", "b"}, 0), 1)
+	require.Len(t, partitionContentTopics([]string{"a", "b"}, -1), 1)
+}
+
+// TestSplitWindowNewestFirst covers the multi-day window walk that generalizes the
+// hash-first backfill to the general history sync (issue #21470-hf). The general path can
+// span up to the ~9-day default sync period, but the classic HistoryRetriever caps each
+// store query to 24h and walks the range backward (see history.go's exceeds24h handling);
+// a single metadata query over a multi-day range would silently cover only the newest 24h
+// while the watermark still advances to `to`, losing the older days. So the metadata walk
+// must be split into consecutive <=24h sub-windows, ordered NEWEST-FIRST so bodies are
+// fetched most-recent-first (matching aa9fa29b5).
+func TestSplitWindowNewestFirst(t *testing.T) {
+	const day = int64(24 * time.Hour)
+
+	// empty / inverted range -> no windows
+	require.Empty(t, splitWindowNewestFirst(1000, 1000, day))
+	require.Empty(t, splitWindowNewestFirst(2000, 1000, day))
+
+	// range <= maxWindow -> a single window equal to the input
+	got := splitWindowNewestFirst(0, day, day)
+	require.Equal(t, []hashFirstTimeWindow{{fromNano: 0, toNano: day}}, got)
+
+	// sub-window range -> a single window equal to the input
+	got = splitWindowNewestFirst(100, 500, day)
+	require.Equal(t, []hashFirstTimeWindow{{fromNano: 100, toNano: 500}}, got)
+
+	// exactly two days -> two full 24h windows, newest first, contiguous, no gaps/overlap
+	got = splitWindowNewestFirst(0, 2*day, day)
+	require.Equal(t, []hashFirstTimeWindow{
+		{fromNano: day, toNano: 2 * day},
+		{fromNano: 0, toNano: day},
+	}, got)
+
+	// nine-day default -> nine contiguous windows, newest-first, covering the whole range
+	got = splitWindowNewestFirst(0, 9*day, day)
+	require.Len(t, got, 9)
+	require.Equal(t, 9*day, got[0].toNano, "first window ends at `to` (newest)")
+	require.Equal(t, int64(0), got[len(got)-1].fromNano, "last window starts at `from` (oldest)")
+	for i := 0; i < len(got); i++ {
+		require.LessOrEqual(t, got[i].toNano-got[i].fromNano, day, "no window exceeds 24h")
+		if i > 0 {
+			require.Equal(t, got[i-1].fromNano, got[i].toNano, "windows are contiguous, no gap/overlap")
+		}
+	}
+
+	// partial trailing window -> oldest window is clamped to `from`, never before it
+	got = splitWindowNewestFirst(0, day+500, day)
+	require.Equal(t, []hashFirstTimeWindow{
+		{fromNano: 500, toNano: day + 500},
+		{fromNano: 0, toNano: 500},
+	}, got)
+
+	// defensive: a non-positive maxWindow must not loop forever; one window spanning the range
+	require.Equal(t, []hashFirstTimeWindow{{fromNano: 0, toNano: 2 * day}}, splitWindowNewestFirst(0, 2*day, 0))
+	require.Equal(t, []hashFirstTimeWindow{{fromNano: 0, toNano: 2 * day}}, splitWindowNewestFirst(0, 2*day, -1))
 }
 
 // TestFilterUnknownHashes covers known-hash filtering: bodies are fetched ONLY for

--- a/pkg/messaging/waku/types/waku.go
+++ b/pkg/messaging/waku/types/waku.go
@@ -234,6 +234,7 @@ type Waku interface {
 		batch MailserverBatch,
 		storenode peer.AddrInfo,
 		processEnvelopes bool,
+		skipBodies bool,
 	) (HashFirstStats, error)
 
 	// IsStorenodeAvailable is used to determine whether a storenode is available or not
@@ -263,6 +264,10 @@ type HashFirstStats struct {
 	HashesKnown   int
 	BodiesFetched int
 	BytesEstimate int64
+	// BodiesSkippedKeyless counts unknown-hash bodies NOT fetched because the node holds
+	// no decryption keys for the community and its description is already resolved, so
+	// every such body is an undecryptable channel message (issue #21470-hf enhancement).
+	BodiesSkippedKeyless int
 }
 
 // Add accumulates another batch's stats into s, so a multi-batch backfill can be
@@ -272,4 +277,5 @@ func (s *HashFirstStats) Add(o HashFirstStats) {
 	s.HashesKnown += o.HashesKnown
 	s.BodiesFetched += o.BodiesFetched
 	s.BytesEstimate += o.BytesEstimate
+	s.BodiesSkippedKeyless += o.BodiesSkippedKeyless
 }

--- a/pkg/messaging/waku/types/waku.go
+++ b/pkg/messaging/waku/types/waku.go
@@ -268,6 +268,11 @@ type HashFirstStats struct {
 	// no decryption keys for the community and its description is already resolved, so
 	// every such body is an undecryptable channel message (issue #21470-hf enhancement).
 	BodiesSkippedKeyless int
+	// BodyFetchThrottled counts how many times the body fetch PAUSED because the ingest
+	// backlog (decrypted envelopes awaiting the retrieve loop) was above the high-water
+	// mark — the flow control that keeps the fetch from ballooning memory ahead of the
+	// slow consumer (issue #21470-hf). Counts pause events, not envelopes.
+	BodyFetchThrottled int
 }
 
 // Add accumulates another batch's stats into s, so a multi-batch backfill can be
@@ -278,4 +283,5 @@ func (s *HashFirstStats) Add(o HashFirstStats) {
 	s.BodiesFetched += o.BodiesFetched
 	s.BytesEstimate += o.BytesEstimate
 	s.BodiesSkippedKeyless += o.BodiesSkippedKeyless
+	s.BodyFetchThrottled += o.BodyFetchThrottled
 }

--- a/pkg/messaging/waku/types/waku.go
+++ b/pkg/messaging/waku/types/waku.go
@@ -225,6 +225,17 @@ type Waku interface {
 		processEnvelopes bool,
 	) error
 
+	// ProcessMailserverBatchHashFirst runs a hash-first backfill of the batch: it pulls
+	// only the window's message hashes, then fetches full bodies solely for hashes not
+	// already held locally, ingesting them exactly as ProcessMailserverBatch does. It
+	// returns per-batch stats (issue #21470-hf).
+	ProcessMailserverBatchHashFirst(
+		ctx context.Context,
+		batch MailserverBatch,
+		storenode peer.AddrInfo,
+		processEnvelopes bool,
+	) (HashFirstStats, error)
+
 	// IsStorenodeAvailable is used to determine whether a storenode is available or not
 	IsStorenodeAvailable(peerID peer.ID) bool
 
@@ -240,4 +251,25 @@ type MailserverBatch struct {
 	PubsubTopic string
 	Topics      []TopicType
 	ChatIDs     []string
+}
+
+// HashFirstStats reports what a single hash-first store-node backfill did (issue
+// #21470-hf): how many message hashes the metadata-only page walk saw, how many were
+// already known locally (so their bodies were skipped), how many bodies were actually
+// fetched, and an estimate of the fetched body bytes. It is the evidence used to
+// verify the byte cut on device.
+type HashFirstStats struct {
+	HashesSeen    int
+	HashesKnown   int
+	BodiesFetched int
+	BytesEstimate int64
+}
+
+// Add accumulates another batch's stats into s, so a multi-batch backfill can be
+// summarised in a single log line.
+func (s *HashFirstStats) Add(o HashFirstStats) {
+	s.HashesSeen += o.HashesSeen
+	s.HashesKnown += o.HashesKnown
+	s.BodiesFetched += o.BodiesFetched
+	s.BytesEstimate += o.BytesEstimate
 }

--- a/protocol/communities/community_description_gate.go
+++ b/protocol/communities/community_description_gate.go
@@ -1,0 +1,114 @@
+package communities
+
+import (
+	"crypto/sha256"
+	"sync"
+)
+
+// descriptionGateEntry records, for one community, the last community description
+// this node FULLY processed: its clock and a content hash of the raw description
+// payload bytes that were handled.
+type descriptionGateEntry struct {
+	clock       uint64
+	contentHash [32]byte
+}
+
+// communityDescriptionGate short-circuits the expensive per-description pipeline
+// for redelivered community descriptions that cannot change local state
+// (issue #21470-hf).
+//
+// status-go re-publishes each community description into every fetch/spectate
+// window, so the same byte-identical ~1.4MB blob is handed to
+// Manager.HandleCommunityDescriptionMessage hundreds of times over a long history
+// sync. Each of those calls otherwise pays, before any clock comparison:
+// proto.Unmarshal of the blob, GetDecryptedCommunityDescription (read) +
+// SaveDecryptedCommunityDescription (write) in preprocessDescription, and GetByID,
+// which re-reads and re-unmarshals the stored community blob — ~10s of CPU per
+// redelivered copy.
+//
+// The gate remembers, per community, the clock+content-hash of the last
+// description that was fully processed, and lets the handler return early for:
+//   - strictly-older clocks (can never win the downstream clock comparison in
+//     Community.UpdateCommunityDescription, which rejects them as outdated), and
+//   - the byte-identical same-clock redelivery (a guaranteed no-op).
+//
+// It deliberately does NOT gate a same-clock description whose content differs:
+// Community.UpdateCommunityDescription intentionally reprocesses identical clocks
+// so a previously-encrypted description can be re-evaluated once the decryption key
+// arrives. For that same reason the gate is cleared when new hash-ratchet keys
+// arrive (Manager.NewHashRatchetKeys) and when a community is deleted
+// (Manager.DeleteCommunity), so those legitimate reprocessing paths are never
+// starved.
+//
+// A community that has only ever been QUEUED for owner validation (never fully
+// processed) has no gate entry, so validateCommunity's re-entry into the handler
+// is never blocked. The gate fails OPEN: any state it does not positively know to
+// be a redelivery proceeds to full processing.
+type communityDescriptionGate struct {
+	mu      sync.Mutex
+	entries map[string]descriptionGateEntry // communityID(hex) -> last processed
+}
+
+func newCommunityDescriptionGate() *communityDescriptionGate {
+	return &communityDescriptionGate{
+		entries: make(map[string]descriptionGateEntry),
+	}
+}
+
+// hashDescriptionPayload returns a content hash of the raw community description
+// payload bytes. SHA-256 makes a collision astronomically unlikely, so a matching
+// (clock, hash) pair is safely treated as a byte-identical redelivery.
+func hashDescriptionPayload(payload []byte) [32]byte {
+	return sha256.Sum256(payload)
+}
+
+// shouldSkip reports whether a description with the given clock and content hash
+// can be skipped because it can neither advance nor change local state. It returns
+// true only for a strictly-older clock, or an equal clock whose content hash matches
+// the last fully-processed description for this community. Everything else (unknown
+// community, newer clock, equal clock with different content) returns false so the
+// handler proceeds.
+func (g *communityDescriptionGate) shouldSkip(id string, clock uint64, hash [32]byte) bool {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	entry, ok := g.entries[id]
+	if !ok {
+		return false
+	}
+	if clock < entry.clock {
+		return true
+	}
+	if clock == entry.clock && hash == entry.contentHash {
+		return true
+	}
+	return false
+}
+
+// recordProcessed advances the gate for a community after a description was fully
+// and successfully processed. It only ever moves the recorded clock forward, so an
+// out-of-order older success can never shadow a newer one.
+func (g *communityDescriptionGate) recordProcessed(id string, clock uint64, hash [32]byte) {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	if entry, ok := g.entries[id]; ok && clock < entry.clock {
+		return
+	}
+	g.entries[id] = descriptionGateEntry{clock: clock, contentHash: hash}
+}
+
+// forget drops the gate entry for a single community so its next description is
+// fully reprocessed. Called when the community is deleted.
+func (g *communityDescriptionGate) forget(id string) {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	delete(g.entries, id)
+}
+
+// forgetAll clears every gate entry. Called when new hash-ratchet key material
+// arrives (which may be community- or channel-scoped) so every community's next
+// description is reprocessed and can decrypt now-available private data.
+func (g *communityDescriptionGate) forgetAll() {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	g.entries = make(map[string]descriptionGateEntry)
+}

--- a/protocol/communities/community_description_gate.go
+++ b/protocol/communities/community_description_gate.go
@@ -32,11 +32,14 @@ type descriptionGateEntry struct {
 //     Community.UpdateCommunityDescription, which rejects them as outdated), and
 //   - the byte-identical same-clock redelivery (a guaranteed no-op).
 //
-// It deliberately does NOT gate a same-clock description whose content differs:
-// Community.UpdateCommunityDescription intentionally reprocesses identical clocks
-// so a previously-encrypted description can be re-evaluated once the decryption key
-// arrives. For that same reason the gate is cleared when new hash-ratchet keys
-// arrive (Manager.NewHashRatchetKeys) and when a community is deleted
+// For a KEYS-HELD community it deliberately does NOT gate a same-clock description
+// whose content differs: Community.UpdateCommunityDescription intentionally
+// reprocesses identical clocks so a previously-encrypted description can be
+// re-evaluated once the decryption key arrives. For a KEYLESS spectator that
+// exception is dropped — an equal-clock re-encrypted republish is useless to a node
+// with no keys, so it is skipped regardless of content (see shouldSkip). For both
+// cases the gate is cleared when new hash-ratchet keys arrive
+// (Manager.NewHashRatchetKeys) and when a community is deleted
 // (Manager.DeleteCommunity), so those legitimate reprocessing paths are never
 // starved.
 //
@@ -63,12 +66,31 @@ func hashDescriptionPayload(payload []byte) [32]byte {
 }
 
 // shouldSkip reports whether a description with the given clock and content hash
-// can be skipped because it can neither advance nor change local state. It returns
-// true only for a strictly-older clock, or an equal clock whose content hash matches
-// the last fully-processed description for this community. Everything else (unknown
-// community, newer clock, equal clock with different content) returns false so the
-// handler proceeds.
-func (g *communityDescriptionGate) shouldSkip(id string, clock uint64, hash [32]byte) bool {
+// can be skipped because it can neither advance nor change local state. holdsKeys
+// says whether this node holds ANY hash-ratchet decryption key for the community;
+// it must be fail-open (true) on any entitlement-lookup error so a transient DB
+// issue never turns into a dropped description.
+//
+// A strictly-older clock is always skippable (it can never win the downstream clock
+// comparison in Community.UpdateCommunityDescription). For an EQUAL clock the rule
+// depends on whether keys are held:
+//
+//   - keys held (member, or fail-open): skip only the byte-identical redelivery.
+//     A same-clock description with DIFFERENT content still proceeds, because
+//     community.go intentionally reprocesses identical clocks so a previously
+//     encrypted description is re-evaluated once the decryption key arrives — the
+//     member key-rotation path. This preserves the pre-refinement behaviour exactly.
+//
+//   - keyless (spectator): skip an equal-clock description REGARDLESS of content
+//     hash. status-go re-encrypts each logical description version ~40 times, so a
+//     keyless node is handed the same clock with different payload bytes over and
+//     over; it can gain nothing from a re-encrypted copy (its encrypted inner fields
+//     are skipped anyway, and key ARRIVAL lifts the whole gate via forgetAll), so
+//     reprocessing only burns CPU. Issue #21470-hf.
+//
+// Everything else (unknown community, newer clock) returns false so the handler
+// proceeds.
+func (g *communityDescriptionGate) shouldSkip(id string, clock uint64, hash [32]byte, holdsKeys bool) bool {
 	g.mu.Lock()
 	defer g.mu.Unlock()
 	entry, ok := g.entries[id]
@@ -78,8 +100,11 @@ func (g *communityDescriptionGate) shouldSkip(id string, clock uint64, hash [32]
 	if clock < entry.clock {
 		return true
 	}
-	if clock == entry.clock && hash == entry.contentHash {
-		return true
+	if clock == entry.clock {
+		if !holdsKeys {
+			return true
+		}
+		return hash == entry.contentHash
 	}
 	return false
 }

--- a/protocol/communities/community_description_gate_test.go
+++ b/protocol/communities/community_description_gate_test.go
@@ -10,11 +10,20 @@ func hashOf(b []byte) [32]byte {
 	return hashDescriptionPayload(b)
 }
 
+// keysHeld/keyless make the holdsKeys argument to shouldSkip read as intent at
+// the call site.
+const (
+	keysHeld = true
+	keyless  = false
+)
+
 // TestDescriptionGateTruthTable exercises the redelivery gate decision across the
-// whole truth table (issue #21470-hf): unknown community, strictly-older clock,
-// byte-identical same-clock redelivery, same-clock-different-content, and a newer
-// clock. Only a strictly-older clock or a byte-identical same-clock redelivery may
-// be skipped; everything else must proceed to full processing.
+// whole truth table (issue #21470-hf) for a KEYS-HELD community (member): unknown
+// community, strictly-older clock, byte-identical same-clock redelivery,
+// same-clock-different-content, and a newer clock. Only a strictly-older clock or a
+// byte-identical same-clock redelivery may be skipped; everything else must proceed
+// to full processing. The same-clock-different-content rule is what keeps key
+// rotation working for members, so it must survive.
 func TestDescriptionGateTruthTable(t *testing.T) {
 	const id = "0xcommunity"
 	payloadA := []byte("description-bytes-A")
@@ -28,28 +37,81 @@ func TestDescriptionGateTruthTable(t *testing.T) {
 	// also the queued-validation guarantee: a community that has only ever been
 	// queued (never fully processed) has no gate entry, so validateCommunity's
 	// re-entry is never blocked.
-	require.False(t, g.shouldSkip(id, 10, hashA), "unknown community must proceed")
+	require.False(t, g.shouldSkip(id, 10, hashA, keysHeld), "unknown community must proceed")
 
 	// Record clock 10 / content A as fully processed.
 	g.recordProcessed(id, 10, hashA)
 
 	// Byte-identical same-clock redelivery: skip.
-	require.True(t, g.shouldSkip(id, 10, hashA), "byte-identical same-clock redelivery must skip")
+	require.True(t, g.shouldSkip(id, 10, hashA, keysHeld), "byte-identical same-clock redelivery must skip")
 
 	// Same clock, different content: MUST proceed (community.go intentionally
 	// reprocesses identical clocks so a previously-encrypted description can be
-	// re-evaluated once keys arrive).
-	require.False(t, g.shouldSkip(id, 10, hashB), "same-clock different-content must proceed")
+	// re-evaluated once keys arrive — this is the member key-rotation path).
+	require.False(t, g.shouldSkip(id, 10, hashB, keysHeld), "same-clock different-content must proceed for a keys-held community")
 
 	// Strictly-older clock: skip (can never win the downstream clock comparison).
-	require.True(t, g.shouldSkip(id, 9, hashA), "older clock must skip")
-	require.True(t, g.shouldSkip(id, 9, hashB), "older clock must skip regardless of content")
+	require.True(t, g.shouldSkip(id, 9, hashA, keysHeld), "older clock must skip")
+	require.True(t, g.shouldSkip(id, 9, hashB, keysHeld), "older clock must skip regardless of content")
 
 	// Newer clock: proceed.
-	require.False(t, g.shouldSkip(id, 11, hashA), "newer clock must proceed")
+	require.False(t, g.shouldSkip(id, 11, hashA, keysHeld), "newer clock must proceed")
 
 	// A different community is unaffected by this one's entry.
-	require.False(t, g.shouldSkip("0xother", 1, hashA), "other community must proceed")
+	require.False(t, g.shouldSkip("0xother", 1, hashA, keysHeld), "other community must proceed")
+}
+
+// TestDescriptionGateKeylessTruthTable exercises the gate for a KEYLESS spectator
+// (holds no decryption keys). status-go re-encrypts each logical description ~40
+// times per version, so a keyless node sees the same clock with DIFFERENT payload
+// bytes over and over. A keyless spectator can gain nothing from a re-encrypted
+// equal-clock copy (its encrypted inner fields are skipped anyway, and key ARRIVAL
+// is handled by forgetAll), so the gate must skip equal-clock republishes
+// REGARDLESS of content hash — the one behaviour that differs from a keys-held
+// community (issue #21470-hf).
+func TestDescriptionGateKeylessTruthTable(t *testing.T) {
+	const id = "0xcommunity"
+	hashA := hashOf([]byte("description-bytes-A"))
+	hashB := hashOf([]byte("description-bytes-B"))
+
+	g := newCommunityDescriptionGate()
+
+	// Unknown community: never skip, even keyless (nothing recorded yet).
+	require.False(t, g.shouldSkip(id, 10, hashA, keyless), "unknown community must proceed")
+
+	g.recordProcessed(id, 10, hashA)
+
+	// Equal clock, same content: skip (same as keys-held).
+	require.True(t, g.shouldSkip(id, 10, hashA, keyless), "keyless equal-clock same-content must skip")
+
+	// Equal clock, DIFFERENT content: skip — this is the refinement. A re-encrypted
+	// republish at the same clock is useless to a keyless spectator.
+	require.True(t, g.shouldSkip(id, 10, hashB, keyless), "keyless equal-clock different-content must skip")
+
+	// Strictly-older clock: skip regardless of content.
+	require.True(t, g.shouldSkip(id, 9, hashA, keyless), "keyless older clock must skip")
+	require.True(t, g.shouldSkip(id, 9, hashB, keyless), "keyless older clock must skip regardless of content")
+
+	// Newer clock: proceed — a genuinely newer description must always be processed.
+	require.False(t, g.shouldSkip(id, 11, hashA, keyless), "keyless newer clock must proceed")
+	require.False(t, g.shouldSkip(id, 11, hashB, keyless), "keyless newer clock must proceed regardless of content")
+}
+
+// TestDescriptionGateFailOpenTreatedAsKeysHeld documents that the fail-open case
+// (entitlement lookup errored, so the Manager reports holdsKeys=true) is exactly the
+// keys-held branch: an equal-clock DIFFERENT-content description still proceeds, so a
+// transient DB error can never make a keyless-style skip drop a description that a
+// member would have reprocessed.
+func TestDescriptionGateFailOpenTreatedAsKeysHeld(t *testing.T) {
+	const id = "0xcommunity"
+	hashA := hashOf([]byte("A"))
+	hashB := hashOf([]byte("B"))
+
+	g := newCommunityDescriptionGate()
+	g.recordProcessed(id, 10, hashA)
+
+	// holdsKeys=true is what communityHoldsAnyDecryptionKey returns on any error.
+	require.False(t, g.shouldSkip(id, 10, hashB, keysHeld), "fail-open (keys-held) equal-clock different-content must proceed")
 }
 
 // TestDescriptionGateRecordIsMonotonic verifies recordProcessed never moves the
@@ -63,9 +125,9 @@ func TestDescriptionGateRecordIsMonotonic(t *testing.T) {
 	g.recordProcessed(id, 20, hash)
 	g.recordProcessed(id, 5, hash) // stale, must not overwrite the newer record
 
-	require.True(t, g.shouldSkip(id, 20, hash), "recorded clock is still 20, identical redelivery skips")
-	require.False(t, g.shouldSkip(id, 21, hash), "a genuinely newer clock still proceeds")
-	require.True(t, g.shouldSkip(id, 4, hash), "older than recorded 20 skips")
+	require.True(t, g.shouldSkip(id, 20, hash, keysHeld), "recorded clock is still 20, identical redelivery skips")
+	require.False(t, g.shouldSkip(id, 21, hash, keysHeld), "a genuinely newer clock still proceeds")
+	require.True(t, g.shouldSkip(id, 4, hash, keysHeld), "older than recorded 20 skips")
 }
 
 // TestDescriptionGateForget verifies a single-community invalidation (community
@@ -76,10 +138,10 @@ func TestDescriptionGateForget(t *testing.T) {
 
 	g := newCommunityDescriptionGate()
 	g.recordProcessed(id, 10, hash)
-	require.True(t, g.shouldSkip(id, 10, hash))
+	require.True(t, g.shouldSkip(id, 10, hash, keysHeld))
 
 	g.forget(id)
-	require.False(t, g.shouldSkip(id, 10, hash), "after forget, identical redelivery reprocesses")
+	require.False(t, g.shouldSkip(id, 10, hash, keysHeld), "after forget, identical redelivery reprocesses")
 }
 
 // TestDescriptionGateForgetAll verifies key-arrival invalidation lifts the gate for
@@ -90,10 +152,10 @@ func TestDescriptionGateForgetAll(t *testing.T) {
 	g := newCommunityDescriptionGate()
 	g.recordProcessed("0xa", 10, hash)
 	g.recordProcessed("0xb", 10, hash)
-	require.True(t, g.shouldSkip("0xa", 10, hash))
-	require.True(t, g.shouldSkip("0xb", 10, hash))
+	require.True(t, g.shouldSkip("0xa", 10, hash, keysHeld))
+	require.True(t, g.shouldSkip("0xb", 10, hash, keysHeld))
 
 	g.forgetAll()
-	require.False(t, g.shouldSkip("0xa", 10, hash))
-	require.False(t, g.shouldSkip("0xb", 10, hash))
+	require.False(t, g.shouldSkip("0xa", 10, hash, keysHeld))
+	require.False(t, g.shouldSkip("0xb", 10, hash, keysHeld))
 }

--- a/protocol/communities/community_description_gate_test.go
+++ b/protocol/communities/community_description_gate_test.go
@@ -1,0 +1,99 @@
+package communities
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func hashOf(b []byte) [32]byte {
+	return hashDescriptionPayload(b)
+}
+
+// TestDescriptionGateTruthTable exercises the redelivery gate decision across the
+// whole truth table (issue #21470-hf): unknown community, strictly-older clock,
+// byte-identical same-clock redelivery, same-clock-different-content, and a newer
+// clock. Only a strictly-older clock or a byte-identical same-clock redelivery may
+// be skipped; everything else must proceed to full processing.
+func TestDescriptionGateTruthTable(t *testing.T) {
+	const id = "0xcommunity"
+	payloadA := []byte("description-bytes-A")
+	payloadB := []byte("description-bytes-B")
+	hashA := hashOf(payloadA)
+	hashB := hashOf(payloadB)
+
+	g := newCommunityDescriptionGate()
+
+	// Unknown community: never skip (fail open — nothing recorded yet). This is
+	// also the queued-validation guarantee: a community that has only ever been
+	// queued (never fully processed) has no gate entry, so validateCommunity's
+	// re-entry is never blocked.
+	require.False(t, g.shouldSkip(id, 10, hashA), "unknown community must proceed")
+
+	// Record clock 10 / content A as fully processed.
+	g.recordProcessed(id, 10, hashA)
+
+	// Byte-identical same-clock redelivery: skip.
+	require.True(t, g.shouldSkip(id, 10, hashA), "byte-identical same-clock redelivery must skip")
+
+	// Same clock, different content: MUST proceed (community.go intentionally
+	// reprocesses identical clocks so a previously-encrypted description can be
+	// re-evaluated once keys arrive).
+	require.False(t, g.shouldSkip(id, 10, hashB), "same-clock different-content must proceed")
+
+	// Strictly-older clock: skip (can never win the downstream clock comparison).
+	require.True(t, g.shouldSkip(id, 9, hashA), "older clock must skip")
+	require.True(t, g.shouldSkip(id, 9, hashB), "older clock must skip regardless of content")
+
+	// Newer clock: proceed.
+	require.False(t, g.shouldSkip(id, 11, hashA), "newer clock must proceed")
+
+	// A different community is unaffected by this one's entry.
+	require.False(t, g.shouldSkip("0xother", 1, hashA), "other community must proceed")
+}
+
+// TestDescriptionGateRecordIsMonotonic verifies recordProcessed never moves the
+// recorded clock backwards, so an out-of-order older success cannot shadow a newer
+// one and cause a newer redelivery to be wrongly skipped.
+func TestDescriptionGateRecordIsMonotonic(t *testing.T) {
+	const id = "0xcommunity"
+	hash := hashOf([]byte("x"))
+
+	g := newCommunityDescriptionGate()
+	g.recordProcessed(id, 20, hash)
+	g.recordProcessed(id, 5, hash) // stale, must not overwrite the newer record
+
+	require.True(t, g.shouldSkip(id, 20, hash), "recorded clock is still 20, identical redelivery skips")
+	require.False(t, g.shouldSkip(id, 21, hash), "a genuinely newer clock still proceeds")
+	require.True(t, g.shouldSkip(id, 4, hash), "older than recorded 20 skips")
+}
+
+// TestDescriptionGateForget verifies a single-community invalidation (community
+// delete) forces the next description to be fully reprocessed.
+func TestDescriptionGateForget(t *testing.T) {
+	const id = "0xcommunity"
+	hash := hashOf([]byte("x"))
+
+	g := newCommunityDescriptionGate()
+	g.recordProcessed(id, 10, hash)
+	require.True(t, g.shouldSkip(id, 10, hash))
+
+	g.forget(id)
+	require.False(t, g.shouldSkip(id, 10, hash), "after forget, identical redelivery reprocesses")
+}
+
+// TestDescriptionGateForgetAll verifies key-arrival invalidation lifts the gate for
+// every community so a byte-identical description can be reprocessed and decrypt
+// now-available private data.
+func TestDescriptionGateForgetAll(t *testing.T) {
+	hash := hashOf([]byte("x"))
+	g := newCommunityDescriptionGate()
+	g.recordProcessed("0xa", 10, hash)
+	g.recordProcessed("0xb", 10, hash)
+	require.True(t, g.shouldSkip("0xa", 10, hash))
+	require.True(t, g.shouldSkip("0xb", 10, hash))
+
+	g.forgetAll()
+	require.False(t, g.shouldSkip("0xa", 10, hash))
+	require.False(t, g.shouldSkip("0xb", 10, hash))
+}

--- a/protocol/communities/community_key_entitlement.go
+++ b/protocol/communities/community_key_entitlement.go
@@ -1,0 +1,97 @@
+package communities
+
+import "sync"
+
+// dropLogInterval is how often (in gated descriptions) a per-community DEBUG
+// checkpoint is emitted after the initial INFO line.
+const dropLogInterval = 1000
+
+// communityKeyEntitlement caches, per community, whether this node holds ANY
+// hash-ratchet decryption key material for that community. A keyless (spectator)
+// node uses the cache to skip the per-key decryption attempts that a re-published
+// community description would otherwise trigger on every fetch — each of which is
+// a guaranteed "no ratchet key" failure (issue #21470). The cache is invalidated
+// when new keys are saved (Manager.NewHashRatchetKeys), so the gate lifts the
+// moment the node acquires keys.
+type communityKeyEntitlement struct {
+	mu      sync.Mutex
+	holds   map[string]bool   // communityID(hex) -> holds any decryption key
+	dropped map[string]uint64 // communityID(hex) -> count of gated descriptions
+	logged  map[string]bool   // communityID(hex) -> INFO already emitted this session
+}
+
+func newCommunityKeyEntitlement() *communityKeyEntitlement {
+	return &communityKeyEntitlement{
+		holds:   make(map[string]bool),
+		dropped: make(map[string]uint64),
+		logged:  make(map[string]bool),
+	}
+}
+
+// known reports the cached entitlement for id and whether it was cached at all.
+func (c *communityKeyEntitlement) known(id string) (holds bool, ok bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	holds, ok = c.holds[id]
+	return holds, ok
+}
+
+// remember stores the entitlement result for id.
+func (c *communityKeyEntitlement) remember(id string, holds bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.holds[id] = holds
+}
+
+// forget drops the cached entitlement for the given ids, forcing a fresh lookup.
+// Called when new keys are saved for a community so the gate re-evaluates and lifts.
+func (c *communityKeyEntitlement) forget(ids ...string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	for _, id := range ids {
+		delete(c.holds, id)
+	}
+}
+
+// forgetAll clears every cached entitlement. Called when new key material arrives
+// (which may be community- or channel-scoped) so all gates re-evaluate and lift.
+func (c *communityKeyEntitlement) forgetAll() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.holds = make(map[string]bool)
+}
+
+// dropLogDecision tells the caller what (if anything) to log for a gated description.
+type dropLogDecision struct {
+	logInfo  bool   // first drop for this community this session
+	logDebug bool   // periodic checkpoint (every dropLogInterval drops)
+	count    uint64 // total gated descriptions for this community this session
+}
+
+// recordDrop increments the gated-description counter for id and returns what to
+// log: an INFO line on the first drop of the session, then a DEBUG checkpoint
+// every dropLogInterval drops. Never logs per envelope.
+func (c *communityKeyEntitlement) recordDrop(id string) dropLogDecision {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.dropped[id]++
+	count := c.dropped[id]
+	d := dropLogDecision{count: count}
+	switch {
+	case !c.logged[id]:
+		c.logged[id] = true
+		d.logInfo = true
+	case count%dropLogInterval == 0:
+		d.logDebug = true
+	}
+	return d
+}
+
+// shouldSkipPrivateDataDecryption reports whether the per-key decryption attempts
+// over a community description's PrivateData should be skipped. They are skipped
+// only when there is encrypted private data to attempt AND the node holds no key
+// material for the community — i.e. a keyless spectator, for whom every attempt is
+// a guaranteed "no ratchet key" failure.
+func shouldSkipPrivateDataDecryption(hasPrivateData, holdsKeys bool) bool {
+	return hasPrivateData && !holdsKeys
+}

--- a/protocol/communities/community_key_entitlement_test.go
+++ b/protocol/communities/community_key_entitlement_test.go
@@ -1,0 +1,77 @@
+package communities
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestShouldSkipPrivateDataDecryption(t *testing.T) {
+	// Skip only when there is encrypted private data AND the node holds no keys.
+	require.True(t, shouldSkipPrivateDataDecryption(true, false), "keyless node with private data must skip")
+	require.False(t, shouldSkipPrivateDataDecryption(true, true), "node holding keys must attempt")
+	require.False(t, shouldSkipPrivateDataDecryption(false, false), "no private data means nothing to skip")
+	require.False(t, shouldSkipPrivateDataDecryption(false, true), "no private data means nothing to skip")
+}
+
+func TestCommunityKeyEntitlementCache(t *testing.T) {
+	c := newCommunityKeyEntitlement()
+
+	// Unknown until remembered.
+	_, ok := c.known("comm-a")
+	require.False(t, ok)
+
+	// Remembered values are returned.
+	c.remember("comm-a", false)
+	holds, ok := c.known("comm-a")
+	require.True(t, ok)
+	require.False(t, holds)
+
+	c.remember("comm-b", true)
+	holds, ok = c.known("comm-b")
+	require.True(t, ok)
+	require.True(t, holds)
+
+	// forget invalidates only the named id, forcing a fresh lookup (gate lift on key arrival).
+	c.forget("comm-a")
+	_, ok = c.known("comm-a")
+	require.False(t, ok)
+	_, ok = c.known("comm-b")
+	require.True(t, ok, "forget must not touch other communities")
+
+	// forgetAll clears every cached entitlement (used when any new key arrives).
+	c.remember("comm-a", false)
+	c.forgetAll()
+	_, ok = c.known("comm-a")
+	require.False(t, ok)
+	_, ok = c.known("comm-b")
+	require.False(t, ok)
+}
+
+func TestCommunityKeyEntitlementDropLogging(t *testing.T) {
+	c := newCommunityKeyEntitlement()
+
+	// First drop for a community => INFO, count 1.
+	d := c.recordDrop("comm-a")
+	require.True(t, d.logInfo)
+	require.False(t, d.logDebug)
+	require.Equal(t, uint64(1), d.count)
+
+	// Subsequent drops below the interval => silent, counting up.
+	for i := 2; i < dropLogInterval; i++ {
+		d = c.recordDrop("comm-a")
+		require.False(t, d.logInfo, "only the first drop logs INFO")
+		require.False(t, d.logDebug)
+	}
+
+	// Every dropLogInterval-th drop => DEBUG checkpoint, never a second INFO.
+	d = c.recordDrop("comm-a")
+	require.False(t, d.logInfo)
+	require.True(t, d.logDebug)
+	require.Equal(t, uint64(dropLogInterval), d.count)
+
+	// A different community gets its own first-drop INFO and independent count.
+	d = c.recordDrop("comm-b")
+	require.True(t, d.logInfo)
+	require.Equal(t, uint64(1), d.count)
+}

--- a/protocol/communities/manager.go
+++ b/protocol/communities/manager.go
@@ -1535,6 +1535,8 @@ func (m *Manager) DeleteCommunity(id types3.HexBytes) error {
 	if m.descriptionGate != nil {
 		m.descriptionGate.forget(id.String())
 	}
+	// Drop the cached community so a redelivery skip can never surface a deleted one.
+	m.cache.Delete(id.String())
 	return m.persistence.DeleteCommunitySettings(id)
 }
 
@@ -2099,7 +2101,14 @@ func (m *Manager) HandleCommunityDescriptionMessage(signer *ecdsa.PublicKey, des
 	// cleared when keys arrive or a community is deleted (see communityDescriptionGate).
 	gateKey := types3.HexBytes(id).String()
 	payloadHash := hashDescriptionPayload(payload)
-	if m.descriptionGate != nil && m.descriptionGate.shouldSkip(gateKey, description.Clock, payloadHash) {
+	// holdsKeys drives the equal-clock gate rule: a keyless spectator skips ALL
+	// equal-clock republishes (status-go re-encrypts each version ~40 times, useless
+	// to a keyless node), while a keys-held community keeps the byte-identical-only
+	// rule so key rotation still reprocesses. communityHoldsAnyDecryptionKey is
+	// cached and fails open (reports true) on any lookup error, so an entitlement
+	// error degrades safely to the keys-held rule (#21470-hf).
+	holdsKeys := m.communityHoldsAnyDecryptionKey(id, description.Chats)
+	if m.descriptionGate != nil && m.descriptionGate.shouldSkip(gateKey, description.Clock, payloadHash, holdsKeys) {
 		// Skip the expensive pipeline (preprocessDescription's decrypted-cache
 		// read+write and handleCommunityDescriptionMessageCommon's ~1.4MB re-save),
 		// but still SURFACE the already-known community with empty changes. The
@@ -2109,10 +2118,7 @@ func (m *Manager) HandleCommunityDescriptionMessage(signer *ecdsa.PublicKey, des
 		// hide the redelivery from that latch and make the pager run to its page
 		// cap. Fail open: if the community is not readable, fall through to full
 		// processing rather than fabricate a skip.
-		m.communityLock.Lock(id)
-		community, err := m.GetByID(id)
-		m.communityLock.Unlock(id)
-		if err == nil && community != nil {
+		if community := m.cachedCommunityForRedelivery(id); community != nil {
 			m.logger.Debug("surfacing redelivered community description without reprocessing",
 				zap.String("communityID", gateKey), zap.Uint64("clock", description.Clock))
 			return &CommunityResponse{Community: community, Changes: community.emptyCommunityChanges()}, nil
@@ -2212,8 +2218,44 @@ func (m *Manager) HandleCommunityDescriptionMessage(signer *ecdsa.PublicKey, des
 	if m.descriptionGate != nil {
 		m.descriptionGate.recordProcessed(gateKey, processedDescription.Clock, payloadHash)
 	}
+	// Warm the redelivery cache with the freshly-processed community so the next
+	// gated redelivery is served without a ~1.4MB GetByID. handleCommunityDescription-
+	// MessageCommon already deleted the stale entry via SaveCommunity, so this sets the
+	// current one (#21470-hf).
+	m.cache.Set(gateKey, ReadonlyCommunity(community), ttlcache.DefaultTTL)
 	r.FailedToDecrypt = failedToDecrypt
 	return r, nil
+}
+
+// cachedCommunityForRedelivery returns the community for a gated (skipped) description
+// redelivery. It serves the shared readonly community cache first — the whole point of
+// the gate is to avoid the ~1.4MB GetByID (SQLite read + proto.Unmarshal) that each
+// skip would otherwise pay — and falls back to a single GetByID on a cache miss,
+// populating the cache so subsequent skips are free. Returns nil (caller falls through
+// to full processing) if the community cannot be read.
+//
+// The cache is coherent for this use: every persisted community mutation funnels
+// through Manager.SaveCommunity, which deletes the entry, so a hit can never be staler
+// than the last persisted description. The skip path only needs the community to
+// (a) trip the store-node description-seen latch, which keys off the community ID alone
+// (communityDescriptionSeen), and (b) be surfaced with empty changes. The store-node
+// pager's minimumDataClock comparison reads the PERSISTED clock via its own GetByID,
+// never this cached copy, so a slightly-stale clock here cannot change pager behaviour.
+func (m *Manager) cachedCommunityForRedelivery(id types3.HexBytes) *Community {
+	idString := id.String()
+	if item := m.cache.Get(idString); item != nil {
+		if community, ok := item.Value().(*Community); ok {
+			return community
+		}
+	}
+	m.communityLock.Lock(id)
+	defer m.communityLock.Unlock(id)
+	community, err := m.GetByID(id)
+	if err != nil || community == nil {
+		return nil
+	}
+	m.cache.Set(idString, ReadonlyCommunity(community), ttlcache.DefaultTTL)
+	return community
 }
 
 func (m *Manager) NewHashRatchetKeys(keys []*types.HashRatchetInfo) error {
@@ -2229,6 +2271,14 @@ func (m *Manager) NewHashRatchetKeys(keys []*types.HashRatchetInfo) error {
 	// must be reprocessed rather than skipped as a redelivery (#21470-hf).
 	if m.descriptionGate != nil && len(keys) > 0 {
 		m.descriptionGate.forgetAll()
+	}
+	// Drop cached communities too: a community processed while keyless was cached
+	// without its decrypted private data, so the cached copy must not be reused once
+	// keys arrive. Keys may be channel-scoped and cannot be mapped back to a single
+	// community cheaply, so clear all — the same reason descriptionGate.forgetAll does
+	// (#21470-hf). Cleared entries simply re-read from the DB on next access.
+	if len(keys) > 0 {
+		m.cache.DeleteAll()
 	}
 	return m.persistence.InvalidateDecryptedCommunityCacheForKeys(keys)
 }

--- a/protocol/communities/manager.go
+++ b/protocol/communities/manager.go
@@ -2212,6 +2212,16 @@ func (m *Manager) communityHoldsAnyDecryptionKey(id types3.HexBytes, chats map[s
 	return holds
 }
 
+// CommunityHoldsAnyDecryptionKey is the exported form of communityHoldsAnyDecryptionKey
+// for callers outside the package (the spectate hash-first backfill, issue #21470-hf).
+// It fails open (reports true) for a nil community so unknown state never drops data.
+func (m *Manager) CommunityHoldsAnyDecryptionKey(community *Community) bool {
+	if community == nil {
+		return true
+	}
+	return m.communityHoldsAnyDecryptionKey(community.ID(), community.Chats())
+}
+
 func (m *Manager) hasHashRatchetKeyForGroup(groupID []byte) bool {
 	key, err := m.messaging.GetCurrentKeyForGroup(groupID)
 	if err != nil {

--- a/protocol/communities/manager.go
+++ b/protocol/communities/manager.go
@@ -113,6 +113,7 @@ type Manager struct {
 	stopped                  bool
 	PermissionChecker        PermissionChecker
 	keyDistributor           KeyDistributor
+	keyEntitlement           *communityKeyEntitlement
 	communityLock            *CommunityLock
 	mediaServer              server.MediaServerInterface
 	communityImageVersions   map[string]uint32
@@ -322,6 +323,7 @@ func NewManager(
 		messaging:              messaging,
 		timesource:             timesource,
 		keyDistributor:         keyDistributor,
+		keyEntitlement:         newCommunityKeyEntitlement(),
 		communityLock:          NewCommunityLock(logger),
 		mediaServer:            mediaServer,
 		communityImageVersions: make(map[string]uint32),
@@ -2171,7 +2173,53 @@ func (m *Manager) HandleCommunityDescriptionMessage(signer *ecdsa.PublicKey, des
 }
 
 func (m *Manager) NewHashRatchetKeys(keys []*types.HashRatchetInfo) error {
+	// Lift the keyless-spectator gate now that key material has arrived, so the next
+	// description fetch re-evaluates entitlement and attempts decryption. Keys may be
+	// community- or channel-scoped, so clear all cached entitlements rather than map
+	// each group id back to a community.
+	if m.keyEntitlement != nil && len(keys) > 0 {
+		m.keyEntitlement.forgetAll()
+	}
 	return m.persistence.InvalidateDecryptedCommunityCacheForKeys(keys)
+}
+
+// communityHoldsAnyDecryptionKey reports whether this node holds any hash-ratchet
+// key material for the community (its community-level group or any of its channel
+// groups). The result is cached per community and invalidated when new keys arrive
+// (NewHashRatchetKeys). On any lookup error it fails open (reports true) so a
+// transient DB issue can never cause legitimate data to be dropped.
+func (m *Manager) communityHoldsAnyDecryptionKey(id types3.HexBytes, chats map[string]*protobuf.CommunityChat) bool {
+	if m.messaging == nil || m.keyEntitlement == nil {
+		return true
+	}
+
+	cacheKey := id.String()
+	if holds, ok := m.keyEntitlement.known(cacheKey); ok {
+		return holds
+	}
+
+	holds := m.hasHashRatchetKeyForGroup(id)
+	if !holds {
+		for channelID := range chats {
+			if m.hasHashRatchetKeyForGroup(types3.HexBytes(id.String() + channelID)) {
+				holds = true
+				break
+			}
+		}
+	}
+
+	m.keyEntitlement.remember(cacheKey, holds)
+	return holds
+}
+
+func (m *Manager) hasHashRatchetKeyForGroup(groupID []byte) bool {
+	key, err := m.messaging.GetCurrentKeyForGroup(groupID)
+	if err != nil {
+		// Fail open: never drop decryptable data because of a lookup error.
+		return true
+	}
+	// GetCurrentKeyForGroup returns a non-nil, empty ratchet when no key exists.
+	return key != nil && len(key.Key) != 0
 }
 
 // NOTE: encrypted_community_description_cache is not a cache for the community description
@@ -2184,6 +2232,26 @@ func (m *Manager) preprocessDescription(id types3.HexBytes, description *protobu
 	}
 	if decryptedCommunity != nil {
 		return nil, decryptedCommunity, nil
+	}
+
+	// Keyless-spectator early drop (#21470): if the description carries encrypted
+	// private data but this node holds no decryption keys for the community, skip
+	// the per-key decryption attempts entirely — each would be a guaranteed
+	// "no ratchet key" failure. The plaintext outer description is still handled;
+	// only the encrypted inner fields are left encrypted (a spectator cannot see
+	// them anyway). The gate lifts automatically once keys arrive.
+	if len(description.PrivateData) > 0 &&
+		shouldSkipPrivateDataDecryption(true, m.communityHoldsAnyDecryptionKey(id, description.Chats)) {
+		decision := m.keyEntitlement.recordDrop(id.String())
+		if decision.logInfo {
+			m.logger.Info("dropping encrypted community payloads (no decryption keys held)",
+				zap.String("communityID", id.String()), zap.Uint64("droppedCount", decision.count))
+		} else if decision.logDebug {
+			m.logger.Debug("still dropping encrypted community payloads (no decryption keys held)",
+				zap.String("communityID", id.String()), zap.Uint64("droppedCount", decision.count))
+		}
+		upgradeTokenPermissions(description)
+		return nil, description, m.persistence.SaveDecryptedCommunityDescription(id, nil, description)
 	}
 
 	response, err := decryptDescription(id, m, description, m.logger)

--- a/protocol/communities/manager.go
+++ b/protocol/communities/manager.go
@@ -589,6 +589,27 @@ func (m *Manager) ValidateCommunityByID(communityID types3.HexBytes) (*Community
 
 }
 
+// HighestQueuedValidationClock returns the greatest clock among the community
+// descriptions currently queued for owner validation for the given community, or
+// 0 if none are queued. The store-node pager uses this to stop requesting more
+// history once we already hold the description and only on-chain owner
+// verification remains: fetching further pages cannot make verification succeed,
+// and verification is retried out-of-band on the owner-verification loop
+// (issue #21470-hf).
+func (m *Manager) HighestQueuedValidationClock(communityID types3.HexBytes) (uint64, error) {
+	queued, err := m.persistence.getCommunityToValidateByID(communityID)
+	if err != nil {
+		return 0, err
+	}
+	var highest uint64
+	for _, c := range queued {
+		if c.clock > highest {
+			highest = c.clock
+		}
+	}
+	return highest, nil
+}
+
 func (m *Manager) validateCommunity(communityToValidateData []communityToValidate) (*CommunityResponse, error) {
 	for _, community := range communityToValidateData {
 		signer, description, err := UnwrapCommunityDescriptionMessage(community.payload)
@@ -611,7 +632,17 @@ func (m *Manager) validateCommunity(communityToValidateData []communityToValidat
 
 		owner, err := m.ownerVerifier.SafeGetSignerPubKey(ctx, chainID, types3.EncodeHex(community.id))
 		if err != nil {
-			m.logger.Error("failed to get owner", zap.Error(err))
+			// Transport-class failure of the on-chain owner lookup (RPC timeout,
+			// dead proxy, rate limit, connection refused). This is NOT a verdict
+			// on the community: we deliberately keep it queued so the
+			// owner-verification loop retries it once the RPC recovers, instead
+			// of the store-node pager reacting to it by fetching more history
+			// (issue #21470-hf). Logged distinctly from an invalid/not-owner
+			// verdict so field debugging can tell the two apart.
+			m.logger.Warn("owner verification unavailable (transport failure); keeping community queued for retry",
+				zap.String("id", types3.EncodeHex(community.id)),
+				zap.Uint64("chainID", chainID),
+				zap.Error(err))
 			continue
 		}
 
@@ -623,7 +654,13 @@ func (m *Manager) validateCommunity(communityToValidateData []communityToValidat
 
 		response, err := m.HandleCommunityDescriptionMessage(signer, description, community.payload, ownerPK)
 		if err != nil {
-			m.logger.Error("failed to handle community", zap.Error(err))
+			// Invalid-class verdict: the owner lookup succeeded but the signed
+			// description does not check out (wrong owner / bad description).
+			// Unlike a transport failure this is terminal, so we drop the entry;
+			// retrying cannot change the outcome (issue #21470-hf).
+			m.logger.Error("community description invalid for resolved owner; dropping from validation queue",
+				zap.String("id", types3.EncodeHex(community.id)),
+				zap.Error(err))
 			err = m.persistence.DeleteCommunityToValidate(community.id, community.clock)
 			if err != nil {
 				m.logger.Error("failed to delete community to validate", zap.Error(err))

--- a/protocol/communities/manager.go
+++ b/protocol/communities/manager.go
@@ -2100,9 +2100,23 @@ func (m *Manager) HandleCommunityDescriptionMessage(signer *ecdsa.PublicKey, des
 	gateKey := types3.HexBytes(id).String()
 	payloadHash := hashDescriptionPayload(payload)
 	if m.descriptionGate != nil && m.descriptionGate.shouldSkip(gateKey, description.Clock, payloadHash) {
-		m.logger.Debug("skipping redelivered community description",
-			zap.String("communityID", gateKey), zap.Uint64("clock", description.Clock))
-		return nil, nil
+		// Skip the expensive pipeline (preprocessDescription's decrypted-cache
+		// read+write and handleCommunityDescriptionMessageCommon's ~1.4MB re-save),
+		// but still SURFACE the already-known community with empty changes. The
+		// store-node pager latches "description seen" from the community appearing
+		// in the handled response and stops paging once it holds the newest
+		// description (issue #21470-hf, commit 6cd6ced1a); returning nil here would
+		// hide the redelivery from that latch and make the pager run to its page
+		// cap. Fail open: if the community is not readable, fall through to full
+		// processing rather than fabricate a skip.
+		m.communityLock.Lock(id)
+		community, err := m.GetByID(id)
+		m.communityLock.Unlock(id)
+		if err == nil && community != nil {
+			m.logger.Debug("surfacing redelivered community description without reprocessing",
+				zap.String("communityID", gateKey), zap.Uint64("clock", description.Clock))
+			return &CommunityResponse{Community: community, Changes: community.emptyCommunityChanges()}, nil
+		}
 	}
 
 	failedToDecrypt, processedDescription, err := m.preprocessDescription(id, description)

--- a/protocol/communities/manager.go
+++ b/protocol/communities/manager.go
@@ -2209,10 +2209,6 @@ func (m *Manager) handleCommunityDescriptionMessageCommon(community *Community, 
 		m.incrementCommunityImageVersion(community.IDString())
 	}
 
-	if err = m.handleCommunityTokensMetadata(community); err != nil {
-		return nil, err
-	}
-
 	hasCommunityArchiveInfo, err := m.persistence.HasCommunityArchiveInfo(community.ID())
 	if err != nil {
 		return nil, err
@@ -2296,6 +2292,10 @@ func (m *Manager) handleCommunityDescriptionMessageCommon(community *Community, 
 	err = m.SaveCommunity(community)
 	if err != nil {
 		return nil, err
+	}
+
+	if len(community.CommunityTokensMetadata()) > 0 {
+		m.handleCommunityTokensMetadataAsync(community.IDString())
 	}
 
 	// We mark our requests as completed, though maybe we should mark
@@ -4506,6 +4506,31 @@ func (m *Manager) handleCommunityTokensMetadata(community *Community) error {
 		}
 	}
 	return nil
+}
+
+func (m *Manager) handleCommunityTokensMetadataAsync(communityID string) {
+	go func() {
+		defer utils.LogOnPanic()
+
+		select {
+		case <-m.quit:
+			return
+		default:
+		}
+
+		community, err := m.GetByIDString(communityID)
+		if err != nil {
+			return
+		}
+
+		err = m.handleCommunityTokensMetadata(community)
+		if err != nil {
+			return
+		}
+
+		m.publish(&Subscription{Community: community})
+
+	}()
 }
 
 func (m *Manager) HandleCommunityGrant(community *Community, grant []byte, clock uint64) (uint64, error) {

--- a/protocol/communities/manager.go
+++ b/protocol/communities/manager.go
@@ -114,6 +114,7 @@ type Manager struct {
 	PermissionChecker        PermissionChecker
 	keyDistributor           KeyDistributor
 	keyEntitlement           *communityKeyEntitlement
+	descriptionGate          *communityDescriptionGate
 	communityLock            *CommunityLock
 	mediaServer              server.MediaServerInterface
 	communityImageVersions   map[string]uint32
@@ -324,6 +325,7 @@ func NewManager(
 		timesource:             timesource,
 		keyDistributor:         keyDistributor,
 		keyEntitlement:         newCommunityKeyEntitlement(),
+		descriptionGate:        newCommunityDescriptionGate(),
 		communityLock:          NewCommunityLock(logger),
 		mediaServer:            mediaServer,
 		communityImageVersions: make(map[string]uint32),
@@ -1528,6 +1530,11 @@ func (m *Manager) DeleteCommunity(id types3.HexBytes) error {
 	if err != nil {
 		return err
 	}
+	// Drop any redelivery-gate entry so a re-fetched description of a deleted
+	// community is fully reprocessed rather than skipped (#21470-hf).
+	if m.descriptionGate != nil {
+		m.descriptionGate.forget(id.String())
+	}
 	return m.persistence.DeleteCommunitySettings(id)
 }
 
@@ -2083,6 +2090,21 @@ func (m *Manager) HandleCommunityDescriptionMessage(signer *ecdsa.PublicKey, des
 		id = crypto.CompressPubkey(signer)
 	}
 
+	// #21470-hf: fast-path redelivered descriptions before any expensive work.
+	// status-go re-publishes the same ~1.4MB description into every fetch window,
+	// and each redelivered copy otherwise pays proto.Unmarshal + preprocessDescription
+	// (decrypted-cache read+write) + GetByID (re-read/re-unmarshal of the stored
+	// blob) BEFORE the downstream clock comparison rejects it. The gate skips only
+	// strictly-older clocks and byte-identical same-clock redeliveries; it is
+	// cleared when keys arrive or a community is deleted (see communityDescriptionGate).
+	gateKey := types3.HexBytes(id).String()
+	payloadHash := hashDescriptionPayload(payload)
+	if m.descriptionGate != nil && m.descriptionGate.shouldSkip(gateKey, description.Clock, payloadHash) {
+		m.logger.Debug("skipping redelivered community description",
+			zap.String("communityID", gateKey), zap.Uint64("clock", description.Clock))
+		return nil, nil
+	}
+
 	failedToDecrypt, processedDescription, err := m.preprocessDescription(id, description)
 	if err != nil {
 		return nil, err
@@ -2168,6 +2190,14 @@ func (m *Manager) HandleCommunityDescriptionMessage(signer *ecdsa.PublicKey, des
 	if err != nil {
 		return nil, err
 	}
+	// Advance the redelivery gate only after fully successful processing, so a
+	// byte-identical same-clock redelivery of THIS description can be skipped.
+	// Deliberately NOT advanced on the queue path or the FailedToDecrypt early
+	// return, so validateCommunity's later re-entry and key-arrival reprocessing
+	// are never blocked (#21470-hf).
+	if m.descriptionGate != nil {
+		m.descriptionGate.recordProcessed(gateKey, processedDescription.Clock, payloadHash)
+	}
 	r.FailedToDecrypt = failedToDecrypt
 	return r, nil
 }
@@ -2179,6 +2209,12 @@ func (m *Manager) NewHashRatchetKeys(keys []*types.HashRatchetInfo) error {
 	// each group id back to a community.
 	if m.keyEntitlement != nil && len(keys) > 0 {
 		m.keyEntitlement.forgetAll()
+	}
+	// Lift the redelivery gate too: a description that was byte-identical to one
+	// already processed may now decrypt previously-encrypted private data, so it
+	// must be reprocessed rather than skipped as a redelivery (#21470-hf).
+	if m.descriptionGate != nil && len(keys) > 0 {
+		m.descriptionGate.forgetAll()
 	}
 	return m.persistence.InvalidateDecryptedCommunityCacheForKeys(keys)
 }

--- a/protocol/communities/manager_test.go
+++ b/protocol/communities/manager_test.go
@@ -1855,10 +1855,11 @@ func (s *ManagerSuite) TestCommunityIDIsHydratedWhenMarshaling() {
 }
 
 // TestHandleCommunityDescriptionRedeliveryGate verifies the redelivery gate
-// (issue #21470-hf): a byte-identical redelivery of an already-processed
-// community description is short-circuited (nil response, no error), while newer
-// clocks are still processed, and new hash-ratchet key material lifts the gate so
-// the same description is reprocessed (it may then decrypt private data).
+// (issue #21470-hf). A byte-identical redelivery of an already-processed community
+// description must skip the expensive pipeline yet still SURFACE the already-known
+// community, so the store-node pager's description-seen latch (commit 6cd6ced1a)
+// trips exactly as it would for a fully-processed redelivery. Newer clocks are
+// still processed, and new hash-ratchet key material lifts the gate.
 func (s *ManagerSuite) TestHandleCommunityDescriptionRedeliveryGate() {
 	// s.manager is the control node that authors the community; m is a separate
 	// receiver (spectator) node that ingests the published description.
@@ -1879,6 +1880,7 @@ func (s *ManagerSuite) TestHandleCommunityDescriptionRedeliveryGate() {
 	// Plain community: no token ownership, so it is processed immediately (not queued).
 	s.Require().Equal(uint64(0), CommunityDescriptionTokenOwnerChainID(description))
 
+	gateKey := community.IDString()
 	buildPayload := func() []byte {
 		payload, err := community.MarshaledDescription()
 		s.Require().NoError(err)
@@ -1889,15 +1891,27 @@ func (s *ManagerSuite) TestHandleCommunityDescriptionRedeliveryGate() {
 
 	payload := buildPayload()
 
+	// The gate starts empty: the first delivery must not be skipped.
+	s.Require().False(m.descriptionGate.shouldSkip(gateKey, description.Clock, hashDescriptionPayload(payload)))
+
 	// First delivery is fully processed and yields a response.
 	resp1, err := m.HandleCommunityDescriptionMessage(&signer.PublicKey, description, payload, nil)
 	s.Require().NoError(err)
 	s.Require().NotNil(resp1)
 
-	// Byte-identical redelivery is short-circuited by the gate (nil response, no error).
+	// The gate now records this description, so a byte-identical redelivery is a skip.
+	s.Require().True(m.descriptionGate.shouldSkip(gateKey, description.Clock, hashDescriptionPayload(payload)))
+
+	// Byte-identical redelivery is short-circuited but STILL surfaces the community
+	// (non-nil, matching ID, empty changes) so downstream description-seen latches.
 	resp2, err := m.HandleCommunityDescriptionMessage(&signer.PublicKey, description, payload, nil)
 	s.Require().NoError(err)
-	s.Require().Nil(resp2)
+	s.Require().NotNil(resp2)
+	s.Require().NotNil(resp2.Community)
+	s.Require().Equal(community.IDString(), resp2.Community.IDString())
+	s.Require().NotNil(resp2.Changes)
+	s.Require().Empty(resp2.Changes.MembersAdded)
+	s.Require().Empty(resp2.Changes.ChatsAdded)
 
 	// A genuinely newer clock still gets processed.
 	community.config.CommunityDescription.Clock++
@@ -1905,18 +1919,16 @@ func (s *ManagerSuite) TestHandleCommunityDescriptionRedeliveryGate() {
 	resp3, err := m.HandleCommunityDescriptionMessage(&signer.PublicKey, description, newerPayload, nil)
 	s.Require().NoError(err)
 	s.Require().NotNil(resp3)
+	s.Require().True(m.descriptionGate.shouldSkip(gateKey, description.Clock, hashDescriptionPayload(newerPayload)))
 
-	// Its identical redelivery is skipped again.
-	resp4, err := m.HandleCommunityDescriptionMessage(&signer.PublicKey, description, newerPayload, nil)
-	s.Require().NoError(err)
-	s.Require().Nil(resp4)
-
-	// New hash-ratchet keys arriving must lift the gate so the same description is
-	// reprocessed (it may now decrypt previously-encrypted private data).
+	// New hash-ratchet keys arriving must lift the gate so the same description can
+	// be reprocessed (it may now decrypt previously-encrypted private data).
 	err = m.NewHashRatchetKeys([]*types.HashRatchetInfo{{GroupID: community.ID(), KeyID: []byte("key-id")}})
 	s.Require().NoError(err)
+	s.Require().False(m.descriptionGate.shouldSkip(gateKey, description.Clock, hashDescriptionPayload(newerPayload)),
+		"gate must be lifted after new keys arrive")
 
 	resp5, err := m.HandleCommunityDescriptionMessage(&signer.PublicKey, description, newerPayload, nil)
 	s.Require().NoError(err)
-	s.Require().NotNil(resp5, "gate must be lifted after new keys arrive")
+	s.Require().NotNil(resp5)
 }

--- a/protocol/communities/manager_test.go
+++ b/protocol/communities/manager_test.go
@@ -1210,10 +1210,18 @@ func (s *ManagerSuite) buildCommunityWithChat() (*Community, string, error) {
 type testOwnerVerifier struct {
 	called    int
 	ownersMap map[string]string
+	// err simulates a transport-class failure of the on-chain owner lookup
+	// (RPC timeout, dead proxy, rate limit). When set, SafeGetSignerPubKey
+	// fails the way a broken wallet RPC stack does, without rejecting the
+	// community as invalid.
+	err error
 }
 
 func (t *testOwnerVerifier) SafeGetSignerPubKey(ctx context.Context, chainID uint64, communityID string) (string, error) {
 	t.called++
+	if t.err != nil {
+		return "", t.err
+	}
 	return t.ownersMap[communityID], nil
 }
 
@@ -1296,6 +1304,139 @@ func (s *ManagerSuite) TestCommunityQueue() {
 	communitiesToValidate, err := m.persistence.getCommunitiesToValidate()
 	s.Require().NoError(err)
 	s.Require().Empty(communitiesToValidate)
+}
+
+// TestHighestQueuedValidationClock verifies the queue read the store-node pager
+// uses to decide it may stop paging (issue #21470-hf): once a community's
+// description is queued for owner validation, HighestQueuedValidationClock
+// reports the greatest queued clock so the pager can compare it against the
+// clock it already holds. With nothing queued (or for an unrelated community) it
+// reports 0, so the pager keeps paging as before.
+func (s *ManagerSuite) TestHighestQueuedValidationClock() {
+	verifier := &testOwnerVerifier{}
+	m, _ := s.buildManagers(verifier)
+
+	communityID := []byte{0x01, 0x02, 0x03}
+
+	clock, err := m.HighestQueuedValidationClock(communityID)
+	s.Require().NoError(err)
+	s.Require().Equal(uint64(0), clock, "nothing queued yet")
+
+	// Queue two descriptions with different clocks, both already due for
+	// validation (validate_at in the past).
+	s.Require().NoError(m.persistence.SaveCommunityToValidate(communityToValidate{
+		id: communityID, clock: 5, payload: []byte("a"), validateAt: 1, signer: []byte("s")}))
+	s.Require().NoError(m.persistence.SaveCommunityToValidate(communityToValidate{
+		id: communityID, clock: 9, payload: []byte("b"), validateAt: 1, signer: []byte("s")}))
+
+	clock, err = m.HighestQueuedValidationClock(communityID)
+	s.Require().NoError(err)
+	s.Require().Equal(uint64(9), clock, "highest queued clock")
+
+	clock, err = m.HighestQueuedValidationClock([]byte{0xaa, 0xbb})
+	s.Require().NoError(err)
+	s.Require().Equal(uint64(0), clock, "unrelated community is unaffected")
+}
+
+// TestCommunityQueueRetriesTransportError verifies the core correctness fix
+// (issue #21470-hf): a transport-class failure of owner verification (RPC
+// timeout / dead proxy / rate limit) must NOT reject the community and must NOT
+// clear the queue — the description stays queued so verification is retried
+// out-of-band, and succeeds once the RPC recovers, publishing
+// TokenCommunityValidated. This decouples verification retries from store-node
+// paging: the pager stops once the description is queued, and recovery happens
+// here rather than by fetching more pages.
+func (s *ManagerSuite) TestCommunityQueueRetriesTransportError() {
+	owner, err := crypto.GenerateKey()
+	s.Require().NoError(err)
+
+	verifier := &testOwnerVerifier{}
+	m, _ := s.buildManagers(verifier)
+
+	createRequest := &requests.CreateCommunity{
+		Name:        "status",
+		Description: "status community description",
+		Membership:  protobuf.CommunityPermissions_AUTO_ACCEPT,
+	}
+	community, err := s.manager.CreateCommunity(createRequest, true)
+	s.Require().NoError(err)
+
+	verifier.ownersMap = make(map[string]string)
+	verifier.ownersMap[community.IDString()] = crypto.PubkeyToHex(&owner.PublicKey)
+
+	description := community.config.CommunityDescription
+	description.TokenPermissions = make(map[string]*protobuf.CommunityTokenPermission)
+	description.TokenPermissions["some-id"] = &protobuf.CommunityTokenPermission{
+		Type: protobuf.CommunityTokenPermission_BECOME_TOKEN_OWNER,
+		Id:   "some-token-id",
+		TokenCriteria: []*protobuf.TokenCriteria{
+			&protobuf.TokenCriteria{
+				ContractAddresses: map[uint64]string{2: "some-address"},
+			},
+		}}
+	s.Require().Equal(uint64(2), CommunityDescriptionTokenOwnerChainID(description))
+
+	payload, err := community.MarshaledDescription()
+	s.Require().NoError(err)
+	payload, err = v.WrapIntoAppLayerMessage(payload, protobuf.ApplicationMetadataMessage_COMMUNITY_DESCRIPTION, owner)
+	s.Require().NoError(err)
+
+	notTheOwner, err := crypto.GenerateKey()
+	s.Require().NoError(err)
+
+	// The description arrives from a non-owner signer, so it is queued for
+	// on-chain owner verification instead of being applied immediately.
+	response, err := m.HandleCommunityDescriptionMessage(&notTheOwner.PublicKey, description, payload, nil)
+	s.Require().NoError(err)
+	s.Require().Nil(response, "must be queued, not applied")
+
+	// The queued description is now in hand: the pager can see it and stop.
+	queuedClock, err := m.HighestQueuedValidationClock(community.ID())
+	s.Require().NoError(err)
+	s.Require().Greater(queuedClock, uint64(0))
+
+	// Transport failure during verification: the community must stay queued and
+	// nothing may be published.
+	subscription := m.Subscribe()
+	verifier.err = errors.New("proxy dead: connection refused")
+
+	resp, err := m.ValidateCommunityByID(community.ID())
+	s.Require().NoError(err, "transport failure must not surface as a validation error")
+	s.Require().Nil(resp)
+
+	queued, err := m.persistence.getCommunityToValidateByID(community.ID())
+	s.Require().NoError(err)
+	s.Require().NotEmpty(queued, "transport-failed validation must remain queued for retry")
+
+	select {
+	case event := <-subscription:
+		s.Require().Nil(event.TokenCommunityValidated, "must not publish on transport failure")
+	default:
+	}
+
+	// Recovery: the RPC works on the next attempt → validated, published, queue
+	// cleared.
+	verifier.err = nil
+	resp, err = m.ValidateCommunityByID(community.ID())
+	s.Require().NoError(err)
+	s.Require().NotNil(resp, "validation must succeed once the RPC recovers")
+
+	published := false
+	for !published {
+		select {
+		case event := <-subscription:
+			if event.TokenCommunityValidated == nil {
+				continue
+			}
+			published = true
+		case <-time.After(2 * time.Second):
+			s.FailNow("TokenCommunityValidated not published after recovery")
+		}
+	}
+
+	queued, err = m.persistence.getCommunityToValidateByID(community.ID())
+	s.Require().NoError(err)
+	s.Require().Empty(queued, "successful validation must clear the queue")
 }
 
 // 1) We create a community

--- a/protocol/communities/manager_test.go
+++ b/protocol/communities/manager_test.go
@@ -1853,3 +1853,70 @@ func (s *ManagerSuite) TestCommunityIDIsHydratedWhenMarshaling() {
 	s.Require().NoError(err)
 	s.Require().Equal(community.IDString(), community.config.CommunityDescription.ID)
 }
+
+// TestHandleCommunityDescriptionRedeliveryGate verifies the redelivery gate
+// (issue #21470-hf): a byte-identical redelivery of an already-processed
+// community description is short-circuited (nil response, no error), while newer
+// clocks are still processed, and new hash-ratchet key material lifts the gate so
+// the same description is reprocessed (it may then decrypt private data).
+func (s *ManagerSuite) TestHandleCommunityDescriptionRedeliveryGate() {
+	// s.manager is the control node that authors the community; m is a separate
+	// receiver (spectator) node that ingests the published description.
+	m, _ := s.buildManagers(nil)
+
+	signer, err := crypto.GenerateKey()
+	s.Require().NoError(err)
+
+	createRequest := &requests.CreateCommunity{
+		Name:        "status",
+		Description: "status community description",
+		Membership:  protobuf.CommunityPermissions_AUTO_ACCEPT,
+	}
+	community, err := s.manager.CreateCommunity(createRequest, true)
+	s.Require().NoError(err)
+
+	description := community.config.CommunityDescription
+	// Plain community: no token ownership, so it is processed immediately (not queued).
+	s.Require().Equal(uint64(0), CommunityDescriptionTokenOwnerChainID(description))
+
+	buildPayload := func() []byte {
+		payload, err := community.MarshaledDescription()
+		s.Require().NoError(err)
+		payload, err = v.WrapIntoAppLayerMessage(payload, protobuf.ApplicationMetadataMessage_COMMUNITY_DESCRIPTION, signer)
+		s.Require().NoError(err)
+		return payload
+	}
+
+	payload := buildPayload()
+
+	// First delivery is fully processed and yields a response.
+	resp1, err := m.HandleCommunityDescriptionMessage(&signer.PublicKey, description, payload, nil)
+	s.Require().NoError(err)
+	s.Require().NotNil(resp1)
+
+	// Byte-identical redelivery is short-circuited by the gate (nil response, no error).
+	resp2, err := m.HandleCommunityDescriptionMessage(&signer.PublicKey, description, payload, nil)
+	s.Require().NoError(err)
+	s.Require().Nil(resp2)
+
+	// A genuinely newer clock still gets processed.
+	community.config.CommunityDescription.Clock++
+	newerPayload := buildPayload()
+	resp3, err := m.HandleCommunityDescriptionMessage(&signer.PublicKey, description, newerPayload, nil)
+	s.Require().NoError(err)
+	s.Require().NotNil(resp3)
+
+	// Its identical redelivery is skipped again.
+	resp4, err := m.HandleCommunityDescriptionMessage(&signer.PublicKey, description, newerPayload, nil)
+	s.Require().NoError(err)
+	s.Require().Nil(resp4)
+
+	// New hash-ratchet keys arriving must lift the gate so the same description is
+	// reprocessed (it may now decrypt previously-encrypted private data).
+	err = m.NewHashRatchetKeys([]*types.HashRatchetInfo{{GroupID: community.ID(), KeyID: []byte("key-id")}})
+	s.Require().NoError(err)
+
+	resp5, err := m.HandleCommunityDescriptionMessage(&signer.PublicKey, description, newerPayload, nil)
+	s.Require().NoError(err)
+	s.Require().NotNil(resp5, "gate must be lifted after new keys arrive")
+}

--- a/protocol/communities/manager_test.go
+++ b/protocol/communities/manager_test.go
@@ -1892,7 +1892,7 @@ func (s *ManagerSuite) TestHandleCommunityDescriptionRedeliveryGate() {
 	payload := buildPayload()
 
 	// The gate starts empty: the first delivery must not be skipped.
-	s.Require().False(m.descriptionGate.shouldSkip(gateKey, description.Clock, hashDescriptionPayload(payload)))
+	s.Require().False(m.descriptionGate.shouldSkip(gateKey, description.Clock, hashDescriptionPayload(payload), keysHeld))
 
 	// First delivery is fully processed and yields a response.
 	resp1, err := m.HandleCommunityDescriptionMessage(&signer.PublicKey, description, payload, nil)
@@ -1900,7 +1900,7 @@ func (s *ManagerSuite) TestHandleCommunityDescriptionRedeliveryGate() {
 	s.Require().NotNil(resp1)
 
 	// The gate now records this description, so a byte-identical redelivery is a skip.
-	s.Require().True(m.descriptionGate.shouldSkip(gateKey, description.Clock, hashDescriptionPayload(payload)))
+	s.Require().True(m.descriptionGate.shouldSkip(gateKey, description.Clock, hashDescriptionPayload(payload), keysHeld))
 
 	// Byte-identical redelivery is short-circuited but STILL surfaces the community
 	// (non-nil, matching ID, empty changes) so downstream description-seen latches.
@@ -1919,16 +1919,81 @@ func (s *ManagerSuite) TestHandleCommunityDescriptionRedeliveryGate() {
 	resp3, err := m.HandleCommunityDescriptionMessage(&signer.PublicKey, description, newerPayload, nil)
 	s.Require().NoError(err)
 	s.Require().NotNil(resp3)
-	s.Require().True(m.descriptionGate.shouldSkip(gateKey, description.Clock, hashDescriptionPayload(newerPayload)))
+	s.Require().True(m.descriptionGate.shouldSkip(gateKey, description.Clock, hashDescriptionPayload(newerPayload), keysHeld))
 
 	// New hash-ratchet keys arriving must lift the gate so the same description can
 	// be reprocessed (it may now decrypt previously-encrypted private data).
 	err = m.NewHashRatchetKeys([]*types.HashRatchetInfo{{GroupID: community.ID(), KeyID: []byte("key-id")}})
 	s.Require().NoError(err)
-	s.Require().False(m.descriptionGate.shouldSkip(gateKey, description.Clock, hashDescriptionPayload(newerPayload)),
+	s.Require().False(m.descriptionGate.shouldSkip(gateKey, description.Clock, hashDescriptionPayload(newerPayload), keysHeld),
 		"gate must be lifted after new keys arrive")
 
 	resp5, err := m.HandleCommunityDescriptionMessage(&signer.PublicKey, description, newerPayload, nil)
 	s.Require().NoError(err)
 	s.Require().NotNil(resp5)
+}
+
+// TestHandleCommunityDescriptionRedeliveryCache verifies the redelivery skip path is
+// served from the in-memory community cache instead of a 1.4MB GetByID per skip
+// (issue #21470-hf). It exercises the cache lifecycle at the Manager seam:
+// populate-on-successful-processing, and invalidation on both NewHashRatchetKeys and
+// DeleteCommunity. Description-update invalidation is already covered by SaveCommunity
+// (every successful processing deletes then repopulates the cache entry).
+func (s *ManagerSuite) TestHandleCommunityDescriptionRedeliveryCache() {
+	m, _ := s.buildManagers(nil)
+
+	signer, err := crypto.GenerateKey()
+	s.Require().NoError(err)
+
+	createRequest := &requests.CreateCommunity{
+		Name:        "status",
+		Description: "status community description",
+		Membership:  protobuf.CommunityPermissions_AUTO_ACCEPT,
+	}
+	community, err := s.manager.CreateCommunity(createRequest, true)
+	s.Require().NoError(err)
+
+	description := community.config.CommunityDescription
+	gateKey := community.IDString()
+	buildPayload := func() []byte {
+		payload, err := community.MarshaledDescription()
+		s.Require().NoError(err)
+		payload, err = v.WrapIntoAppLayerMessage(payload, protobuf.ApplicationMetadataMessage_COMMUNITY_DESCRIPTION, signer)
+		s.Require().NoError(err)
+		return payload
+	}
+	payload := buildPayload()
+
+	// The cache starts empty for an unseen community.
+	s.Require().Nil(m.cache.Get(gateKey), "cache must be empty before first processing")
+
+	// POPULATE-ON-PROCESS: after a successful full processing the just-processed
+	// community is cached so the first redelivery skip serves it without a GetByID.
+	_, err = m.HandleCommunityDescriptionMessage(&signer.PublicKey, description, payload, nil)
+	s.Require().NoError(err)
+	cached := m.cache.Get(gateKey)
+	s.Require().NotNil(cached, "community must be cached after successful processing")
+	s.Require().True(bytes.Equal(community.ID(), cached.Value().ID()), "cached community must match")
+
+	// The redelivery skip surfaces the community (from cache) with empty changes.
+	resp, err := m.HandleCommunityDescriptionMessage(&signer.PublicKey, description, payload, nil)
+	s.Require().NoError(err)
+	s.Require().NotNil(resp)
+	s.Require().NotNil(resp.Community)
+	s.Require().Equal(community.IDString(), resp.Community.IDString())
+
+	// INVALIDATE on NewHashRatchetKeys: keys arriving must drop the cached community
+	// (its next read reflects any now-decryptable state after reprocessing).
+	err = m.NewHashRatchetKeys([]*types.HashRatchetInfo{{GroupID: community.ID(), KeyID: []byte("key-id")}})
+	s.Require().NoError(err)
+	s.Require().Nil(m.cache.Get(gateKey), "new keys must invalidate the cached community")
+
+	// Reprocess to repopulate, then INVALIDATE on DeleteCommunity.
+	_, err = m.HandleCommunityDescriptionMessage(&signer.PublicKey, description, payload, nil)
+	s.Require().NoError(err)
+	s.Require().NotNil(m.cache.Get(gateKey), "reprocessing must repopulate the cache")
+
+	err = m.DeleteCommunity(community.ID())
+	s.Require().NoError(err)
+	s.Require().Nil(m.cache.Get(gateKey), "deleting the community must invalidate the cached community")
 }

--- a/protocol/communities_events_utils_test.go
+++ b/protocol/communities_events_utils_test.go
@@ -1866,16 +1866,33 @@ func testAddAndSyncTokenFromControlNode(base CommunityEventsTestsInterface, comm
 	waitOnMessengerResponse(s, checkTokenAdded, base.GetMember())
 	waitOnMessengerResponse(s, checkTokenAdded, base.GetEventSender())
 
-	// check CommunityToken was added to the DB
-	syncTokens, err := base.GetEventSender().communitiesManager.GetAllCommunityTokens()
+	// Token metadata arrives via messenger response first; DB persistence can complete shortly after.
+	err = testutils.RetryWithBackOff(func() error {
+		syncTokens, err := base.GetEventSender().communitiesManager.GetAllCommunityTokens()
+		if err != nil {
+			return err
+		}
+		if len(syncTokens) != 1 {
+			return errors.New("event sender tokens should be 1")
+		}
+		if syncTokens[0].PrivilegesLevel != privilegesLvl {
+			return errors.New("event sender token privileges level does not match")
+		}
+		return nil
+	})
 	s.Require().NoError(err)
-	s.Require().Len(syncTokens, 1)
-	s.Require().Equal(syncTokens[0].PrivilegesLevel, privilegesLvl)
 
-	// check CommunityToken was added to the DB
-	syncTokens, err = base.GetMember().communitiesManager.GetAllCommunityTokens()
+	err = testutils.RetryWithBackOff(func() error {
+		syncTokens, err := base.GetMember().communitiesManager.GetAllCommunityTokens()
+		if err != nil {
+			return err
+		}
+		if len(syncTokens) != 1 {
+			return errors.New("member tokens should be 1")
+		}
+		return nil
+	})
 	s.Require().NoError(err)
-	s.Require().Len(syncTokens, 1)
 }
 
 func testAddAndSyncOwnerTokenFromControlNode(base CommunityEventsTestsInterface, community *communities.Community,

--- a/protocol/messenger.go
+++ b/protocol/messenger.go
@@ -2776,6 +2776,32 @@ func (m *Messenger) RetrieveAll() (*MessengerResponse, error) {
 // preserving the same ~1s latency as the previous polling loop.
 const retrieveMessagesDebounceInterval = time.Second
 
+// retrieveMessagesMaxLatency bounds how long a flush can be deferred while
+// matches keep arriving. Without it a sustained envelope flood (e.g. the
+// community-description storm behind #21470) resets the debounce window on
+// every match, the 1s quiet gap never arrives, ProcessAllMessages is starved,
+// and freshly synced messages persisted to the DB are never surfaced to the
+// UI until the app restarts. The ceiling forces a flush at least this often
+// under continuous matches; quiet/normal traffic is unaffected because the
+// debounce interval fits comfortably under it.
+const retrieveMessagesMaxLatency = 3 * time.Second
+
+// nextFlushDeadline decides when the retrieve loop should next call
+// ProcessAllMessages. pendingSince is the time of the first match not yet
+// flushed; now is the time of the match currently being processed. The flush
+// normally fires a debounce window after the latest match, but is capped at
+// maxLatency measured from the first unflushed match so a continuous flood
+// cannot postpone delivery indefinitely. It returns the earlier of the two
+// deadlines.
+func nextFlushDeadline(pendingSince, now time.Time, debounce, maxLatency time.Duration) time.Time {
+	quietDeadline := now.Add(debounce)
+	ceilingDeadline := pendingSince.Add(maxLatency)
+	if ceilingDeadline.Before(quietDeadline) {
+		return ceilingDeadline
+	}
+	return quietDeadline
+}
+
 func (m *Messenger) StartRetrieveMessagesLoop(_ time.Duration, cancel <-chan struct{}) {
 	m.shutdownWaitGroup.Add(1)
 	go func() {
@@ -2787,27 +2813,46 @@ func (m *Messenger) StartRetrieveMessagesLoop(_ time.Duration, cancel <-chan str
 
 		var debounceTimer *time.Timer
 		var debounceCh <-chan time.Time
+		// Time of the first match since the last flush; zero when no flush is
+		// pending. Anchors the max-latency ceiling.
+		var pendingSince time.Time
+
+		stopTimer := func() {
+			if debounceTimer != nil && !debounceTimer.Stop() {
+				select {
+				case <-debounceTimer.C:
+				default:
+				}
+			}
+		}
 
 		for {
 			select {
 			case <-matchedCh:
-				// Reset the debounce window on every new match to coalesce bursts.
-				if debounceTimer != nil && !debounceTimer.Stop() {
-					select {
-					case <-debounceTimer.C:
-					default:
-					}
+				now := time.Now()
+				if pendingSince.IsZero() {
+					pendingSince = now
 				}
-				debounceTimer = time.NewTimer(retrieveMessagesDebounceInterval)
+				// Reset the debounce window on every new match to coalesce
+				// bursts, but never later than the max-latency ceiling.
+				stopTimer()
+				delay := nextFlushDeadline(pendingSince, now, retrieveMessagesDebounceInterval, retrieveMessagesMaxLatency).Sub(now)
+				if delay < 0 {
+					delay = 0
+				}
+				debounceTimer = time.NewTimer(delay)
 				debounceCh = debounceTimer.C
 
 			case <-debounceCh:
 				debounceCh = nil
+				pendingSince = time.Time{}
 				m.ProcessAllMessages()
 
 			case <-cancel:
+				stopTimer()
 				return
 			case <-m.quit:
+				stopTimer()
 				return
 			}
 		}

--- a/protocol/messenger.go
+++ b/protocol/messenger.go
@@ -2859,13 +2859,19 @@ func (m *Messenger) StartRetrieveMessagesLoop(_ time.Duration, cancel <-chan str
 	}()
 }
 
-func (m *Messenger) ProcessAllMessages() {
+// ProcessAllMessages retrieves and publishes all pending messages. It returns
+// the resulting MessengerResponse so callers that need to observe what was
+// handled (e.g. the store-node pager checking whether a community description
+// was processed this page — issue #21470-hf) can inspect it; callers that only
+// want the side effect may ignore the return value.
+func (m *Messenger) ProcessAllMessages() *MessengerResponse {
 	response, err := m.RetrieveAll()
 	if err != nil {
 		m.logger.Error("failed to retrieve raw messages", zap.Error(err))
-		return
+		return nil
 	}
 	m.PublishMessengerResponse(response)
+	return response
 }
 
 func (m *Messenger) PublishMessengerResponse(response *MessengerResponse) {

--- a/protocol/messenger.go
+++ b/protocol/messenger.go
@@ -153,6 +153,10 @@ type Messenger struct {
 	historicSyncInFlight      bool
 	lastHistoricSyncRequestAt time.Time
 
+	// communityHistoryFetches tracks cancellable, per-community spectate backfills
+	// so they can be aborted on leave / app-background (issue #21470-hf).
+	communityHistoryFetches *communityHistoryFetchRegistry
+
 	connectionStateMutex  sync.RWMutex
 	connectionState       connection.State
 	contractMaker         *contracts.ContractMaker
@@ -424,21 +428,22 @@ func NewMessenger(
 			logger: logger,
 			me:     selfContact,
 		},
-		allInstallations:      new(installationMap),
-		installationID:        installationID,
-		modifiedInstallations: new(stringBoolMap),
-		database:              database,
-		multiAccounts:         c.multiAccount,
-		settings:              settings,
-		verificationDatabase:  verification.NewPersistence(database),
-		mailserversDatabase:   c.mailserversDatabase,
-		account:               c.account,
-		quit:                  make(chan struct{}),
-		ctx:                   ctx,
-		cancel:                cancel,
-		importingCommunities:  make(map[string]bool),
-		importingChannels:     make(map[string]bool),
-		importRateLimiter:     rate.NewLimiter(rate.Every(importSlowRate), 1),
+		allInstallations:        new(installationMap),
+		installationID:          installationID,
+		modifiedInstallations:   new(stringBoolMap),
+		database:                database,
+		multiAccounts:           c.multiAccount,
+		settings:                settings,
+		verificationDatabase:    verification.NewPersistence(database),
+		mailserversDatabase:     c.mailserversDatabase,
+		account:                 c.account,
+		quit:                    make(chan struct{}),
+		ctx:                     ctx,
+		cancel:                  cancel,
+		importingCommunities:    make(map[string]bool),
+		importingChannels:       make(map[string]bool),
+		communityHistoryFetches: newCommunityHistoryFetchRegistry(),
+		importRateLimiter:       rate.NewLimiter(rate.Every(importSlowRate), 1),
 		importDelayer: struct {
 			wait chan struct{}
 			once sync.Once
@@ -553,6 +558,11 @@ func (m *Messenger) processSentMessage(id string) error {
 
 func (m *Messenger) SetPaused(paused bool) {
 	m.paused.Store(paused)
+	if paused {
+		// Backgrounding stops any in-flight scoped community history backfills, which
+		// on device were measured continuing headless after the UI died (#21470-hf).
+		m.communityHistoryFetches.cancelAll()
+	}
 	if m.ensVerifier != nil {
 		m.ensVerifier.SetPaused(paused)
 	}

--- a/protocol/messenger_communities.go
+++ b/protocol/messenger_communities.go
@@ -958,7 +958,14 @@ func (m *Messenger) SpectatedCommunities() ([]*communities.Community, error) {
 	return m.communitiesManager.Spectated()
 }
 
-func (m *Messenger) initCommunityChats(community *communities.Community) ([]*Chat, error) {
+// initCommunityChats initialises a community's chats and filters. When spectated is
+// true the broad, full-period history sync is NOT scheduled here — the caller
+// (SpectateCommunity) drives a scoped 24h backfill instead (issue #21470-hf). A
+// keyless spectator's full-period backfill of the community's single universal
+// content topic ingests gigabytes of undecryptable payloads; the broad sync scheduled
+// here would race the scoped one for the topic watermark and defeat the scoping.
+// Joining keeps today's behavior (the broad sync runs).
+func (m *Messenger) initCommunityChats(community *communities.Community, spectated bool) ([]*Chat, error) {
 	logger := m.logger.Named("initCommunityChats")
 
 	chats := CreateCommunityChats(community, m.getTimesource())
@@ -983,10 +990,13 @@ func (m *Messenger) initCommunityChats(community *communities.Community) ([]*Cha
 		filters = append(filters, communityFilters...)
 	}
 
-	willSync, err := m.scheduleSyncFilters(filters)
-	if err != nil {
-		logger.Debug("m.scheduleSyncFilters error", zap.Error(err))
-		return nil, err
+	willSync := false
+	if scoped, _ := communityInitialHistorySync(spectated); !scoped {
+		willSync, err = m.scheduleSyncFilters(filters)
+		if err != nil {
+			logger.Debug("m.scheduleSyncFilters error", zap.Error(err))
+			return nil, err
+		}
 	}
 
 	if !willSync {
@@ -1062,7 +1072,7 @@ func (m *Messenger) joinCommunity(ctx context.Context, communityID types3.HexByt
 
 	// chats and settings are already initialized for spectated communities
 	if !community.Spectated() {
-		chats, err := m.initCommunityChats(community)
+		chats, err := m.initCommunityChats(community, false)
 		if err != nil {
 			return nil, err
 		}
@@ -1147,7 +1157,7 @@ func (m *Messenger) SpectateCommunity(communityID types3.HexBytes) (*MessengerRe
 		return nil, err
 	}
 
-	chats, err := m.initCommunityChats(community)
+	chats, err := m.initCommunityChats(community, true)
 	if err != nil {
 		return nil, err
 	}
@@ -1161,8 +1171,12 @@ func (m *Messenger) SpectateCommunity(communityID types3.HexBytes) (*MessengerRe
 
 	response.AddCommunity(community)
 
-	// sync community
-	m.asyncRequestAllHistoricMessages()
+	// #21470-hf: a spectator holds no community keys, so the previous global
+	// full-period backfill of every filter pulled the community's single universal
+	// content topic as gigabytes of undecryptable payloads (measured ~2-3GB/11min at
+	// ~330% service CPU). Backfill ONLY this community's filters over a scoped 24h
+	// window, cancellable on leave / app-background.
+	m.asyncSyncSpectatedCommunity(community)
 
 	return response, nil
 }
@@ -2245,6 +2259,10 @@ func (m *Messenger) LeaveCommunity(communityID types3.HexBytes) (*MessengerRespo
 
 func (m *Messenger) leaveCommunity(communityID types3.HexBytes) (*MessengerResponse, error) {
 	response := &MessengerResponse{}
+
+	// Leaving (or unspectating) a community stops any in-flight scoped history
+	// backfill for it (issue #21470-hf).
+	m.communityHistoryFetches.cancel(communityID.String())
 
 	community, err := m.communitiesManager.LeaveCommunity(communityID)
 	if err != nil {
@@ -3633,7 +3651,7 @@ func (m *Messenger) InitHistoryArchiveTasks(communities []*communities.Community
 			}
 
 			// Request possibly missed waku messages for community
-			_, err = m.syncFiltersFrom(peerInfo, filters, uint32(latestWakuMessageTimestamp))
+			_, err = m.syncFiltersFrom(m.ctx, peerInfo, filters, uint32(latestWakuMessageTimestamp))
 			if err != nil {
 				m.logger.Error("failed to request missing messages", zap.Error(err))
 				continue

--- a/protocol/messenger_communities.go
+++ b/protocol/messenger_communities.go
@@ -3651,7 +3651,7 @@ func (m *Messenger) InitHistoryArchiveTasks(communities []*communities.Community
 			}
 
 			// Request possibly missed waku messages for community
-			_, err = m.syncFiltersFrom(m.ctx, peerInfo, filters, uint32(latestWakuMessageTimestamp))
+			_, err = m.syncFiltersFrom(m.ctx, peerInfo, filters, uint32(latestWakuMessageTimestamp), nil)
 			if err != nil {
 				m.logger.Error("failed to request missing messages", zap.Error(err))
 				continue

--- a/protocol/messenger_mailserver.go
+++ b/protocol/messenger_mailserver.go
@@ -18,7 +18,6 @@ import (
 	"github.com/status-im/status-go/internal/crypto"
 	"github.com/status-im/status-go/internal/crypto/types"
 	types2 "github.com/status-im/status-go/pkg/messaging/types"
-	wakutypes "github.com/status-im/status-go/pkg/messaging/waku/types"
 	"github.com/status-im/status-go/protocol/common"
 	"github.com/status-im/status-go/protocol/protobuf"
 	"github.com/status-im/status-go/services/mailservers"
@@ -422,12 +421,12 @@ func getPrioritizedBatches() []int {
 }
 
 // syncFiltersFrom backfills the given filters from the store node starting at
-// lastRequest. When hashFirstStats is non-nil the spectate hash-first path is used
-// (issue #21470-hf): each batch fetches only the window's hashes and then bodies for the
-// hashes not already held locally, and per-batch stats are accumulated into
-// hashFirstStats for the caller's once-per-backfill log. A nil hashFirstStats keeps the
-// classic full-body path (the general, non-spectate syncFilters callers).
-func (m *Messenger) syncFiltersFrom(ctx context.Context, peerInfo peer.AddrInfo, filters types2.ChatFilters, lastRequest uint32, hashFirstStats *wakutypes.HashFirstStats) (*MessengerResponse, error) {
+// lastRequest. When hf is non-nil the spectate hash-first path is used (issue #21470-hf):
+// each batch fetches only the window's hashes and then bodies for the hashes not already
+// held locally (skipping the body fetch entirely when hf.skipEncryptedBodies is set), and
+// per-batch stats are accumulated into hf.stats for the caller's once-per-backfill log. A
+// nil hf keeps the classic full-body path (the general, non-spectate syncFilters callers).
+func (m *Messenger) syncFiltersFrom(ctx context.Context, peerInfo peer.AddrInfo, filters types2.ChatFilters, lastRequest uint32, hf *hashFirstBackfill) (*MessengerResponse, error) {
 	canSync, err := m.canSyncWithStoreNodes()
 	if err != nil {
 		return nil, err
@@ -567,8 +566,8 @@ func (m *Messenger) syncFiltersFrom(ctx context.Context, peerInfo peer.AddrInfo,
 		sort.Ints(batchKeys)
 		for _, k := range batchKeys {
 			var err error
-			if hashFirstStats != nil {
-				err = m.processMailserverBatchHashFirst(ctx, peerInfo, batches[pubsubTopic][k], hashFirstStats)
+			if hf != nil {
+				err = m.processMailserverBatchHashFirst(ctx, peerInfo, batches[pubsubTopic][k], hf)
 			} else {
 				err = m.processMailserverBatchWithContext(ctx, peerInfo, batches[pubsubTopic][k])
 			}
@@ -721,11 +720,12 @@ func (m *Messenger) processMailserverBatchWithContext(ctx context.Context, peerI
 // processMailserverBatchHashFirst is the hash-first counterpart of
 // processMailserverBatchWithContext used by the spectate backfill (issue #21470-hf): it
 // fetches only the window's message hashes and then full bodies for the hashes not
-// already held locally, accumulating per-batch stats into stats. It preserves the same
-// metered-network gate (canSyncWithStoreNodes) and cancellation semantics as the classic
-// path; watermark bookkeeping stays in syncFiltersFrom and advances only after this
-// returns without error, so a cancelled batch marks nothing fetched.
-func (m *Messenger) processMailserverBatchHashFirst(ctx context.Context, peerInfo peer.AddrInfo, batch types2.StoreNodeBatch, stats *wakutypes.HashFirstStats) error {
+// already held locally (skipping the body fetch entirely when hf.skipEncryptedBodies is
+// set), accumulating per-batch stats into hf.stats. It preserves the same metered-network
+// gate (canSyncWithStoreNodes) and cancellation semantics as the classic path; watermark
+// bookkeeping stays in syncFiltersFrom and advances only after this returns without error,
+// so a cancelled batch marks nothing fetched.
+func (m *Messenger) processMailserverBatchHashFirst(ctx context.Context, peerInfo peer.AddrInfo, batch types2.StoreNodeBatch, hf *hashFirstBackfill) error {
 	canSync, err := m.canSyncWithStoreNodes()
 	if err != nil {
 		return err
@@ -734,11 +734,11 @@ func (m *Messenger) processMailserverBatchHashFirst(ctx context.Context, peerInf
 		return nil
 	}
 
-	batchStats, err := m.messaging.ProcessMailserverBatchHashFirst(ctx, batch, peerInfo, false)
+	batchStats, err := m.messaging.ProcessMailserverBatchHashFirst(ctx, batch, peerInfo, false, hf.skipEncryptedBodies)
 	if err != nil {
 		return err
 	}
-	stats.Add(batchStats)
+	hf.stats.Add(batchStats)
 	return nil
 }
 

--- a/protocol/messenger_mailserver.go
+++ b/protocol/messenger_mailserver.go
@@ -312,9 +312,26 @@ func (m *Messenger) requestAllHistoricMessages(withRetries bool, aggregateRespon
 
 		peerInfo := m.messaging.GetActiveStorenode()
 
+		// The general all-filters history sync runs hash-first: each batch fetches only the
+		// window's hashes and then bodies for the hashes not already held locally, so the
+		// classic path no longer re-downloads (full-body) community/personal history we
+		// already have (issue #21470-hf). skipEncryptedBodies stays false — this is the
+		// all-filters sync and personal/1-1/contact bodies are always wanted; the keyless
+		// body-skip is exclusive to the spectate call site.
+		hf := &hashFirstBackfill{}
+		defer func() {
+			// One INFO line per requestAllHistoricMessages run (not per batch): the on-device
+			// evidence of the byte cut — hashes walked vs. bodies actually fetched.
+			m.logger.Info("history sync hash-first",
+				zap.Int("hashesSeen", hf.stats.HashesSeen),
+				zap.Int("hashesKnown", hf.stats.HashesKnown),
+				zap.Int("bodiesFetched", hf.stats.BodiesFetched),
+				zap.Int64("bytesEstimate", hf.stats.BytesEstimate))
+		}()
+
 		if withRetries {
 			response, err := m.performStorenodeTask(func() (*MessengerResponse, error) {
-				return m.syncFilters(peerInfo, filters)
+				return m.syncFiltersFrom(m.ctx, peerInfo, filters, 0, hf)
 			}, history.WithPeerID(peerInfo.ID))
 			if err != nil {
 				return nil, err
@@ -326,7 +343,7 @@ func (m *Messenger) requestAllHistoricMessages(withRetries bool, aggregateRespon
 			return allResponses, nil
 		}
 
-		response, err := m.syncFilters(peerInfo, filters)
+		response, err := m.syncFiltersFrom(m.ctx, peerInfo, filters, 0, hf)
 		if err != nil {
 			return nil, err
 		}
@@ -630,7 +647,11 @@ func (m *Messenger) syncFiltersFrom(ctx context.Context, peerInfo peer.AddrInfo,
 }
 
 func (m *Messenger) syncFilters(peerInfo peer.AddrInfo, filters types2.ChatFilters) (*MessengerResponse, error) {
-	return m.syncFiltersFrom(m.ctx, peerInfo, filters, 0, nil)
+	// General (non-spectate) filter sync runs hash-first, fetching bodies only for hashes
+	// not already held locally (issue #21470-hf). skipEncryptedBodies stays false — these
+	// are the scheduled/per-chat syncs where personal/1-1/contact bodies are always wanted;
+	// the keyless body-skip is exclusive to the spectate call site.
+	return m.syncFiltersFrom(m.ctx, peerInfo, filters, 0, &hashFirstBackfill{})
 }
 
 func (m *Messenger) calculateGapForChat(chat *Chat, from uint32) (*common.Message, error) {
@@ -697,6 +718,16 @@ func (m *Messenger) ConnectionChanged(state connection.State) {
 
 func (m *Messenger) processMailserverBatch(peerInfo peer.AddrInfo, batch types2.StoreNodeBatch) error {
 	return m.processMailserverBatchWithContext(m.ctx, peerInfo, batch)
+}
+
+// processMailserverBatchPersonal runs a single-batch backfill hash-first on the messenger
+// context, always fetching bodies for unknown hashes (skipEncryptedBodies=false — the
+// on-demand single-chat paths want personal/1-1/contact bodies). Like the general sync it
+// only stops re-downloading bodies already held locally (issue #21470-hf). The metadata
+// walk chunks topics and splits a multi-day window into <=24h sub-windows, so it covers the
+// same range as the classic processMailserverBatch it replaces on these paths.
+func (m *Messenger) processMailserverBatchPersonal(peerInfo peer.AddrInfo, batch types2.StoreNodeBatch) error {
+	return m.processMailserverBatchHashFirst(m.ctx, peerInfo, batch, &hashFirstBackfill{})
 }
 
 // processMailserverBatchWithContext is processMailserverBatch with a caller-supplied
@@ -792,7 +823,7 @@ func (m *Messenger) SyncChatFromSyncedFrom(chatID string) (uint32, error) {
 			m.config.messengerSignalsHandler.HistoryRequestStarted(1)
 		}
 
-		err = m.processMailserverBatch(peerInfo, batch)
+		err = m.processMailserverBatchPersonal(peerInfo, batch)
 		if err != nil {
 			return nil, err
 		}
@@ -935,7 +966,7 @@ func (m *Messenger) fetchMessages(chatID string, duration time.Duration) (uint32
 			m.config.messengerSignalsHandler.HistoryRequestStarted(1)
 		}
 
-		err = m.processMailserverBatch(peerInfo, batch)
+		err = m.processMailserverBatchPersonal(peerInfo, batch)
 		if err != nil {
 			return nil, err
 		}

--- a/protocol/messenger_mailserver.go
+++ b/protocol/messenger_mailserver.go
@@ -1,6 +1,7 @@
 package protocol
 
 import (
+	"context"
 	"fmt"
 	"sort"
 	"time"
@@ -419,7 +420,7 @@ func getPrioritizedBatches() []int {
 	return []int{1, 5, 10}
 }
 
-func (m *Messenger) syncFiltersFrom(peerInfo peer.AddrInfo, filters types2.ChatFilters, lastRequest uint32) (*MessengerResponse, error) {
+func (m *Messenger) syncFiltersFrom(ctx context.Context, peerInfo peer.AddrInfo, filters types2.ChatFilters, lastRequest uint32) (*MessengerResponse, error) {
 	canSync, err := m.canSyncWithStoreNodes()
 	if err != nil {
 		return nil, err
@@ -558,7 +559,7 @@ func (m *Messenger) syncFiltersFrom(peerInfo peer.AddrInfo, filters types2.ChatF
 		batchKeys := maps.Keys(batches[pubsubTopic])
 		sort.Ints(batchKeys)
 		for _, k := range batchKeys {
-			err := m.processMailserverBatch(peerInfo, batches[pubsubTopic][k])
+			err := m.processMailserverBatchWithContext(ctx, peerInfo, batches[pubsubTopic][k])
 			if err != nil {
 				m.logger.Error("error syncing topics", zap.Error(err))
 				return nil, err
@@ -618,7 +619,7 @@ func (m *Messenger) syncFiltersFrom(peerInfo peer.AddrInfo, filters types2.ChatF
 }
 
 func (m *Messenger) syncFilters(peerInfo peer.AddrInfo, filters types2.ChatFilters) (*MessengerResponse, error) {
-	return m.syncFiltersFrom(peerInfo, filters, 0)
+	return m.syncFiltersFrom(m.ctx, peerInfo, filters, 0)
 }
 
 func (m *Messenger) calculateGapForChat(chat *Chat, from uint32) (*common.Message, error) {
@@ -684,6 +685,16 @@ func (m *Messenger) ConnectionChanged(state connection.State) {
 }
 
 func (m *Messenger) processMailserverBatch(peerInfo peer.AddrInfo, batch types2.StoreNodeBatch) error {
+	return m.processMailserverBatchWithContext(m.ctx, peerInfo, batch)
+}
+
+// processMailserverBatchWithContext is processMailserverBatch with a caller-supplied
+// context, so a request can be cancelled independently of the messenger lifetime
+// (used by the cancellable spectate backfill, issue #21470-hf). The go-waku history
+// paging loop checks ctx.Done() between pages, so cancelling ctx aborts an in-flight
+// request; watermarks are advanced only after a batch completes, so an aborted batch
+// leaves them untouched.
+func (m *Messenger) processMailserverBatchWithContext(ctx context.Context, peerInfo peer.AddrInfo, batch types2.StoreNodeBatch) error {
 	canSync, err := m.canSyncWithStoreNodes()
 	if err != nil {
 		return err
@@ -692,7 +703,7 @@ func (m *Messenger) processMailserverBatch(peerInfo peer.AddrInfo, batch types2.
 		return nil
 	}
 
-	return m.messaging.ProcessMailserverBatch(m.ctx, batch, peerInfo, defaultStoreNodeRequestPageSize, nil, false)
+	return m.messaging.ProcessMailserverBatch(ctx, batch, peerInfo, defaultStoreNodeRequestPageSize, nil, false)
 }
 
 func (m *Messenger) processMailserverBatchWithOptions(peerInfo peer.AddrInfo, batch types2.StoreNodeBatch, pageLimit uint64, shouldProcessNextPage func(int) (bool, uint64), processEnvelopes bool) error {

--- a/protocol/messenger_mailserver.go
+++ b/protocol/messenger_mailserver.go
@@ -18,6 +18,7 @@ import (
 	"github.com/status-im/status-go/internal/crypto"
 	"github.com/status-im/status-go/internal/crypto/types"
 	types2 "github.com/status-im/status-go/pkg/messaging/types"
+	wakutypes "github.com/status-im/status-go/pkg/messaging/waku/types"
 	"github.com/status-im/status-go/protocol/common"
 	"github.com/status-im/status-go/protocol/protobuf"
 	"github.com/status-im/status-go/services/mailservers"
@@ -420,7 +421,13 @@ func getPrioritizedBatches() []int {
 	return []int{1, 5, 10}
 }
 
-func (m *Messenger) syncFiltersFrom(ctx context.Context, peerInfo peer.AddrInfo, filters types2.ChatFilters, lastRequest uint32) (*MessengerResponse, error) {
+// syncFiltersFrom backfills the given filters from the store node starting at
+// lastRequest. When hashFirstStats is non-nil the spectate hash-first path is used
+// (issue #21470-hf): each batch fetches only the window's hashes and then bodies for the
+// hashes not already held locally, and per-batch stats are accumulated into
+// hashFirstStats for the caller's once-per-backfill log. A nil hashFirstStats keeps the
+// classic full-body path (the general, non-spectate syncFilters callers).
+func (m *Messenger) syncFiltersFrom(ctx context.Context, peerInfo peer.AddrInfo, filters types2.ChatFilters, lastRequest uint32, hashFirstStats *wakutypes.HashFirstStats) (*MessengerResponse, error) {
 	canSync, err := m.canSyncWithStoreNodes()
 	if err != nil {
 		return nil, err
@@ -559,7 +566,12 @@ func (m *Messenger) syncFiltersFrom(ctx context.Context, peerInfo peer.AddrInfo,
 		batchKeys := maps.Keys(batches[pubsubTopic])
 		sort.Ints(batchKeys)
 		for _, k := range batchKeys {
-			err := m.processMailserverBatchWithContext(ctx, peerInfo, batches[pubsubTopic][k])
+			var err error
+			if hashFirstStats != nil {
+				err = m.processMailserverBatchHashFirst(ctx, peerInfo, batches[pubsubTopic][k], hashFirstStats)
+			} else {
+				err = m.processMailserverBatchWithContext(ctx, peerInfo, batches[pubsubTopic][k])
+			}
 			if err != nil {
 				m.logger.Error("error syncing topics", zap.Error(err))
 				return nil, err
@@ -619,7 +631,7 @@ func (m *Messenger) syncFiltersFrom(ctx context.Context, peerInfo peer.AddrInfo,
 }
 
 func (m *Messenger) syncFilters(peerInfo peer.AddrInfo, filters types2.ChatFilters) (*MessengerResponse, error) {
-	return m.syncFiltersFrom(m.ctx, peerInfo, filters, 0)
+	return m.syncFiltersFrom(m.ctx, peerInfo, filters, 0, nil)
 }
 
 func (m *Messenger) calculateGapForChat(chat *Chat, from uint32) (*common.Message, error) {
@@ -704,6 +716,30 @@ func (m *Messenger) processMailserverBatchWithContext(ctx context.Context, peerI
 	}
 
 	return m.messaging.ProcessMailserverBatch(ctx, batch, peerInfo, defaultStoreNodeRequestPageSize, nil, false)
+}
+
+// processMailserverBatchHashFirst is the hash-first counterpart of
+// processMailserverBatchWithContext used by the spectate backfill (issue #21470-hf): it
+// fetches only the window's message hashes and then full bodies for the hashes not
+// already held locally, accumulating per-batch stats into stats. It preserves the same
+// metered-network gate (canSyncWithStoreNodes) and cancellation semantics as the classic
+// path; watermark bookkeeping stays in syncFiltersFrom and advances only after this
+// returns without error, so a cancelled batch marks nothing fetched.
+func (m *Messenger) processMailserverBatchHashFirst(ctx context.Context, peerInfo peer.AddrInfo, batch types2.StoreNodeBatch, stats *wakutypes.HashFirstStats) error {
+	canSync, err := m.canSyncWithStoreNodes()
+	if err != nil {
+		return err
+	}
+	if !canSync {
+		return nil
+	}
+
+	batchStats, err := m.messaging.ProcessMailserverBatchHashFirst(ctx, batch, peerInfo, false)
+	if err != nil {
+		return err
+	}
+	stats.Add(batchStats)
+	return nil
 }
 
 func (m *Messenger) processMailserverBatchWithOptions(peerInfo peer.AddrInfo, batch types2.StoreNodeBatch, pageLimit uint64, shouldProcessNextPage func(int) (bool, uint64), processEnvelopes bool) error {

--- a/protocol/messenger_mailserver.go
+++ b/protocol/messenger_mailserver.go
@@ -326,7 +326,8 @@ func (m *Messenger) requestAllHistoricMessages(withRetries bool, aggregateRespon
 				zap.Int("hashesSeen", hf.stats.HashesSeen),
 				zap.Int("hashesKnown", hf.stats.HashesKnown),
 				zap.Int("bodiesFetched", hf.stats.BodiesFetched),
-				zap.Int64("bytesEstimate", hf.stats.BytesEstimate))
+				zap.Int64("bytesEstimate", hf.stats.BytesEstimate),
+				zap.Int("bodyFetchThrottled", hf.stats.BodyFetchThrottled))
 		}()
 
 		if withRetries {

--- a/protocol/messenger_retrieve_loop_test.go
+++ b/protocol/messenger_retrieve_loop_test.go
@@ -1,0 +1,65 @@
+package protocol
+
+import (
+	"testing"
+	"time"
+)
+
+// TestNextFlushDeadline verifies the scheduling decision that bounds the
+// retrieve-loop debounce latency: normally the flush fires after a quiet
+// window (debounce) following the last match, but under a sustained match
+// flood the ceiling (maxLatency measured from the first unflushed match)
+// caps how long the flush can be delayed. See issue #21470.
+func TestNextFlushDeadline(t *testing.T) {
+	base := time.Unix(1000, 0)
+	debounce := time.Second
+	maxLatency := 3 * time.Second
+
+	tests := []struct {
+		name         string
+		pendingSince time.Time
+		now          time.Time
+		want         time.Time
+	}{
+		{
+			// First/isolated match: quiet window still fits under the ceiling,
+			// so behaviour is unchanged from the pure debounce.
+			name:         "quiet path debounce wins",
+			pendingSince: base,
+			now:          base,
+			want:         base.Add(debounce),
+		},
+		{
+			// Matches have been arriving for 2.5s without a quiet gap; the
+			// ceiling (pendingSince+3s) is sooner than now+1s and must win.
+			name:         "flood ceiling caps latency",
+			pendingSince: base.Add(-2500 * time.Millisecond),
+			now:          base,
+			want:         base.Add(500 * time.Millisecond),
+		},
+		{
+			// Exactly at the crossover: both deadlines land on now+1s.
+			name:         "boundary deadlines equal",
+			pendingSince: base.Add(-2 * time.Second),
+			now:          base,
+			want:         base.Add(debounce),
+		},
+		{
+			// Just past the crossover: ceiling wins by 1ms.
+			name:         "just past boundary ceiling wins",
+			pendingSince: base.Add(-2001 * time.Millisecond),
+			now:          base,
+			want:         base.Add(999 * time.Millisecond),
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := nextFlushDeadline(tc.pendingSince, tc.now, debounce, maxLatency)
+			if !got.Equal(tc.want) {
+				t.Fatalf("nextFlushDeadline(%v, %v, %v, %v) = %v, want %v",
+					tc.pendingSince, tc.now, debounce, maxLatency, got, tc.want)
+			}
+		})
+	}
+}

--- a/protocol/messenger_spectate_history_sync.go
+++ b/protocol/messenger_spectate_history_sync.go
@@ -296,7 +296,8 @@ func (m *Messenger) asyncSyncSpectatedCommunity(community *communities.Community
 			zap.Int("hashesKnown", hf.stats.HashesKnown),
 			zap.Int("bodiesFetched", hf.stats.BodiesFetched),
 			zap.Int64("bytesEstimate", hf.stats.BytesEstimate),
-			zap.Int("bodiesSkippedKeyless", hf.stats.BodiesSkippedKeyless))
+			zap.Int("bodiesSkippedKeyless", hf.stats.BodiesSkippedKeyless),
+			zap.Int("bodyFetchThrottled", hf.stats.BodyFetchThrottled))
 	}()
 }
 

--- a/protocol/messenger_spectate_history_sync.go
+++ b/protocol/messenger_spectate_history_sync.go
@@ -12,6 +12,7 @@ import (
 
 	gocommon "github.com/status-im/status-go/common"
 	types2 "github.com/status-im/status-go/pkg/messaging/types"
+	wakutypes "github.com/status-im/status-go/pkg/messaging/waku/types"
 	"github.com/status-im/status-go/protocol/communities"
 	"github.com/status-im/status-go/services/mailservers"
 )
@@ -185,9 +186,10 @@ func (m *Messenger) asyncSyncSpectatedCommunity(community *communities.Community
 			return
 		}
 
+		stats := &wakutypes.HashFirstStats{}
 		peerInfo := m.messaging.GetActiveStorenode()
 		_, err := m.performStorenodeTask(func() (*MessengerResponse, error) {
-			response, err := m.syncFiltersFrom(ctx, peerInfo, filters, from)
+			response, err := m.syncFiltersFrom(ctx, peerInfo, filters, from, stats)
 			if err != nil {
 				if ctx.Err() != nil {
 					// Cancelled by leave / background: stop cleanly, without retrying
@@ -209,6 +211,15 @@ func (m *Messenger) asyncSyncSpectatedCommunity(community *communities.Community
 			m.logger.Error("failed to perform spectated community history request",
 				zap.String("communityID", communityID), zap.Error(err))
 		}
+
+		// One INFO line per backfill: the on-device evidence of the byte cut — hashes
+		// walked vs. bodies actually fetched (issue #21470-hf).
+		m.logger.Info("spectated community hash-first backfill",
+			zap.String("communityID", communityID),
+			zap.Int("hashesSeen", stats.HashesSeen),
+			zap.Int("hashesKnown", stats.HashesKnown),
+			zap.Int("bodiesFetched", stats.BodiesFetched),
+			zap.Int64("bytesEstimate", stats.BytesEstimate))
 	}()
 }
 

--- a/protocol/messenger_spectate_history_sync.go
+++ b/protocol/messenger_spectate_history_sync.go
@@ -46,6 +46,32 @@ func communityInitialHistorySync(spectated bool) (scoped bool, window time.Durat
 	return false, 0
 }
 
+// hashFirstBackfill carries the spectate hash-first backfill's options and accumulated
+// stats through syncFiltersFrom (issue #21470-hf). A nil *hashFirstBackfill selects the
+// classic full-body path used by the general (non-spectate) syncFilters callers.
+type hashFirstBackfill struct {
+	// skipEncryptedBodies drops the body-fetch phase for a keyless spectator whose
+	// community description is already resolved (see spectateShouldSkipKeylessBodies).
+	skipEncryptedBodies bool
+	// stats accumulates each batch's hash-first counters for the once-per-backfill log.
+	stats wakutypes.HashFirstStats
+}
+
+// spectateShouldSkipKeylessBodies decides whether a spectator's hash-first backfill
+// should skip the body-fetch phase entirely (issue #21470-hf enhancement).
+//
+// The community's channels and its description share ONE content topic, so a hash cannot
+// tell them apart. But the spectator's OWN state can: when the node holds no decryption
+// keys for the community (holdsKeys false) AND the community description is already
+// resolved (the spectate flow fetches it before this backfill runs), every body on that
+// topic is either a description we already hold or an undecryptable channel message.
+// Fetching them is pure heat, so we skip — the hashes are still walked so the watermark
+// advances, and the bodies stay on the store node, re-fetchable in full after a join.
+// A keyed user (joined) legitimately wants the bodies, so it never skips.
+func spectateShouldSkipKeylessBodies(holdsKeys, descriptionResolved bool) bool {
+	return !holdsKeys && descriptionResolved
+}
+
 // mailserverTopicRef identifies a store-node topic (its pubsub + content topic).
 type mailserverTopicRef struct {
 	pubsubTopic  string
@@ -186,10 +212,19 @@ func (m *Messenger) asyncSyncSpectatedCommunity(community *communities.Community
 			return
 		}
 
-		stats := &wakutypes.HashFirstStats{}
+		// Keyless-spectator body skip (issue #21470-hf enhancement): a spectator holds no
+		// community keys and its description is already resolved by the time this backfill
+		// runs, so every body on the shared community content topic is undecryptable or
+		// already held — skip fetching bodies entirely.
+		holdsKeys := m.communitiesManager.CommunityHoldsAnyDecryptionKey(community)
+		descriptionResolved := community.Description() != nil
+		hf := &hashFirstBackfill{
+			skipEncryptedBodies: spectateShouldSkipKeylessBodies(holdsKeys, descriptionResolved),
+		}
+
 		peerInfo := m.messaging.GetActiveStorenode()
 		_, err := m.performStorenodeTask(func() (*MessengerResponse, error) {
-			response, err := m.syncFiltersFrom(ctx, peerInfo, filters, from, stats)
+			response, err := m.syncFiltersFrom(ctx, peerInfo, filters, from, hf)
 			if err != nil {
 				if ctx.Err() != nil {
 					// Cancelled by leave / background: stop cleanly, without retrying
@@ -213,13 +248,14 @@ func (m *Messenger) asyncSyncSpectatedCommunity(community *communities.Community
 		}
 
 		// One INFO line per backfill: the on-device evidence of the byte cut — hashes
-		// walked vs. bodies actually fetched (issue #21470-hf).
+		// walked vs. bodies actually fetched vs. bodies skipped as keyless heat (#21470-hf).
 		m.logger.Info("spectated community hash-first backfill",
 			zap.String("communityID", communityID),
-			zap.Int("hashesSeen", stats.HashesSeen),
-			zap.Int("hashesKnown", stats.HashesKnown),
-			zap.Int("bodiesFetched", stats.BodiesFetched),
-			zap.Int64("bytesEstimate", stats.BytesEstimate))
+			zap.Int("hashesSeen", hf.stats.HashesSeen),
+			zap.Int("hashesKnown", hf.stats.HashesKnown),
+			zap.Int("bodiesFetched", hf.stats.BodiesFetched),
+			zap.Int64("bytesEstimate", hf.stats.BytesEstimate),
+			zap.Int("bodiesSkippedKeyless", hf.stats.BodiesSkippedKeyless))
 	}()
 }
 

--- a/protocol/messenger_spectate_history_sync.go
+++ b/protocol/messenger_spectate_history_sync.go
@@ -1,0 +1,289 @@
+package protocol
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"go.uber.org/zap"
+
+	"github.com/waku-org/go-waku/waku/v2/api/history"
+
+	gocommon "github.com/status-im/status-go/common"
+	types2 "github.com/status-im/status-go/pkg/messaging/types"
+	"github.com/status-im/status-go/protocol/communities"
+	"github.com/status-im/status-go/services/mailservers"
+)
+
+// spectatedCommunityInitialSyncPeriod bounds the history backfill triggered when a
+// user spectates a community (issue #21470-hf).
+//
+// A spectator holds no community decryption keys, and every channel in a community
+// rides ONE universal content topic, so a full default-period (9-day) backfill pulls
+// the entire community's traffic as undecryptable payloads. Device measurement
+// (Samsung S21FE, fresh account spectating the Status community): ~2-3GB ingested in
+// ~11min at ~330% service CPU, GC-bound. Because all channels share one content
+// topic, per-channel scoping is impossible — the WINDOW is the only byte-cutting
+// lever, so spectate is bounded to 24h.
+const spectatedCommunityInitialSyncPeriod = 24 * time.Hour
+
+// spectatedCommunitySyncFrom returns the store-node "from" timestamp (unix seconds)
+// for a spectator's scoped backfill: now minus the spectate window.
+func spectatedCommunitySyncFrom(nowUnixSeconds uint32) uint32 {
+	return nowUnixSeconds - uint32(spectatedCommunityInitialSyncPeriod/time.Second)
+}
+
+// communityInitialHistorySync decides how a community's FIRST history backfill is
+// scoped. Spectators get the tight 24h window (deeper history is undecryptable heat);
+// joiners keep today's behavior — a full default-period backfill — because they hold
+// keys and legitimately want the history.
+func communityInitialHistorySync(spectated bool) (scoped bool, window time.Duration) {
+	if spectated {
+		return true, spectatedCommunityInitialSyncPeriod
+	}
+	return false, 0
+}
+
+// mailserverTopicRef identifies a store-node topic (its pubsub + content topic).
+type mailserverTopicRef struct {
+	pubsubTopic  string
+	contentTopic string
+}
+
+// mailserverTopicKey is the map key syncFiltersFrom uses to look topics up; the seed
+// path must match it so a seeded topic is recognised as "already tracked".
+func mailserverTopicKey(pubsubTopic, contentTopic string) string {
+	return fmt.Sprintf("%s-%s", pubsubTopic, contentTopic)
+}
+
+// communityHistorySeedTopics returns the watermark rows to insert so a spectator's
+// first backfill of the given topics is bounded to lastRequest.
+//
+// syncFiltersFrom ignores its lastRequest argument for topics not yet present in the
+// mailserver DB (it hardcodes the default sync period for fresh topics), so without a
+// pre-seeded watermark a spectate would refetch the full default period. Topics
+// already tracked are skipped — AddTopics is INSERT-OR-REPLACE, and rewinding a good
+// watermark would refetch history we already have. Each topic is seeded at most once.
+func communityHistorySeedTopics(refs []mailserverTopicRef, existing map[string]struct{}, lastRequest int) []mailservers.MailserverTopic {
+	seeded := make(map[string]struct{}, len(refs))
+	var seeds []mailservers.MailserverTopic
+	for _, ref := range refs {
+		key := mailserverTopicKey(ref.pubsubTopic, ref.contentTopic)
+		if _, ok := existing[key]; ok {
+			continue
+		}
+		if _, ok := seeded[key]; ok {
+			continue
+		}
+		seeded[key] = struct{}{}
+		seeds = append(seeds, mailservers.MailserverTopic{
+			PubsubTopic:  ref.pubsubTopic,
+			ContentTopic: ref.contentTopic,
+			LastRequest:  lastRequest,
+		})
+	}
+	return seeds
+}
+
+// communitySyncFilters returns the transport filters that carry a community's
+// traffic: its single universal content topic plus the community-level filters. It
+// resolves the community's DefaultFilters chat ids to the live filters created when
+// the community was initialised. Every channel rides the one universal (community-id)
+// content topic, so this set covers all of the community's store-node bytes.
+func (m *Messenger) communitySyncFilters(community *communities.Community) types2.ChatFilters {
+	var filters types2.ChatFilters
+	seen := make(map[string]struct{})
+	for _, spec := range m.DefaultFilters(community) {
+		filter := m.messaging.ChatFilterByChatID(spec.ChatID)
+		if filter == nil {
+			continue
+		}
+		if _, ok := seen[filter.ChatID()]; ok {
+			continue
+		}
+		seen[filter.ChatID()] = struct{}{}
+		filters = append(filters, filter)
+	}
+	return filters
+}
+
+// seedCommunityHistoryWatermarks pre-seeds the mailserver watermark for each of the
+// given filters' topics that is not already tracked, so the spectate backfill's first
+// fetch is bounded to lastRequest instead of the full default sync period.
+func (m *Messenger) seedCommunityHistoryWatermarks(filters types2.ChatFilters, lastRequest int) error {
+	if m.mailserversDatabase == nil {
+		return nil
+	}
+
+	existingTopics, err := m.mailserversDatabase.Topics()
+	if err != nil {
+		return err
+	}
+	existing := make(map[string]struct{}, len(existingTopics))
+	for _, t := range existingTopics {
+		existing[mailserverTopicKey(t.PubsubTopic, t.ContentTopic)] = struct{}{}
+	}
+
+	refs := make([]mailserverTopicRef, 0, len(filters))
+	for _, filter := range filters {
+		refs = append(refs, mailserverTopicRef{
+			pubsubTopic:  filter.PubsubTopic(),
+			contentTopic: filter.ContentTopic().String(),
+		})
+	}
+
+	seeds := communityHistorySeedTopics(refs, existing, lastRequest)
+	if len(seeds) == 0 {
+		return nil
+	}
+	return m.mailserversDatabase.AddTopics(seeds)
+}
+
+// asyncSyncSpectatedCommunity backfills a freshly-spectated community's history over
+// the scoped 24h window (issue #21470-hf), replacing the global all-filters,
+// full-period backfill that spectating previously triggered. The fetch runs under a
+// per-community cancellable context registered on the messenger, so it stops when the
+// user leaves the community or the app is backgrounded.
+//
+// No message loss: skipped (older or cancelled) history stays on the store node; each
+// completed batch advances the per-topic watermark so later syncs resume exactly where
+// this one stopped; live relay delivery is unaffected; and the missing-message
+// verifier remains a net for anything not covered. A cancelled batch advances no
+// watermark, so nothing is marked fetched that was not.
+func (m *Messenger) asyncSyncSpectatedCommunity(community *communities.Community) {
+	shouldSync, err := m.shouldSync()
+	if err != nil {
+		m.logger.Error("failed to get shouldSync for spectated community", zap.Error(err))
+		return
+	}
+	if !shouldSync {
+		return
+	}
+
+	filters := m.communitySyncFilters(community)
+	if len(filters) == 0 {
+		return
+	}
+
+	communityID := community.IDString()
+	from := spectatedCommunitySyncFrom(uint32(m.getTimesource().GetCurrentTime() / 1000))
+
+	ctx, cancel := context.WithCancel(m.ctx)
+	token := m.communityHistoryFetches.register(communityID, cancel)
+
+	m.shutdownWaitGroup.Add(1)
+	go func() {
+		defer gocommon.LogOnPanic()
+		defer m.shutdownWaitGroup.Done()
+		defer cancel()
+		defer m.communityHistoryFetches.finish(communityID, token)
+
+		if err := m.seedCommunityHistoryWatermarks(filters, int(from)); err != nil {
+			m.logger.Warn("failed to seed spectated community history watermarks",
+				zap.String("communityID", communityID), zap.Error(err))
+			return
+		}
+
+		peerInfo := m.messaging.GetActiveStorenode()
+		_, err := m.performStorenodeTask(func() (*MessengerResponse, error) {
+			response, err := m.syncFiltersFrom(ctx, peerInfo, filters, from)
+			if err != nil {
+				if ctx.Err() != nil {
+					// Cancelled by leave / background: stop cleanly, without retrying
+					// or penalising the storenode's failure accounting.
+					m.logger.Debug("spectated community history sync cancelled",
+						zap.String("communityID", communityID))
+					return nil, nil
+				}
+				m.logger.Error("failed to sync spectated community history",
+					zap.String("communityID", communityID), zap.Error(err))
+				return nil, err
+			}
+			if m.config.messengerSignalsHandler != nil {
+				m.config.messengerSignalsHandler.MessengerResponse(response)
+			}
+			return response, nil
+		}, history.WithPeerID(peerInfo.ID))
+		if err != nil {
+			m.logger.Error("failed to perform spectated community history request",
+				zap.String("communityID", communityID), zap.Error(err))
+		}
+	}()
+}
+
+// communityHistoryFetchRegistry tracks the cancellable, per-community spectate
+// backfill goroutines so they can be aborted when the user leaves the community or
+// the app is backgrounded (issue #21470-hf, part B). On device the backfill was
+// measured continuing headless after the UI process died; cancellation stops it.
+//
+// Each registration is tagged with a monotonic token so a goroutine finishing on its
+// own only removes the map entry it still owns, never a fresher registration that
+// replaced it (context.CancelFunc values are not comparable, hence the token).
+type communityHistoryFetchRegistry struct {
+	mu      sync.Mutex
+	seq     uint64
+	entries map[string]communityHistoryFetchEntry
+}
+
+type communityHistoryFetchEntry struct {
+	token  uint64
+	cancel context.CancelFunc
+}
+
+func newCommunityHistoryFetchRegistry() *communityHistoryFetchRegistry {
+	return &communityHistoryFetchRegistry{
+		entries: make(map[string]communityHistoryFetchEntry),
+	}
+}
+
+// register records a new in-flight fetch for communityID, cancelling and replacing
+// any fetch already registered for it (e.g. a rapid re-spectate). It returns a token
+// identifying this registration, to be passed to finish.
+func (r *communityHistoryFetchRegistry) register(communityID string, cancel context.CancelFunc) uint64 {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if existing, ok := r.entries[communityID]; ok {
+		existing.cancel()
+	}
+	r.seq++
+	token := r.seq
+	r.entries[communityID] = communityHistoryFetchEntry{token: token, cancel: cancel}
+	return token
+}
+
+// cancel aborts the in-flight fetch for communityID (leave / unspectate path). It is
+// a no-op if none is registered.
+func (r *communityHistoryFetchRegistry) cancel(communityID string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if entry, ok := r.entries[communityID]; ok {
+		entry.cancel()
+		delete(r.entries, communityID)
+	}
+}
+
+// cancelAll aborts every in-flight fetch (app backgrounded).
+func (r *communityHistoryFetchRegistry) cancelAll() {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	for communityID, entry := range r.entries {
+		entry.cancel()
+		delete(r.entries, communityID)
+	}
+}
+
+// finish removes the registration for communityID IFF token still identifies the
+// current entry. A goroutine calls this on natural completion; if a newer fetch has
+// since replaced it, the entry is left untouched so the newer fetch stays cancellable.
+func (r *communityHistoryFetchRegistry) finish(communityID string, token uint64) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if entry, ok := r.entries[communityID]; ok && entry.token == token {
+		delete(r.entries, communityID)
+	}
+}

--- a/protocol/messenger_spectate_history_sync.go
+++ b/protocol/messenger_spectate_history_sync.go
@@ -20,14 +20,16 @@ import (
 // spectatedCommunityInitialSyncPeriod bounds the history backfill triggered when a
 // user spectates a community (issue #21470-hf).
 //
-// A spectator holds no community decryption keys, and every channel in a community
-// rides ONE universal content topic, so a full default-period (9-day) backfill pulls
-// the entire community's traffic as undecryptable payloads. Device measurement
-// (Samsung S21FE, fresh account spectating the Status community): ~2-3GB ingested in
-// ~11min at ~330% service CPU, GC-bound. Because all channels share one content
-// topic, per-channel scoping is impossible — the WINDOW is the only byte-cutting
-// lever, so spectate is bounded to 24h.
-const spectatedCommunityInitialSyncPeriod = 24 * time.Hour
+// History: this was briefly 24h as a byte-mitigation when the backfill fetched full
+// bodies for the whole universal topic (measured ~2-3GB / ~11min at ~330% service
+// CPU on a Samsung S21FE). With the backfill now hash-first (bodies fetched only
+// for unknown hashes), keyless spectators skipping undecryptable bodies entirely,
+// and the early-drop gates making residual bodies cheap, the full default sync
+// period is affordable again — so spectators get the same 9-day history horizon as
+// everyone else. The real wins of this path are retained: the sync is scoped to the
+// community's own filters (not the global all-filters sync), cancellable on
+// leave/background, and watermark-seeded.
+const spectatedCommunityInitialSyncPeriod = 9 * 24 * time.Hour
 
 // spectatedCommunitySyncFrom returns the store-node "from" timestamp (unix seconds)
 // for a spectator's scoped backfill: now minus the spectate window.
@@ -36,9 +38,9 @@ func spectatedCommunitySyncFrom(nowUnixSeconds uint32) uint32 {
 }
 
 // communityInitialHistorySync decides how a community's FIRST history backfill is
-// scoped. Spectators get the tight 24h window (deeper history is undecryptable heat);
-// joiners keep today's behavior — a full default-period backfill — because they hold
-// keys and legitimately want the history.
+// scoped. Spectators get a community-scoped default-period window (fetched
+// hash-first); joiners keep today's behavior — the full global backfill — because
+// they hold keys and legitimately want everything.
 func communityInitialHistorySync(spectated bool) (scoped bool, window time.Duration) {
 	if spectated {
 		return true, spectatedCommunityInitialSyncPeriod

--- a/protocol/messenger_spectate_history_sync.go
+++ b/protocol/messenger_spectate_history_sync.go
@@ -61,15 +61,52 @@ type hashFirstBackfill struct {
 // should skip the body-fetch phase entirely (issue #21470-hf enhancement).
 //
 // The community's channels and its description share ONE content topic, so a hash cannot
-// tell them apart. But the spectator's OWN state can: when the node holds no decryption
-// keys for the community (holdsKeys false) AND the community description is already
-// resolved (the spectate flow fetches it before this backfill runs), every body on that
-// topic is either a description we already hold or an undecryptable channel message.
-// Fetching them is pure heat, so we skip — the hashes are still walked so the watermark
-// advances, and the bodies stay on the store node, re-fetchable in full after a join.
-// A keyed user (joined) legitimately wants the bodies, so it never skips.
-func spectateShouldSkipKeylessBodies(holdsKeys, descriptionResolved bool) bool {
-	return !holdsKeys && descriptionResolved
+// tell them apart. We may skip fetching bodies only when ALL THREE hold:
+//   - holdsKeys is false: the node has no community decryption keys, so gated channels
+//     are undecryptable heat;
+//   - descriptionResolved: the description is already held (the spectate flow resolves it
+//     before this backfill), so we do not need it from here;
+//   - fullyEncrypted: EVERY channel is key-gated. An encrypted community can still contain
+//     PUBLIC channels readable without keys (the Status community is mixed). Because all
+//     channels share one topic, skipping bodies would also drop those public channels'
+//     readable history — so if any public channel exists we must fetch.
+//
+// All three inputs fail safe toward FETCHING, so uncertainty never drops readable data.
+func spectateShouldSkipKeylessBodies(holdsKeys, descriptionResolved, fullyEncrypted bool) bool {
+	return !holdsKeys && descriptionResolved && fullyEncrypted
+}
+
+// allChannelsEncrypted reports whether EVERY channel id is key-gated per the supplied
+// per-channel check (a channel readable without keys makes it false). An empty channel
+// set returns false — fail safe toward fetching, since "no known channels" must never be
+// read as "nothing readable to lose".
+func allChannelsEncrypted(channelIDs []string, encrypted func(string) bool) bool {
+	if len(channelIDs) == 0 {
+		return false
+	}
+	for _, channelID := range channelIDs {
+		if !encrypted(channelID) {
+			return false
+		}
+	}
+	return true
+}
+
+// communityFullyEncryptedForNonMembers reports whether the community has NO channel a
+// keyless spectator could read: every channel is key-gated (see Community.ChannelEncrypted
+// — a channel is readable without keys when it is public / viewable-by-everyone). If any
+// readable channel exists, a keyless spectate must still fetch bodies so that channel's
+// history is not lost (issue #21470-hf enhancement). Fails safe toward fetching.
+func communityFullyEncryptedForNonMembers(community *communities.Community) bool {
+	if community == nil {
+		return false
+	}
+	chats := community.Chats()
+	channelIDs := make([]string, 0, len(chats))
+	for channelID := range chats {
+		channelIDs = append(channelIDs, channelID)
+	}
+	return allChannelsEncrypted(channelIDs, community.ChannelEncrypted)
 }
 
 // mailserverTopicRef identifies a store-node topic (its pubsub + content topic).
@@ -212,14 +249,16 @@ func (m *Messenger) asyncSyncSpectatedCommunity(community *communities.Community
 			return
 		}
 
-		// Keyless-spectator body skip (issue #21470-hf enhancement): a spectator holds no
-		// community keys and its description is already resolved by the time this backfill
-		// runs, so every body on the shared community content topic is undecryptable or
-		// already held — skip fetching bodies entirely.
+		// Keyless-spectator body skip (issue #21470-hf enhancement): skip fetching bodies
+		// only when the node holds no community keys, the description is already resolved,
+		// AND every channel is key-gated. A mixed community (encrypted, but with public
+		// channels — like Status) keeps full body fetch so its public channels' readable
+		// history is not dropped, since all channels share one content topic.
 		holdsKeys := m.communitiesManager.CommunityHoldsAnyDecryptionKey(community)
 		descriptionResolved := community.Description() != nil
+		fullyEncrypted := communityFullyEncryptedForNonMembers(community)
 		hf := &hashFirstBackfill{
-			skipEncryptedBodies: spectateShouldSkipKeylessBodies(holdsKeys, descriptionResolved),
+			skipEncryptedBodies: spectateShouldSkipKeylessBodies(holdsKeys, descriptionResolved, fullyEncrypted),
 		}
 
 		peerInfo := m.messaging.GetActiveStorenode()

--- a/protocol/messenger_spectate_history_sync_test.go
+++ b/protocol/messenger_spectate_history_sync_test.go
@@ -37,6 +37,23 @@ func TestCommunityInitialHistorySync(t *testing.T) {
 	require.Equal(t, time.Duration(0), window)
 }
 
+// TestSpectateShouldSkipKeylessBodies verifies the keyless body-skip gate (issue
+// #21470-hf enhancement). Only a keyless spectator whose description is already resolved
+// may skip fetching bodies — every body on the shared community content topic is then
+// either a description already held or an undecryptable channel message. A keyed user
+// (joined) must never skip; an unresolved description must never skip (we still need it).
+func TestSpectateShouldSkipKeylessBodies(t *testing.T) {
+	require.True(t, spectateShouldSkipKeylessBodies(false /* no keys */, true /* description resolved */),
+		"keyless spectator with a resolved description skips bodies")
+
+	require.False(t, spectateShouldSkipKeylessBodies(true /* holds keys */, true),
+		"a keyed (joined) user must fetch bodies")
+	require.False(t, spectateShouldSkipKeylessBodies(false, false /* description not resolved */),
+		"an unresolved description must still be fetched")
+	require.False(t, spectateShouldSkipKeylessBodies(true, false),
+		"keyed and unresolved: fetch")
+}
+
 // TestCommunityHistorySeedTopics verifies the watermark seeding that bounds a
 // spectator's FIRST backfill to the scoped window (issue #21470-hf). syncFiltersFrom
 // ignores its `lastRequest` argument for topics not yet tracked — a fresh topic

--- a/protocol/messenger_spectate_history_sync_test.go
+++ b/protocol/messenger_spectate_history_sync_test.go
@@ -38,20 +38,44 @@ func TestCommunityInitialHistorySync(t *testing.T) {
 }
 
 // TestSpectateShouldSkipKeylessBodies verifies the keyless body-skip gate (issue
-// #21470-hf enhancement). Only a keyless spectator whose description is already resolved
-// may skip fetching bodies — every body on the shared community content topic is then
-// either a description already held or an undecryptable channel message. A keyed user
-// (joined) must never skip; an unresolved description must never skip (we still need it).
+// #21470-hf enhancement). Bodies may be skipped ONLY when the node holds no keys AND the
+// description is already resolved AND every channel is key-gated. In particular a MIXED
+// community (fullyEncrypted=false: an encrypted community with public channels, like
+// Status) must keep full body fetch, or the public channels' readable history is dropped.
+// All three inputs fail safe toward fetching.
 func TestSpectateShouldSkipKeylessBodies(t *testing.T) {
-	require.True(t, spectateShouldSkipKeylessBodies(false /* no keys */, true /* description resolved */),
-		"keyless spectator with a resolved description skips bodies")
+	// the ONLY skip case: keyless + resolved + fully encrypted
+	require.True(t, spectateShouldSkipKeylessBodies(false /* no keys */, true /* resolved */, true /* fully encrypted */),
+		"keyless spectator, resolved description, all channels gated -> skip")
 
-	require.False(t, spectateShouldSkipKeylessBodies(true /* holds keys */, true),
+	// mixed community: a readable public channel exists -> must fetch
+	require.False(t, spectateShouldSkipKeylessBodies(false, true, false /* NOT fully encrypted */),
+		"mixed community (public channel present) must fetch bodies")
+
+	require.False(t, spectateShouldSkipKeylessBodies(true /* holds keys */, true, true),
 		"a keyed (joined) user must fetch bodies")
-	require.False(t, spectateShouldSkipKeylessBodies(false, false /* description not resolved */),
+	require.False(t, spectateShouldSkipKeylessBodies(false, false /* description not resolved */, true),
 		"an unresolved description must still be fetched")
-	require.False(t, spectateShouldSkipKeylessBodies(true, false),
-		"keyed and unresolved: fetch")
+	require.False(t, spectateShouldSkipKeylessBodies(true, false, false),
+		"keyed, unresolved, mixed: fetch")
+}
+
+// TestAllChannelsEncrypted verifies the "every channel is key-gated" derivation (issue
+// #21470-hf enhancement): if ANY channel is readable without keys the community is not
+// fully encrypted, and an empty channel set fails safe (false -> fetch).
+func TestAllChannelsEncrypted(t *testing.T) {
+	// encrypted set: only "gated" channels are key-gated
+	gated := map[string]bool{"gated1": true, "gated2": true, "public": false}
+	enc := func(id string) bool { return gated[id] }
+
+	require.True(t, allChannelsEncrypted([]string{"gated1", "gated2"}, enc),
+		"all channels gated -> fully encrypted")
+	require.False(t, allChannelsEncrypted([]string{"gated1", "public"}, enc),
+		"a readable public channel -> not fully encrypted (mixed)")
+	require.False(t, allChannelsEncrypted(nil, enc),
+		"no known channels must fail safe toward fetching")
+	require.False(t, allChannelsEncrypted([]string{}, enc),
+		"empty channel set must fail safe toward fetching")
 }
 
 // TestCommunityHistorySeedTopics verifies the watermark seeding that bounds a

--- a/protocol/messenger_spectate_history_sync_test.go
+++ b/protocol/messenger_spectate_history_sync_test.go
@@ -14,13 +14,13 @@ import (
 // payloads (measured ~2-3GB/11min at ~330% service CPU on a Samsung S21FE). The
 // only byte-cutting lever is the WINDOW, because every channel rides one content
 // topic so per-channel scoping is impossible. Spectate is therefore bounded to a
-// tight 24h window; `from = now - 24h`.
+// scoped window matching the app's default sync period (9 days).
 func TestSpectatedCommunitySyncFrom(t *testing.T) {
-	require.Equal(t, 24*time.Hour, spectatedCommunityInitialSyncPeriod,
-		"spectate window must stay 24h — the measured heat lever")
+	require.Equal(t, 9*24*time.Hour, spectatedCommunityInitialSyncPeriod,
+		"spectate window matches the 9-day default sync period — affordable since hash-first + keyless-skip")
 
 	const now = uint32(1_700_000_000)
-	require.Equal(t, now-uint32(24*60*60), spectatedCommunitySyncFrom(now))
+	require.Equal(t, now-uint32(9*24*60*60), spectatedCommunitySyncFrom(now))
 }
 
 // TestCommunityInitialHistorySync verifies the spectate-vs-join scoping decision

--- a/protocol/messenger_spectate_history_sync_test.go
+++ b/protocol/messenger_spectate_history_sync_test.go
@@ -1,0 +1,162 @@
+package protocol
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestSpectatedCommunitySyncFrom verifies the spectate backfill window computation
+// (issue #21470-hf). A keyless spectator's full default-period backfill of a
+// community's single universal content topic ingests gigabytes of undecryptable
+// payloads (measured ~2-3GB/11min at ~330% service CPU on a Samsung S21FE). The
+// only byte-cutting lever is the WINDOW, because every channel rides one content
+// topic so per-channel scoping is impossible. Spectate is therefore bounded to a
+// tight 24h window; `from = now - 24h`.
+func TestSpectatedCommunitySyncFrom(t *testing.T) {
+	require.Equal(t, 24*time.Hour, spectatedCommunityInitialSyncPeriod,
+		"spectate window must stay 24h — the measured heat lever")
+
+	const now = uint32(1_700_000_000)
+	require.Equal(t, now-uint32(24*60*60), spectatedCommunitySyncFrom(now))
+}
+
+// TestCommunityInitialHistorySync verifies the spectate-vs-join scoping decision
+// (issue #21470-hf). A spectator holds no decryption keys, so deeper history is
+// pure heat and is scoped to 24h. A joiner holds keys and legitimately wants the
+// full default-period backfill, so joining must KEEP today's behavior (unscoped).
+func TestCommunityInitialHistorySync(t *testing.T) {
+	scoped, window := communityInitialHistorySync(true /* spectated */)
+	require.True(t, scoped, "spectators must use the scoped window")
+	require.Equal(t, spectatedCommunityInitialSyncPeriod, window)
+
+	scoped, window = communityInitialHistorySync(false /* joined */)
+	require.False(t, scoped, "joining must keep today's unscoped full-period backfill")
+	require.Equal(t, time.Duration(0), window)
+}
+
+// TestCommunityHistorySeedTopics verifies the watermark seeding that bounds a
+// spectator's FIRST backfill to the scoped window (issue #21470-hf). syncFiltersFrom
+// ignores its `lastRequest` argument for topics not yet tracked — a fresh topic
+// always defaults to the full sync period. So before syncing we seed each of the
+// community's topics with a `now-24h` watermark. Topics already tracked must be
+// SKIPPED (INSERT-OR-REPLACE would otherwise rewind a good watermark and refetch),
+// and each topic is seeded at most once.
+func TestCommunityHistorySeedTopics(t *testing.T) {
+	const from = 1_699_913_600 // now - 24h
+
+	refs := []mailserverTopicRef{
+		{pubsubTopic: "pubA", contentTopic: "0x01"}, // fresh -> seed
+		{pubsubTopic: "pubA", contentTopic: "0x02"}, // already tracked -> skip
+		{pubsubTopic: "pubA", contentTopic: "0x01"}, // duplicate of the first -> seed once
+	}
+	existing := map[string]struct{}{
+		mailserverTopicKey("pubA", "0x02"): {},
+	}
+
+	seeds := communityHistorySeedTopics(refs, existing, from)
+
+	require.Len(t, seeds, 1, "only the fresh topic is seeded, exactly once")
+	require.Equal(t, "pubA", seeds[0].PubsubTopic)
+	require.Equal(t, "0x01", seeds[0].ContentTopic)
+	require.Equal(t, from, seeds[0].LastRequest)
+}
+
+// TestCommunityHistorySeedTopics_AllTracked verifies that when every topic is already
+// tracked, nothing is seeded (leaving each topic's existing watermark to drive an
+// incremental, already-bounded sync).
+func TestCommunityHistorySeedTopics_AllTracked(t *testing.T) {
+	refs := []mailserverTopicRef{{pubsubTopic: "pubA", contentTopic: "0x01"}}
+	existing := map[string]struct{}{mailserverTopicKey("pubA", "0x01"): {}}
+
+	require.Empty(t, communityHistorySeedTopics(refs, existing, 123))
+}
+
+// --- cancel registry -------------------------------------------------------
+
+// fakeCancel records how many times it was invoked, standing in for a
+// context.CancelFunc without needing a live context.
+type fakeCancel struct {
+	calls *int
+}
+
+func (f fakeCancel) cancel() { *f.calls++ }
+
+// TestCommunityHistoryFetchRegistry_LeaveAndBackground verifies the cancel-registry
+// semantics that make the spectate backfill cancellable (issue #21470-hf, part B):
+// the device-measured backfill continues headless after the UI dies, so leaving a
+// community and backgrounding the app must both stop it.
+func TestCommunityHistoryFetchRegistry_LeaveAndBackground(t *testing.T) {
+	r := newCommunityHistoryFetchRegistry()
+
+	aCalls, bCalls := 0, 0
+	a := fakeCancel{&aCalls}
+	b := fakeCancel{&bCalls}
+
+	// register two in-flight community fetches
+	_ = r.register("communityA", a.cancel)
+	_ = r.register("communityB", b.cancel)
+
+	// leaving communityA cancels only its fetch
+	r.cancel("communityA")
+	require.Equal(t, 1, aCalls)
+	require.Equal(t, 0, bCalls)
+
+	// cancelling an already-cancelled / unknown id is a no-op
+	r.cancel("communityA")
+	r.cancel("unknown")
+	require.Equal(t, 1, aCalls)
+
+	// backgrounding cancels everything still in flight
+	r.cancelAll()
+	require.Equal(t, 1, bCalls)
+	require.Equal(t, 1, aCalls, "A was already removed by leave, must not be re-cancelled")
+}
+
+// TestCommunityHistoryFetchRegistry_ReplaceAndFinish verifies that re-spectating the
+// same community cancels the stale in-flight fetch, and that a fetch which finishes
+// on its own only cleans up the map entry it still owns (never a newer one's).
+func TestCommunityHistoryFetchRegistry_ReplaceAndFinish(t *testing.T) {
+	r := newCommunityHistoryFetchRegistry()
+
+	firstCalls, secondCalls := 0, 0
+	first := fakeCancel{&firstCalls}
+	second := fakeCancel{&secondCalls}
+
+	tok1 := r.register("communityA", first.cancel)
+
+	// re-spectating communityA replaces (and cancels) the stale fetch
+	tok2 := r.register("communityA", second.cancel)
+	require.Equal(t, 1, firstCalls, "stale fetch must be cancelled on re-register")
+	require.NotEqual(t, tok1, tok2, "each registration gets a distinct token")
+
+	// the FIRST fetch's goroutine now finishes and tries to clean up. It must NOT
+	// remove the second fetch's entry (it no longer owns the slot).
+	r.finish("communityA", tok1)
+
+	// cancelling communityA must still reach the second (current) fetch
+	r.cancel("communityA")
+	require.Equal(t, 1, secondCalls, "current fetch must remain cancellable after a stale finish")
+
+	// a fetch that finishes on its own removes its entry, so a later cancel is a no-op
+	thirdCalls := 0
+	third := fakeCancel{&thirdCalls}
+	tok3 := r.register("communityA", third.cancel)
+	r.finish("communityA", tok3)
+	r.cancel("communityA")
+	require.Equal(t, 0, thirdCalls, "finish removed the entry, so cancel must not reach the completed fetch")
+}
+
+// TestCommunityHistoryFetchRegistry_ContextCancelFunc is a light integration check
+// that a real context.CancelFunc registered in the registry cancels its context.
+func TestCommunityHistoryFetchRegistry_ContextCancelFunc(t *testing.T) {
+	r := newCommunityHistoryFetchRegistry()
+	ctx, cancel := context.WithCancel(context.Background())
+	_ = r.register("communityA", cancel)
+
+	require.NoError(t, ctx.Err())
+	r.cancel("communityA")
+	require.ErrorIs(t, ctx.Err(), context.Canceled)
+}

--- a/protocol/messenger_store_node_request_manager.go
+++ b/protocol/messenger_store_node_request_manager.go
@@ -407,6 +407,26 @@ func (r *storeNodeRequest) shouldFetchNextPageUncapped(envelopesCount int) (bool
 		}
 
 		if community == nil {
+			// The community is absent from the community table, but it may already
+			// be in hand and merely withheld pending on-chain owner validation. In
+			// that state the description has been fetched and only verification is
+			// blocking persistence; verification retries out-of-band on the
+			// owner-verification loop. Fetching more store-node pages cannot make a
+			// failed verification succeed — it only floods the network and starves
+			// the very RPC calls whose success would end the request (issue
+			// #21470-hf). So once the description is queued for validation, stop.
+			queuedClock, qErr := r.manager.messenger.communitiesManager.HighestQueuedValidationClock(communityID)
+			if qErr != nil {
+				logger.Warn("failed to read community validation queue; continuing to page",
+					zap.String("communityID", r.requestID.DataID),
+					zap.Error(qErr))
+			} else if gateNextPageByValidationQueue(false, queuedClock, r.minimumDataClock) {
+				logger.Info("community description queued for owner validation; stopping pagination (verification retries out-of-band)",
+					zap.Uint64("queuedClock", queuedClock),
+					zap.Uint64("minimumDataClock", r.minimumDataClock))
+				return false, 0
+			}
+
 			// community not found in the database, request next page
 			logger.Debug("community still not fetched")
 			return true, r.config.FurtherPageSize

--- a/protocol/messenger_store_node_request_manager.go
+++ b/protocol/messenger_store_node_request_manager.go
@@ -83,7 +83,7 @@ func NewStoreNodeRequestManager(m *Messenger) *StoreNodeRequestManager {
 // Automatically waits for an available store node.
 // When a `nil` community and `nil` error is returned, that means the community wasn't found at the store node.
 func (m *StoreNodeRequestManager) FetchCommunity(ctx context.Context, communityID string, opts []StoreNodeRequestOption) (*communities.Community, StoreNodeRequestStats, error) {
-	cfg := buildStoreNodeRequestConfig(opts)
+	cfg := buildCommunityStoreNodeRequestConfig(opts)
 
 	m.logger.Info("requesting community from store node",
 		zap.String("community", communityID),
@@ -433,7 +433,21 @@ func (r *storeNodeRequest) shouldFetchNextPageUncapped(envelopesCount int) (bool
 	// Force all received envelopes to be processed. We keep the resulting
 	// response so a community request can tell whether this page actually
 	// carried a description for the target community (issue #21470-hf).
-	response := r.manager.messenger.ProcessAllMessages()
+	//
+	// Skip the walk entirely for an empty page: ProcessAllMessages traverses the
+	// messenger's whole pending backlog, but its only job here is to flush THIS
+	// page's envelopes into the DB before the GetByID check. With zero envelopes
+	// there is nothing of ours to flush, and during a channel backfill re-walking
+	// that fat queue on every empty page — to the cap, per dead id — is the CPU/GC
+	// storm behind the device overheat (issue #21470-hf). The DB check below still
+	// runs, so a description delivered by a parallel channel-sync page is not
+	// missed; only the redundant processing is dropped.
+	var response *MessengerResponse
+	if shouldProcessStoreNodePage(envelopesCount) {
+		response = r.manager.messenger.ProcessAllMessages()
+	} else {
+		logger.Debug("skipping ProcessAllMessages for empty store node page")
+	}
 
 	// Try to get community from database
 	switch r.requestID.RequestType {

--- a/protocol/messenger_store_node_request_manager.go
+++ b/protocol/messenger_store_node_request_manager.go
@@ -1,6 +1,7 @@
 package protocol
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"sync"
@@ -270,6 +271,13 @@ type storeNodeRequest struct {
 	minimumDataClock uint64
 	config           StoreNodeRequestConfig
 
+	// descriptionSeen latches true once a description for the requested community
+	// has been processed in this request. Store-node history is paged
+	// newest-first, so any later page can only carry an older description; once
+	// this is set, further paging cannot yield a newer one and is stopped by
+	// gateNextPageByDescriptionSeen (issue #21470-hf).
+	descriptionSeen bool
+
 	// request corresponding metadata to be used in finalize
 	filterToForget *types2.ChatFilter
 
@@ -342,6 +350,14 @@ func (r *storeNodeRequest) finalize() {
 func (r *storeNodeRequest) shouldFetchNextPage(envelopesCount int) (bool, uint64) {
 	fetchNext, pageSize := r.shouldFetchNextPageUncapped(envelopesCount)
 
+	fetchNext, descriptionGateTripped := r.config.gateNextPageByDescriptionSeen(fetchNext, r.descriptionSeen)
+	if descriptionGateTripped {
+		r.manager.logger.Info("community description seen and not newer; stopping pagination (older pages cannot contain newer descriptions)",
+			zap.Any("requestID", r.requestID),
+			zap.Int("fetchedPagesCount", r.result.stats.FetchedPagesCount),
+			zap.Int("fetchedEnvelopesCount", r.result.stats.FetchedEnvelopesCount))
+	}
+
 	fetchNext, pageSize, capTripped := r.config.gateNextPageByCap(fetchNext, pageSize, r.result.stats.FetchedPagesCount)
 	if capTripped {
 		r.manager.logger.Warn("store node request reached page cap; stopping pagination to bound runaway fetch",
@@ -362,8 +378,10 @@ func (r *storeNodeRequest) shouldFetchNextPageUncapped(envelopesCount int) (bool
 	r.result.stats.FetchedEnvelopesCount += envelopesCount
 	r.result.stats.FetchedPagesCount++
 
-	// Force all received envelopes to be processed
-	r.manager.messenger.ProcessAllMessages()
+	// Force all received envelopes to be processed. We keep the resulting
+	// response so a community request can tell whether this page actually
+	// carried a description for the target community (issue #21470-hf).
+	response := r.manager.messenger.ProcessAllMessages()
 
 	// Try to get community from database
 	switch r.requestID.RequestType {
@@ -378,6 +396,14 @@ func (r *storeNodeRequest) shouldFetchNextPageUncapped(envelopesCount int) (bool
 				err:       fmt.Errorf("failed to decode community ID: %w", err),
 			}
 			return false, 0 // failed to decode community ID, no sense to continue the procedure
+		}
+
+		// Store-node history is paged newest-first, so the first page that carries
+		// a description for this community carries the newest available one. Latch
+		// that here; once set, gateNextPageByDescriptionSeen stops paging because
+		// older pages cannot contain a newer description (issue #21470-hf).
+		if !r.descriptionSeen && communityDescriptionSeen(response, communityID) {
+			r.descriptionSeen = true
 		}
 
 		// check if community is waiting for a verification and do a verification manually
@@ -531,4 +557,25 @@ func (r *storeNodeRequest) routine() {
 
 func (r *storeNodeRequest) start() {
 	go r.routine()
+}
+
+// communityDescriptionSeen reports whether the processed-messages response
+// carries a description for the given community. A processed community
+// description surfaces the community in the MessengerResponse via
+// handleCommunityResponse -> AddCommunity — including the equal-clock
+// re-processing that drives issue #21470-hf (UpdateCommunityDescription only
+// rejects strictly-older clocks, so a re-fetched identical description still
+// flows through and is added). Its presence is therefore the request-scoped
+// "a description for this community was processed this page" signal used by
+// gateNextPageByDescriptionSeen.
+func communityDescriptionSeen(response *MessengerResponse, communityID []byte) bool {
+	if response == nil {
+		return false
+	}
+	for _, c := range response.Communities() {
+		if c != nil && bytes.Equal(c.ID(), communityID) {
+			return true
+		}
+	}
+	return false
 }

--- a/protocol/messenger_store_node_request_manager.go
+++ b/protocol/messenger_store_node_request_manager.go
@@ -54,18 +54,25 @@ type StoreNodeRequestManager struct {
 	activeRequests map[storeNodeRequestID]*storeNodeRequest
 
 	// activeRequestsLock should be locked each time activeRequests is being accessed or changed.
+	// It also guards communityNotFoundCooldown (record/clear/suppress).
 	activeRequestsLock sync.RWMutex
+
+	// communityNotFoundCooldown suppresses back-to-back re-fetches of community
+	// ids that just finalized as not-found (issue #21470-hf). Guarded by
+	// activeRequestsLock.
+	communityNotFoundCooldown *communityNotFoundCooldown
 
 	onPerformingBatch func(types2.StoreNodeBatch)
 }
 
 func NewStoreNodeRequestManager(m *Messenger) *StoreNodeRequestManager {
 	return &StoreNodeRequestManager{
-		messenger:          m,
-		logger:             m.logger.Named("StoreNodeRequestManager"),
-		activeRequests:     map[storeNodeRequestID]*storeNodeRequest{},
-		activeRequestsLock: sync.RWMutex{},
-		onPerformingBatch:  nil,
+		messenger:                 m,
+		logger:                    m.logger.Named("StoreNodeRequestManager"),
+		activeRequests:            map[storeNodeRequestID]*storeNodeRequest{},
+		activeRequestsLock:        sync.RWMutex{},
+		communityNotFoundCooldown: newCommunityNotFoundCooldown(communityNotFoundCooldownTTL),
+		onPerformingBatch:         nil,
 	}
 }
 
@@ -148,6 +155,21 @@ func (m *StoreNodeRequestManager) subscribeToRequest(ctx context.Context, reques
 	request, requestFound := m.activeRequests[requestID]
 
 	if !requestFound {
+		// Negative-result cooldown: if this community id finalized as not-found
+		// within the TTL, don't spawn another pager — deliver an immediate
+		// not-found through the normal subscription/finalize contract. Only
+		// applies to community requests; contact requests are untouched. An
+		// already-active request (requestFound) is joined above, never suppressed
+		// (issue #21470-hf).
+		if requestType == storeNodeCommunityRequest {
+			if suppressed, remaining := m.communityNotFoundCooldown.suppress(dataID, time.Now()); suppressed {
+				m.logger.Info("community fetch suppressed by not-found cooldown",
+					zap.String("communityID", dataID),
+					zap.Duration("remainingTTL", remaining))
+				return m.newImmediateNotFoundSubscription(), nil
+			}
+		}
+
 		// Create corresponding filter
 		var err error
 		var filter *types2.ChatFilter
@@ -175,6 +197,19 @@ func (m *StoreNodeRequestManager) subscribeToRequest(ctx context.Context, reques
 	}
 
 	return request.subscribe(), nil
+}
+
+// newImmediateNotFoundSubscription returns a subscription that already carries a
+// not-found result (nil community, nil contact, nil error) and is closed. It lets
+// a cooldown-suppressed request satisfy the exact same subscription contract as a
+// live request without spawning a pager, creating a filter, or touching the
+// network (issue #21470-hf). The buffered send never blocks; the caller reads the
+// single result and sees the closed channel.
+func (m *StoreNodeRequestManager) newImmediateNotFoundSubscription() storeNodeResponseSubscription {
+	channel := make(storeNodeResponseSubscription, 1)
+	channel <- storeNodeRequestResult{}
+	close(channel)
+	return channel
 }
 
 // newStoreNodeRequest creates a new storeNodeRequest struct
@@ -328,6 +363,19 @@ func (r *storeNodeRequest) finalize() {
 
 	if r.result.community != nil {
 		r.manager.messenger.passStoredCommunityInfoToSignalHandler(r.result.community)
+	}
+
+	// Maintain the negative-result cooldown for community requests (issue
+	// #21470-hf). A nil community outcome (not-found, cap-tripped, queued-stop)
+	// arms the cooldown so the next fresh request for this id is suppressed; a
+	// successful fetch clears it so a legitimate re-fetch is never blocked. Runs
+	// under activeRequestsLock, already held here.
+	if r.requestID.RequestType == storeNodeCommunityRequest {
+		if r.result.community != nil {
+			r.manager.communityNotFoundCooldown.clear(r.requestID.DataID)
+		} else {
+			r.manager.communityNotFoundCooldown.recordNilFinalize(r.requestID.DataID, time.Now())
+		}
 	}
 
 	delete(r.manager.activeRequests, r.requestID)

--- a/protocol/messenger_store_node_request_manager.go
+++ b/protocol/messenger_store_node_request_manager.go
@@ -54,25 +54,26 @@ type StoreNodeRequestManager struct {
 	activeRequests map[storeNodeRequestID]*storeNodeRequest
 
 	// activeRequestsLock should be locked each time activeRequests is being accessed or changed.
-	// It also guards communityNotFoundCooldown (record/clear/suppress).
+	// It also guards communityFetchBackoff (record/clear/suppress).
 	activeRequestsLock sync.RWMutex
 
-	// communityNotFoundCooldown suppresses back-to-back re-fetches of community
-	// ids that just finalized as not-found (issue #21470-hf). Guarded by
-	// activeRequestsLock.
-	communityNotFoundCooldown *communityNotFoundCooldown
+	// communityFetchBackoff throttles back-to-back re-fetches of community ids that
+	// keep finalizing as not-found, with a per-id exponential backoff so a cold
+	// start's rapid retries are barely delayed while a genuinely dead id converges
+	// to one run per maxDelay (issue #21470-hf). Guarded by activeRequestsLock.
+	communityFetchBackoff *communityFetchBackoff
 
 	onPerformingBatch func(types2.StoreNodeBatch)
 }
 
 func NewStoreNodeRequestManager(m *Messenger) *StoreNodeRequestManager {
 	return &StoreNodeRequestManager{
-		messenger:                 m,
-		logger:                    m.logger.Named("StoreNodeRequestManager"),
-		activeRequests:            map[storeNodeRequestID]*storeNodeRequest{},
-		activeRequestsLock:        sync.RWMutex{},
-		communityNotFoundCooldown: newCommunityNotFoundCooldown(communityNotFoundCooldownTTL),
-		onPerformingBatch:         nil,
+		messenger:             m,
+		logger:                m.logger.Named("StoreNodeRequestManager"),
+		activeRequests:        map[storeNodeRequestID]*storeNodeRequest{},
+		activeRequestsLock:    sync.RWMutex{},
+		communityFetchBackoff: newCommunityFetchBackoff(communityFetchBackoffBaseDelay, communityFetchBackoffMaxDelay),
+		onPerformingBatch:     nil,
 	}
 }
 
@@ -155,17 +156,19 @@ func (m *StoreNodeRequestManager) subscribeToRequest(ctx context.Context, reques
 	request, requestFound := m.activeRequests[requestID]
 
 	if !requestFound {
-		// Negative-result cooldown: if this community id finalized as not-found
-		// within the TTL, don't spawn another pager — deliver an immediate
-		// not-found through the normal subscription/finalize contract. Only
-		// applies to community requests; contact requests are untouched. An
-		// already-active request (requestFound) is joined above, never suppressed
-		// (issue #21470-hf).
+		// Per-id exponential backoff: if this community id keeps finalizing as
+		// not-found, throttle re-fetches without spawning another pager — deliver an
+		// immediate not-found through the normal subscription/finalize contract. The
+		// backoff grows only on real nil finalizes, so a cold start's rapid retries
+		// pass through while a dead id converges to one run per maxDelay. Only applies
+		// to community requests; contact requests are untouched. An already-active
+		// request (requestFound) is joined above, never suppressed (issue #21470-hf).
 		if requestType == storeNodeCommunityRequest {
-			if suppressed, remaining := m.communityNotFoundCooldown.suppress(dataID, time.Now()); suppressed {
-				m.logger.Info("community fetch suppressed by not-found cooldown",
+			if suppressed, misses, remaining := m.communityFetchBackoff.suppress(dataID, time.Now()); suppressed {
+				m.logger.Info("community fetch suppressed by backoff",
 					zap.String("communityID", dataID),
-					zap.Duration("remainingTTL", remaining))
+					zap.Int("consecutiveMisses", misses),
+					zap.Duration("retryInSeconds", remaining))
 				return m.newImmediateNotFoundSubscription(), nil
 			}
 		}
@@ -365,16 +368,17 @@ func (r *storeNodeRequest) finalize() {
 		r.manager.messenger.passStoredCommunityInfoToSignalHandler(r.result.community)
 	}
 
-	// Maintain the negative-result cooldown for community requests (issue
-	// #21470-hf). A nil community outcome (not-found, cap-tripped, queued-stop)
-	// arms the cooldown so the next fresh request for this id is suppressed; a
-	// successful fetch clears it so a legitimate re-fetch is never blocked. Runs
-	// under activeRequestsLock, already held here.
+	// Maintain the per-id fetch backoff for community requests (issue #21470-hf).
+	// A nil community outcome (not-found, cap-tripped, queued-stop) advances the
+	// backoff streak so the next fresh request for this id is throttled with a
+	// geometrically growing delay; a successful fetch clears it so a legitimate
+	// re-fetch starts from a clean schedule. Runs under activeRequestsLock, already
+	// held here.
 	if r.requestID.RequestType == storeNodeCommunityRequest {
 		if r.result.community != nil {
-			r.manager.communityNotFoundCooldown.clear(r.requestID.DataID)
+			r.manager.communityFetchBackoff.clear(r.requestID.DataID)
 		} else {
-			r.manager.communityNotFoundCooldown.recordNilFinalize(r.requestID.DataID, time.Now())
+			r.manager.communityFetchBackoff.recordNilFinalize(r.requestID.DataID, time.Now())
 		}
 	}
 

--- a/protocol/messenger_store_node_request_manager.go
+++ b/protocol/messenger_store_node_request_manager.go
@@ -329,7 +329,32 @@ func (r *storeNodeRequest) finalize() {
 	}
 }
 
+// shouldFetchNextPage decides whether the store-node pager should request
+// another page. It wraps the natural per-page decision with a hard page ceiling
+// (issue #21470-hf): once a request has processed config.MaxPageCount pages
+// without resolving, pagination is stopped even if the natural decision would
+// keep going. This bounds requests that can never terminate (e.g. a token-owned
+// community stuck in owner validation) so they don't drain the full store-node
+// window and overheat the device. Requests that resolve before the cap are
+// completely unaffected. On a cap-forced stop we return false, which drives the
+// request through the same finalize() path as an ordinary "not found" result,
+// so the UI's loading state clears normally.
 func (r *storeNodeRequest) shouldFetchNextPage(envelopesCount int) (bool, uint64) {
+	fetchNext, pageSize := r.shouldFetchNextPageUncapped(envelopesCount)
+
+	fetchNext, pageSize, capTripped := r.config.gateNextPageByCap(fetchNext, pageSize, r.result.stats.FetchedPagesCount)
+	if capTripped {
+		r.manager.logger.Warn("store node request reached page cap; stopping pagination to bound runaway fetch",
+			zap.Any("requestID", r.requestID),
+			zap.Int("fetchedPagesCount", r.result.stats.FetchedPagesCount),
+			zap.Int("fetchedEnvelopesCount", r.result.stats.FetchedEnvelopesCount),
+			zap.Int("maxPageCount", r.config.MaxPageCount))
+	}
+
+	return fetchNext, pageSize
+}
+
+func (r *storeNodeRequest) shouldFetchNextPageUncapped(envelopesCount int) (bool, uint64) {
 	logger := r.manager.logger.With(
 		zap.Any("requestID", r.requestID),
 		zap.Int("envelopesCount", envelopesCount))

--- a/protocol/messenger_store_node_request_manager_config.go
+++ b/protocol/messenger_store_node_request_manager_config.go
@@ -2,73 +2,122 @@ package protocol
 
 import "time"
 
-// communityNotFoundCooldownTTL is how long a community id stays on the
-// negative-result cooldown after a store-node request finalized without
-// producing a community (issue #21470-hf). The dev curated directory carries
-// "dead" ids whose descriptions never arrive; without a cooldown any client-side
-// loop (Communities Portal re-requesting per delegate, curated refreshes, …)
-// re-issues FetchCommunity for them back-to-back, each run paging to the cap and
-// finalizing not-found — a sustained CPU/GC storm that overheats the device.
+// communityFetchBackoff{BaseDelay,MaxDelay} parameterise the per-id exponential
+// backoff that throttles store-node community fetches which keep finalizing as
+// not-found (issue #21470-hf). The dev curated directory carries "dead" ids whose
+// descriptions never arrive; without throttling any client-side loop (Communities
+// Portal re-requesting per delegate, curated refreshes, …) re-issues FetchCommunity
+// for them back-to-back, each run paging to the cap and finalizing not-found — a
+// sustained CPU/GC storm that overheats the device.
 //
-// Trade-off: a user's manual retry within the TTL of a definitive not-found
-// no-ops (returns not-found immediately without hitting the network). This is
-// acceptable because the fetch would fail identically anyway — nothing on the
-// store node changed in two minutes — and a successful fetch or an active
-// in-flight request are both unaffected (a live request is joined, not
-// suppressed; a success clears the entry immediately).
-const communityNotFoundCooldownTTL = 2 * time.Minute
+// A flat cooldown (the first cut of this fix) over-suppressed a COLD start: on a
+// loaded store node a capped request often finalizes nil BEFORE the community's
+// large description has been served, and the empirically-observed way descriptions
+// land is the rapid retries that immediately follow. A flat 2-minute ban blocked
+// exactly those retries (device: 346 attempts → 249 suppressed → 0 descriptions
+// resolved in 9 min). Exponential backoff keeps the warm-up cadence almost
+// untouched — the first handful of retries fire within seconds — while a genuinely
+// dead id geometrically converges to one 30-page run per MaxDelay.
+//
+// backoffFor(n) = min(BaseDelay * 2^(n-1), MaxDelay). With Base=5s, Max=2m the
+// schedule is 5s, 10s, 20s, 40s, 80s, then 120s for every further miss.
+const (
+	communityFetchBackoffBaseDelay = 5 * time.Second
+	communityFetchBackoffMaxDelay  = 2 * time.Minute
+)
 
-// communityNotFoundCooldown records, per community id, the time its last
-// store-node request finalized without producing a community. A fresh request
-// for an id whose last nil-result finalize is younger than ttl is suppressed
-// (delivered an immediate not-found) instead of spawning another pager. Entries
-// expire lazily on read — there is no janitor goroutine.
-//
-// It carries no lock of its own: the owning StoreNodeRequestManager guards every
-// access with its activeRequestsLock (the same lock that guards activeRequests
-// and is already held across finalize()), so record/clear/suppress are always
-// called under that lock. It must therefore never be copied by value once
-// populated; the manager holds it by pointer.
-type communityNotFoundCooldown struct {
-	ttl     time.Duration
-	entries map[string]time.Time
+// communityFetchBackoffEntry tracks, per community id, how many consecutive REAL
+// store-node requests finalized without producing a community, and when the most
+// recent such finalize happened. Only a real nil finalize advances the streak; a
+// suppressed attempt never does (no self-extending bans).
+type communityFetchBackoffEntry struct {
+	consecutiveNilFinalizes int
+	lastNilFinalizeAt       time.Time
 }
 
-func newCommunityNotFoundCooldown(ttl time.Duration) *communityNotFoundCooldown {
-	return &communityNotFoundCooldown{
-		ttl:     ttl,
-		entries: map[string]time.Time{},
+// communityFetchBackoff decides whether a fresh community fetch may proceed. A new
+// request for an id is allowed only once now >= lastNilFinalizeAt +
+// backoffFor(consecutiveNilFinalizes); otherwise it is suppressed (delivered an
+// immediate not-found) instead of spawning another pager. Unlike a TTL cooldown,
+// an entry is NOT evicted when its window expires — the streak count must survive
+// an allowed retry so a still-dead id keeps climbing toward MaxDelay. Only a
+// successful fetch (clear) removes the entry.
+//
+// It carries no lock of its own: the owning StoreNodeRequestManager guards every
+// access with its activeRequestsLock (the same lock that guards activeRequests and
+// is already held across finalize()), so record/clear/suppress are always called
+// under that lock. It must therefore never be copied by value once populated; the
+// manager holds it by pointer.
+type communityFetchBackoff struct {
+	baseDelay time.Duration
+	maxDelay  time.Duration
+	entries   map[string]*communityFetchBackoffEntry
+}
+
+func newCommunityFetchBackoff(baseDelay, maxDelay time.Duration) *communityFetchBackoff {
+	return &communityFetchBackoff{
+		baseDelay: baseDelay,
+		maxDelay:  maxDelay,
+		entries:   map[string]*communityFetchBackoffEntry{},
 	}
 }
 
-// recordNilFinalize arms (or re-arms) the cooldown for communityID at now. Called
-// when a community request finalizes with a nil community (not-found, cap-tripped
-// or queued-stop). Re-arming slides the window to the newest finalize.
-func (c *communityNotFoundCooldown) recordNilFinalize(communityID string, now time.Time) {
-	c.entries[communityID] = now
+// backoffFor returns min(baseDelay * 2^(consecutiveMisses-1), maxDelay). Zero (or
+// negative) misses means no backoff. The doubling loop stops at maxDelay so it can
+// never overflow, however large the streak grows.
+func (c *communityFetchBackoff) backoffFor(consecutiveMisses int) time.Duration {
+	if consecutiveMisses <= 0 {
+		return 0
+	}
+	delay := c.baseDelay
+	for i := 1; i < consecutiveMisses; i++ {
+		delay *= 2
+		if delay >= c.maxDelay {
+			return c.maxDelay
+		}
+	}
+	if delay > c.maxDelay {
+		return c.maxDelay
+	}
+	return delay
 }
 
-// clear drops any cooldown for communityID. Called when a community request
-// finalizes WITH a community, so a subsequent legitimate re-fetch is never
-// suppressed by a stale negative result.
-func (c *communityNotFoundCooldown) clear(communityID string) {
+// recordNilFinalize advances the backoff streak for communityID and stamps the
+// finalize time. Called when a REAL community request finalizes with a nil
+// community (not-found, cap-tripped or queued-stop). Each call widens the next
+// allowed-retry window by doubling the backoff.
+func (c *communityFetchBackoff) recordNilFinalize(communityID string, now time.Time) {
+	entry, ok := c.entries[communityID]
+	if !ok {
+		entry = &communityFetchBackoffEntry{}
+		c.entries[communityID] = entry
+	}
+	entry.consecutiveNilFinalizes++
+	entry.lastNilFinalizeAt = now
+}
+
+// clear drops the backoff entry for communityID. Called when a community request
+// finalizes WITH a community, so a subsequent legitimate re-fetch starts from a
+// clean schedule and is never suppressed by a stale negative streak.
+func (c *communityFetchBackoff) clear(communityID string) {
 	delete(c.entries, communityID)
 }
 
 // suppress reports whether a fresh request for communityID should be suppressed,
-// and the remaining cooldown (for logging). An entry at or past the TTL does not
-// suppress and is evicted on read. A missing entry never suppresses.
-func (c *communityNotFoundCooldown) suppress(communityID string, now time.Time) (bool, time.Duration) {
-	last, ok := c.entries[communityID]
+// the current consecutive-miss count and the remaining backoff (both for logging).
+// A missing entry never suppresses. An entry whose window has elapsed does not
+// suppress but is deliberately kept, so a subsequent nil finalize climbs the
+// streak rather than restarting it. Reading never mutates the streak.
+func (c *communityFetchBackoff) suppress(communityID string, now time.Time) (bool, int, time.Duration) {
+	entry, ok := c.entries[communityID]
 	if !ok {
-		return false, 0
+		return false, 0, 0
 	}
-	remaining := c.ttl - now.Sub(last)
+	remaining := entry.lastNilFinalizeAt.Add(c.backoffFor(entry.consecutiveNilFinalizes)).Sub(now)
 	if remaining <= 0 {
-		delete(c.entries, communityID)
-		return false, 0
+		return false, entry.consecutiveNilFinalizes, 0
 	}
-	return true, remaining
+	return true, entry.consecutiveNilFinalizes, remaining
 }
 
 // maxStoreNodeRequestPageCount is a hard ceiling on the number of store-node

--- a/protocol/messenger_store_node_request_manager_config.go
+++ b/protocol/messenger_store_node_request_manager_config.go
@@ -60,6 +60,35 @@ func gateNextPageByValidationQueue(communityInDB bool, queuedClock, minimumDataC
 	return queuedClock > minimumDataClock
 }
 
+// gateNextPageByDescriptionSeen decides whether store-node pagination for a
+// community request should stop because a description for the target community
+// has already been processed in this request (issue #21470-hf).
+//
+// Store-node history is paged newest-first: the go-waku HistoryRetriever builds
+// each StoreQueryRequest with PaginationForward unset (proto3 default false =
+// backward) and walks the time window from newest to oldest. So the first
+// description encountered for the community is the newest available, and every
+// later page can only carry an older one. Once any description has been
+// processed, continuing to page cannot yield a newer description; each extra
+// page merely re-unmarshals and re-preprocesses the (large, ~1.4MB) description,
+// driving a GC storm that overheats the device. This is the flood that remains
+// after the page-cap and validation-queue gates: the "community persisted but
+// not newer than minimumDataClock" branch keeps paging to the cap and is
+// re-issued perpetually as the spectated community's description is re-fetched.
+//
+// Like the other gates it only ever converts a "fetch next page" decision into a
+// stop; it never forces paging. When StopWhenDataFound is false the caller wants
+// a full-window walk regardless of what is found (mirroring the success-path
+// `!StopWhenDataFound` return), so this gate is disabled and returns the natural
+// decision unchanged. gateTripped reports whether this gate forced the stop, so
+// the caller can log it distinctly from an ordinary completion.
+func (c StoreNodeRequestConfig) gateNextPageByDescriptionSeen(fetchNext, descriptionSeen bool) (shouldFetch, gateTripped bool) {
+	if fetchNext && c.StopWhenDataFound && descriptionSeen {
+		return false, true
+	}
+	return fetchNext, false
+}
+
 type StoreNodeRequestOption func(*StoreNodeRequestConfig)
 
 func defaultStoreNodeRequestConfig() StoreNodeRequestConfig {

--- a/protocol/messenger_store_node_request_manager_config.go
+++ b/protocol/messenger_store_node_request_manager_config.go
@@ -129,6 +129,19 @@ func (c *communityFetchBackoff) suppress(communityID string, now time.Time) (boo
 // full 31-day store-node window and burns CPU/battery on the device.
 const maxStoreNodeRequestPageCount = 30
 
+// maxCommunityStoreNodeRequestPageCount caps community fetches far more tightly
+// than the generic contact cap (issue #21470-hf). Store queries page newest-first
+// (verified in go-waku history.go: PaginationForward unset => proto3 default false
+// => backward) and community descriptions are republished periodically, so a live
+// community's description lands within the first pages; the description-seen gate
+// (6cd6ced1a) then stops the request on that hit. Deeper paging can therefore only
+// ever chew empty/irrelevant history — exactly the device failure mode: dead
+// curated ids each cost a ~minutes-long 30-page run finalizing with
+// fetchedEnvelopesCount=0. 3 pages keeps a healthy fetch (1-2 pages) untouched
+// while collapsing a dead-id run to a fraction of its former cost. Applied only at
+// the community construction site; the contact/default cap stays at 30.
+const maxCommunityStoreNodeRequestPageCount = 3
+
 type StoreNodeRequestConfig struct {
 	WaitForResponse   bool
 	StopWhenDataFound bool
@@ -209,6 +222,19 @@ func (c StoreNodeRequestConfig) gateNextPageByDescriptionSeen(fetchNext, descrip
 	return fetchNext, false
 }
 
+// shouldProcessStoreNodePage reports whether the forced per-page
+// Messenger.ProcessAllMessages should run for a page that carried envelopesCount
+// envelopes (issue #21470-hf). ProcessAllMessages walks the messenger's whole
+// pending backlog; the store-node pager only forces it to flush THIS request's
+// just-fetched envelopes into the DB before the GetByID check. A page with zero
+// envelopes has nothing of ours to flush, so processing it only re-walks the
+// (possibly fat) backfill queue for no gain — the CPU/GC amplification observed on
+// device. Skip it; the subsequent DB check still runs so a description delivered
+// by a parallel channel-sync page is not missed.
+func shouldProcessStoreNodePage(envelopesCount int) bool {
+	return envelopesCount > 0
+}
+
 type StoreNodeRequestOption func(*StoreNodeRequestConfig)
 
 func defaultStoreNodeRequestConfig() StoreNodeRequestConfig {
@@ -221,14 +247,34 @@ func defaultStoreNodeRequestConfig() StoreNodeRequestConfig {
 	}
 }
 
-func buildStoreNodeRequestConfig(opts []StoreNodeRequestOption) StoreNodeRequestConfig {
+// defaultCommunityStoreNodeRequestConfig is the base config for community fetches.
+// It matches the shared default in every field except the page cap, which is
+// tightened to maxCommunityStoreNodeRequestPageCount (issue #21470-hf).
+func defaultCommunityStoreNodeRequestConfig() StoreNodeRequestConfig {
 	cfg := defaultStoreNodeRequestConfig()
+	cfg.MaxPageCount = maxCommunityStoreNodeRequestPageCount
+	return cfg
+}
 
+func applyStoreNodeRequestOptions(cfg StoreNodeRequestConfig, opts []StoreNodeRequestOption) StoreNodeRequestConfig {
 	for _, opt := range opts {
 		opt(&cfg)
 	}
 
 	return cfg
+}
+
+// buildStoreNodeRequestConfig builds the config for a contact fetch (the generic
+// default, 30-page cap). Caller options are folded on top.
+func buildStoreNodeRequestConfig(opts []StoreNodeRequestOption) StoreNodeRequestConfig {
+	return applyStoreNodeRequestOptions(defaultStoreNodeRequestConfig(), opts)
+}
+
+// buildCommunityStoreNodeRequestConfig builds the config for a community fetch,
+// starting from the tighter community default (3-page cap). Caller options are
+// still folded on top and can override the cap (issue #21470-hf).
+func buildCommunityStoreNodeRequestConfig(opts []StoreNodeRequestOption) StoreNodeRequestConfig {
+	return applyStoreNodeRequestOptions(defaultCommunityStoreNodeRequestConfig(), opts)
 }
 
 func WithWaitForResponseOption(waitForResponse bool) StoreNodeRequestOption {

--- a/protocol/messenger_store_node_request_manager_config.go
+++ b/protocol/messenger_store_node_request_manager_config.go
@@ -129,18 +129,18 @@ func (c *communityFetchBackoff) suppress(communityID string, now time.Time) (boo
 // full 31-day store-node window and burns CPU/battery on the device.
 const maxStoreNodeRequestPageCount = 30
 
-// maxCommunityStoreNodeRequestPageCount caps community fetches far more tightly
-// than the generic contact cap (issue #21470-hf). Store queries page newest-first
-// (verified in go-waku history.go: PaginationForward unset => proto3 default false
-// => backward) and community descriptions are republished periodically, so a live
-// community's description lands within the first pages; the description-seen gate
-// (6cd6ced1a) then stops the request on that hit. Deeper paging can therefore only
-// ever chew empty/irrelevant history — exactly the device failure mode: dead
-// curated ids each cost a ~minutes-long 30-page run finalizing with
-// fetchedEnvelopesCount=0. 3 pages keeps a healthy fetch (1-2 pages) untouched
-// while collapsing a dead-id run to a fraction of its former cost. Applied only at
-// the community construction site; the contact/default cap stays at 30.
-const maxCommunityStoreNodeRequestPageCount = 3
+// maxCommunityStoreNodeRequestPageCount caps community fetches (issue #21470-hf).
+// Store queries page newest-first, but on a HIGH-TRAFFIC community the universal
+// content topic carries all channels' messages, so the periodically-republished
+// description can sit well below the newest pages: on-device (Samsung S21FE, dev
+// fleet) a 3-page cap made the Status community's 1.4MB description UNREACHABLE —
+// 62 capped fetch attempts, zero resolves, community permanently absent from
+// Discover — while low-traffic communities resolved in 1-2 pages. 30 pages
+// (~1500 envelopes) reliably reached it in every measured run. Deep pages are
+// affordable now that undecryptable envelopes drop early (keyless gate,
+// 36dd3cf7f) and empty pages skip processing; the description-seen gate
+// (6cd6ced1a) still stops a request the moment the description appears.
+const maxCommunityStoreNodeRequestPageCount = 30
 
 type StoreNodeRequestConfig struct {
 	WaitForResponse   bool

--- a/protocol/messenger_store_node_request_manager_config.go
+++ b/protocol/messenger_store_node_request_manager_config.go
@@ -1,10 +1,35 @@
 package protocol
 
+// maxStoreNodeRequestPageCount is a hard ceiling on the number of store-node
+// response pages a single storeNodeRequest may process before giving up (issue
+// #21470-hf). Normal community/contact fetches resolve in 1-2 pages; this is
+// deliberately generous (~15x) so it never affects healthy requests, while
+// still bounding a request that can never terminate — e.g. a token-owned
+// community whose owner validation keeps failing, which otherwise drains the
+// full 31-day store-node window and burns CPU/battery on the device.
+const maxStoreNodeRequestPageCount = 30
+
 type StoreNodeRequestConfig struct {
 	WaitForResponse   bool
 	StopWhenDataFound bool
 	InitialPageSize   uint64
 	FurtherPageSize   uint64
+	// MaxPageCount caps how many pages a single request may process. A value
+	// of 0 disables the cap.
+	MaxPageCount int
+}
+
+// gateNextPageByCap applies the per-request page ceiling to a natural
+// pagination decision. It only ever converts a "fetch next page" decision into
+// a stop; it never forces additional paging, and it is a no-op both when the
+// natural decision is already to stop and when the cap is disabled
+// (MaxPageCount <= 0). capTripped reports whether the cap itself forced the
+// stop, so the caller can log it distinctly from an ordinary completion.
+func (c StoreNodeRequestConfig) gateNextPageByCap(fetchNext bool, nextPageSize uint64, fetchedPagesCount int) (shouldFetch bool, pageSize uint64, capTripped bool) {
+	if fetchNext && c.MaxPageCount > 0 && fetchedPagesCount >= c.MaxPageCount {
+		return false, 0, true
+	}
+	return fetchNext, nextPageSize, false
 }
 
 type StoreNodeRequestOption func(*StoreNodeRequestConfig)
@@ -15,6 +40,7 @@ func defaultStoreNodeRequestConfig() StoreNodeRequestConfig {
 		StopWhenDataFound: true,
 		InitialPageSize:   initialStoreNodeRequestPageSize,
 		FurtherPageSize:   defaultStoreNodeRequestPageSize,
+		MaxPageCount:      maxStoreNodeRequestPageCount,
 	}
 }
 
@@ -49,5 +75,11 @@ func WithInitialPageSize(initialPageSize uint64) StoreNodeRequestOption {
 func WithFurtherPageSize(furtherPageSize uint64) StoreNodeRequestOption {
 	return func(c *StoreNodeRequestConfig) {
 		c.FurtherPageSize = furtherPageSize
+	}
+}
+
+func WithMaxPageCount(maxPageCount int) StoreNodeRequestOption {
+	return func(c *StoreNodeRequestConfig) {
+		c.MaxPageCount = maxPageCount
 	}
 }

--- a/protocol/messenger_store_node_request_manager_config.go
+++ b/protocol/messenger_store_node_request_manager_config.go
@@ -1,5 +1,76 @@
 package protocol
 
+import "time"
+
+// communityNotFoundCooldownTTL is how long a community id stays on the
+// negative-result cooldown after a store-node request finalized without
+// producing a community (issue #21470-hf). The dev curated directory carries
+// "dead" ids whose descriptions never arrive; without a cooldown any client-side
+// loop (Communities Portal re-requesting per delegate, curated refreshes, …)
+// re-issues FetchCommunity for them back-to-back, each run paging to the cap and
+// finalizing not-found — a sustained CPU/GC storm that overheats the device.
+//
+// Trade-off: a user's manual retry within the TTL of a definitive not-found
+// no-ops (returns not-found immediately without hitting the network). This is
+// acceptable because the fetch would fail identically anyway — nothing on the
+// store node changed in two minutes — and a successful fetch or an active
+// in-flight request are both unaffected (a live request is joined, not
+// suppressed; a success clears the entry immediately).
+const communityNotFoundCooldownTTL = 2 * time.Minute
+
+// communityNotFoundCooldown records, per community id, the time its last
+// store-node request finalized without producing a community. A fresh request
+// for an id whose last nil-result finalize is younger than ttl is suppressed
+// (delivered an immediate not-found) instead of spawning another pager. Entries
+// expire lazily on read — there is no janitor goroutine.
+//
+// It carries no lock of its own: the owning StoreNodeRequestManager guards every
+// access with its activeRequestsLock (the same lock that guards activeRequests
+// and is already held across finalize()), so record/clear/suppress are always
+// called under that lock. It must therefore never be copied by value once
+// populated; the manager holds it by pointer.
+type communityNotFoundCooldown struct {
+	ttl     time.Duration
+	entries map[string]time.Time
+}
+
+func newCommunityNotFoundCooldown(ttl time.Duration) *communityNotFoundCooldown {
+	return &communityNotFoundCooldown{
+		ttl:     ttl,
+		entries: map[string]time.Time{},
+	}
+}
+
+// recordNilFinalize arms (or re-arms) the cooldown for communityID at now. Called
+// when a community request finalizes with a nil community (not-found, cap-tripped
+// or queued-stop). Re-arming slides the window to the newest finalize.
+func (c *communityNotFoundCooldown) recordNilFinalize(communityID string, now time.Time) {
+	c.entries[communityID] = now
+}
+
+// clear drops any cooldown for communityID. Called when a community request
+// finalizes WITH a community, so a subsequent legitimate re-fetch is never
+// suppressed by a stale negative result.
+func (c *communityNotFoundCooldown) clear(communityID string) {
+	delete(c.entries, communityID)
+}
+
+// suppress reports whether a fresh request for communityID should be suppressed,
+// and the remaining cooldown (for logging). An entry at or past the TTL does not
+// suppress and is evicted on read. A missing entry never suppresses.
+func (c *communityNotFoundCooldown) suppress(communityID string, now time.Time) (bool, time.Duration) {
+	last, ok := c.entries[communityID]
+	if !ok {
+		return false, 0
+	}
+	remaining := c.ttl - now.Sub(last)
+	if remaining <= 0 {
+		delete(c.entries, communityID)
+		return false, 0
+	}
+	return true, remaining
+}
+
 // maxStoreNodeRequestPageCount is a hard ceiling on the number of store-node
 // response pages a single storeNodeRequest may process before giving up (issue
 // #21470-hf). Normal community/contact fetches resolve in 1-2 pages; this is

--- a/protocol/messenger_store_node_request_manager_config.go
+++ b/protocol/messenger_store_node_request_manager_config.go
@@ -32,6 +32,34 @@ func (c StoreNodeRequestConfig) gateNextPageByCap(fetchNext bool, nextPageSize u
 	return fetchNext, nextPageSize, false
 }
 
+// gateNextPageByValidationQueue decides whether store-node pagination for a
+// community request should stop because the community's description is already
+// in hand and only blocked on owner validation (issue #21470-hf).
+//
+// For a token-owned community the pager stops when the community is persisted,
+// but persistence is withheld until on-chain owner verification succeeds. On a
+// transport failure (RPC timeout, dead proxy, rate limit) verification neither
+// succeeds nor rejects, so the pager — which only knows "community not in the
+// table yet" — wrongly requests another page. A new page cannot revive a dead
+// RPC; it only floods the network and starves the very verification calls whose
+// success would end the request. Once we hold the description (it is queued for
+// validation), fetching more pages is pointless: verification retries out-of-band
+// on the owner-verification loop and publishes once it eventually succeeds.
+//
+// queuedClock is the highest clock among the descriptions queued for validation
+// for this community (0 if none are queued). A queued description only supersedes
+// further paging when it is newer than the clock we already hold
+// (minimumDataClock) — mirroring the "is this description newer" test the pager
+// applies when the community IS found. communityInDB short-circuits to false so
+// the found path (with its own clock check) remains solely responsible for that
+// case.
+func gateNextPageByValidationQueue(communityInDB bool, queuedClock, minimumDataClock uint64) bool {
+	if communityInDB {
+		return false
+	}
+	return queuedClock > minimumDataClock
+}
+
 type StoreNodeRequestOption func(*StoreNodeRequestConfig)
 
 func defaultStoreNodeRequestConfig() StoreNodeRequestConfig {

--- a/protocol/messenger_store_node_request_manager_config_test.go
+++ b/protocol/messenger_store_node_request_manager_config_test.go
@@ -100,3 +100,89 @@ func TestGateNextPageByValidationQueue(t *testing.T) {
 		require.False(t, gateNextPageByValidationQueue(false, 90, 100))
 	})
 }
+
+// TestGateNextPageByDescriptionSeen verifies the decision that stops store-node
+// pagination for a community request once a description for the target community
+// has already been processed in this request (issue #21470-hf). Store-node
+// history is paged newest-first, so the first description encountered is the
+// newest available and every later page can only carry an older one. Continuing
+// to page therefore cannot yield a newer description; it only re-unmarshals and
+// re-preprocesses the (large) description on each page, driving a GC storm and
+// overheating the device. This is the remaining flood after the page cap and
+// validation-queue gates: the "community persisted but not newer" branch
+// (messenger_store_node_request_manager.go, community.Clock() <= minimumDataClock)
+// which today keeps paging to the cap and is re-issued perpetually.
+func TestGateNextPageByDescriptionSeen(t *testing.T) {
+	t.Run("description not seen keeps the natural decision", func(t *testing.T) {
+		// No description for this community has been processed yet, so paging must
+		// continue up to the cap exactly as before.
+		cfg := StoreNodeRequestConfig{StopWhenDataFound: true}
+		fetch, tripped := cfg.gateNextPageByDescriptionSeen(true, false)
+		require.True(t, fetch)
+		require.False(t, tripped)
+	})
+
+	t.Run("description seen stops paging and reports the trip", func(t *testing.T) {
+		// The core #21470-hf bug: a spectated community is re-fetched,
+		// minimumDataClock == its clock, so every page hits the "not newer" branch
+		// and would keep paging. Once the description was processed this request,
+		// older pages cannot beat it, so we stop and report the trip so the caller
+		// can log it distinctly.
+		cfg := StoreNodeRequestConfig{StopWhenDataFound: true}
+		fetch, tripped := cfg.gateNextPageByDescriptionSeen(true, true)
+		require.False(t, fetch)
+		require.True(t, tripped)
+	})
+
+	t.Run("natural stop is never overridden and never reports a trip", func(t *testing.T) {
+		// The uncapped decision is already "stop" (e.g. found-and-newer, or a
+		// decode/validate error). Even with the description seen, this gate must
+		// not claim responsibility for the stop.
+		cfg := StoreNodeRequestConfig{StopWhenDataFound: true}
+		fetch, tripped := cfg.gateNextPageByDescriptionSeen(false, true)
+		require.False(t, fetch)
+		require.False(t, tripped)
+	})
+
+	t.Run("full-window walk (StopWhenDataFound=false) is never cut short", func(t *testing.T) {
+		// Mirrors the success-path `!StopWhenDataFound` return: a caller that
+		// wants the entire window must keep paging even after the description is
+		// seen. The gate is disabled and returns the natural decision unchanged.
+		cfg := StoreNodeRequestConfig{StopWhenDataFound: false}
+		fetch, tripped := cfg.gateNextPageByDescriptionSeen(true, true)
+		require.True(t, fetch)
+		require.False(t, tripped)
+	})
+}
+
+// TestCommunityDescriptionSeen verifies the request-scoped signal that feeds the
+// description-seen gate: whether the messages processed for a store-node page
+// carried a description for the target community. A processed description
+// surfaces the community in the MessengerResponse (handleCommunityResponse ->
+// AddCommunity), including the equal-clock re-processing that drives issue
+// #21470-hf, so its presence in the response is the "a description for this
+// community was processed this page" signal.
+func TestCommunityDescriptionSeen(t *testing.T) {
+	community := createTestCommunityWithImage(t)
+
+	t.Run("nil response is not seen", func(t *testing.T) {
+		require.False(t, communityDescriptionSeen(nil, community.ID()))
+	})
+
+	t.Run("empty response is not seen", func(t *testing.T) {
+		require.False(t, communityDescriptionSeen(&MessengerResponse{}, community.ID()))
+	})
+
+	t.Run("response carrying the community is seen", func(t *testing.T) {
+		response := &MessengerResponse{}
+		response.AddCommunity(community)
+		require.True(t, communityDescriptionSeen(response, community.ID()))
+	})
+
+	t.Run("response carrying a different community is not seen", func(t *testing.T) {
+		other := createTestCommunityWithImage(t)
+		response := &MessengerResponse{}
+		response.AddCommunity(other)
+		require.False(t, communityDescriptionSeen(response, community.ID()))
+	})
+}

--- a/protocol/messenger_store_node_request_manager_config_test.go
+++ b/protocol/messenger_store_node_request_manager_config_test.go
@@ -225,6 +225,67 @@ func TestStoreNodeRequestPageCap(t *testing.T) {
 	})
 }
 
+// TestCommunityStoreNodeRequestPageCap verifies that community fetches get a much
+// tighter page cap than contact fetches (issue #21470-hf). Store queries page
+// newest-first (go-waku history.go: PaginationForward unset = backward) and
+// community descriptions are republished periodically, so a live community's
+// description appears within the first few pages; with the description-seen gate
+// (6cd6ced1a) a hit stops the request anyway, so deep paging can only ever chew
+// empty/irrelevant history. The device evidence: dead curated ids each cost a
+// ~minutes-long 30-page run with fetchedEnvelopesCount=0 at cap-trip. Contact
+// fetches keep the generous 30-page cap; only the community construction site is
+// tightened, never the shared default.
+func TestCommunityStoreNodeRequestPageCap(t *testing.T) {
+	t.Run("community construction caps at 3 pages", func(t *testing.T) {
+		require.Equal(t, 3, maxCommunityStoreNodeRequestPageCount)
+		cfg := buildCommunityStoreNodeRequestConfig(nil)
+		require.Equal(t, maxCommunityStoreNodeRequestPageCount, cfg.MaxPageCount)
+	})
+
+	t.Run("contact construction keeps the generous 30-page cap", func(t *testing.T) {
+		require.Equal(t, 30, maxStoreNodeRequestPageCount)
+		cfg := buildStoreNodeRequestConfig(nil)
+		require.Equal(t, maxStoreNodeRequestPageCount, cfg.MaxPageCount)
+	})
+
+	t.Run("community construction is tighter than contact construction", func(t *testing.T) {
+		community := buildCommunityStoreNodeRequestConfig(nil)
+		contact := buildStoreNodeRequestConfig(nil)
+		require.Less(t, community.MaxPageCount, contact.MaxPageCount)
+	})
+
+	t.Run("community construction inherits the shared non-cap defaults", func(t *testing.T) {
+		cfg := buildCommunityStoreNodeRequestConfig(nil)
+		base := defaultStoreNodeRequestConfig()
+		require.Equal(t, base.WaitForResponse, cfg.WaitForResponse)
+		require.Equal(t, base.StopWhenDataFound, cfg.StopWhenDataFound)
+		require.Equal(t, base.InitialPageSize, cfg.InitialPageSize)
+		require.Equal(t, base.FurtherPageSize, cfg.FurtherPageSize)
+	})
+
+	t.Run("caller options still override the community cap", func(t *testing.T) {
+		cfg := buildCommunityStoreNodeRequestConfig([]StoreNodeRequestOption{WithMaxPageCount(7)})
+		require.Equal(t, 7, cfg.MaxPageCount)
+	})
+}
+
+// TestShouldProcessStoreNodePage verifies the decision that skips the forced
+// per-page Messenger.ProcessAllMessages when the just-fetched page carried zero
+// envelopes (issue #21470-hf). That call exists solely to flush THIS request's
+// envelopes into the DB before the GetByID check; with zero envelopes there is
+// nothing of ours to flush, yet ProcessAllMessages still walks the messenger's
+// whole pending backlog. During the legitimate channel backfill that means
+// re-walking a fat queue on every empty page — up to the page cap, continuously,
+// for each dead curated id — the CPU/GC storm seen on device (GC 67%, service
+// 320-370%). Skipping the walk on empty pages removes that amplification; the DB
+// check still runs (a parallel channel-sync page may have delivered the
+// description).
+func TestShouldProcessStoreNodePage(t *testing.T) {
+	require.False(t, shouldProcessStoreNodePage(0), "empty page has nothing of ours to flush")
+	require.True(t, shouldProcessStoreNodePage(1), "a page with envelopes must be processed")
+	require.True(t, shouldProcessStoreNodePage(50), "a full page must be processed")
+}
+
 // TestGateNextPageByValidationQueue verifies the decision that stops store-node
 // pagination for a community request once the community's description is already
 // in hand and only blocked on owner validation (issue #21470-hf). For a

--- a/protocol/messenger_store_node_request_manager_config_test.go
+++ b/protocol/messenger_store_node_request_manager_config_test.go
@@ -7,90 +7,163 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestCommunityNotFoundCooldown verifies the negative-result cooldown that stops
-// a fresh store-node community fetch from being spawned right after the same
-// community just finalized as not-found (issue #21470-hf). The dev curated
-// directory carries "dead" community ids whose descriptions never arrive; any
-// client-side loop re-issues FetchCommunity for them, each run pages to the cap,
-// finalizes not-found, and the next call starts a fresh run — a sustained CPU
-// storm. Once an id finalizes with a nil community we record the time; a new
-// request for that id inside the TTL is suppressed instead of spawning a pager.
-// A successful fetch clears the entry, and entries expire on read (no janitor).
-func TestCommunityNotFoundCooldown(t *testing.T) {
-	const ttl = 2 * time.Minute
-	base := time.Date(2026, 7, 14, 12, 0, 0, 0, time.UTC)
+// TestCommunityFetchBackoff verifies the per-id exponential backoff that throttles
+// repeated store-node community fetches which keep finalizing as not-found (issue
+// #21470-hf). The dev curated directory carries "dead" community ids whose
+// descriptions never arrive; any client-side loop re-issues FetchCommunity for
+// them, each run pages to the cap, finalizes not-found, and the next call starts
+// a fresh run — a sustained CPU storm.
+//
+// An earlier hotfix (b7992077f) used a FLAT 2-minute cooldown after the first
+// nil finalize. On-device that over-suppressed a COLD start: a capped request
+// commonly finalizes nil before the slow, loaded store node has served a
+// community's large description, and the flat cooldown then blocked exactly the
+// rapid retries that empirically are how descriptions land (346 attempts → 249
+// suppressed → 0 descriptions resolved in 9 min). This backoff instead barely
+// touches the warm-up cadence (first retries within seconds) while a genuinely
+// dead id converges to one run per maxDelay.
+//
+// backoffFor(n) = min(baseDelay * 2^(n-1), maxDelay). Only a REAL request that
+// finalizes nil increments n (recordNilFinalize); a suppressed attempt must not
+// self-extend the ban. A success clears the entry entirely.
+func TestCommunityFetchBackoff(t *testing.T) {
+	const base = 5 * time.Second
+	const max = 2 * time.Minute
+	baseTime := time.Date(2026, 7, 14, 12, 0, 0, 0, time.UTC)
 
-	t.Run("fresh cooldown suppresses nothing", func(t *testing.T) {
-		c := newCommunityNotFoundCooldown(ttl)
-		suppress, remaining := c.suppress("0xdead", base)
+	t.Run("no entry suppresses nothing", func(t *testing.T) {
+		c := newCommunityFetchBackoff(base, max)
+		suppress, misses, remaining := c.suppress("0xdead", baseTime)
 		require.False(t, suppress)
+		require.Equal(t, 0, misses)
 		require.Equal(t, time.Duration(0), remaining)
 	})
 
-	t.Run("record then a fresh request within the TTL is suppressed", func(t *testing.T) {
-		c := newCommunityNotFoundCooldown(ttl)
-		c.recordNilFinalize("0xdead", base)
+	t.Run("backoff schedule doubles per miss up to the cap", func(t *testing.T) {
+		c := newCommunityFetchBackoff(base, max)
+		require.Equal(t, time.Duration(0), c.backoffFor(0))
+		for _, tc := range []struct {
+			misses int
+			want   time.Duration
+		}{
+			{1, 5 * time.Second},
+			{2, 10 * time.Second},
+			{3, 20 * time.Second},
+			{4, 40 * time.Second},
+			{5, 80 * time.Second},
+			{6, 120 * time.Second},
+			{7, 120 * time.Second},
+			{20, 120 * time.Second},
+		} {
+			require.Equalf(t, tc.want, c.backoffFor(tc.misses), "backoffFor(%d)", tc.misses)
+		}
+	})
 
-		suppress, remaining := c.suppress("0xdead", base.Add(30*time.Second))
+	t.Run("warm-up retries are barely delayed; a dead id converges to the cap", func(t *testing.T) {
+		for _, tc := range []struct {
+			misses int
+			window time.Duration
+		}{
+			{1, 5 * time.Second},
+			{2, 10 * time.Second},
+			{3, 20 * time.Second},
+			{6, 120 * time.Second},
+		} {
+			c := newCommunityFetchBackoff(base, max)
+			for i := 0; i < tc.misses; i++ {
+				c.recordNilFinalize("0xdead", baseTime)
+			}
+			// Just before the window ends: suppressed, one ns of backoff left.
+			suppress, misses, remaining := c.suppress("0xdead", baseTime.Add(tc.window-time.Nanosecond))
+			require.Truef(t, suppress, "misses=%d", tc.misses)
+			require.Equal(t, tc.misses, misses)
+			require.Equal(t, time.Nanosecond, remaining)
+			// Exactly at the window boundary: allowed to retry.
+			suppress, _, remaining = c.suppress("0xdead", baseTime.Add(tc.window))
+			require.Falsef(t, suppress, "misses=%d", tc.misses)
+			require.Equal(t, time.Duration(0), remaining)
+		}
+	})
+
+	t.Run("a suppressed attempt does not increment the counter (no self-extending ban)", func(t *testing.T) {
+		c := newCommunityFetchBackoff(base, max)
+		c.recordNilFinalize("0xdead", baseTime) // n=1, window 5s
+
+		// Hammer suppress within the window; none of these may advance n or slide
+		// the window.
+		for i := 0; i < 5; i++ {
+			suppress, misses, _ := c.suppress("0xdead", baseTime.Add(2*time.Second))
+			require.True(t, suppress)
+			require.Equal(t, 1, misses)
+		}
+		// Still n=1, so the retry is allowed exactly at +5s (window never moved).
+		suppress, misses, _ := c.suppress("0xdead", baseTime.Add(5*time.Second))
+		require.False(t, suppress)
+		require.Equal(t, 1, misses)
+	})
+
+	t.Run("only a real nil finalize advances the backoff", func(t *testing.T) {
+		c := newCommunityFetchBackoff(base, max)
+		c.recordNilFinalize("0xdead", baseTime)                    // n=1
+		c.recordNilFinalize("0xdead", baseTime.Add(5*time.Second)) // n=2, window 10s from +5s
+
+		suppress, misses, remaining := c.suppress("0xdead", baseTime.Add(6*time.Second))
 		require.True(t, suppress)
-		require.Equal(t, 90*time.Second, remaining)
+		require.Equal(t, 2, misses)
+		require.Equal(t, 9*time.Second, remaining)
 	})
 
-	t.Run("a different id is not affected by another id's cooldown", func(t *testing.T) {
-		c := newCommunityNotFoundCooldown(ttl)
-		c.recordNilFinalize("0xdead", base)
+	t.Run("an allowed retry keeps the counter so a dead id keeps climbing", func(t *testing.T) {
+		c := newCommunityFetchBackoff(base, max)
+		c.recordNilFinalize("0xdead", baseTime)
+		c.recordNilFinalize("0xdead", baseTime) // n=2, window 10s
 
-		suppress, remaining := c.suppress("0xlive", base.Add(time.Second))
+		// Past the window: allowed, but the n=2 entry must persist (not evicted like
+		// the old TTL) so the next finalize climbs to n=3, not resets to n=1.
+		suppress, misses, _ := c.suppress("0xdead", baseTime.Add(30*time.Second))
 		require.False(t, suppress)
+		require.Equal(t, 2, misses)
+
+		c.recordNilFinalize("0xdead", baseTime.Add(30*time.Second)) // -> n=3, window 20s
+		suppress, misses, remaining := c.suppress("0xdead", baseTime.Add(31*time.Second))
+		require.True(t, suppress)
+		require.Equal(t, 3, misses)
+		require.Equal(t, 19*time.Second, remaining)
+	})
+
+	t.Run("a different id is independent", func(t *testing.T) {
+		c := newCommunityFetchBackoff(base, max)
+		c.recordNilFinalize("0xdead", baseTime)
+
+		suppress, misses, remaining := c.suppress("0xlive", baseTime.Add(time.Second))
+		require.False(t, suppress)
+		require.Equal(t, 0, misses)
 		require.Equal(t, time.Duration(0), remaining)
 	})
 
-	t.Run("entry past the TTL does not suppress and is evicted on read", func(t *testing.T) {
-		c := newCommunityNotFoundCooldown(ttl)
-		c.recordNilFinalize("0xdead", base)
-
-		suppress, remaining := c.suppress("0xdead", base.Add(ttl+time.Second))
-		require.False(t, suppress)
-		require.Equal(t, time.Duration(0), remaining)
-
-		// A second query at a time that WOULD be inside a fresh TTL still does not
-		// suppress, proving the stale entry was evicted rather than lingering.
-		suppress, _ = c.suppress("0xdead", base.Add(ttl+2*time.Second))
-		require.False(t, suppress)
-	})
-
-	t.Run("exactly at the TTL boundary does not suppress", func(t *testing.T) {
-		c := newCommunityNotFoundCooldown(ttl)
-		c.recordNilFinalize("0xdead", base)
-
-		suppress, remaining := c.suppress("0xdead", base.Add(ttl))
-		require.False(t, suppress)
-		require.Equal(t, time.Duration(0), remaining)
-	})
-
-	t.Run("a successful fetch clears the cooldown", func(t *testing.T) {
-		c := newCommunityNotFoundCooldown(ttl)
-		c.recordNilFinalize("0xdead", base)
+	t.Run("a successful fetch clears the entry and resets the schedule", func(t *testing.T) {
+		c := newCommunityFetchBackoff(base, max)
+		c.recordNilFinalize("0xdead", baseTime)
+		c.recordNilFinalize("0xdead", baseTime) // n=2
 		c.clear("0xdead")
 
-		suppress, remaining := c.suppress("0xdead", base.Add(time.Second))
+		suppress, misses, remaining := c.suppress("0xdead", baseTime.Add(time.Second))
 		require.False(t, suppress)
+		require.Equal(t, 0, misses)
 		require.Equal(t, time.Duration(0), remaining)
-	})
 
-	t.Run("a later not-found re-arms the cooldown from the new time", func(t *testing.T) {
-		c := newCommunityNotFoundCooldown(ttl)
-		c.recordNilFinalize("0xdead", base)
-		// Re-finalize not-found later; the window must slide to the new finalize.
-		c.recordNilFinalize("0xdead", base.Add(5*time.Minute))
-
-		suppress, remaining := c.suppress("0xdead", base.Add(5*time.Minute+time.Second))
+		// After a clear, a fresh nil finalize starts back at n=1 (5s), not where the
+		// prior streak left off.
+		c.recordNilFinalize("0xdead", baseTime.Add(time.Minute))
+		suppress, misses, remaining = c.suppress("0xdead", baseTime.Add(time.Minute+time.Second))
 		require.True(t, suppress)
-		require.Equal(t, ttl-time.Second, remaining)
+		require.Equal(t, 1, misses)
+		require.Equal(t, 4*time.Second, remaining)
 	})
 
-	t.Run("default TTL is enabled and conservative", func(t *testing.T) {
-		require.Equal(t, 2*time.Minute, communityNotFoundCooldownTTL)
+	t.Run("default base/max delays keep warm-up fast and cap steady state", func(t *testing.T) {
+		require.Equal(t, 5*time.Second, communityFetchBackoffBaseDelay)
+		require.Equal(t, 2*time.Minute, communityFetchBackoffMaxDelay)
 	})
 }
 

--- a/protocol/messenger_store_node_request_manager_config_test.go
+++ b/protocol/messenger_store_node_request_manager_config_test.go
@@ -236,8 +236,8 @@ func TestStoreNodeRequestPageCap(t *testing.T) {
 // fetches keep the generous 30-page cap; only the community construction site is
 // tightened, never the shared default.
 func TestCommunityStoreNodeRequestPageCap(t *testing.T) {
-	t.Run("community construction caps at 3 pages", func(t *testing.T) {
-		require.Equal(t, 3, maxCommunityStoreNodeRequestPageCount)
+	t.Run("community construction caps at 30 pages", func(t *testing.T) {
+		require.Equal(t, 30, maxCommunityStoreNodeRequestPageCount)
 		cfg := buildCommunityStoreNodeRequestConfig(nil)
 		require.Equal(t, maxCommunityStoreNodeRequestPageCount, cfg.MaxPageCount)
 	})
@@ -248,10 +248,10 @@ func TestCommunityStoreNodeRequestPageCap(t *testing.T) {
 		require.Equal(t, maxStoreNodeRequestPageCount, cfg.MaxPageCount)
 	})
 
-	t.Run("community construction is tighter than contact construction", func(t *testing.T) {
+	t.Run("community construction is not looser than contact construction", func(t *testing.T) {
 		community := buildCommunityStoreNodeRequestConfig(nil)
 		contact := buildStoreNodeRequestConfig(nil)
-		require.Less(t, community.MaxPageCount, contact.MaxPageCount)
+		require.LessOrEqual(t, community.MaxPageCount, contact.MaxPageCount)
 	})
 
 	t.Run("community construction inherits the shared non-cap defaults", func(t *testing.T) {

--- a/protocol/messenger_store_node_request_manager_config_test.go
+++ b/protocol/messenger_store_node_request_manager_config_test.go
@@ -63,3 +63,40 @@ func TestStoreNodeRequestPageCap(t *testing.T) {
 		require.GreaterOrEqual(t, cfg.MaxPageCount, 20, "cap must be generous vs the 1-2 page normal fetch")
 	})
 }
+
+// TestGateNextPageByValidationQueue verifies the decision that stops store-node
+// pagination for a community request once the community's description is already
+// in hand and only blocked on owner validation (issue #21470-hf). For a
+// token-owned community the store-node pager's natural stop condition is
+// "community persisted", but persistence is withheld until on-chain owner
+// verification succeeds. A transport failure during verification is
+// indistinguishable, to the pager, from "not fetched yet", so it wrongly fetches
+// another page — which cannot make a dead RPC succeed and only floods the
+// network. Once the description is queued for validation, more pages genuinely
+// cannot help: verification retries out-of-band on the owner-verification loop.
+func TestGateNextPageByValidationQueue(t *testing.T) {
+	t.Run("community already in DB never stops for validation", func(t *testing.T) {
+		// The found path (clock check) owns this case; the validation gate must
+		// not interfere regardless of what is queued.
+		require.False(t, gateNextPageByValidationQueue(true, 100, 0))
+	})
+
+	t.Run("nothing queued keeps paging (genuine not-found)", func(t *testing.T) {
+		require.False(t, gateNextPageByValidationQueue(false, 0, 0))
+	})
+
+	t.Run("queued description newer than what we hold stops paging", func(t *testing.T) {
+		// Description is in hand, only owner verification is pending; the
+		// verification loop will retry it. More pages cannot help.
+		require.True(t, gateNextPageByValidationQueue(false, 100, 0))
+		require.True(t, gateNextPageByValidationQueue(false, 101, 100))
+	})
+
+	t.Run("queued description not newer than what we hold keeps paging", func(t *testing.T) {
+		// The queued description is stale relative to the clock we already have;
+		// a newer page could still legitimately arrive. Mirrors the found-path
+		// "is this newer" test (community.Clock() <= minimumDataClock).
+		require.False(t, gateNextPageByValidationQueue(false, 100, 100))
+		require.False(t, gateNextPageByValidationQueue(false, 90, 100))
+	})
+}

--- a/protocol/messenger_store_node_request_manager_config_test.go
+++ b/protocol/messenger_store_node_request_manager_config_test.go
@@ -1,0 +1,65 @@
+package protocol
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestStoreNodeRequestPageCap verifies the per-request page ceiling that bounds
+// a runaway store-node history fetch (issue #21470-hf). The cap must only ever
+// turn a "fetch next page" decision into a stop; it must never force extra
+// paging, and it must be a no-op when the natural decision is already to stop
+// (e.g. StopWhenDataFound with the data found) or when the cap is disabled.
+func TestStoreNodeRequestPageCap(t *testing.T) {
+	const cap = 30
+
+	t.Run("disabled cap (MaxPageCount==0) never trips", func(t *testing.T) {
+		cfg := StoreNodeRequestConfig{MaxPageCount: 0, FurtherPageSize: 50}
+		fetch, size, tripped := cfg.gateNextPageByCap(true, cfg.FurtherPageSize, 1_000_000)
+		require.True(t, fetch)
+		require.Equal(t, uint64(50), size)
+		require.False(t, tripped)
+	})
+
+	t.Run("below cap keeps paging", func(t *testing.T) {
+		cfg := StoreNodeRequestConfig{MaxPageCount: cap, FurtherPageSize: 50}
+		fetch, size, tripped := cfg.gateNextPageByCap(true, cfg.FurtherPageSize, cap-1)
+		require.True(t, fetch)
+		require.Equal(t, uint64(50), size)
+		require.False(t, tripped)
+	})
+
+	t.Run("exactly at cap trips and stops", func(t *testing.T) {
+		cfg := StoreNodeRequestConfig{MaxPageCount: cap, FurtherPageSize: 50}
+		fetch, size, tripped := cfg.gateNextPageByCap(true, cfg.FurtherPageSize, cap)
+		require.False(t, fetch)
+		require.Equal(t, uint64(0), size)
+		require.True(t, tripped)
+	})
+
+	t.Run("above cap trips and stops", func(t *testing.T) {
+		cfg := StoreNodeRequestConfig{MaxPageCount: cap, FurtherPageSize: 50}
+		fetch, size, tripped := cfg.gateNextPageByCap(true, cfg.FurtherPageSize, cap+5)
+		require.False(t, fetch)
+		require.Equal(t, uint64(0), size)
+		require.True(t, tripped)
+	})
+
+	t.Run("natural stop is never overridden and never reports a trip", func(t *testing.T) {
+		// Models StopWhenDataFound with the community found, or the decode/validate
+		// error branches: the uncapped decision is already "stop". Even past the
+		// cap, the cap must not claim responsibility for the stop.
+		cfg := StoreNodeRequestConfig{MaxPageCount: cap, FurtherPageSize: 50}
+		fetch, size, tripped := cfg.gateNextPageByCap(false, 0, cap+100)
+		require.False(t, fetch)
+		require.Equal(t, uint64(0), size)
+		require.False(t, tripped)
+	})
+
+	t.Run("default config ships a generous, enabled cap", func(t *testing.T) {
+		cfg := defaultStoreNodeRequestConfig()
+		require.Greater(t, cfg.MaxPageCount, 1, "cap must be enabled by default")
+		require.GreaterOrEqual(t, cfg.MaxPageCount, 20, "cap must be generous vs the 1-2 page normal fetch")
+	})
+}

--- a/protocol/messenger_store_node_request_manager_config_test.go
+++ b/protocol/messenger_store_node_request_manager_config_test.go
@@ -2,9 +2,97 @@ package protocol
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 )
+
+// TestCommunityNotFoundCooldown verifies the negative-result cooldown that stops
+// a fresh store-node community fetch from being spawned right after the same
+// community just finalized as not-found (issue #21470-hf). The dev curated
+// directory carries "dead" community ids whose descriptions never arrive; any
+// client-side loop re-issues FetchCommunity for them, each run pages to the cap,
+// finalizes not-found, and the next call starts a fresh run — a sustained CPU
+// storm. Once an id finalizes with a nil community we record the time; a new
+// request for that id inside the TTL is suppressed instead of spawning a pager.
+// A successful fetch clears the entry, and entries expire on read (no janitor).
+func TestCommunityNotFoundCooldown(t *testing.T) {
+	const ttl = 2 * time.Minute
+	base := time.Date(2026, 7, 14, 12, 0, 0, 0, time.UTC)
+
+	t.Run("fresh cooldown suppresses nothing", func(t *testing.T) {
+		c := newCommunityNotFoundCooldown(ttl)
+		suppress, remaining := c.suppress("0xdead", base)
+		require.False(t, suppress)
+		require.Equal(t, time.Duration(0), remaining)
+	})
+
+	t.Run("record then a fresh request within the TTL is suppressed", func(t *testing.T) {
+		c := newCommunityNotFoundCooldown(ttl)
+		c.recordNilFinalize("0xdead", base)
+
+		suppress, remaining := c.suppress("0xdead", base.Add(30*time.Second))
+		require.True(t, suppress)
+		require.Equal(t, 90*time.Second, remaining)
+	})
+
+	t.Run("a different id is not affected by another id's cooldown", func(t *testing.T) {
+		c := newCommunityNotFoundCooldown(ttl)
+		c.recordNilFinalize("0xdead", base)
+
+		suppress, remaining := c.suppress("0xlive", base.Add(time.Second))
+		require.False(t, suppress)
+		require.Equal(t, time.Duration(0), remaining)
+	})
+
+	t.Run("entry past the TTL does not suppress and is evicted on read", func(t *testing.T) {
+		c := newCommunityNotFoundCooldown(ttl)
+		c.recordNilFinalize("0xdead", base)
+
+		suppress, remaining := c.suppress("0xdead", base.Add(ttl+time.Second))
+		require.False(t, suppress)
+		require.Equal(t, time.Duration(0), remaining)
+
+		// A second query at a time that WOULD be inside a fresh TTL still does not
+		// suppress, proving the stale entry was evicted rather than lingering.
+		suppress, _ = c.suppress("0xdead", base.Add(ttl+2*time.Second))
+		require.False(t, suppress)
+	})
+
+	t.Run("exactly at the TTL boundary does not suppress", func(t *testing.T) {
+		c := newCommunityNotFoundCooldown(ttl)
+		c.recordNilFinalize("0xdead", base)
+
+		suppress, remaining := c.suppress("0xdead", base.Add(ttl))
+		require.False(t, suppress)
+		require.Equal(t, time.Duration(0), remaining)
+	})
+
+	t.Run("a successful fetch clears the cooldown", func(t *testing.T) {
+		c := newCommunityNotFoundCooldown(ttl)
+		c.recordNilFinalize("0xdead", base)
+		c.clear("0xdead")
+
+		suppress, remaining := c.suppress("0xdead", base.Add(time.Second))
+		require.False(t, suppress)
+		require.Equal(t, time.Duration(0), remaining)
+	})
+
+	t.Run("a later not-found re-arms the cooldown from the new time", func(t *testing.T) {
+		c := newCommunityNotFoundCooldown(ttl)
+		c.recordNilFinalize("0xdead", base)
+		// Re-finalize not-found later; the window must slide to the new finalize.
+		c.recordNilFinalize("0xdead", base.Add(5*time.Minute))
+
+		suppress, remaining := c.suppress("0xdead", base.Add(5*time.Minute+time.Second))
+		require.True(t, suppress)
+		require.Equal(t, ttl-time.Second, remaining)
+	})
+
+	t.Run("default TTL is enabled and conservative", func(t *testing.T) {
+		require.Equal(t, 2*time.Minute, communityNotFoundCooldownTTL)
+	})
+}
 
 // TestStoreNodeRequestPageCap verifies the per-request page ceiling that bounds
 // a runaway store-node history fetch (issue #21470-hf). The cap must only ever


### PR DESCRIPTION
## [DRAFT] Fix Android overheating on community spectate (status-app#21470)

**Draft** — code-complete (25 commits); ready for review. The verification appendix at the bottom documents the full measured progression including two honest regressions found and fixed during verification.

### Problem
status-im/status-app#21470 — on Android (Samsung S21/S21FE, v2.38.x), a fresh profile spectating the Status community and opening `#general` drives the device to 50–52 °C skin temperature, with a permanent loading spinner. Regression trajectory: 2.37.1 bearable → 2.38.x bad.

### Measured baseline (unfixed, Samsung S21FE, fresh profile spectating Status)
- status-go service process: **275% CPU sustained (peak 743%)**, GC = 60–72% of it (40 GB allocations / 13 min)
- **3.9 MB/s network, indefinitely** (6.8 GB in one session); battery drained **while on the charger** (−869 mA mean)
- AP (SoC) 64 °C, skin 47–50 °C; `#general` spinner never cleared; service RSS 876 MB; DB grew by GB of undecryptable blobs

### Root causes found (each device-verified)
1. **Unbounded store-node pager**: fetching a token-owned community whose on-chain owner-verification fails walks the entire sync window, re-processing the ~1.4 MB `CommunityDescription` on every page (a transport failure was treated as "fetch more pages").
2. **Delivery starvation** (v10.34 regression, `60fe88895`): the event-based retrieve loop's 1 s-quiet debounce never fires under a sustained flood → messages persist but never surface → eternal spinner, content only after restart.
3. **Keyless processing waste**: spectators hold no community keys, yet every encrypted envelope paid full segmentation + per-key ratchet lookups and was **parked in SQLCipher for replay** (7,188 decrypt failures; gigabytes of dead blobs).
4. **Oversized spectate backfill**: spectating fired the **global** 9-day all-filters sync — **twice** (two racing call paths) — over the community's single universal content topic; it also continued headless after UI death (pause only covered the reliability layer).
5. **Traffic is ~1000× the useful content**: the description is heartbeat-republished re-encrypted, so every copy has a unique hash (dedup-proof); one run downloaded 1,245 × 1.4 MB reassemblies for 31 logical versions. Waku dedup is post-download, so byte-identical dups (42%) also paid full bytes.

### Commits (in order) with measured effect

| Commit | Change | Measured effect (same device/repro) |
|---|---|---|
| `b11cfdf76` | `mobile_pprof` build tag (tooling, gated off by default) | enabled on-device Go profiling |
| `1273b34eb` | 30-page cap per store-node request | bounds any runaway walk; with it alone: service 275%→~24% between re-issues |
| `30b60b3fd` | retrieve-loop 3 s max-latency flush | spinner clears; messages render mid-session |
| `3d6857f3c` | stop paging once description queued for validation; verify-retry decoupled from paging + transport/invalid log split | stuck token-community fetch: full-window drain → ~1 page/tick |
| `6cd6ced1a` | stop pagination once *any* description seen (store pages are newest-first; older pages cannot contain newer clocks) | "not newer" update checks: 30 pages → 1 |
| `b7992077f` | flat 2-min not-found cooldown | **superseded** — starved cold-start resolves (249/346 suppressed, 0 resolves) |
| `95fef281a` | → per-id exponential backoff (5 s→2 min, streak survives retries) | cold-start resolves restored; dead ids converge to 1 capped run / 2 min |
| `17f1f2fab` | cherry-pick from develop (`2bee8b6a3`): async community-token metadata fetch | removes ~35 s blocking fetch per community save |
| `cae6698f6` | skip per-page `ProcessAllMessages` on empty pages (+3-page cap, later reverted) | empty dead-id pages stop re-walking the ingest backlog |
| `36dd3cf7f` | keyless early-drop gates (description inner fields; hash-ratchet park-drop behind flag) | decrypt-failure spam 7,188 → **0** |
| `2e1dc628e` | restore 30-page community cap (3 pages starved busy-topic descriptions: 62 attempts, 0 resolves, Status absent from Discover) | Status resolves again; correction with evidence |
| `f75d64116` | enable gate 2 (drop undecryptable hash-ratchet messages instead of SQLite parking) | service RSS **876 → 480 MB**; data dir **144 MB** after 3 GB ingested (was GB-scale growth) |
| `2b5d6fc7a` | spectate = community-scoped **24 h** window (was global 9-day ×2 racing paths), cancellable on leave/background | headless-after-UI-death: 78–89% CPU + 3 MB/s forever → **16–36% and falling, cancel log present**; session bytes ~3 GB → 1.5 GB |
| `b8623592e` | hash-first spectate backfill (hash walk → fetch bodies only for unknown hashes) | kills the 42% byte-identical dup tier; store node unclogged (`#general` in **49 s**, was 3–10 min) |
| `6df91538e` | keyless spectator skips the body phase entirely | fully-key-gated communities: **0 bodies fetched** on spectate |
| `aa9fa29b5` | newest-first hash walk | cancelled partial fetches keep the most recent window |
| `23bc41c30` | mixed communities (any public channel) keep fetching bodies | **correctness**: spectators keep public-channel history (Status is mixed) |

### End-state measurements (run 9, all commits, fresh spectate of Status)
- `#general` open in **49 s** (baseline: 3–10 min or never)
- Service CPU **5–22%** during and after channel load (baseline: 275–400% sustained); skin ≤41 °C on charger
- Session download **~630 MB** (baseline 6.8 GB) — remaining volume identified: the **general** (non-spectate) history sync still fetches full bodies on the classic path; fix in flight (see below)
- Spinner clears, public-channel messages render, goroutines stable, RSS ~400 MB

### Verification appendix (runs 10–12, same device/repro)
Later commits extended the stack after run 9; the final A/B story:

- **Hash-first extended to the general sync** (`5eaffbbd8`, with >24h windows split into 24h sub-windows — fixing a silent coverage loss) and the **spectate window restored to the 9-day default** (`74f073111`) — spectators keep full UX parity; the 24h window was rejected as a palliative since spectators typically join (which runs the full sync anyway).
- **Run 10 exposed the deferred pipeline costs at 9-day volume** (1,643 description-handler passes ≈10s each; 2,858 O(N²) segment reassemblies; a 1.45GB transient RSS balloon from unboundedly fetching faster than ingesting). Fixed by `acbffec23`/`5e1a17e23` (clock/content-hash gate before expensive description processing, latch-preserving), `4b29d6aa3` (O(N) segmentation), `60225523c` (ingest backpressure, RSS peak 1.45GB→481MB), `9e0097ed1` (keyless equal-clock republish skip + cached community for gated redeliveries).
- **Run 12 isolated the final multiplier**: the mobile-only `debug.SetMemoryLimit(150MB)` sat ~3× below the working set, forcing permanent GC thrash. A/B on the identical 9-day walk (~1.7GB): 150MB limit → GC 61% of CPU, service 150–390%; limit lifted → service **46–127%**, GC out of the profile's top consumers. Shipped as `8d138212b` (1GB).

**End state (9-day window, fresh spectate of the Status community):** `#general` opens in ~2–3.5 min; service CPU 46–127% during the bounded sync then idle; RSS peak ~620MB (bounded); no decrypt-failure spam; spinner clears; messages render; background/leave cancels the sync. Remaining known cost is the raw ingest volume itself (~1.7GB — dominated by re-encrypted description republishes, dedup-proof by design), which is the store/protocol follow-up below; and the JOIN path (keys held → full processing) is a tracked follow-up measurement.

### Follow-ups (not in this PR — proposed as separate issues)
1. **Protocol: description republish is dedup-proof** — heartbeat republishes re-encrypt the (identical) description, so stores accumulate ~40 unique-hash copies per logical version and every fresh client downloads them all. Stable republish hashes, store-side collapse, or a dedicated description topic would fix the ~1000× waste for every client on every platform. This also affects `develop` (unscoped spectate sync + 9-day window there).
2. **Missing-message-verifier scoping/cadence** for keyless-spectated communities (it is already hash-first; verified negligible — scoping is hygiene, not heat).
3. **Pause coverage** for history sync/MMV: only the reliability layer honors `SetPaused`; measured a headless service at full throttle after UI death pre-fix.
4. **Per-envelope processing costs** (profiled, ranked): early clock/content-hash gate before description handling (~10 s re-paid per redelivery), O(N²) segmentation reassembly (26% of allocations are SQL blob double-copies), `GOGC`/`GOMEMLIMIT` tuning.
5. Dev builds have no smart-proxy RPC credentials (only the public demo Infura token) → chronic owner-verification failures in dev; overstates production failure rates but the conflation defect was real in production too.

### Test/verification methodology
Dev-only auto-repro driver (fresh account → Communities Portal → spectate Status → `#general`, compile-gated, desktop repo) + adb sampler (per-process CPU, per-UID network, thermal zones, battery) + on-device Go pprof via the `mobile_pprof` tag. All fixes developed red→green TDD on pure seams; full regression battery green at every commit; every fix independently audited and device-verified on a Samsung S21FE against the live fleet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
