### PR TITLE
fix: Android overheating on community spectate — minimal hotfix (status-app#21470)

### DIFF
--- a/pkg/backend/geth_backend.go
+++ b/pkg/backend/geth_backend.go
@@ -125,7 +125,15 @@ func NewStatusBackend(logger *zap.Logger) *StatusBackend {
 		zap.String("IpfsGatewayURL", gocommon.IpfsGatewayURL))
 
 	if gocommon.IsMobilePlatform() {
-		debug.SetMemoryLimit(1024 * 1024 * 150) // 150MB
+		// #21470: the previous 150MB soft limit sat ~3x below the measured
+		// working set (350-620MB while syncing a large community), which forces
+		// the Go GC into permanent maximum-aggression mode. Measured on a
+		// Samsung S21FE (identical 9-day community sync, ~1.7GB ingested):
+		// with 150MB the GC was 61% of service CPU and the process ran at
+		// 150-390% CPU; with the limit lifted the same walk ran at 46-127%
+		// CPU with GC no longer in the profile's top consumers. 1GB keeps an
+		// OOM guard well above the working set without starving the GC.
+		debug.SetMemoryLimit(1024 * 1024 * 1024) // 1GB
 	}
 
 	return backend

--- a/pkg/messaging/controller/controller.go
+++ b/pkg/messaging/controller/controller.go
@@ -46,11 +46,19 @@ func NewController(
 	logger *zap.Logger,
 	tracer trace.Tracer,
 ) *Controller {
+	proc := processor.NewProcessor(identity, stack, messageConfirmationStorage, hashRatchetStorage, logger, tracer)
+	// #21470 gate #2: drop undecryptable hash-ratchet messages instead of
+	// parking them in SQLite for replay. Device-validated (Samsung S21FE,
+	// spectating the Status community): service RSS 876MB -> 480MB, data dir
+	// 144MB after ~3GB ingested (previously grew by gigabytes of parked
+	// blobs); key distribution (SeqNo==0) and plaintext channels unaffected.
+	// Dropped content remains on the store node and is re-fetched after join.
+	proc.SetDropUndecryptableWithoutKeys(true)
 	return &Controller{
 		identity:                   identity,
 		stack:                      stack,
 		sender:                     sender.NewSender(identity, stack, logger, tracer),
-		processor:                  processor.NewProcessor(identity, stack, messageConfirmationStorage, hashRatchetStorage, logger, tracer),
+		processor:                  proc,
 		messageConfirmationStorage: messageConfirmationStorage,
 		hashRatchetStorage:         hashRatchetStorage,
 		publisher:                  publisher,

--- a/pkg/messaging/controller/processor/keyless_drop.go
+++ b/pkg/messaging/controller/processor/keyless_drop.go
@@ -1,0 +1,17 @@
+package processor
+
+// shouldDropUndecryptableHashRatchetMessage reports whether an incoming
+// hash-ratchet message that could not be decrypted (ErrHashRatchetGroupIDNotFound)
+// should be dropped instead of parked for retroactive replay.
+//
+// It drops only when the feature is enabled AND the node holds no key material at
+// all for the message's group — i.e. a keyless spectator receiving a community
+// channel's encrypted data plane (issue #21470). A member missing only this
+// rotation's key still holds other keys for the group, so the message is kept so
+// it can be replayed once the newer key arrives.
+//
+// Key-exchange messages (HR header SeqNo == 0) decrypt successfully and never
+// reach this branch, so a drop can never discard key-distribution traffic.
+func shouldDropUndecryptableHashRatchetMessage(enabled, holdsKeys bool) bool {
+	return enabled && !holdsKeys
+}

--- a/pkg/messaging/controller/processor/keyless_drop_test.go
+++ b/pkg/messaging/controller/processor/keyless_drop_test.go
@@ -1,0 +1,19 @@
+package processor
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestShouldDropUndecryptableHashRatchetMessage(t *testing.T) {
+	// Disabled: never drop, regardless of key material (default-off behaviour).
+	require.False(t, shouldDropUndecryptableHashRatchetMessage(false, false))
+	require.False(t, shouldDropUndecryptableHashRatchetMessage(false, true))
+
+	// Enabled: drop only when the node holds no key material for the group
+	// (keyless spectator). A member missing this rotation's key still holds
+	// other keys, so the message is kept for retroactive replay.
+	require.True(t, shouldDropUndecryptableHashRatchetMessage(true, false))
+	require.False(t, shouldDropUndecryptableHashRatchetMessage(true, true))
+}

--- a/pkg/messaging/controller/processor/processor.go
+++ b/pkg/messaging/controller/processor/processor.go
@@ -43,6 +43,30 @@ type Processor struct {
 	logger    *zap.Logger
 
 	tracer trace.Tracer
+
+	// dropUndecryptableWithoutKeys enables the keyless early-drop of undecryptable
+	// hash-ratchet messages (issue #21470, gate #2). Default off pending on-device
+	// validation of this shared processing path; toggle via
+	// SetDropUndecryptableWithoutKeys.
+	dropUndecryptableWithoutKeys bool
+}
+
+// SetDropUndecryptableWithoutKeys toggles gate #2 (#21470): when enabled, an
+// incoming hash-ratchet message the node cannot decrypt AND holds no key material
+// for is dropped instead of parked in the DB for retroactive replay. Default off.
+func (r *Processor) SetDropUndecryptableWithoutKeys(enabled bool) {
+	r.dropUndecryptableWithoutKeys = enabled
+}
+
+// holdsKeysForGroup reports whether the node holds any hash-ratchet key material
+// for groupID. Fails open (true) on lookup error so a transient DB issue never
+// causes a message to be dropped.
+func (r *Processor) holdsKeysForGroup(groupID []byte) bool {
+	keys, err := r.stack.Encryption.GetKeysForGroup(groupID)
+	if err != nil {
+		return true
+	}
+	return len(keys) > 0
 }
 
 func NewProcessor(
@@ -157,6 +181,15 @@ func (r *Processor) processMessage(m *messagingtypes.ReceivedMessage) (*processM
 			span.AddEvent("hash ratchet with group id not found yet", oteltrace.WithAttributes(
 				otelattribute.String("groupID", types.ToHex(info.GroupID)),
 			))
+			// #21470 gate #2: a keyless spectator receiving a community channel's
+			// encrypted data plane will never obtain this group's key, so parking
+			// the message for replay only grows the DB. Drop it; the store node
+			// retains it for post-join backfill/MMV recovery.
+			if r.dropUndecryptableWithoutKeys &&
+				shouldDropUndecryptableHashRatchetMessage(true, r.holdsKeysForGroup(info.GroupID)) {
+				span.AddEvent("dropping undecryptable hash ratchet message (no keys held)")
+				return nil, nil
+			}
 			return nil, r.hashRatchetStorage.SaveMessage(info.GroupID, info.KeyID, m)
 		} else {
 			span.AddEvent("encryption layer not processed", oteltrace.WithAttributes(

--- a/pkg/messaging/layers/segmentation/persistence.go
+++ b/pkg/messaging/layers/segmentation/persistence.go
@@ -7,6 +7,12 @@ import (
 type Persistence interface {
 	IsMessageAlreadyCompleted(hash []byte) (bool, error)
 	SaveMessageSegment(segment *Message, sigPubKey *ecdsa.PublicKey, timestamp int64) error
+	// GetMessageSegmentsCompletionInfo returns the number of stored segments for a
+	// message and the SegmentsCount its data segments advertise (0 if none stored
+	// yet). It is a cheap aggregate (COUNT + MAX, no payload blobs copied) used to
+	// avoid loading every stored segment via GetMessageSegments until the message
+	// can actually be reassembled (issue #21470-hf).
+	GetMessageSegmentsCompletionInfo(hash []byte, sigPubKey *ecdsa.PublicKey) (storedCount int, segmentsCount uint32, err error)
 	GetMessageSegments(hash []byte, sigPubKey *ecdsa.PublicKey) ([]*Message, error)
 	CompleteMessageSegments(hash []byte, sigPubKey *ecdsa.PublicKey, timestamp int64) error
 	RemoveMessageSegmentsOlderThan(timestamp int64) error

--- a/pkg/messaging/layers/segmentation/segmenter.go
+++ b/pkg/messaging/layers/segmentation/segmenter.go
@@ -153,6 +153,21 @@ func (s *Segmenter) Reconstruct(payload []byte, sigPubKey *ecdsa.PublicKey, tran
 		return nil, nil, err
 	}
 
+	// Cheap completion precheck (issue #21470-hf): a message can only be reassembled
+	// once at least SegmentsCount segments (data + parity) are stored. Until then,
+	// skip the expensive GetMessageSegments below, which copies every stored payload
+	// blob out of sqlcipher — for an N-segment message arriving one segment at a time
+	// that full read would otherwise run on every arrival (O(N^2) blob copies).
+	// This is a NECESSARY-condition filter only; the authoritative completeness and
+	// hash checks still run on the fully loaded segments below.
+	storedCount, expectedCount, err := s.persistence.GetMessageSegmentsCompletionInfo(segmentMessage.EntireMessageHash, sigPubKey)
+	if err != nil {
+		return nil, nil, err
+	}
+	if expectedCount == 0 || storedCount < int(expectedCount) {
+		return nil, nil, ErrIncomplete
+	}
+
 	segments, err := s.persistence.GetMessageSegments(segmentMessage.EntireMessageHash, sigPubKey)
 	if err != nil {
 		return nil, nil, err

--- a/pkg/messaging/layers/segmentation/segmenter_test.go
+++ b/pkg/messaging/layers/segmentation/segmenter_test.go
@@ -1,6 +1,7 @@
 package segmentation
 
 import (
+	"crypto/ecdsa"
 	_ "embed"
 	"testing"
 
@@ -185,4 +186,137 @@ func (s *MessageSegmentationSuite) TestProtobufMissDecoding() {
 
 	// Ensure that the sanity check for the segmented message fails, as expected.
 	s.Require().False(segmentedMessage.IsValid())
+}
+
+// countingPersistence wraps a real Persistence and counts GetMessageSegments
+// calls, so tests can assert the expensive full-segment read (which copies every
+// stored payload blob out of sqlcipher) happens only once, on completion —
+// instead of on every arriving segment (the O(N^2) behavior, issue #21470-hf).
+type countingPersistence struct {
+	Persistence
+	getSegmentsCalls int
+}
+
+func (c *countingPersistence) GetMessageSegments(hash []byte, sigPubKey *ecdsa.PublicKey) ([]*Message, error) {
+	c.getSegmentsCalls++
+	return c.Persistence.GetMessageSegments(hash, sigPubKey)
+}
+
+func (s *MessageSegmentationSuite) newCountingSegmenter() (*Segmenter, *countingPersistence) {
+	db, err := testutils.SetupTestMemorySQLDB(testutils.NewTestDBInitializer([]*bindata.AssetSource{
+		{
+			Names:     migrations.AssetNames(),
+			AssetFunc: migrations.Asset,
+		},
+	}))
+	s.Require().NoError(err)
+	counting := &countingPersistence{Persistence: NewSQLitePersistence(db)}
+	return NewSegmenter(counting, zap.Must(zap.NewDevelopment())), counting
+}
+
+// TestReadsAllSegmentsOnlyOnCompletion (no parity) verifies that arriving segments
+// before the last do NOT trigger a full read of every stored segment, and the last
+// one triggers exactly one such read (issue #21470-hf: O(N) instead of O(N^2)).
+func (s *MessageSegmentationSuite) TestReadsAllSegmentsOnlyOnCompletion() {
+	segmenter, counting := s.newCountingSegmenter()
+
+	signer, err := crypto.GenerateKey()
+	s.Require().NoError(err)
+
+	segmentsCount := 5 // floor(5*0.125)=0 parity segments
+	segSize := (len(s.testPayload) + segmentsCount - 1) / segmentsCount
+	segs, err := segmenter.Segment(s.testPayload, segSize)
+	s.Require().NoError(err)
+	s.Require().Len(segs, segmentsCount)
+
+	for i := 0; i < segmentsCount-1; i++ {
+		_, _, err := segmenter.Reconstruct(segs[i], &signer.PublicKey, nil)
+		s.Require().ErrorIs(err, ErrIncomplete)
+	}
+	s.Require().Equal(0, counting.getSegmentsCalls, "must not read all segments before completion")
+
+	payload, _, err := segmenter.Reconstruct(segs[segmentsCount-1], &signer.PublicKey, nil)
+	s.Require().NoError(err)
+	s.Require().ElementsMatch(s.testPayload, payload)
+	s.Require().Equal(1, counting.getSegmentsCalls, "reads all segments exactly once, on completion")
+}
+
+// TestReadsAllSegmentsOnlyOnCompletionOutOfOrder verifies the completion precheck
+// is order-independent: the full read still fires exactly once, on the arrival that
+// brings the stored count up to SegmentsCount.
+func (s *MessageSegmentationSuite) TestReadsAllSegmentsOnlyOnCompletionOutOfOrder() {
+	segmenter, counting := s.newCountingSegmenter()
+
+	signer, err := crypto.GenerateKey()
+	s.Require().NoError(err)
+
+	segmentsCount := 5
+	segSize := (len(s.testPayload) + segmentsCount - 1) / segmentsCount
+	segs, err := segmenter.Segment(s.testPayload, segSize)
+	s.Require().NoError(err)
+
+	order := []int{3, 0, 4, 1, 2}
+	for i, idx := range order {
+		payload, _, err := segmenter.Reconstruct(segs[idx], &signer.PublicKey, nil)
+		if i < segmentsCount-1 {
+			s.Require().ErrorIs(err, ErrIncomplete)
+			s.Require().Equal(0, counting.getSegmentsCalls)
+		} else {
+			s.Require().NoError(err)
+			s.Require().ElementsMatch(s.testPayload, payload)
+			s.Require().Equal(1, counting.getSegmentsCalls)
+		}
+	}
+}
+
+// TestDuplicateSegmentDoesNotTriggerRead verifies a duplicate arrival (which
+// REPLACEs its row and leaves the stored count unchanged) neither completes the
+// message nor triggers a full read.
+func (s *MessageSegmentationSuite) TestDuplicateSegmentDoesNotTriggerRead() {
+	segmenter, counting := s.newCountingSegmenter()
+
+	signer, err := crypto.GenerateKey()
+	s.Require().NoError(err)
+
+	segmentsCount := 5
+	segSize := (len(s.testPayload) + segmentsCount - 1) / segmentsCount
+	segs, err := segmenter.Segment(s.testPayload, segSize)
+	s.Require().NoError(err)
+
+	_, _, err = segmenter.Reconstruct(segs[0], &signer.PublicKey, nil)
+	s.Require().ErrorIs(err, ErrIncomplete)
+	_, _, err = segmenter.Reconstruct(segs[0], &signer.PublicKey, nil) // duplicate
+	s.Require().ErrorIs(err, ErrIncomplete)
+	s.Require().Equal(0, counting.getSegmentsCalls, "duplicate must not trigger a full read")
+}
+
+// TestParityCompletionReadsOnce verifies the completion precheck fires the single
+// full read even when the completing segment is a parity segment (reedsolomon
+// reconstruction with one data segment missing).
+func (s *MessageSegmentationSuite) TestParityCompletionReadsOnce() {
+	segmenter, counting := s.newCountingSegmenter()
+
+	signer, err := crypto.GenerateKey()
+	s.Require().NoError(err)
+
+	segmentsCount := 8 // floor(8*0.125)=1 parity segment
+	segSize := (len(s.testPayload) + segmentsCount - 1) / segmentsCount
+	segs, err := segmenter.Segment(s.testPayload, segSize)
+	s.Require().NoError(err)
+	s.Require().Len(segs, segmentsCount+1) // 8 data + 1 parity
+
+	// Deliver 7 of the 8 data segments (index 0..6), then the parity segment
+	// (index 8) which brings the stored count to 8 and completes via parity.
+	arrival := []int{0, 1, 2, 3, 4, 5, 6, 8}
+	for i, idx := range arrival {
+		payload, _, err := segmenter.Reconstruct(segs[idx], &signer.PublicKey, nil)
+		if i < segmentsCount-1 {
+			s.Require().ErrorIs(err, ErrIncomplete)
+			s.Require().Equal(0, counting.getSegmentsCalls)
+		} else {
+			s.Require().NoError(err)
+			s.Require().ElementsMatch(s.testPayload, payload)
+			s.Require().Equal(1, counting.getSegmentsCalls)
+		}
+	}
 }

--- a/pkg/messaging/layers/segmentation/sqlite_persistence.go
+++ b/pkg/messaging/layers/segmentation/sqlite_persistence.go
@@ -36,6 +36,26 @@ func (s *SQLitePersistence) SaveMessageSegment(segment *Message, sigPubKey *ecds
 	return err
 }
 
+// GetMessageSegmentsCompletionInfo returns how many segments are stored for the
+// message and the SegmentsCount its data segments advertise. Data segments carry
+// segments_count = N (> 0); parity segments carry 0, so MAX(segments_count) is N
+// once any data segment is stored, and 0 while only parity has arrived. This is a
+// cheap aggregate over just this message's rows (via the primary-key prefix
+// hash+sig_pub_key) that copies no payload blobs (issue #21470-hf).
+func (s *SQLitePersistence) GetMessageSegmentsCompletionInfo(hash []byte, sigPubKey *ecdsa.PublicKey) (int, uint32, error) {
+	sigPubKeyBlob := crypto.CompressPubkey(sigPubKey)
+
+	var storedCount int
+	var segmentsCount uint32
+	err := s.db.QueryRow(
+		"SELECT COUNT(*), COALESCE(MAX(segments_count), 0) FROM message_segments WHERE hash = ? AND sig_pub_key = ?",
+		hash, sigPubKeyBlob).Scan(&storedCount, &segmentsCount)
+	if err != nil {
+		return 0, 0, err
+	}
+	return storedCount, segmentsCount, nil
+}
+
 // Get ordered message segments for given hash
 func (s *SQLitePersistence) GetMessageSegments(hash []byte, sigPubKey *ecdsa.PublicKey) ([]*Message, error) {
 	sigPubKeyBlob := crypto.CompressPubkey(sigPubKey)

--- a/protocol/communities/community_description_gate.go
+++ b/protocol/communities/community_description_gate.go
@@ -1,0 +1,114 @@
+package communities
+
+import (
+	"crypto/sha256"
+	"sync"
+)
+
+// descriptionGateEntry records, for one community, the last community description
+// this node FULLY processed: its clock and a content hash of the raw description
+// payload bytes that were handled.
+type descriptionGateEntry struct {
+	clock       uint64
+	contentHash [32]byte
+}
+
+// communityDescriptionGate short-circuits the expensive per-description pipeline
+// for redelivered community descriptions that cannot change local state
+// (issue #21470-hf).
+//
+// status-go re-publishes each community description into every fetch/spectate
+// window, so the same byte-identical ~1.4MB blob is handed to
+// Manager.HandleCommunityDescriptionMessage hundreds of times over a long history
+// sync. Each of those calls otherwise pays, before any clock comparison:
+// proto.Unmarshal of the blob, GetDecryptedCommunityDescription (read) +
+// SaveDecryptedCommunityDescription (write) in preprocessDescription, and GetByID,
+// which re-reads and re-unmarshals the stored community blob — ~10s of CPU per
+// redelivered copy.
+//
+// The gate remembers, per community, the clock+content-hash of the last
+// description that was fully processed, and lets the handler return early for:
+//   - strictly-older clocks (can never win the downstream clock comparison in
+//     Community.UpdateCommunityDescription, which rejects them as outdated), and
+//   - the byte-identical same-clock redelivery (a guaranteed no-op).
+//
+// It deliberately does NOT gate a same-clock description whose content differs:
+// Community.UpdateCommunityDescription intentionally reprocesses identical clocks
+// so a previously-encrypted description can be re-evaluated once the decryption key
+// arrives. For that same reason the gate is cleared when new hash-ratchet keys
+// arrive (Manager.NewHashRatchetKeys) and when a community is deleted
+// (Manager.DeleteCommunity), so those legitimate reprocessing paths are never
+// starved.
+//
+// A community that has only ever been QUEUED for owner validation (never fully
+// processed) has no gate entry, so validateCommunity's re-entry into the handler
+// is never blocked. The gate fails OPEN: any state it does not positively know to
+// be a redelivery proceeds to full processing.
+type communityDescriptionGate struct {
+	mu      sync.Mutex
+	entries map[string]descriptionGateEntry // communityID(hex) -> last processed
+}
+
+func newCommunityDescriptionGate() *communityDescriptionGate {
+	return &communityDescriptionGate{
+		entries: make(map[string]descriptionGateEntry),
+	}
+}
+
+// hashDescriptionPayload returns a content hash of the raw community description
+// payload bytes. SHA-256 makes a collision astronomically unlikely, so a matching
+// (clock, hash) pair is safely treated as a byte-identical redelivery.
+func hashDescriptionPayload(payload []byte) [32]byte {
+	return sha256.Sum256(payload)
+}
+
+// shouldSkip reports whether a description with the given clock and content hash
+// can be skipped because it can neither advance nor change local state. It returns
+// true only for a strictly-older clock, or an equal clock whose content hash matches
+// the last fully-processed description for this community. Everything else (unknown
+// community, newer clock, equal clock with different content) returns false so the
+// handler proceeds.
+func (g *communityDescriptionGate) shouldSkip(id string, clock uint64, hash [32]byte) bool {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	entry, ok := g.entries[id]
+	if !ok {
+		return false
+	}
+	if clock < entry.clock {
+		return true
+	}
+	if clock == entry.clock && hash == entry.contentHash {
+		return true
+	}
+	return false
+}
+
+// recordProcessed advances the gate for a community after a description was fully
+// and successfully processed. It only ever moves the recorded clock forward, so an
+// out-of-order older success can never shadow a newer one.
+func (g *communityDescriptionGate) recordProcessed(id string, clock uint64, hash [32]byte) {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	if entry, ok := g.entries[id]; ok && clock < entry.clock {
+		return
+	}
+	g.entries[id] = descriptionGateEntry{clock: clock, contentHash: hash}
+}
+
+// forget drops the gate entry for a single community so its next description is
+// fully reprocessed. Called when the community is deleted.
+func (g *communityDescriptionGate) forget(id string) {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	delete(g.entries, id)
+}
+
+// forgetAll clears every gate entry. Called when new hash-ratchet key material
+// arrives (which may be community- or channel-scoped) so every community's next
+// description is reprocessed and can decrypt now-available private data.
+func (g *communityDescriptionGate) forgetAll() {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	g.entries = make(map[string]descriptionGateEntry)
+}

--- a/protocol/communities/community_description_gate.go
+++ b/protocol/communities/community_description_gate.go
@@ -32,11 +32,14 @@ type descriptionGateEntry struct {
 //     Community.UpdateCommunityDescription, which rejects them as outdated), and
 //   - the byte-identical same-clock redelivery (a guaranteed no-op).
 //
-// It deliberately does NOT gate a same-clock description whose content differs:
-// Community.UpdateCommunityDescription intentionally reprocesses identical clocks
-// so a previously-encrypted description can be re-evaluated once the decryption key
-// arrives. For that same reason the gate is cleared when new hash-ratchet keys
-// arrive (Manager.NewHashRatchetKeys) and when a community is deleted
+// For a KEYS-HELD community it deliberately does NOT gate a same-clock description
+// whose content differs: Community.UpdateCommunityDescription intentionally
+// reprocesses identical clocks so a previously-encrypted description can be
+// re-evaluated once the decryption key arrives. For a KEYLESS spectator that
+// exception is dropped — an equal-clock re-encrypted republish is useless to a node
+// with no keys, so it is skipped regardless of content (see shouldSkip). For both
+// cases the gate is cleared when new hash-ratchet keys arrive
+// (Manager.NewHashRatchetKeys) and when a community is deleted
 // (Manager.DeleteCommunity), so those legitimate reprocessing paths are never
 // starved.
 //
@@ -63,12 +66,31 @@ func hashDescriptionPayload(payload []byte) [32]byte {
 }
 
 // shouldSkip reports whether a description with the given clock and content hash
-// can be skipped because it can neither advance nor change local state. It returns
-// true only for a strictly-older clock, or an equal clock whose content hash matches
-// the last fully-processed description for this community. Everything else (unknown
-// community, newer clock, equal clock with different content) returns false so the
-// handler proceeds.
-func (g *communityDescriptionGate) shouldSkip(id string, clock uint64, hash [32]byte) bool {
+// can be skipped because it can neither advance nor change local state. holdsKeys
+// says whether this node holds ANY hash-ratchet decryption key for the community;
+// it must be fail-open (true) on any entitlement-lookup error so a transient DB
+// issue never turns into a dropped description.
+//
+// A strictly-older clock is always skippable (it can never win the downstream clock
+// comparison in Community.UpdateCommunityDescription). For an EQUAL clock the rule
+// depends on whether keys are held:
+//
+//   - keys held (member, or fail-open): skip only the byte-identical redelivery.
+//     A same-clock description with DIFFERENT content still proceeds, because
+//     community.go intentionally reprocesses identical clocks so a previously
+//     encrypted description is re-evaluated once the decryption key arrives — the
+//     member key-rotation path. This preserves the pre-refinement behaviour exactly.
+//
+//   - keyless (spectator): skip an equal-clock description REGARDLESS of content
+//     hash. status-go re-encrypts each logical description version ~40 times, so a
+//     keyless node is handed the same clock with different payload bytes over and
+//     over; it can gain nothing from a re-encrypted copy (its encrypted inner fields
+//     are skipped anyway, and key ARRIVAL lifts the whole gate via forgetAll), so
+//     reprocessing only burns CPU. Issue #21470-hf.
+//
+// Everything else (unknown community, newer clock) returns false so the handler
+// proceeds.
+func (g *communityDescriptionGate) shouldSkip(id string, clock uint64, hash [32]byte, holdsKeys bool) bool {
 	g.mu.Lock()
 	defer g.mu.Unlock()
 	entry, ok := g.entries[id]
@@ -78,8 +100,11 @@ func (g *communityDescriptionGate) shouldSkip(id string, clock uint64, hash [32]
 	if clock < entry.clock {
 		return true
 	}
-	if clock == entry.clock && hash == entry.contentHash {
-		return true
+	if clock == entry.clock {
+		if !holdsKeys {
+			return true
+		}
+		return hash == entry.contentHash
 	}
 	return false
 }

--- a/protocol/communities/community_description_gate_test.go
+++ b/protocol/communities/community_description_gate_test.go
@@ -10,11 +10,20 @@ func hashOf(b []byte) [32]byte {
 	return hashDescriptionPayload(b)
 }
 
+// keysHeld/keyless make the holdsKeys argument to shouldSkip read as intent at
+// the call site.
+const (
+	keysHeld = true
+	keyless  = false
+)
+
 // TestDescriptionGateTruthTable exercises the redelivery gate decision across the
-// whole truth table (issue #21470-hf): unknown community, strictly-older clock,
-// byte-identical same-clock redelivery, same-clock-different-content, and a newer
-// clock. Only a strictly-older clock or a byte-identical same-clock redelivery may
-// be skipped; everything else must proceed to full processing.
+// whole truth table (issue #21470-hf) for a KEYS-HELD community (member): unknown
+// community, strictly-older clock, byte-identical same-clock redelivery,
+// same-clock-different-content, and a newer clock. Only a strictly-older clock or a
+// byte-identical same-clock redelivery may be skipped; everything else must proceed
+// to full processing. The same-clock-different-content rule is what keeps key
+// rotation working for members, so it must survive.
 func TestDescriptionGateTruthTable(t *testing.T) {
 	const id = "0xcommunity"
 	payloadA := []byte("description-bytes-A")
@@ -28,28 +37,81 @@ func TestDescriptionGateTruthTable(t *testing.T) {
 	// also the queued-validation guarantee: a community that has only ever been
 	// queued (never fully processed) has no gate entry, so validateCommunity's
 	// re-entry is never blocked.
-	require.False(t, g.shouldSkip(id, 10, hashA), "unknown community must proceed")
+	require.False(t, g.shouldSkip(id, 10, hashA, keysHeld), "unknown community must proceed")
 
 	// Record clock 10 / content A as fully processed.
 	g.recordProcessed(id, 10, hashA)
 
 	// Byte-identical same-clock redelivery: skip.
-	require.True(t, g.shouldSkip(id, 10, hashA), "byte-identical same-clock redelivery must skip")
+	require.True(t, g.shouldSkip(id, 10, hashA, keysHeld), "byte-identical same-clock redelivery must skip")
 
 	// Same clock, different content: MUST proceed (community.go intentionally
 	// reprocesses identical clocks so a previously-encrypted description can be
-	// re-evaluated once keys arrive).
-	require.False(t, g.shouldSkip(id, 10, hashB), "same-clock different-content must proceed")
+	// re-evaluated once keys arrive — this is the member key-rotation path).
+	require.False(t, g.shouldSkip(id, 10, hashB, keysHeld), "same-clock different-content must proceed for a keys-held community")
 
 	// Strictly-older clock: skip (can never win the downstream clock comparison).
-	require.True(t, g.shouldSkip(id, 9, hashA), "older clock must skip")
-	require.True(t, g.shouldSkip(id, 9, hashB), "older clock must skip regardless of content")
+	require.True(t, g.shouldSkip(id, 9, hashA, keysHeld), "older clock must skip")
+	require.True(t, g.shouldSkip(id, 9, hashB, keysHeld), "older clock must skip regardless of content")
 
 	// Newer clock: proceed.
-	require.False(t, g.shouldSkip(id, 11, hashA), "newer clock must proceed")
+	require.False(t, g.shouldSkip(id, 11, hashA, keysHeld), "newer clock must proceed")
 
 	// A different community is unaffected by this one's entry.
-	require.False(t, g.shouldSkip("0xother", 1, hashA), "other community must proceed")
+	require.False(t, g.shouldSkip("0xother", 1, hashA, keysHeld), "other community must proceed")
+}
+
+// TestDescriptionGateKeylessTruthTable exercises the gate for a KEYLESS spectator
+// (holds no decryption keys). status-go re-encrypts each logical description ~40
+// times per version, so a keyless node sees the same clock with DIFFERENT payload
+// bytes over and over. A keyless spectator can gain nothing from a re-encrypted
+// equal-clock copy (its encrypted inner fields are skipped anyway, and key ARRIVAL
+// is handled by forgetAll), so the gate must skip equal-clock republishes
+// REGARDLESS of content hash — the one behaviour that differs from a keys-held
+// community (issue #21470-hf).
+func TestDescriptionGateKeylessTruthTable(t *testing.T) {
+	const id = "0xcommunity"
+	hashA := hashOf([]byte("description-bytes-A"))
+	hashB := hashOf([]byte("description-bytes-B"))
+
+	g := newCommunityDescriptionGate()
+
+	// Unknown community: never skip, even keyless (nothing recorded yet).
+	require.False(t, g.shouldSkip(id, 10, hashA, keyless), "unknown community must proceed")
+
+	g.recordProcessed(id, 10, hashA)
+
+	// Equal clock, same content: skip (same as keys-held).
+	require.True(t, g.shouldSkip(id, 10, hashA, keyless), "keyless equal-clock same-content must skip")
+
+	// Equal clock, DIFFERENT content: skip — this is the refinement. A re-encrypted
+	// republish at the same clock is useless to a keyless spectator.
+	require.True(t, g.shouldSkip(id, 10, hashB, keyless), "keyless equal-clock different-content must skip")
+
+	// Strictly-older clock: skip regardless of content.
+	require.True(t, g.shouldSkip(id, 9, hashA, keyless), "keyless older clock must skip")
+	require.True(t, g.shouldSkip(id, 9, hashB, keyless), "keyless older clock must skip regardless of content")
+
+	// Newer clock: proceed — a genuinely newer description must always be processed.
+	require.False(t, g.shouldSkip(id, 11, hashA, keyless), "keyless newer clock must proceed")
+	require.False(t, g.shouldSkip(id, 11, hashB, keyless), "keyless newer clock must proceed regardless of content")
+}
+
+// TestDescriptionGateFailOpenTreatedAsKeysHeld documents that the fail-open case
+// (entitlement lookup errored, so the Manager reports holdsKeys=true) is exactly the
+// keys-held branch: an equal-clock DIFFERENT-content description still proceeds, so a
+// transient DB error can never make a keyless-style skip drop a description that a
+// member would have reprocessed.
+func TestDescriptionGateFailOpenTreatedAsKeysHeld(t *testing.T) {
+	const id = "0xcommunity"
+	hashA := hashOf([]byte("A"))
+	hashB := hashOf([]byte("B"))
+
+	g := newCommunityDescriptionGate()
+	g.recordProcessed(id, 10, hashA)
+
+	// holdsKeys=true is what communityHoldsAnyDecryptionKey returns on any error.
+	require.False(t, g.shouldSkip(id, 10, hashB, keysHeld), "fail-open (keys-held) equal-clock different-content must proceed")
 }
 
 // TestDescriptionGateRecordIsMonotonic verifies recordProcessed never moves the
@@ -63,9 +125,9 @@ func TestDescriptionGateRecordIsMonotonic(t *testing.T) {
 	g.recordProcessed(id, 20, hash)
 	g.recordProcessed(id, 5, hash) // stale, must not overwrite the newer record
 
-	require.True(t, g.shouldSkip(id, 20, hash), "recorded clock is still 20, identical redelivery skips")
-	require.False(t, g.shouldSkip(id, 21, hash), "a genuinely newer clock still proceeds")
-	require.True(t, g.shouldSkip(id, 4, hash), "older than recorded 20 skips")
+	require.True(t, g.shouldSkip(id, 20, hash, keysHeld), "recorded clock is still 20, identical redelivery skips")
+	require.False(t, g.shouldSkip(id, 21, hash, keysHeld), "a genuinely newer clock still proceeds")
+	require.True(t, g.shouldSkip(id, 4, hash, keysHeld), "older than recorded 20 skips")
 }
 
 // TestDescriptionGateForget verifies a single-community invalidation (community
@@ -76,10 +138,10 @@ func TestDescriptionGateForget(t *testing.T) {
 
 	g := newCommunityDescriptionGate()
 	g.recordProcessed(id, 10, hash)
-	require.True(t, g.shouldSkip(id, 10, hash))
+	require.True(t, g.shouldSkip(id, 10, hash, keysHeld))
 
 	g.forget(id)
-	require.False(t, g.shouldSkip(id, 10, hash), "after forget, identical redelivery reprocesses")
+	require.False(t, g.shouldSkip(id, 10, hash, keysHeld), "after forget, identical redelivery reprocesses")
 }
 
 // TestDescriptionGateForgetAll verifies key-arrival invalidation lifts the gate for
@@ -90,10 +152,10 @@ func TestDescriptionGateForgetAll(t *testing.T) {
 	g := newCommunityDescriptionGate()
 	g.recordProcessed("0xa", 10, hash)
 	g.recordProcessed("0xb", 10, hash)
-	require.True(t, g.shouldSkip("0xa", 10, hash))
-	require.True(t, g.shouldSkip("0xb", 10, hash))
+	require.True(t, g.shouldSkip("0xa", 10, hash, keysHeld))
+	require.True(t, g.shouldSkip("0xb", 10, hash, keysHeld))
 
 	g.forgetAll()
-	require.False(t, g.shouldSkip("0xa", 10, hash))
-	require.False(t, g.shouldSkip("0xb", 10, hash))
+	require.False(t, g.shouldSkip("0xa", 10, hash, keysHeld))
+	require.False(t, g.shouldSkip("0xb", 10, hash, keysHeld))
 }

--- a/protocol/communities/community_description_gate_test.go
+++ b/protocol/communities/community_description_gate_test.go
@@ -1,0 +1,99 @@
+package communities
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func hashOf(b []byte) [32]byte {
+	return hashDescriptionPayload(b)
+}
+
+// TestDescriptionGateTruthTable exercises the redelivery gate decision across the
+// whole truth table (issue #21470-hf): unknown community, strictly-older clock,
+// byte-identical same-clock redelivery, same-clock-different-content, and a newer
+// clock. Only a strictly-older clock or a byte-identical same-clock redelivery may
+// be skipped; everything else must proceed to full processing.
+func TestDescriptionGateTruthTable(t *testing.T) {
+	const id = "0xcommunity"
+	payloadA := []byte("description-bytes-A")
+	payloadB := []byte("description-bytes-B")
+	hashA := hashOf(payloadA)
+	hashB := hashOf(payloadB)
+
+	g := newCommunityDescriptionGate()
+
+	// Unknown community: never skip (fail open — nothing recorded yet). This is
+	// also the queued-validation guarantee: a community that has only ever been
+	// queued (never fully processed) has no gate entry, so validateCommunity's
+	// re-entry is never blocked.
+	require.False(t, g.shouldSkip(id, 10, hashA), "unknown community must proceed")
+
+	// Record clock 10 / content A as fully processed.
+	g.recordProcessed(id, 10, hashA)
+
+	// Byte-identical same-clock redelivery: skip.
+	require.True(t, g.shouldSkip(id, 10, hashA), "byte-identical same-clock redelivery must skip")
+
+	// Same clock, different content: MUST proceed (community.go intentionally
+	// reprocesses identical clocks so a previously-encrypted description can be
+	// re-evaluated once keys arrive).
+	require.False(t, g.shouldSkip(id, 10, hashB), "same-clock different-content must proceed")
+
+	// Strictly-older clock: skip (can never win the downstream clock comparison).
+	require.True(t, g.shouldSkip(id, 9, hashA), "older clock must skip")
+	require.True(t, g.shouldSkip(id, 9, hashB), "older clock must skip regardless of content")
+
+	// Newer clock: proceed.
+	require.False(t, g.shouldSkip(id, 11, hashA), "newer clock must proceed")
+
+	// A different community is unaffected by this one's entry.
+	require.False(t, g.shouldSkip("0xother", 1, hashA), "other community must proceed")
+}
+
+// TestDescriptionGateRecordIsMonotonic verifies recordProcessed never moves the
+// recorded clock backwards, so an out-of-order older success cannot shadow a newer
+// one and cause a newer redelivery to be wrongly skipped.
+func TestDescriptionGateRecordIsMonotonic(t *testing.T) {
+	const id = "0xcommunity"
+	hash := hashOf([]byte("x"))
+
+	g := newCommunityDescriptionGate()
+	g.recordProcessed(id, 20, hash)
+	g.recordProcessed(id, 5, hash) // stale, must not overwrite the newer record
+
+	require.True(t, g.shouldSkip(id, 20, hash), "recorded clock is still 20, identical redelivery skips")
+	require.False(t, g.shouldSkip(id, 21, hash), "a genuinely newer clock still proceeds")
+	require.True(t, g.shouldSkip(id, 4, hash), "older than recorded 20 skips")
+}
+
+// TestDescriptionGateForget verifies a single-community invalidation (community
+// delete) forces the next description to be fully reprocessed.
+func TestDescriptionGateForget(t *testing.T) {
+	const id = "0xcommunity"
+	hash := hashOf([]byte("x"))
+
+	g := newCommunityDescriptionGate()
+	g.recordProcessed(id, 10, hash)
+	require.True(t, g.shouldSkip(id, 10, hash))
+
+	g.forget(id)
+	require.False(t, g.shouldSkip(id, 10, hash), "after forget, identical redelivery reprocesses")
+}
+
+// TestDescriptionGateForgetAll verifies key-arrival invalidation lifts the gate for
+// every community so a byte-identical description can be reprocessed and decrypt
+// now-available private data.
+func TestDescriptionGateForgetAll(t *testing.T) {
+	hash := hashOf([]byte("x"))
+	g := newCommunityDescriptionGate()
+	g.recordProcessed("0xa", 10, hash)
+	g.recordProcessed("0xb", 10, hash)
+	require.True(t, g.shouldSkip("0xa", 10, hash))
+	require.True(t, g.shouldSkip("0xb", 10, hash))
+
+	g.forgetAll()
+	require.False(t, g.shouldSkip("0xa", 10, hash))
+	require.False(t, g.shouldSkip("0xb", 10, hash))
+}

--- a/protocol/communities/community_key_entitlement.go
+++ b/protocol/communities/community_key_entitlement.go
@@ -1,0 +1,97 @@
+package communities
+
+import "sync"
+
+// dropLogInterval is how often (in gated descriptions) a per-community DEBUG
+// checkpoint is emitted after the initial INFO line.
+const dropLogInterval = 1000
+
+// communityKeyEntitlement caches, per community, whether this node holds ANY
+// hash-ratchet decryption key material for that community. A keyless (spectator)
+// node uses the cache to skip the per-key decryption attempts that a re-published
+// community description would otherwise trigger on every fetch — each of which is
+// a guaranteed "no ratchet key" failure (issue #21470). The cache is invalidated
+// when new keys are saved (Manager.NewHashRatchetKeys), so the gate lifts the
+// moment the node acquires keys.
+type communityKeyEntitlement struct {
+	mu      sync.Mutex
+	holds   map[string]bool   // communityID(hex) -> holds any decryption key
+	dropped map[string]uint64 // communityID(hex) -> count of gated descriptions
+	logged  map[string]bool   // communityID(hex) -> INFO already emitted this session
+}
+
+func newCommunityKeyEntitlement() *communityKeyEntitlement {
+	return &communityKeyEntitlement{
+		holds:   make(map[string]bool),
+		dropped: make(map[string]uint64),
+		logged:  make(map[string]bool),
+	}
+}
+
+// known reports the cached entitlement for id and whether it was cached at all.
+func (c *communityKeyEntitlement) known(id string) (holds bool, ok bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	holds, ok = c.holds[id]
+	return holds, ok
+}
+
+// remember stores the entitlement result for id.
+func (c *communityKeyEntitlement) remember(id string, holds bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.holds[id] = holds
+}
+
+// forget drops the cached entitlement for the given ids, forcing a fresh lookup.
+// Called when new keys are saved for a community so the gate re-evaluates and lifts.
+func (c *communityKeyEntitlement) forget(ids ...string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	for _, id := range ids {
+		delete(c.holds, id)
+	}
+}
+
+// forgetAll clears every cached entitlement. Called when new key material arrives
+// (which may be community- or channel-scoped) so all gates re-evaluate and lift.
+func (c *communityKeyEntitlement) forgetAll() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.holds = make(map[string]bool)
+}
+
+// dropLogDecision tells the caller what (if anything) to log for a gated description.
+type dropLogDecision struct {
+	logInfo  bool   // first drop for this community this session
+	logDebug bool   // periodic checkpoint (every dropLogInterval drops)
+	count    uint64 // total gated descriptions for this community this session
+}
+
+// recordDrop increments the gated-description counter for id and returns what to
+// log: an INFO line on the first drop of the session, then a DEBUG checkpoint
+// every dropLogInterval drops. Never logs per envelope.
+func (c *communityKeyEntitlement) recordDrop(id string) dropLogDecision {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.dropped[id]++
+	count := c.dropped[id]
+	d := dropLogDecision{count: count}
+	switch {
+	case !c.logged[id]:
+		c.logged[id] = true
+		d.logInfo = true
+	case count%dropLogInterval == 0:
+		d.logDebug = true
+	}
+	return d
+}
+
+// shouldSkipPrivateDataDecryption reports whether the per-key decryption attempts
+// over a community description's PrivateData should be skipped. They are skipped
+// only when there is encrypted private data to attempt AND the node holds no key
+// material for the community — i.e. a keyless spectator, for whom every attempt is
+// a guaranteed "no ratchet key" failure.
+func shouldSkipPrivateDataDecryption(hasPrivateData, holdsKeys bool) bool {
+	return hasPrivateData && !holdsKeys
+}

--- a/protocol/communities/community_key_entitlement_test.go
+++ b/protocol/communities/community_key_entitlement_test.go
@@ -1,0 +1,77 @@
+package communities
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestShouldSkipPrivateDataDecryption(t *testing.T) {
+	// Skip only when there is encrypted private data AND the node holds no keys.
+	require.True(t, shouldSkipPrivateDataDecryption(true, false), "keyless node with private data must skip")
+	require.False(t, shouldSkipPrivateDataDecryption(true, true), "node holding keys must attempt")
+	require.False(t, shouldSkipPrivateDataDecryption(false, false), "no private data means nothing to skip")
+	require.False(t, shouldSkipPrivateDataDecryption(false, true), "no private data means nothing to skip")
+}
+
+func TestCommunityKeyEntitlementCache(t *testing.T) {
+	c := newCommunityKeyEntitlement()
+
+	// Unknown until remembered.
+	_, ok := c.known("comm-a")
+	require.False(t, ok)
+
+	// Remembered values are returned.
+	c.remember("comm-a", false)
+	holds, ok := c.known("comm-a")
+	require.True(t, ok)
+	require.False(t, holds)
+
+	c.remember("comm-b", true)
+	holds, ok = c.known("comm-b")
+	require.True(t, ok)
+	require.True(t, holds)
+
+	// forget invalidates only the named id, forcing a fresh lookup (gate lift on key arrival).
+	c.forget("comm-a")
+	_, ok = c.known("comm-a")
+	require.False(t, ok)
+	_, ok = c.known("comm-b")
+	require.True(t, ok, "forget must not touch other communities")
+
+	// forgetAll clears every cached entitlement (used when any new key arrives).
+	c.remember("comm-a", false)
+	c.forgetAll()
+	_, ok = c.known("comm-a")
+	require.False(t, ok)
+	_, ok = c.known("comm-b")
+	require.False(t, ok)
+}
+
+func TestCommunityKeyEntitlementDropLogging(t *testing.T) {
+	c := newCommunityKeyEntitlement()
+
+	// First drop for a community => INFO, count 1.
+	d := c.recordDrop("comm-a")
+	require.True(t, d.logInfo)
+	require.False(t, d.logDebug)
+	require.Equal(t, uint64(1), d.count)
+
+	// Subsequent drops below the interval => silent, counting up.
+	for i := 2; i < dropLogInterval; i++ {
+		d = c.recordDrop("comm-a")
+		require.False(t, d.logInfo, "only the first drop logs INFO")
+		require.False(t, d.logDebug)
+	}
+
+	// Every dropLogInterval-th drop => DEBUG checkpoint, never a second INFO.
+	d = c.recordDrop("comm-a")
+	require.False(t, d.logInfo)
+	require.True(t, d.logDebug)
+	require.Equal(t, uint64(dropLogInterval), d.count)
+
+	// A different community gets its own first-drop INFO and independent count.
+	d = c.recordDrop("comm-b")
+	require.True(t, d.logInfo)
+	require.Equal(t, uint64(1), d.count)
+}

--- a/protocol/communities/manager.go
+++ b/protocol/communities/manager.go
@@ -1535,6 +1535,8 @@ func (m *Manager) DeleteCommunity(id types3.HexBytes) error {
 	if m.descriptionGate != nil {
 		m.descriptionGate.forget(id.String())
 	}
+	// Drop the cached community so a redelivery skip can never surface a deleted one.
+	m.cache.Delete(id.String())
 	return m.persistence.DeleteCommunitySettings(id)
 }
 
@@ -2099,7 +2101,14 @@ func (m *Manager) HandleCommunityDescriptionMessage(signer *ecdsa.PublicKey, des
 	// cleared when keys arrive or a community is deleted (see communityDescriptionGate).
 	gateKey := types3.HexBytes(id).String()
 	payloadHash := hashDescriptionPayload(payload)
-	if m.descriptionGate != nil && m.descriptionGate.shouldSkip(gateKey, description.Clock, payloadHash) {
+	// holdsKeys drives the equal-clock gate rule: a keyless spectator skips ALL
+	// equal-clock republishes (status-go re-encrypts each version ~40 times, useless
+	// to a keyless node), while a keys-held community keeps the byte-identical-only
+	// rule so key rotation still reprocesses. communityHoldsAnyDecryptionKey is
+	// cached and fails open (reports true) on any lookup error, so an entitlement
+	// error degrades safely to the keys-held rule (#21470-hf).
+	holdsKeys := m.communityHoldsAnyDecryptionKey(id, description.Chats)
+	if m.descriptionGate != nil && m.descriptionGate.shouldSkip(gateKey, description.Clock, payloadHash, holdsKeys) {
 		// Skip the expensive pipeline (preprocessDescription's decrypted-cache
 		// read+write and handleCommunityDescriptionMessageCommon's ~1.4MB re-save),
 		// but still SURFACE the already-known community with empty changes. The
@@ -2109,10 +2118,7 @@ func (m *Manager) HandleCommunityDescriptionMessage(signer *ecdsa.PublicKey, des
 		// hide the redelivery from that latch and make the pager run to its page
 		// cap. Fail open: if the community is not readable, fall through to full
 		// processing rather than fabricate a skip.
-		m.communityLock.Lock(id)
-		community, err := m.GetByID(id)
-		m.communityLock.Unlock(id)
-		if err == nil && community != nil {
+		if community := m.cachedCommunityForRedelivery(id); community != nil {
 			m.logger.Debug("surfacing redelivered community description without reprocessing",
 				zap.String("communityID", gateKey), zap.Uint64("clock", description.Clock))
 			return &CommunityResponse{Community: community, Changes: community.emptyCommunityChanges()}, nil
@@ -2212,8 +2218,44 @@ func (m *Manager) HandleCommunityDescriptionMessage(signer *ecdsa.PublicKey, des
 	if m.descriptionGate != nil {
 		m.descriptionGate.recordProcessed(gateKey, processedDescription.Clock, payloadHash)
 	}
+	// Warm the redelivery cache with the freshly-processed community so the next
+	// gated redelivery is served without a ~1.4MB GetByID. handleCommunityDescription-
+	// MessageCommon already deleted the stale entry via SaveCommunity, so this sets the
+	// current one (#21470-hf).
+	m.cache.Set(gateKey, ReadonlyCommunity(community), ttlcache.DefaultTTL)
 	r.FailedToDecrypt = failedToDecrypt
 	return r, nil
+}
+
+// cachedCommunityForRedelivery returns the community for a gated (skipped) description
+// redelivery. It serves the shared readonly community cache first — the whole point of
+// the gate is to avoid the ~1.4MB GetByID (SQLite read + proto.Unmarshal) that each
+// skip would otherwise pay — and falls back to a single GetByID on a cache miss,
+// populating the cache so subsequent skips are free. Returns nil (caller falls through
+// to full processing) if the community cannot be read.
+//
+// The cache is coherent for this use: every persisted community mutation funnels
+// through Manager.SaveCommunity, which deletes the entry, so a hit can never be staler
+// than the last persisted description. The skip path only needs the community to
+// (a) trip the store-node description-seen latch, which keys off the community ID alone
+// (communityDescriptionSeen), and (b) be surfaced with empty changes. The store-node
+// pager's minimumDataClock comparison reads the PERSISTED clock via its own GetByID,
+// never this cached copy, so a slightly-stale clock here cannot change pager behaviour.
+func (m *Manager) cachedCommunityForRedelivery(id types3.HexBytes) *Community {
+	idString := id.String()
+	if item := m.cache.Get(idString); item != nil {
+		if community, ok := item.Value().(*Community); ok {
+			return community
+		}
+	}
+	m.communityLock.Lock(id)
+	defer m.communityLock.Unlock(id)
+	community, err := m.GetByID(id)
+	if err != nil || community == nil {
+		return nil
+	}
+	m.cache.Set(idString, ReadonlyCommunity(community), ttlcache.DefaultTTL)
+	return community
 }
 
 func (m *Manager) NewHashRatchetKeys(keys []*types.HashRatchetInfo) error {
@@ -2229,6 +2271,14 @@ func (m *Manager) NewHashRatchetKeys(keys []*types.HashRatchetInfo) error {
 	// must be reprocessed rather than skipped as a redelivery (#21470-hf).
 	if m.descriptionGate != nil && len(keys) > 0 {
 		m.descriptionGate.forgetAll()
+	}
+	// Drop cached communities too: a community processed while keyless was cached
+	// without its decrypted private data, so the cached copy must not be reused once
+	// keys arrive. Keys may be channel-scoped and cannot be mapped back to a single
+	// community cheaply, so clear all — the same reason descriptionGate.forgetAll does
+	// (#21470-hf). Cleared entries simply re-read from the DB on next access.
+	if len(keys) > 0 {
+		m.cache.DeleteAll()
 	}
 	return m.persistence.InvalidateDecryptedCommunityCacheForKeys(keys)
 }

--- a/protocol/communities/manager.go
+++ b/protocol/communities/manager.go
@@ -113,6 +113,7 @@ type Manager struct {
 	stopped                  bool
 	PermissionChecker        PermissionChecker
 	keyDistributor           KeyDistributor
+	keyEntitlement           *communityKeyEntitlement
 	communityLock            *CommunityLock
 	mediaServer              server.MediaServerInterface
 	communityImageVersions   map[string]uint32
@@ -322,6 +323,7 @@ func NewManager(
 		messaging:              messaging,
 		timesource:             timesource,
 		keyDistributor:         keyDistributor,
+		keyEntitlement:         newCommunityKeyEntitlement(),
 		communityLock:          NewCommunityLock(logger),
 		mediaServer:            mediaServer,
 		communityImageVersions: make(map[string]uint32),
@@ -2171,7 +2173,53 @@ func (m *Manager) HandleCommunityDescriptionMessage(signer *ecdsa.PublicKey, des
 }
 
 func (m *Manager) NewHashRatchetKeys(keys []*types.HashRatchetInfo) error {
+	// Lift the keyless-spectator gate now that key material has arrived, so the next
+	// description fetch re-evaluates entitlement and attempts decryption. Keys may be
+	// community- or channel-scoped, so clear all cached entitlements rather than map
+	// each group id back to a community.
+	if m.keyEntitlement != nil && len(keys) > 0 {
+		m.keyEntitlement.forgetAll()
+	}
 	return m.persistence.InvalidateDecryptedCommunityCacheForKeys(keys)
+}
+
+// communityHoldsAnyDecryptionKey reports whether this node holds any hash-ratchet
+// key material for the community (its community-level group or any of its channel
+// groups). The result is cached per community and invalidated when new keys arrive
+// (NewHashRatchetKeys). On any lookup error it fails open (reports true) so a
+// transient DB issue can never cause legitimate data to be dropped.
+func (m *Manager) communityHoldsAnyDecryptionKey(id types3.HexBytes, chats map[string]*protobuf.CommunityChat) bool {
+	if m.messaging == nil || m.keyEntitlement == nil {
+		return true
+	}
+
+	cacheKey := id.String()
+	if holds, ok := m.keyEntitlement.known(cacheKey); ok {
+		return holds
+	}
+
+	holds := m.hasHashRatchetKeyForGroup(id)
+	if !holds {
+		for channelID := range chats {
+			if m.hasHashRatchetKeyForGroup(types3.HexBytes(id.String() + channelID)) {
+				holds = true
+				break
+			}
+		}
+	}
+
+	m.keyEntitlement.remember(cacheKey, holds)
+	return holds
+}
+
+func (m *Manager) hasHashRatchetKeyForGroup(groupID []byte) bool {
+	key, err := m.messaging.GetCurrentKeyForGroup(groupID)
+	if err != nil {
+		// Fail open: never drop decryptable data because of a lookup error.
+		return true
+	}
+	// GetCurrentKeyForGroup returns a non-nil, empty ratchet when no key exists.
+	return key != nil && len(key.Key) != 0
 }
 
 // NOTE: encrypted_community_description_cache is not a cache for the community description
@@ -2184,6 +2232,26 @@ func (m *Manager) preprocessDescription(id types3.HexBytes, description *protobu
 	}
 	if decryptedCommunity != nil {
 		return nil, decryptedCommunity, nil
+	}
+
+	// Keyless-spectator early drop (#21470): if the description carries encrypted
+	// private data but this node holds no decryption keys for the community, skip
+	// the per-key decryption attempts entirely — each would be a guaranteed
+	// "no ratchet key" failure. The plaintext outer description is still handled;
+	// only the encrypted inner fields are left encrypted (a spectator cannot see
+	// them anyway). The gate lifts automatically once keys arrive.
+	if len(description.PrivateData) > 0 &&
+		shouldSkipPrivateDataDecryption(true, m.communityHoldsAnyDecryptionKey(id, description.Chats)) {
+		decision := m.keyEntitlement.recordDrop(id.String())
+		if decision.logInfo {
+			m.logger.Info("dropping encrypted community payloads (no decryption keys held)",
+				zap.String("communityID", id.String()), zap.Uint64("droppedCount", decision.count))
+		} else if decision.logDebug {
+			m.logger.Debug("still dropping encrypted community payloads (no decryption keys held)",
+				zap.String("communityID", id.String()), zap.Uint64("droppedCount", decision.count))
+		}
+		upgradeTokenPermissions(description)
+		return nil, description, m.persistence.SaveDecryptedCommunityDescription(id, nil, description)
 	}
 
 	response, err := decryptDescription(id, m, description, m.logger)

--- a/protocol/communities/manager.go
+++ b/protocol/communities/manager.go
@@ -589,6 +589,27 @@ func (m *Manager) ValidateCommunityByID(communityID types3.HexBytes) (*Community
 
 }
 
+// HighestQueuedValidationClock returns the greatest clock among the community
+// descriptions currently queued for owner validation for the given community, or
+// 0 if none are queued. The store-node pager uses this to stop requesting more
+// history once we already hold the description and only on-chain owner
+// verification remains: fetching further pages cannot make verification succeed,
+// and verification is retried out-of-band on the owner-verification loop
+// (issue #21470-hf).
+func (m *Manager) HighestQueuedValidationClock(communityID types3.HexBytes) (uint64, error) {
+	queued, err := m.persistence.getCommunityToValidateByID(communityID)
+	if err != nil {
+		return 0, err
+	}
+	var highest uint64
+	for _, c := range queued {
+		if c.clock > highest {
+			highest = c.clock
+		}
+	}
+	return highest, nil
+}
+
 func (m *Manager) validateCommunity(communityToValidateData []communityToValidate) (*CommunityResponse, error) {
 	for _, community := range communityToValidateData {
 		signer, description, err := UnwrapCommunityDescriptionMessage(community.payload)
@@ -611,7 +632,17 @@ func (m *Manager) validateCommunity(communityToValidateData []communityToValidat
 
 		owner, err := m.ownerVerifier.SafeGetSignerPubKey(ctx, chainID, types3.EncodeHex(community.id))
 		if err != nil {
-			m.logger.Error("failed to get owner", zap.Error(err))
+			// Transport-class failure of the on-chain owner lookup (RPC timeout,
+			// dead proxy, rate limit, connection refused). This is NOT a verdict
+			// on the community: we deliberately keep it queued so the
+			// owner-verification loop retries it once the RPC recovers, instead
+			// of the store-node pager reacting to it by fetching more history
+			// (issue #21470-hf). Logged distinctly from an invalid/not-owner
+			// verdict so field debugging can tell the two apart.
+			m.logger.Warn("owner verification unavailable (transport failure); keeping community queued for retry",
+				zap.String("id", types3.EncodeHex(community.id)),
+				zap.Uint64("chainID", chainID),
+				zap.Error(err))
 			continue
 		}
 
@@ -623,7 +654,13 @@ func (m *Manager) validateCommunity(communityToValidateData []communityToValidat
 
 		response, err := m.HandleCommunityDescriptionMessage(signer, description, community.payload, ownerPK)
 		if err != nil {
-			m.logger.Error("failed to handle community", zap.Error(err))
+			// Invalid-class verdict: the owner lookup succeeded but the signed
+			// description does not check out (wrong owner / bad description).
+			// Unlike a transport failure this is terminal, so we drop the entry;
+			// retrying cannot change the outcome (issue #21470-hf).
+			m.logger.Error("community description invalid for resolved owner; dropping from validation queue",
+				zap.String("id", types3.EncodeHex(community.id)),
+				zap.Error(err))
 			err = m.persistence.DeleteCommunityToValidate(community.id, community.clock)
 			if err != nil {
 				m.logger.Error("failed to delete community to validate", zap.Error(err))

--- a/protocol/communities/manager.go
+++ b/protocol/communities/manager.go
@@ -2100,9 +2100,23 @@ func (m *Manager) HandleCommunityDescriptionMessage(signer *ecdsa.PublicKey, des
 	gateKey := types3.HexBytes(id).String()
 	payloadHash := hashDescriptionPayload(payload)
 	if m.descriptionGate != nil && m.descriptionGate.shouldSkip(gateKey, description.Clock, payloadHash) {
-		m.logger.Debug("skipping redelivered community description",
-			zap.String("communityID", gateKey), zap.Uint64("clock", description.Clock))
-		return nil, nil
+		// Skip the expensive pipeline (preprocessDescription's decrypted-cache
+		// read+write and handleCommunityDescriptionMessageCommon's ~1.4MB re-save),
+		// but still SURFACE the already-known community with empty changes. The
+		// store-node pager latches "description seen" from the community appearing
+		// in the handled response and stops paging once it holds the newest
+		// description (issue #21470-hf, commit 6cd6ced1a); returning nil here would
+		// hide the redelivery from that latch and make the pager run to its page
+		// cap. Fail open: if the community is not readable, fall through to full
+		// processing rather than fabricate a skip.
+		m.communityLock.Lock(id)
+		community, err := m.GetByID(id)
+		m.communityLock.Unlock(id)
+		if err == nil && community != nil {
+			m.logger.Debug("surfacing redelivered community description without reprocessing",
+				zap.String("communityID", gateKey), zap.Uint64("clock", description.Clock))
+			return &CommunityResponse{Community: community, Changes: community.emptyCommunityChanges()}, nil
+		}
 	}
 
 	failedToDecrypt, processedDescription, err := m.preprocessDescription(id, description)

--- a/protocol/communities/manager.go
+++ b/protocol/communities/manager.go
@@ -2209,10 +2209,6 @@ func (m *Manager) handleCommunityDescriptionMessageCommon(community *Community, 
 		m.incrementCommunityImageVersion(community.IDString())
 	}
 
-	if err = m.handleCommunityTokensMetadata(community); err != nil {
-		return nil, err
-	}
-
 	hasCommunityArchiveInfo, err := m.persistence.HasCommunityArchiveInfo(community.ID())
 	if err != nil {
 		return nil, err
@@ -2296,6 +2292,10 @@ func (m *Manager) handleCommunityDescriptionMessageCommon(community *Community, 
 	err = m.SaveCommunity(community)
 	if err != nil {
 		return nil, err
+	}
+
+	if len(community.CommunityTokensMetadata()) > 0 {
+		m.handleCommunityTokensMetadataAsync(community.IDString())
 	}
 
 	// We mark our requests as completed, though maybe we should mark
@@ -4506,6 +4506,31 @@ func (m *Manager) handleCommunityTokensMetadata(community *Community) error {
 		}
 	}
 	return nil
+}
+
+func (m *Manager) handleCommunityTokensMetadataAsync(communityID string) {
+	go func() {
+		defer utils.LogOnPanic()
+
+		select {
+		case <-m.quit:
+			return
+		default:
+		}
+
+		community, err := m.GetByIDString(communityID)
+		if err != nil {
+			return
+		}
+
+		err = m.handleCommunityTokensMetadata(community)
+		if err != nil {
+			return
+		}
+
+		m.publish(&Subscription{Community: community})
+
+	}()
 }
 
 func (m *Manager) HandleCommunityGrant(community *Community, grant []byte, clock uint64) (uint64, error) {

--- a/protocol/communities/manager.go
+++ b/protocol/communities/manager.go
@@ -114,6 +114,7 @@ type Manager struct {
 	PermissionChecker        PermissionChecker
 	keyDistributor           KeyDistributor
 	keyEntitlement           *communityKeyEntitlement
+	descriptionGate          *communityDescriptionGate
 	communityLock            *CommunityLock
 	mediaServer              server.MediaServerInterface
 	communityImageVersions   map[string]uint32
@@ -324,6 +325,7 @@ func NewManager(
 		timesource:             timesource,
 		keyDistributor:         keyDistributor,
 		keyEntitlement:         newCommunityKeyEntitlement(),
+		descriptionGate:        newCommunityDescriptionGate(),
 		communityLock:          NewCommunityLock(logger),
 		mediaServer:            mediaServer,
 		communityImageVersions: make(map[string]uint32),
@@ -1528,6 +1530,11 @@ func (m *Manager) DeleteCommunity(id types3.HexBytes) error {
 	if err != nil {
 		return err
 	}
+	// Drop any redelivery-gate entry so a re-fetched description of a deleted
+	// community is fully reprocessed rather than skipped (#21470-hf).
+	if m.descriptionGate != nil {
+		m.descriptionGate.forget(id.String())
+	}
 	return m.persistence.DeleteCommunitySettings(id)
 }
 
@@ -2083,6 +2090,21 @@ func (m *Manager) HandleCommunityDescriptionMessage(signer *ecdsa.PublicKey, des
 		id = crypto.CompressPubkey(signer)
 	}
 
+	// #21470-hf: fast-path redelivered descriptions before any expensive work.
+	// status-go re-publishes the same ~1.4MB description into every fetch window,
+	// and each redelivered copy otherwise pays proto.Unmarshal + preprocessDescription
+	// (decrypted-cache read+write) + GetByID (re-read/re-unmarshal of the stored
+	// blob) BEFORE the downstream clock comparison rejects it. The gate skips only
+	// strictly-older clocks and byte-identical same-clock redeliveries; it is
+	// cleared when keys arrive or a community is deleted (see communityDescriptionGate).
+	gateKey := types3.HexBytes(id).String()
+	payloadHash := hashDescriptionPayload(payload)
+	if m.descriptionGate != nil && m.descriptionGate.shouldSkip(gateKey, description.Clock, payloadHash) {
+		m.logger.Debug("skipping redelivered community description",
+			zap.String("communityID", gateKey), zap.Uint64("clock", description.Clock))
+		return nil, nil
+	}
+
 	failedToDecrypt, processedDescription, err := m.preprocessDescription(id, description)
 	if err != nil {
 		return nil, err
@@ -2168,6 +2190,14 @@ func (m *Manager) HandleCommunityDescriptionMessage(signer *ecdsa.PublicKey, des
 	if err != nil {
 		return nil, err
 	}
+	// Advance the redelivery gate only after fully successful processing, so a
+	// byte-identical same-clock redelivery of THIS description can be skipped.
+	// Deliberately NOT advanced on the queue path or the FailedToDecrypt early
+	// return, so validateCommunity's later re-entry and key-arrival reprocessing
+	// are never blocked (#21470-hf).
+	if m.descriptionGate != nil {
+		m.descriptionGate.recordProcessed(gateKey, processedDescription.Clock, payloadHash)
+	}
 	r.FailedToDecrypt = failedToDecrypt
 	return r, nil
 }
@@ -2179,6 +2209,12 @@ func (m *Manager) NewHashRatchetKeys(keys []*types.HashRatchetInfo) error {
 	// each group id back to a community.
 	if m.keyEntitlement != nil && len(keys) > 0 {
 		m.keyEntitlement.forgetAll()
+	}
+	// Lift the redelivery gate too: a description that was byte-identical to one
+	// already processed may now decrypt previously-encrypted private data, so it
+	// must be reprocessed rather than skipped as a redelivery (#21470-hf).
+	if m.descriptionGate != nil && len(keys) > 0 {
+		m.descriptionGate.forgetAll()
 	}
 	return m.persistence.InvalidateDecryptedCommunityCacheForKeys(keys)
 }

--- a/protocol/communities/manager_test.go
+++ b/protocol/communities/manager_test.go
@@ -1855,10 +1855,11 @@ func (s *ManagerSuite) TestCommunityIDIsHydratedWhenMarshaling() {
 }
 
 // TestHandleCommunityDescriptionRedeliveryGate verifies the redelivery gate
-// (issue #21470-hf): a byte-identical redelivery of an already-processed
-// community description is short-circuited (nil response, no error), while newer
-// clocks are still processed, and new hash-ratchet key material lifts the gate so
-// the same description is reprocessed (it may then decrypt private data).
+// (issue #21470-hf). A byte-identical redelivery of an already-processed community
+// description must skip the expensive pipeline yet still SURFACE the already-known
+// community, so the store-node pager's description-seen latch (commit 6cd6ced1a)
+// trips exactly as it would for a fully-processed redelivery. Newer clocks are
+// still processed, and new hash-ratchet key material lifts the gate.
 func (s *ManagerSuite) TestHandleCommunityDescriptionRedeliveryGate() {
 	// s.manager is the control node that authors the community; m is a separate
 	// receiver (spectator) node that ingests the published description.
@@ -1879,6 +1880,7 @@ func (s *ManagerSuite) TestHandleCommunityDescriptionRedeliveryGate() {
 	// Plain community: no token ownership, so it is processed immediately (not queued).
 	s.Require().Equal(uint64(0), CommunityDescriptionTokenOwnerChainID(description))
 
+	gateKey := community.IDString()
 	buildPayload := func() []byte {
 		payload, err := community.MarshaledDescription()
 		s.Require().NoError(err)
@@ -1889,15 +1891,27 @@ func (s *ManagerSuite) TestHandleCommunityDescriptionRedeliveryGate() {
 
 	payload := buildPayload()
 
+	// The gate starts empty: the first delivery must not be skipped.
+	s.Require().False(m.descriptionGate.shouldSkip(gateKey, description.Clock, hashDescriptionPayload(payload)))
+
 	// First delivery is fully processed and yields a response.
 	resp1, err := m.HandleCommunityDescriptionMessage(&signer.PublicKey, description, payload, nil)
 	s.Require().NoError(err)
 	s.Require().NotNil(resp1)
 
-	// Byte-identical redelivery is short-circuited by the gate (nil response, no error).
+	// The gate now records this description, so a byte-identical redelivery is a skip.
+	s.Require().True(m.descriptionGate.shouldSkip(gateKey, description.Clock, hashDescriptionPayload(payload)))
+
+	// Byte-identical redelivery is short-circuited but STILL surfaces the community
+	// (non-nil, matching ID, empty changes) so downstream description-seen latches.
 	resp2, err := m.HandleCommunityDescriptionMessage(&signer.PublicKey, description, payload, nil)
 	s.Require().NoError(err)
-	s.Require().Nil(resp2)
+	s.Require().NotNil(resp2)
+	s.Require().NotNil(resp2.Community)
+	s.Require().Equal(community.IDString(), resp2.Community.IDString())
+	s.Require().NotNil(resp2.Changes)
+	s.Require().Empty(resp2.Changes.MembersAdded)
+	s.Require().Empty(resp2.Changes.ChatsAdded)
 
 	// A genuinely newer clock still gets processed.
 	community.config.CommunityDescription.Clock++
@@ -1905,18 +1919,16 @@ func (s *ManagerSuite) TestHandleCommunityDescriptionRedeliveryGate() {
 	resp3, err := m.HandleCommunityDescriptionMessage(&signer.PublicKey, description, newerPayload, nil)
 	s.Require().NoError(err)
 	s.Require().NotNil(resp3)
+	s.Require().True(m.descriptionGate.shouldSkip(gateKey, description.Clock, hashDescriptionPayload(newerPayload)))
 
-	// Its identical redelivery is skipped again.
-	resp4, err := m.HandleCommunityDescriptionMessage(&signer.PublicKey, description, newerPayload, nil)
-	s.Require().NoError(err)
-	s.Require().Nil(resp4)
-
-	// New hash-ratchet keys arriving must lift the gate so the same description is
-	// reprocessed (it may now decrypt previously-encrypted private data).
+	// New hash-ratchet keys arriving must lift the gate so the same description can
+	// be reprocessed (it may now decrypt previously-encrypted private data).
 	err = m.NewHashRatchetKeys([]*types.HashRatchetInfo{{GroupID: community.ID(), KeyID: []byte("key-id")}})
 	s.Require().NoError(err)
+	s.Require().False(m.descriptionGate.shouldSkip(gateKey, description.Clock, hashDescriptionPayload(newerPayload)),
+		"gate must be lifted after new keys arrive")
 
 	resp5, err := m.HandleCommunityDescriptionMessage(&signer.PublicKey, description, newerPayload, nil)
 	s.Require().NoError(err)
-	s.Require().NotNil(resp5, "gate must be lifted after new keys arrive")
+	s.Require().NotNil(resp5)
 }

--- a/protocol/communities/manager_test.go
+++ b/protocol/communities/manager_test.go
@@ -1210,10 +1210,18 @@ func (s *ManagerSuite) buildCommunityWithChat() (*Community, string, error) {
 type testOwnerVerifier struct {
 	called    int
 	ownersMap map[string]string
+	// err simulates a transport-class failure of the on-chain owner lookup
+	// (RPC timeout, dead proxy, rate limit). When set, SafeGetSignerPubKey
+	// fails the way a broken wallet RPC stack does, without rejecting the
+	// community as invalid.
+	err error
 }
 
 func (t *testOwnerVerifier) SafeGetSignerPubKey(ctx context.Context, chainID uint64, communityID string) (string, error) {
 	t.called++
+	if t.err != nil {
+		return "", t.err
+	}
 	return t.ownersMap[communityID], nil
 }
 
@@ -1296,6 +1304,139 @@ func (s *ManagerSuite) TestCommunityQueue() {
 	communitiesToValidate, err := m.persistence.getCommunitiesToValidate()
 	s.Require().NoError(err)
 	s.Require().Empty(communitiesToValidate)
+}
+
+// TestHighestQueuedValidationClock verifies the queue read the store-node pager
+// uses to decide it may stop paging (issue #21470-hf): once a community's
+// description is queued for owner validation, HighestQueuedValidationClock
+// reports the greatest queued clock so the pager can compare it against the
+// clock it already holds. With nothing queued (or for an unrelated community) it
+// reports 0, so the pager keeps paging as before.
+func (s *ManagerSuite) TestHighestQueuedValidationClock() {
+	verifier := &testOwnerVerifier{}
+	m, _ := s.buildManagers(verifier)
+
+	communityID := []byte{0x01, 0x02, 0x03}
+
+	clock, err := m.HighestQueuedValidationClock(communityID)
+	s.Require().NoError(err)
+	s.Require().Equal(uint64(0), clock, "nothing queued yet")
+
+	// Queue two descriptions with different clocks, both already due for
+	// validation (validate_at in the past).
+	s.Require().NoError(m.persistence.SaveCommunityToValidate(communityToValidate{
+		id: communityID, clock: 5, payload: []byte("a"), validateAt: 1, signer: []byte("s")}))
+	s.Require().NoError(m.persistence.SaveCommunityToValidate(communityToValidate{
+		id: communityID, clock: 9, payload: []byte("b"), validateAt: 1, signer: []byte("s")}))
+
+	clock, err = m.HighestQueuedValidationClock(communityID)
+	s.Require().NoError(err)
+	s.Require().Equal(uint64(9), clock, "highest queued clock")
+
+	clock, err = m.HighestQueuedValidationClock([]byte{0xaa, 0xbb})
+	s.Require().NoError(err)
+	s.Require().Equal(uint64(0), clock, "unrelated community is unaffected")
+}
+
+// TestCommunityQueueRetriesTransportError verifies the core correctness fix
+// (issue #21470-hf): a transport-class failure of owner verification (RPC
+// timeout / dead proxy / rate limit) must NOT reject the community and must NOT
+// clear the queue — the description stays queued so verification is retried
+// out-of-band, and succeeds once the RPC recovers, publishing
+// TokenCommunityValidated. This decouples verification retries from store-node
+// paging: the pager stops once the description is queued, and recovery happens
+// here rather than by fetching more pages.
+func (s *ManagerSuite) TestCommunityQueueRetriesTransportError() {
+	owner, err := crypto.GenerateKey()
+	s.Require().NoError(err)
+
+	verifier := &testOwnerVerifier{}
+	m, _ := s.buildManagers(verifier)
+
+	createRequest := &requests.CreateCommunity{
+		Name:        "status",
+		Description: "status community description",
+		Membership:  protobuf.CommunityPermissions_AUTO_ACCEPT,
+	}
+	community, err := s.manager.CreateCommunity(createRequest, true)
+	s.Require().NoError(err)
+
+	verifier.ownersMap = make(map[string]string)
+	verifier.ownersMap[community.IDString()] = crypto.PubkeyToHex(&owner.PublicKey)
+
+	description := community.config.CommunityDescription
+	description.TokenPermissions = make(map[string]*protobuf.CommunityTokenPermission)
+	description.TokenPermissions["some-id"] = &protobuf.CommunityTokenPermission{
+		Type: protobuf.CommunityTokenPermission_BECOME_TOKEN_OWNER,
+		Id:   "some-token-id",
+		TokenCriteria: []*protobuf.TokenCriteria{
+			&protobuf.TokenCriteria{
+				ContractAddresses: map[uint64]string{2: "some-address"},
+			},
+		}}
+	s.Require().Equal(uint64(2), CommunityDescriptionTokenOwnerChainID(description))
+
+	payload, err := community.MarshaledDescription()
+	s.Require().NoError(err)
+	payload, err = v.WrapIntoAppLayerMessage(payload, protobuf.ApplicationMetadataMessage_COMMUNITY_DESCRIPTION, owner)
+	s.Require().NoError(err)
+
+	notTheOwner, err := crypto.GenerateKey()
+	s.Require().NoError(err)
+
+	// The description arrives from a non-owner signer, so it is queued for
+	// on-chain owner verification instead of being applied immediately.
+	response, err := m.HandleCommunityDescriptionMessage(&notTheOwner.PublicKey, description, payload, nil)
+	s.Require().NoError(err)
+	s.Require().Nil(response, "must be queued, not applied")
+
+	// The queued description is now in hand: the pager can see it and stop.
+	queuedClock, err := m.HighestQueuedValidationClock(community.ID())
+	s.Require().NoError(err)
+	s.Require().Greater(queuedClock, uint64(0))
+
+	// Transport failure during verification: the community must stay queued and
+	// nothing may be published.
+	subscription := m.Subscribe()
+	verifier.err = errors.New("proxy dead: connection refused")
+
+	resp, err := m.ValidateCommunityByID(community.ID())
+	s.Require().NoError(err, "transport failure must not surface as a validation error")
+	s.Require().Nil(resp)
+
+	queued, err := m.persistence.getCommunityToValidateByID(community.ID())
+	s.Require().NoError(err)
+	s.Require().NotEmpty(queued, "transport-failed validation must remain queued for retry")
+
+	select {
+	case event := <-subscription:
+		s.Require().Nil(event.TokenCommunityValidated, "must not publish on transport failure")
+	default:
+	}
+
+	// Recovery: the RPC works on the next attempt → validated, published, queue
+	// cleared.
+	verifier.err = nil
+	resp, err = m.ValidateCommunityByID(community.ID())
+	s.Require().NoError(err)
+	s.Require().NotNil(resp, "validation must succeed once the RPC recovers")
+
+	published := false
+	for !published {
+		select {
+		case event := <-subscription:
+			if event.TokenCommunityValidated == nil {
+				continue
+			}
+			published = true
+		case <-time.After(2 * time.Second):
+			s.FailNow("TokenCommunityValidated not published after recovery")
+		}
+	}
+
+	queued, err = m.persistence.getCommunityToValidateByID(community.ID())
+	s.Require().NoError(err)
+	s.Require().Empty(queued, "successful validation must clear the queue")
 }
 
 // 1) We create a community

--- a/protocol/communities/manager_test.go
+++ b/protocol/communities/manager_test.go
@@ -1853,3 +1853,70 @@ func (s *ManagerSuite) TestCommunityIDIsHydratedWhenMarshaling() {
 	s.Require().NoError(err)
 	s.Require().Equal(community.IDString(), community.config.CommunityDescription.ID)
 }
+
+// TestHandleCommunityDescriptionRedeliveryGate verifies the redelivery gate
+// (issue #21470-hf): a byte-identical redelivery of an already-processed
+// community description is short-circuited (nil response, no error), while newer
+// clocks are still processed, and new hash-ratchet key material lifts the gate so
+// the same description is reprocessed (it may then decrypt private data).
+func (s *ManagerSuite) TestHandleCommunityDescriptionRedeliveryGate() {
+	// s.manager is the control node that authors the community; m is a separate
+	// receiver (spectator) node that ingests the published description.
+	m, _ := s.buildManagers(nil)
+
+	signer, err := crypto.GenerateKey()
+	s.Require().NoError(err)
+
+	createRequest := &requests.CreateCommunity{
+		Name:        "status",
+		Description: "status community description",
+		Membership:  protobuf.CommunityPermissions_AUTO_ACCEPT,
+	}
+	community, err := s.manager.CreateCommunity(createRequest, true)
+	s.Require().NoError(err)
+
+	description := community.config.CommunityDescription
+	// Plain community: no token ownership, so it is processed immediately (not queued).
+	s.Require().Equal(uint64(0), CommunityDescriptionTokenOwnerChainID(description))
+
+	buildPayload := func() []byte {
+		payload, err := community.MarshaledDescription()
+		s.Require().NoError(err)
+		payload, err = v.WrapIntoAppLayerMessage(payload, protobuf.ApplicationMetadataMessage_COMMUNITY_DESCRIPTION, signer)
+		s.Require().NoError(err)
+		return payload
+	}
+
+	payload := buildPayload()
+
+	// First delivery is fully processed and yields a response.
+	resp1, err := m.HandleCommunityDescriptionMessage(&signer.PublicKey, description, payload, nil)
+	s.Require().NoError(err)
+	s.Require().NotNil(resp1)
+
+	// Byte-identical redelivery is short-circuited by the gate (nil response, no error).
+	resp2, err := m.HandleCommunityDescriptionMessage(&signer.PublicKey, description, payload, nil)
+	s.Require().NoError(err)
+	s.Require().Nil(resp2)
+
+	// A genuinely newer clock still gets processed.
+	community.config.CommunityDescription.Clock++
+	newerPayload := buildPayload()
+	resp3, err := m.HandleCommunityDescriptionMessage(&signer.PublicKey, description, newerPayload, nil)
+	s.Require().NoError(err)
+	s.Require().NotNil(resp3)
+
+	// Its identical redelivery is skipped again.
+	resp4, err := m.HandleCommunityDescriptionMessage(&signer.PublicKey, description, newerPayload, nil)
+	s.Require().NoError(err)
+	s.Require().Nil(resp4)
+
+	// New hash-ratchet keys arriving must lift the gate so the same description is
+	// reprocessed (it may now decrypt previously-encrypted private data).
+	err = m.NewHashRatchetKeys([]*types.HashRatchetInfo{{GroupID: community.ID(), KeyID: []byte("key-id")}})
+	s.Require().NoError(err)
+
+	resp5, err := m.HandleCommunityDescriptionMessage(&signer.PublicKey, description, newerPayload, nil)
+	s.Require().NoError(err)
+	s.Require().NotNil(resp5, "gate must be lifted after new keys arrive")
+}

--- a/protocol/communities/manager_test.go
+++ b/protocol/communities/manager_test.go
@@ -1892,7 +1892,7 @@ func (s *ManagerSuite) TestHandleCommunityDescriptionRedeliveryGate() {
 	payload := buildPayload()
 
 	// The gate starts empty: the first delivery must not be skipped.
-	s.Require().False(m.descriptionGate.shouldSkip(gateKey, description.Clock, hashDescriptionPayload(payload)))
+	s.Require().False(m.descriptionGate.shouldSkip(gateKey, description.Clock, hashDescriptionPayload(payload), keysHeld))
 
 	// First delivery is fully processed and yields a response.
 	resp1, err := m.HandleCommunityDescriptionMessage(&signer.PublicKey, description, payload, nil)
@@ -1900,7 +1900,7 @@ func (s *ManagerSuite) TestHandleCommunityDescriptionRedeliveryGate() {
 	s.Require().NotNil(resp1)
 
 	// The gate now records this description, so a byte-identical redelivery is a skip.
-	s.Require().True(m.descriptionGate.shouldSkip(gateKey, description.Clock, hashDescriptionPayload(payload)))
+	s.Require().True(m.descriptionGate.shouldSkip(gateKey, description.Clock, hashDescriptionPayload(payload), keysHeld))
 
 	// Byte-identical redelivery is short-circuited but STILL surfaces the community
 	// (non-nil, matching ID, empty changes) so downstream description-seen latches.
@@ -1919,16 +1919,81 @@ func (s *ManagerSuite) TestHandleCommunityDescriptionRedeliveryGate() {
 	resp3, err := m.HandleCommunityDescriptionMessage(&signer.PublicKey, description, newerPayload, nil)
 	s.Require().NoError(err)
 	s.Require().NotNil(resp3)
-	s.Require().True(m.descriptionGate.shouldSkip(gateKey, description.Clock, hashDescriptionPayload(newerPayload)))
+	s.Require().True(m.descriptionGate.shouldSkip(gateKey, description.Clock, hashDescriptionPayload(newerPayload), keysHeld))
 
 	// New hash-ratchet keys arriving must lift the gate so the same description can
 	// be reprocessed (it may now decrypt previously-encrypted private data).
 	err = m.NewHashRatchetKeys([]*types.HashRatchetInfo{{GroupID: community.ID(), KeyID: []byte("key-id")}})
 	s.Require().NoError(err)
-	s.Require().False(m.descriptionGate.shouldSkip(gateKey, description.Clock, hashDescriptionPayload(newerPayload)),
+	s.Require().False(m.descriptionGate.shouldSkip(gateKey, description.Clock, hashDescriptionPayload(newerPayload), keysHeld),
 		"gate must be lifted after new keys arrive")
 
 	resp5, err := m.HandleCommunityDescriptionMessage(&signer.PublicKey, description, newerPayload, nil)
 	s.Require().NoError(err)
 	s.Require().NotNil(resp5)
+}
+
+// TestHandleCommunityDescriptionRedeliveryCache verifies the redelivery skip path is
+// served from the in-memory community cache instead of a 1.4MB GetByID per skip
+// (issue #21470-hf). It exercises the cache lifecycle at the Manager seam:
+// populate-on-successful-processing, and invalidation on both NewHashRatchetKeys and
+// DeleteCommunity. Description-update invalidation is already covered by SaveCommunity
+// (every successful processing deletes then repopulates the cache entry).
+func (s *ManagerSuite) TestHandleCommunityDescriptionRedeliveryCache() {
+	m, _ := s.buildManagers(nil)
+
+	signer, err := crypto.GenerateKey()
+	s.Require().NoError(err)
+
+	createRequest := &requests.CreateCommunity{
+		Name:        "status",
+		Description: "status community description",
+		Membership:  protobuf.CommunityPermissions_AUTO_ACCEPT,
+	}
+	community, err := s.manager.CreateCommunity(createRequest, true)
+	s.Require().NoError(err)
+
+	description := community.config.CommunityDescription
+	gateKey := community.IDString()
+	buildPayload := func() []byte {
+		payload, err := community.MarshaledDescription()
+		s.Require().NoError(err)
+		payload, err = v.WrapIntoAppLayerMessage(payload, protobuf.ApplicationMetadataMessage_COMMUNITY_DESCRIPTION, signer)
+		s.Require().NoError(err)
+		return payload
+	}
+	payload := buildPayload()
+
+	// The cache starts empty for an unseen community.
+	s.Require().Nil(m.cache.Get(gateKey), "cache must be empty before first processing")
+
+	// POPULATE-ON-PROCESS: after a successful full processing the just-processed
+	// community is cached so the first redelivery skip serves it without a GetByID.
+	_, err = m.HandleCommunityDescriptionMessage(&signer.PublicKey, description, payload, nil)
+	s.Require().NoError(err)
+	cached := m.cache.Get(gateKey)
+	s.Require().NotNil(cached, "community must be cached after successful processing")
+	s.Require().True(bytes.Equal(community.ID(), cached.Value().ID()), "cached community must match")
+
+	// The redelivery skip surfaces the community (from cache) with empty changes.
+	resp, err := m.HandleCommunityDescriptionMessage(&signer.PublicKey, description, payload, nil)
+	s.Require().NoError(err)
+	s.Require().NotNil(resp)
+	s.Require().NotNil(resp.Community)
+	s.Require().Equal(community.IDString(), resp.Community.IDString())
+
+	// INVALIDATE on NewHashRatchetKeys: keys arriving must drop the cached community
+	// (its next read reflects any now-decryptable state after reprocessing).
+	err = m.NewHashRatchetKeys([]*types.HashRatchetInfo{{GroupID: community.ID(), KeyID: []byte("key-id")}})
+	s.Require().NoError(err)
+	s.Require().Nil(m.cache.Get(gateKey), "new keys must invalidate the cached community")
+
+	// Reprocess to repopulate, then INVALIDATE on DeleteCommunity.
+	_, err = m.HandleCommunityDescriptionMessage(&signer.PublicKey, description, payload, nil)
+	s.Require().NoError(err)
+	s.Require().NotNil(m.cache.Get(gateKey), "reprocessing must repopulate the cache")
+
+	err = m.DeleteCommunity(community.ID())
+	s.Require().NoError(err)
+	s.Require().Nil(m.cache.Get(gateKey), "deleting the community must invalidate the cached community")
 }

--- a/protocol/communities_events_utils_test.go
+++ b/protocol/communities_events_utils_test.go
@@ -1866,16 +1866,33 @@ func testAddAndSyncTokenFromControlNode(base CommunityEventsTestsInterface, comm
 	waitOnMessengerResponse(s, checkTokenAdded, base.GetMember())
 	waitOnMessengerResponse(s, checkTokenAdded, base.GetEventSender())
 
-	// check CommunityToken was added to the DB
-	syncTokens, err := base.GetEventSender().communitiesManager.GetAllCommunityTokens()
+	// Token metadata arrives via messenger response first; DB persistence can complete shortly after.
+	err = testutils.RetryWithBackOff(func() error {
+		syncTokens, err := base.GetEventSender().communitiesManager.GetAllCommunityTokens()
+		if err != nil {
+			return err
+		}
+		if len(syncTokens) != 1 {
+			return errors.New("event sender tokens should be 1")
+		}
+		if syncTokens[0].PrivilegesLevel != privilegesLvl {
+			return errors.New("event sender token privileges level does not match")
+		}
+		return nil
+	})
 	s.Require().NoError(err)
-	s.Require().Len(syncTokens, 1)
-	s.Require().Equal(syncTokens[0].PrivilegesLevel, privilegesLvl)
 
-	// check CommunityToken was added to the DB
-	syncTokens, err = base.GetMember().communitiesManager.GetAllCommunityTokens()
+	err = testutils.RetryWithBackOff(func() error {
+		syncTokens, err := base.GetMember().communitiesManager.GetAllCommunityTokens()
+		if err != nil {
+			return err
+		}
+		if len(syncTokens) != 1 {
+			return errors.New("member tokens should be 1")
+		}
+		return nil
+	})
 	s.Require().NoError(err)
-	s.Require().Len(syncTokens, 1)
 }
 
 func testAddAndSyncOwnerTokenFromControlNode(base CommunityEventsTestsInterface, community *communities.Community,

--- a/protocol/messenger.go
+++ b/protocol/messenger.go
@@ -2776,6 +2776,32 @@ func (m *Messenger) RetrieveAll() (*MessengerResponse, error) {
 // preserving the same ~1s latency as the previous polling loop.
 const retrieveMessagesDebounceInterval = time.Second
 
+// retrieveMessagesMaxLatency bounds how long a flush can be deferred while
+// matches keep arriving. Without it a sustained envelope flood (e.g. the
+// community-description storm behind #21470) resets the debounce window on
+// every match, the 1s quiet gap never arrives, ProcessAllMessages is starved,
+// and freshly synced messages persisted to the DB are never surfaced to the
+// UI until the app restarts. The ceiling forces a flush at least this often
+// under continuous matches; quiet/normal traffic is unaffected because the
+// debounce interval fits comfortably under it.
+const retrieveMessagesMaxLatency = 3 * time.Second
+
+// nextFlushDeadline decides when the retrieve loop should next call
+// ProcessAllMessages. pendingSince is the time of the first match not yet
+// flushed; now is the time of the match currently being processed. The flush
+// normally fires a debounce window after the latest match, but is capped at
+// maxLatency measured from the first unflushed match so a continuous flood
+// cannot postpone delivery indefinitely. It returns the earlier of the two
+// deadlines.
+func nextFlushDeadline(pendingSince, now time.Time, debounce, maxLatency time.Duration) time.Time {
+	quietDeadline := now.Add(debounce)
+	ceilingDeadline := pendingSince.Add(maxLatency)
+	if ceilingDeadline.Before(quietDeadline) {
+		return ceilingDeadline
+	}
+	return quietDeadline
+}
+
 func (m *Messenger) StartRetrieveMessagesLoop(_ time.Duration, cancel <-chan struct{}) {
 	m.shutdownWaitGroup.Add(1)
 	go func() {
@@ -2787,27 +2813,46 @@ func (m *Messenger) StartRetrieveMessagesLoop(_ time.Duration, cancel <-chan str
 
 		var debounceTimer *time.Timer
 		var debounceCh <-chan time.Time
+		// Time of the first match since the last flush; zero when no flush is
+		// pending. Anchors the max-latency ceiling.
+		var pendingSince time.Time
+
+		stopTimer := func() {
+			if debounceTimer != nil && !debounceTimer.Stop() {
+				select {
+				case <-debounceTimer.C:
+				default:
+				}
+			}
+		}
 
 		for {
 			select {
 			case <-matchedCh:
-				// Reset the debounce window on every new match to coalesce bursts.
-				if debounceTimer != nil && !debounceTimer.Stop() {
-					select {
-					case <-debounceTimer.C:
-					default:
-					}
+				now := time.Now()
+				if pendingSince.IsZero() {
+					pendingSince = now
 				}
-				debounceTimer = time.NewTimer(retrieveMessagesDebounceInterval)
+				// Reset the debounce window on every new match to coalesce
+				// bursts, but never later than the max-latency ceiling.
+				stopTimer()
+				delay := nextFlushDeadline(pendingSince, now, retrieveMessagesDebounceInterval, retrieveMessagesMaxLatency).Sub(now)
+				if delay < 0 {
+					delay = 0
+				}
+				debounceTimer = time.NewTimer(delay)
 				debounceCh = debounceTimer.C
 
 			case <-debounceCh:
 				debounceCh = nil
+				pendingSince = time.Time{}
 				m.ProcessAllMessages()
 
 			case <-cancel:
+				stopTimer()
 				return
 			case <-m.quit:
+				stopTimer()
 				return
 			}
 		}

--- a/protocol/messenger.go
+++ b/protocol/messenger.go
@@ -2859,13 +2859,19 @@ func (m *Messenger) StartRetrieveMessagesLoop(_ time.Duration, cancel <-chan str
 	}()
 }
 
-func (m *Messenger) ProcessAllMessages() {
+// ProcessAllMessages retrieves and publishes all pending messages. It returns
+// the resulting MessengerResponse so callers that need to observe what was
+// handled (e.g. the store-node pager checking whether a community description
+// was processed this page — issue #21470-hf) can inspect it; callers that only
+// want the side effect may ignore the return value.
+func (m *Messenger) ProcessAllMessages() *MessengerResponse {
 	response, err := m.RetrieveAll()
 	if err != nil {
 		m.logger.Error("failed to retrieve raw messages", zap.Error(err))
-		return
+		return nil
 	}
 	m.PublishMessengerResponse(response)
+	return response
 }
 
 func (m *Messenger) PublishMessengerResponse(response *MessengerResponse) {

--- a/protocol/messenger.go
+++ b/protocol/messenger.go
@@ -153,6 +153,10 @@ type Messenger struct {
 	historicSyncInFlight      bool
 	lastHistoricSyncRequestAt time.Time
 
+	// communityHistoryFetches tracks cancellable, per-community spectate backfills
+	// so they can be aborted on leave / app-background (issue #21470-hf).
+	communityHistoryFetches *communityHistoryFetchRegistry
+
 	connectionStateMutex  sync.RWMutex
 	connectionState       connection.State
 	contractMaker         *contracts.ContractMaker
@@ -424,21 +428,22 @@ func NewMessenger(
 			logger: logger,
 			me:     selfContact,
 		},
-		allInstallations:      new(installationMap),
-		installationID:        installationID,
-		modifiedInstallations: new(stringBoolMap),
-		database:              database,
-		multiAccounts:         c.multiAccount,
-		settings:              settings,
-		verificationDatabase:  verification.NewPersistence(database),
-		mailserversDatabase:   c.mailserversDatabase,
-		account:               c.account,
-		quit:                  make(chan struct{}),
-		ctx:                   ctx,
-		cancel:                cancel,
-		importingCommunities:  make(map[string]bool),
-		importingChannels:     make(map[string]bool),
-		importRateLimiter:     rate.NewLimiter(rate.Every(importSlowRate), 1),
+		allInstallations:        new(installationMap),
+		installationID:          installationID,
+		modifiedInstallations:   new(stringBoolMap),
+		database:                database,
+		multiAccounts:           c.multiAccount,
+		settings:                settings,
+		verificationDatabase:    verification.NewPersistence(database),
+		mailserversDatabase:     c.mailserversDatabase,
+		account:                 c.account,
+		quit:                    make(chan struct{}),
+		ctx:                     ctx,
+		cancel:                  cancel,
+		importingCommunities:    make(map[string]bool),
+		importingChannels:       make(map[string]bool),
+		communityHistoryFetches: newCommunityHistoryFetchRegistry(),
+		importRateLimiter:       rate.NewLimiter(rate.Every(importSlowRate), 1),
 		importDelayer: struct {
 			wait chan struct{}
 			once sync.Once
@@ -553,6 +558,11 @@ func (m *Messenger) processSentMessage(id string) error {
 
 func (m *Messenger) SetPaused(paused bool) {
 	m.paused.Store(paused)
+	if paused {
+		// Backgrounding stops any in-flight scoped community history backfills, which
+		// on device were measured continuing headless after the UI died (#21470-hf).
+		m.communityHistoryFetches.cancelAll()
+	}
 	if m.ensVerifier != nil {
 		m.ensVerifier.SetPaused(paused)
 	}

--- a/protocol/messenger_communities.go
+++ b/protocol/messenger_communities.go
@@ -958,7 +958,14 @@ func (m *Messenger) SpectatedCommunities() ([]*communities.Community, error) {
 	return m.communitiesManager.Spectated()
 }
 
-func (m *Messenger) initCommunityChats(community *communities.Community) ([]*Chat, error) {
+// initCommunityChats initialises a community's chats and filters. When spectated is
+// true the broad, full-period history sync is NOT scheduled here — the caller
+// (SpectateCommunity) drives a scoped 24h backfill instead (issue #21470-hf). A
+// keyless spectator's full-period backfill of the community's single universal
+// content topic ingests gigabytes of undecryptable payloads; the broad sync scheduled
+// here would race the scoped one for the topic watermark and defeat the scoping.
+// Joining keeps today's behavior (the broad sync runs).
+func (m *Messenger) initCommunityChats(community *communities.Community, spectated bool) ([]*Chat, error) {
 	logger := m.logger.Named("initCommunityChats")
 
 	chats := CreateCommunityChats(community, m.getTimesource())
@@ -983,10 +990,13 @@ func (m *Messenger) initCommunityChats(community *communities.Community) ([]*Cha
 		filters = append(filters, communityFilters...)
 	}
 
-	willSync, err := m.scheduleSyncFilters(filters)
-	if err != nil {
-		logger.Debug("m.scheduleSyncFilters error", zap.Error(err))
-		return nil, err
+	willSync := false
+	if scoped, _ := communityInitialHistorySync(spectated); !scoped {
+		willSync, err = m.scheduleSyncFilters(filters)
+		if err != nil {
+			logger.Debug("m.scheduleSyncFilters error", zap.Error(err))
+			return nil, err
+		}
 	}
 
 	if !willSync {
@@ -1062,7 +1072,7 @@ func (m *Messenger) joinCommunity(ctx context.Context, communityID types3.HexByt
 
 	// chats and settings are already initialized for spectated communities
 	if !community.Spectated() {
-		chats, err := m.initCommunityChats(community)
+		chats, err := m.initCommunityChats(community, false)
 		if err != nil {
 			return nil, err
 		}
@@ -1147,7 +1157,7 @@ func (m *Messenger) SpectateCommunity(communityID types3.HexBytes) (*MessengerRe
 		return nil, err
 	}
 
-	chats, err := m.initCommunityChats(community)
+	chats, err := m.initCommunityChats(community, true)
 	if err != nil {
 		return nil, err
 	}
@@ -1161,8 +1171,12 @@ func (m *Messenger) SpectateCommunity(communityID types3.HexBytes) (*MessengerRe
 
 	response.AddCommunity(community)
 
-	// sync community
-	m.asyncRequestAllHistoricMessages()
+	// #21470-hf: a spectator holds no community keys, so the previous global
+	// full-period backfill of every filter pulled the community's single universal
+	// content topic as gigabytes of undecryptable payloads (measured ~2-3GB/11min at
+	// ~330% service CPU). Backfill ONLY this community's filters over a scoped 24h
+	// window, cancellable on leave / app-background.
+	m.asyncSyncSpectatedCommunity(community)
 
 	return response, nil
 }
@@ -2245,6 +2259,10 @@ func (m *Messenger) LeaveCommunity(communityID types3.HexBytes) (*MessengerRespo
 
 func (m *Messenger) leaveCommunity(communityID types3.HexBytes) (*MessengerResponse, error) {
 	response := &MessengerResponse{}
+
+	// Leaving (or unspectating) a community stops any in-flight scoped history
+	// backfill for it (issue #21470-hf).
+	m.communityHistoryFetches.cancel(communityID.String())
 
 	community, err := m.communitiesManager.LeaveCommunity(communityID)
 	if err != nil {
@@ -3633,7 +3651,7 @@ func (m *Messenger) InitHistoryArchiveTasks(communities []*communities.Community
 			}
 
 			// Request possibly missed waku messages for community
-			_, err = m.syncFiltersFrom(peerInfo, filters, uint32(latestWakuMessageTimestamp))
+			_, err = m.syncFiltersFrom(m.ctx, peerInfo, filters, uint32(latestWakuMessageTimestamp))
 			if err != nil {
 				m.logger.Error("failed to request missing messages", zap.Error(err))
 				continue

--- a/protocol/messenger_mailserver.go
+++ b/protocol/messenger_mailserver.go
@@ -1,6 +1,7 @@
 package protocol
 
 import (
+	"context"
 	"fmt"
 	"sort"
 	"time"
@@ -419,7 +420,7 @@ func getPrioritizedBatches() []int {
 	return []int{1, 5, 10}
 }
 
-func (m *Messenger) syncFiltersFrom(peerInfo peer.AddrInfo, filters types2.ChatFilters, lastRequest uint32) (*MessengerResponse, error) {
+func (m *Messenger) syncFiltersFrom(ctx context.Context, peerInfo peer.AddrInfo, filters types2.ChatFilters, lastRequest uint32) (*MessengerResponse, error) {
 	canSync, err := m.canSyncWithStoreNodes()
 	if err != nil {
 		return nil, err
@@ -558,7 +559,7 @@ func (m *Messenger) syncFiltersFrom(peerInfo peer.AddrInfo, filters types2.ChatF
 		batchKeys := maps.Keys(batches[pubsubTopic])
 		sort.Ints(batchKeys)
 		for _, k := range batchKeys {
-			err := m.processMailserverBatch(peerInfo, batches[pubsubTopic][k])
+			err := m.processMailserverBatchWithContext(ctx, peerInfo, batches[pubsubTopic][k])
 			if err != nil {
 				m.logger.Error("error syncing topics", zap.Error(err))
 				return nil, err
@@ -618,7 +619,7 @@ func (m *Messenger) syncFiltersFrom(peerInfo peer.AddrInfo, filters types2.ChatF
 }
 
 func (m *Messenger) syncFilters(peerInfo peer.AddrInfo, filters types2.ChatFilters) (*MessengerResponse, error) {
-	return m.syncFiltersFrom(peerInfo, filters, 0)
+	return m.syncFiltersFrom(m.ctx, peerInfo, filters, 0)
 }
 
 func (m *Messenger) calculateGapForChat(chat *Chat, from uint32) (*common.Message, error) {
@@ -684,6 +685,16 @@ func (m *Messenger) ConnectionChanged(state connection.State) {
 }
 
 func (m *Messenger) processMailserverBatch(peerInfo peer.AddrInfo, batch types2.StoreNodeBatch) error {
+	return m.processMailserverBatchWithContext(m.ctx, peerInfo, batch)
+}
+
+// processMailserverBatchWithContext is processMailserverBatch with a caller-supplied
+// context, so a request can be cancelled independently of the messenger lifetime
+// (used by the cancellable spectate backfill, issue #21470-hf). The go-waku history
+// paging loop checks ctx.Done() between pages, so cancelling ctx aborts an in-flight
+// request; watermarks are advanced only after a batch completes, so an aborted batch
+// leaves them untouched.
+func (m *Messenger) processMailserverBatchWithContext(ctx context.Context, peerInfo peer.AddrInfo, batch types2.StoreNodeBatch) error {
 	canSync, err := m.canSyncWithStoreNodes()
 	if err != nil {
 		return err
@@ -692,7 +703,7 @@ func (m *Messenger) processMailserverBatch(peerInfo peer.AddrInfo, batch types2.
 		return nil
 	}
 
-	return m.messaging.ProcessMailserverBatch(m.ctx, batch, peerInfo, defaultStoreNodeRequestPageSize, nil, false)
+	return m.messaging.ProcessMailserverBatch(ctx, batch, peerInfo, defaultStoreNodeRequestPageSize, nil, false)
 }
 
 func (m *Messenger) processMailserverBatchWithOptions(peerInfo peer.AddrInfo, batch types2.StoreNodeBatch, pageLimit uint64, shouldProcessNextPage func(int) (bool, uint64), processEnvelopes bool) error {

--- a/protocol/messenger_retrieve_loop_test.go
+++ b/protocol/messenger_retrieve_loop_test.go
@@ -1,0 +1,65 @@
+package protocol
+
+import (
+	"testing"
+	"time"
+)
+
+// TestNextFlushDeadline verifies the scheduling decision that bounds the
+// retrieve-loop debounce latency: normally the flush fires after a quiet
+// window (debounce) following the last match, but under a sustained match
+// flood the ceiling (maxLatency measured from the first unflushed match)
+// caps how long the flush can be delayed. See issue #21470.
+func TestNextFlushDeadline(t *testing.T) {
+	base := time.Unix(1000, 0)
+	debounce := time.Second
+	maxLatency := 3 * time.Second
+
+	tests := []struct {
+		name         string
+		pendingSince time.Time
+		now          time.Time
+		want         time.Time
+	}{
+		{
+			// First/isolated match: quiet window still fits under the ceiling,
+			// so behaviour is unchanged from the pure debounce.
+			name:         "quiet path debounce wins",
+			pendingSince: base,
+			now:          base,
+			want:         base.Add(debounce),
+		},
+		{
+			// Matches have been arriving for 2.5s without a quiet gap; the
+			// ceiling (pendingSince+3s) is sooner than now+1s and must win.
+			name:         "flood ceiling caps latency",
+			pendingSince: base.Add(-2500 * time.Millisecond),
+			now:          base,
+			want:         base.Add(500 * time.Millisecond),
+		},
+		{
+			// Exactly at the crossover: both deadlines land on now+1s.
+			name:         "boundary deadlines equal",
+			pendingSince: base.Add(-2 * time.Second),
+			now:          base,
+			want:         base.Add(debounce),
+		},
+		{
+			// Just past the crossover: ceiling wins by 1ms.
+			name:         "just past boundary ceiling wins",
+			pendingSince: base.Add(-2001 * time.Millisecond),
+			now:          base,
+			want:         base.Add(999 * time.Millisecond),
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := nextFlushDeadline(tc.pendingSince, tc.now, debounce, maxLatency)
+			if !got.Equal(tc.want) {
+				t.Fatalf("nextFlushDeadline(%v, %v, %v, %v) = %v, want %v",
+					tc.pendingSince, tc.now, debounce, maxLatency, got, tc.want)
+			}
+		})
+	}
+}

--- a/protocol/messenger_spectate_history_sync.go
+++ b/protocol/messenger_spectate_history_sync.go
@@ -19,14 +19,16 @@ import (
 // spectatedCommunityInitialSyncPeriod bounds the history backfill triggered when a
 // user spectates a community (issue #21470-hf).
 //
-// A spectator holds no community decryption keys, and every channel in a community
-// rides ONE universal content topic, so a full default-period (9-day) backfill pulls
-// the entire community's traffic as undecryptable payloads. Device measurement
-// (Samsung S21FE, fresh account spectating the Status community): ~2-3GB ingested in
-// ~11min at ~330% service CPU, GC-bound. Because all channels share one content
-// topic, per-channel scoping is impossible — the WINDOW is the only byte-cutting
-// lever, so spectate is bounded to 24h.
-const spectatedCommunityInitialSyncPeriod = 24 * time.Hour
+// History: this was briefly 24h as a byte-mitigation when the backfill fetched full
+// bodies for the whole universal topic (measured ~2-3GB / ~11min at ~330% service
+// CPU on a Samsung S21FE). With the backfill now hash-first (bodies fetched only
+// for unknown hashes), keyless spectators skipping undecryptable bodies entirely,
+// and the early-drop gates making residual bodies cheap, the full default sync
+// period is affordable again — so spectators get the same 9-day history horizon as
+// everyone else. The real wins of this path are retained: the sync is scoped to the
+// community's own filters (not the global all-filters sync), cancellable on
+// leave/background, and watermark-seeded.
+const spectatedCommunityInitialSyncPeriod = 9 * 24 * time.Hour
 
 // spectatedCommunitySyncFrom returns the store-node "from" timestamp (unix seconds)
 // for a spectator's scoped backfill: now minus the spectate window.
@@ -35,9 +37,9 @@ func spectatedCommunitySyncFrom(nowUnixSeconds uint32) uint32 {
 }
 
 // communityInitialHistorySync decides how a community's FIRST history backfill is
-// scoped. Spectators get the tight 24h window (deeper history is undecryptable heat);
-// joiners keep today's behavior — a full default-period backfill — because they hold
-// keys and legitimately want the history.
+// scoped. Spectators get a community-scoped default-period window (fetched
+// hash-first); joiners keep today's behavior — the full global backfill — because
+// they hold keys and legitimately want everything.
 func communityInitialHistorySync(spectated bool) (scoped bool, window time.Duration) {
 	if spectated {
 		return true, spectatedCommunityInitialSyncPeriod

--- a/protocol/messenger_spectate_history_sync.go
+++ b/protocol/messenger_spectate_history_sync.go
@@ -19,15 +19,15 @@ import (
 // spectatedCommunityInitialSyncPeriod bounds the history backfill triggered when a
 // user spectates a community (issue #21470-hf).
 //
-// History: this was briefly 24h as a byte-mitigation when the backfill fetched full
-// bodies for the whole universal topic (measured ~2-3GB / ~11min at ~330% service
-// CPU on a Samsung S21FE). With the backfill now hash-first (bodies fetched only
-// for unknown hashes), keyless spectators skipping undecryptable bodies entirely,
-// and the early-drop gates making residual bodies cheap, the full default sync
-// period is affordable again — so spectators get the same 9-day history horizon as
-// everyone else. The real wins of this path are retained: the sync is scoped to the
-// community's own filters (not the global all-filters sync), cancellable on
-// leave/background, and watermark-seeded.
+// The window matches the app-wide default sync period so spectators keep the
+// same history horizon as everyone else. What makes it affordable are the
+// processing fixes shipped alongside: undecryptable payloads drop early
+// instead of being ratchet-probed and parked (keyless gates), redelivered
+// descriptions short-circuit before the expensive pipeline (clock/hash gate),
+// segment reassembly is O(N), and the Go memory limit no longer forces
+// permanent GC thrash. The wins of this path itself: the sync is scoped to
+// the community's own filters (not the global all-filters sync), cancellable
+// on leave/background, and watermark-seeded.
 const spectatedCommunityInitialSyncPeriod = 9 * 24 * time.Hour
 
 // spectatedCommunitySyncFrom returns the store-node "from" timestamp (unix seconds)

--- a/protocol/messenger_spectate_history_sync.go
+++ b/protocol/messenger_spectate_history_sync.go
@@ -1,0 +1,289 @@
+package protocol
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"go.uber.org/zap"
+
+	"github.com/waku-org/go-waku/waku/v2/api/history"
+
+	gocommon "github.com/status-im/status-go/common"
+	types2 "github.com/status-im/status-go/pkg/messaging/types"
+	"github.com/status-im/status-go/protocol/communities"
+	"github.com/status-im/status-go/services/mailservers"
+)
+
+// spectatedCommunityInitialSyncPeriod bounds the history backfill triggered when a
+// user spectates a community (issue #21470-hf).
+//
+// A spectator holds no community decryption keys, and every channel in a community
+// rides ONE universal content topic, so a full default-period (9-day) backfill pulls
+// the entire community's traffic as undecryptable payloads. Device measurement
+// (Samsung S21FE, fresh account spectating the Status community): ~2-3GB ingested in
+// ~11min at ~330% service CPU, GC-bound. Because all channels share one content
+// topic, per-channel scoping is impossible — the WINDOW is the only byte-cutting
+// lever, so spectate is bounded to 24h.
+const spectatedCommunityInitialSyncPeriod = 24 * time.Hour
+
+// spectatedCommunitySyncFrom returns the store-node "from" timestamp (unix seconds)
+// for a spectator's scoped backfill: now minus the spectate window.
+func spectatedCommunitySyncFrom(nowUnixSeconds uint32) uint32 {
+	return nowUnixSeconds - uint32(spectatedCommunityInitialSyncPeriod/time.Second)
+}
+
+// communityInitialHistorySync decides how a community's FIRST history backfill is
+// scoped. Spectators get the tight 24h window (deeper history is undecryptable heat);
+// joiners keep today's behavior — a full default-period backfill — because they hold
+// keys and legitimately want the history.
+func communityInitialHistorySync(spectated bool) (scoped bool, window time.Duration) {
+	if spectated {
+		return true, spectatedCommunityInitialSyncPeriod
+	}
+	return false, 0
+}
+
+// mailserverTopicRef identifies a store-node topic (its pubsub + content topic).
+type mailserverTopicRef struct {
+	pubsubTopic  string
+	contentTopic string
+}
+
+// mailserverTopicKey is the map key syncFiltersFrom uses to look topics up; the seed
+// path must match it so a seeded topic is recognised as "already tracked".
+func mailserverTopicKey(pubsubTopic, contentTopic string) string {
+	return fmt.Sprintf("%s-%s", pubsubTopic, contentTopic)
+}
+
+// communityHistorySeedTopics returns the watermark rows to insert so a spectator's
+// first backfill of the given topics is bounded to lastRequest.
+//
+// syncFiltersFrom ignores its lastRequest argument for topics not yet present in the
+// mailserver DB (it hardcodes the default sync period for fresh topics), so without a
+// pre-seeded watermark a spectate would refetch the full default period. Topics
+// already tracked are skipped — AddTopics is INSERT-OR-REPLACE, and rewinding a good
+// watermark would refetch history we already have. Each topic is seeded at most once.
+func communityHistorySeedTopics(refs []mailserverTopicRef, existing map[string]struct{}, lastRequest int) []mailservers.MailserverTopic {
+	seeded := make(map[string]struct{}, len(refs))
+	var seeds []mailservers.MailserverTopic
+	for _, ref := range refs {
+		key := mailserverTopicKey(ref.pubsubTopic, ref.contentTopic)
+		if _, ok := existing[key]; ok {
+			continue
+		}
+		if _, ok := seeded[key]; ok {
+			continue
+		}
+		seeded[key] = struct{}{}
+		seeds = append(seeds, mailservers.MailserverTopic{
+			PubsubTopic:  ref.pubsubTopic,
+			ContentTopic: ref.contentTopic,
+			LastRequest:  lastRequest,
+		})
+	}
+	return seeds
+}
+
+// communitySyncFilters returns the transport filters that carry a community's
+// traffic: its single universal content topic plus the community-level filters. It
+// resolves the community's DefaultFilters chat ids to the live filters created when
+// the community was initialised. Every channel rides the one universal (community-id)
+// content topic, so this set covers all of the community's store-node bytes.
+func (m *Messenger) communitySyncFilters(community *communities.Community) types2.ChatFilters {
+	var filters types2.ChatFilters
+	seen := make(map[string]struct{})
+	for _, spec := range m.DefaultFilters(community) {
+		filter := m.messaging.ChatFilterByChatID(spec.ChatID)
+		if filter == nil {
+			continue
+		}
+		if _, ok := seen[filter.ChatID()]; ok {
+			continue
+		}
+		seen[filter.ChatID()] = struct{}{}
+		filters = append(filters, filter)
+	}
+	return filters
+}
+
+// seedCommunityHistoryWatermarks pre-seeds the mailserver watermark for each of the
+// given filters' topics that is not already tracked, so the spectate backfill's first
+// fetch is bounded to lastRequest instead of the full default sync period.
+func (m *Messenger) seedCommunityHistoryWatermarks(filters types2.ChatFilters, lastRequest int) error {
+	if m.mailserversDatabase == nil {
+		return nil
+	}
+
+	existingTopics, err := m.mailserversDatabase.Topics()
+	if err != nil {
+		return err
+	}
+	existing := make(map[string]struct{}, len(existingTopics))
+	for _, t := range existingTopics {
+		existing[mailserverTopicKey(t.PubsubTopic, t.ContentTopic)] = struct{}{}
+	}
+
+	refs := make([]mailserverTopicRef, 0, len(filters))
+	for _, filter := range filters {
+		refs = append(refs, mailserverTopicRef{
+			pubsubTopic:  filter.PubsubTopic(),
+			contentTopic: filter.ContentTopic().String(),
+		})
+	}
+
+	seeds := communityHistorySeedTopics(refs, existing, lastRequest)
+	if len(seeds) == 0 {
+		return nil
+	}
+	return m.mailserversDatabase.AddTopics(seeds)
+}
+
+// asyncSyncSpectatedCommunity backfills a freshly-spectated community's history over
+// the scoped 24h window (issue #21470-hf), replacing the global all-filters,
+// full-period backfill that spectating previously triggered. The fetch runs under a
+// per-community cancellable context registered on the messenger, so it stops when the
+// user leaves the community or the app is backgrounded.
+//
+// No message loss: skipped (older or cancelled) history stays on the store node; each
+// completed batch advances the per-topic watermark so later syncs resume exactly where
+// this one stopped; live relay delivery is unaffected; and the missing-message
+// verifier remains a net for anything not covered. A cancelled batch advances no
+// watermark, so nothing is marked fetched that was not.
+func (m *Messenger) asyncSyncSpectatedCommunity(community *communities.Community) {
+	shouldSync, err := m.shouldSync()
+	if err != nil {
+		m.logger.Error("failed to get shouldSync for spectated community", zap.Error(err))
+		return
+	}
+	if !shouldSync {
+		return
+	}
+
+	filters := m.communitySyncFilters(community)
+	if len(filters) == 0 {
+		return
+	}
+
+	communityID := community.IDString()
+	from := spectatedCommunitySyncFrom(uint32(m.getTimesource().GetCurrentTime() / 1000))
+
+	ctx, cancel := context.WithCancel(m.ctx)
+	token := m.communityHistoryFetches.register(communityID, cancel)
+
+	m.shutdownWaitGroup.Add(1)
+	go func() {
+		defer gocommon.LogOnPanic()
+		defer m.shutdownWaitGroup.Done()
+		defer cancel()
+		defer m.communityHistoryFetches.finish(communityID, token)
+
+		if err := m.seedCommunityHistoryWatermarks(filters, int(from)); err != nil {
+			m.logger.Warn("failed to seed spectated community history watermarks",
+				zap.String("communityID", communityID), zap.Error(err))
+			return
+		}
+
+		peerInfo := m.messaging.GetActiveStorenode()
+		_, err := m.performStorenodeTask(func() (*MessengerResponse, error) {
+			response, err := m.syncFiltersFrom(ctx, peerInfo, filters, from)
+			if err != nil {
+				if ctx.Err() != nil {
+					// Cancelled by leave / background: stop cleanly, without retrying
+					// or penalising the storenode's failure accounting.
+					m.logger.Debug("spectated community history sync cancelled",
+						zap.String("communityID", communityID))
+					return nil, nil
+				}
+				m.logger.Error("failed to sync spectated community history",
+					zap.String("communityID", communityID), zap.Error(err))
+				return nil, err
+			}
+			if m.config.messengerSignalsHandler != nil {
+				m.config.messengerSignalsHandler.MessengerResponse(response)
+			}
+			return response, nil
+		}, history.WithPeerID(peerInfo.ID))
+		if err != nil {
+			m.logger.Error("failed to perform spectated community history request",
+				zap.String("communityID", communityID), zap.Error(err))
+		}
+	}()
+}
+
+// communityHistoryFetchRegistry tracks the cancellable, per-community spectate
+// backfill goroutines so they can be aborted when the user leaves the community or
+// the app is backgrounded (issue #21470-hf, part B). On device the backfill was
+// measured continuing headless after the UI process died; cancellation stops it.
+//
+// Each registration is tagged with a monotonic token so a goroutine finishing on its
+// own only removes the map entry it still owns, never a fresher registration that
+// replaced it (context.CancelFunc values are not comparable, hence the token).
+type communityHistoryFetchRegistry struct {
+	mu      sync.Mutex
+	seq     uint64
+	entries map[string]communityHistoryFetchEntry
+}
+
+type communityHistoryFetchEntry struct {
+	token  uint64
+	cancel context.CancelFunc
+}
+
+func newCommunityHistoryFetchRegistry() *communityHistoryFetchRegistry {
+	return &communityHistoryFetchRegistry{
+		entries: make(map[string]communityHistoryFetchEntry),
+	}
+}
+
+// register records a new in-flight fetch for communityID, cancelling and replacing
+// any fetch already registered for it (e.g. a rapid re-spectate). It returns a token
+// identifying this registration, to be passed to finish.
+func (r *communityHistoryFetchRegistry) register(communityID string, cancel context.CancelFunc) uint64 {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if existing, ok := r.entries[communityID]; ok {
+		existing.cancel()
+	}
+	r.seq++
+	token := r.seq
+	r.entries[communityID] = communityHistoryFetchEntry{token: token, cancel: cancel}
+	return token
+}
+
+// cancel aborts the in-flight fetch for communityID (leave / unspectate path). It is
+// a no-op if none is registered.
+func (r *communityHistoryFetchRegistry) cancel(communityID string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if entry, ok := r.entries[communityID]; ok {
+		entry.cancel()
+		delete(r.entries, communityID)
+	}
+}
+
+// cancelAll aborts every in-flight fetch (app backgrounded).
+func (r *communityHistoryFetchRegistry) cancelAll() {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	for communityID, entry := range r.entries {
+		entry.cancel()
+		delete(r.entries, communityID)
+	}
+}
+
+// finish removes the registration for communityID IFF token still identifies the
+// current entry. A goroutine calls this on natural completion; if a newer fetch has
+// since replaced it, the entry is left untouched so the newer fetch stays cancellable.
+func (r *communityHistoryFetchRegistry) finish(communityID string, token uint64) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if entry, ok := r.entries[communityID]; ok && entry.token == token {
+		delete(r.entries, communityID)
+	}
+}

--- a/protocol/messenger_spectate_history_sync_test.go
+++ b/protocol/messenger_spectate_history_sync_test.go
@@ -14,13 +14,13 @@ import (
 // payloads (measured ~2-3GB/11min at ~330% service CPU on a Samsung S21FE). The
 // only byte-cutting lever is the WINDOW, because every channel rides one content
 // topic so per-channel scoping is impossible. Spectate is therefore bounded to a
-// tight 24h window; `from = now - 24h`.
+// scoped window matching the app's default sync period (9 days).
 func TestSpectatedCommunitySyncFrom(t *testing.T) {
-	require.Equal(t, 24*time.Hour, spectatedCommunityInitialSyncPeriod,
-		"spectate window must stay 24h — the measured heat lever")
+	require.Equal(t, 9*24*time.Hour, spectatedCommunityInitialSyncPeriod,
+		"spectate window matches the 9-day default sync period — affordable since hash-first + keyless-skip")
 
 	const now = uint32(1_700_000_000)
-	require.Equal(t, now-uint32(24*60*60), spectatedCommunitySyncFrom(now))
+	require.Equal(t, now-uint32(9*24*60*60), spectatedCommunitySyncFrom(now))
 }
 
 // TestCommunityInitialHistorySync verifies the spectate-vs-join scoping decision

--- a/protocol/messenger_spectate_history_sync_test.go
+++ b/protocol/messenger_spectate_history_sync_test.go
@@ -1,0 +1,162 @@
+package protocol
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestSpectatedCommunitySyncFrom verifies the spectate backfill window computation
+// (issue #21470-hf). A keyless spectator's full default-period backfill of a
+// community's single universal content topic ingests gigabytes of undecryptable
+// payloads (measured ~2-3GB/11min at ~330% service CPU on a Samsung S21FE). The
+// only byte-cutting lever is the WINDOW, because every channel rides one content
+// topic so per-channel scoping is impossible. Spectate is therefore bounded to a
+// tight 24h window; `from = now - 24h`.
+func TestSpectatedCommunitySyncFrom(t *testing.T) {
+	require.Equal(t, 24*time.Hour, spectatedCommunityInitialSyncPeriod,
+		"spectate window must stay 24h — the measured heat lever")
+
+	const now = uint32(1_700_000_000)
+	require.Equal(t, now-uint32(24*60*60), spectatedCommunitySyncFrom(now))
+}
+
+// TestCommunityInitialHistorySync verifies the spectate-vs-join scoping decision
+// (issue #21470-hf). A spectator holds no decryption keys, so deeper history is
+// pure heat and is scoped to 24h. A joiner holds keys and legitimately wants the
+// full default-period backfill, so joining must KEEP today's behavior (unscoped).
+func TestCommunityInitialHistorySync(t *testing.T) {
+	scoped, window := communityInitialHistorySync(true /* spectated */)
+	require.True(t, scoped, "spectators must use the scoped window")
+	require.Equal(t, spectatedCommunityInitialSyncPeriod, window)
+
+	scoped, window = communityInitialHistorySync(false /* joined */)
+	require.False(t, scoped, "joining must keep today's unscoped full-period backfill")
+	require.Equal(t, time.Duration(0), window)
+}
+
+// TestCommunityHistorySeedTopics verifies the watermark seeding that bounds a
+// spectator's FIRST backfill to the scoped window (issue #21470-hf). syncFiltersFrom
+// ignores its `lastRequest` argument for topics not yet tracked — a fresh topic
+// always defaults to the full sync period. So before syncing we seed each of the
+// community's topics with a `now-24h` watermark. Topics already tracked must be
+// SKIPPED (INSERT-OR-REPLACE would otherwise rewind a good watermark and refetch),
+// and each topic is seeded at most once.
+func TestCommunityHistorySeedTopics(t *testing.T) {
+	const from = 1_699_913_600 // now - 24h
+
+	refs := []mailserverTopicRef{
+		{pubsubTopic: "pubA", contentTopic: "0x01"}, // fresh -> seed
+		{pubsubTopic: "pubA", contentTopic: "0x02"}, // already tracked -> skip
+		{pubsubTopic: "pubA", contentTopic: "0x01"}, // duplicate of the first -> seed once
+	}
+	existing := map[string]struct{}{
+		mailserverTopicKey("pubA", "0x02"): {},
+	}
+
+	seeds := communityHistorySeedTopics(refs, existing, from)
+
+	require.Len(t, seeds, 1, "only the fresh topic is seeded, exactly once")
+	require.Equal(t, "pubA", seeds[0].PubsubTopic)
+	require.Equal(t, "0x01", seeds[0].ContentTopic)
+	require.Equal(t, from, seeds[0].LastRequest)
+}
+
+// TestCommunityHistorySeedTopics_AllTracked verifies that when every topic is already
+// tracked, nothing is seeded (leaving each topic's existing watermark to drive an
+// incremental, already-bounded sync).
+func TestCommunityHistorySeedTopics_AllTracked(t *testing.T) {
+	refs := []mailserverTopicRef{{pubsubTopic: "pubA", contentTopic: "0x01"}}
+	existing := map[string]struct{}{mailserverTopicKey("pubA", "0x01"): {}}
+
+	require.Empty(t, communityHistorySeedTopics(refs, existing, 123))
+}
+
+// --- cancel registry -------------------------------------------------------
+
+// fakeCancel records how many times it was invoked, standing in for a
+// context.CancelFunc without needing a live context.
+type fakeCancel struct {
+	calls *int
+}
+
+func (f fakeCancel) cancel() { *f.calls++ }
+
+// TestCommunityHistoryFetchRegistry_LeaveAndBackground verifies the cancel-registry
+// semantics that make the spectate backfill cancellable (issue #21470-hf, part B):
+// the device-measured backfill continues headless after the UI dies, so leaving a
+// community and backgrounding the app must both stop it.
+func TestCommunityHistoryFetchRegistry_LeaveAndBackground(t *testing.T) {
+	r := newCommunityHistoryFetchRegistry()
+
+	aCalls, bCalls := 0, 0
+	a := fakeCancel{&aCalls}
+	b := fakeCancel{&bCalls}
+
+	// register two in-flight community fetches
+	_ = r.register("communityA", a.cancel)
+	_ = r.register("communityB", b.cancel)
+
+	// leaving communityA cancels only its fetch
+	r.cancel("communityA")
+	require.Equal(t, 1, aCalls)
+	require.Equal(t, 0, bCalls)
+
+	// cancelling an already-cancelled / unknown id is a no-op
+	r.cancel("communityA")
+	r.cancel("unknown")
+	require.Equal(t, 1, aCalls)
+
+	// backgrounding cancels everything still in flight
+	r.cancelAll()
+	require.Equal(t, 1, bCalls)
+	require.Equal(t, 1, aCalls, "A was already removed by leave, must not be re-cancelled")
+}
+
+// TestCommunityHistoryFetchRegistry_ReplaceAndFinish verifies that re-spectating the
+// same community cancels the stale in-flight fetch, and that a fetch which finishes
+// on its own only cleans up the map entry it still owns (never a newer one's).
+func TestCommunityHistoryFetchRegistry_ReplaceAndFinish(t *testing.T) {
+	r := newCommunityHistoryFetchRegistry()
+
+	firstCalls, secondCalls := 0, 0
+	first := fakeCancel{&firstCalls}
+	second := fakeCancel{&secondCalls}
+
+	tok1 := r.register("communityA", first.cancel)
+
+	// re-spectating communityA replaces (and cancels) the stale fetch
+	tok2 := r.register("communityA", second.cancel)
+	require.Equal(t, 1, firstCalls, "stale fetch must be cancelled on re-register")
+	require.NotEqual(t, tok1, tok2, "each registration gets a distinct token")
+
+	// the FIRST fetch's goroutine now finishes and tries to clean up. It must NOT
+	// remove the second fetch's entry (it no longer owns the slot).
+	r.finish("communityA", tok1)
+
+	// cancelling communityA must still reach the second (current) fetch
+	r.cancel("communityA")
+	require.Equal(t, 1, secondCalls, "current fetch must remain cancellable after a stale finish")
+
+	// a fetch that finishes on its own removes its entry, so a later cancel is a no-op
+	thirdCalls := 0
+	third := fakeCancel{&thirdCalls}
+	tok3 := r.register("communityA", third.cancel)
+	r.finish("communityA", tok3)
+	r.cancel("communityA")
+	require.Equal(t, 0, thirdCalls, "finish removed the entry, so cancel must not reach the completed fetch")
+}
+
+// TestCommunityHistoryFetchRegistry_ContextCancelFunc is a light integration check
+// that a real context.CancelFunc registered in the registry cancels its context.
+func TestCommunityHistoryFetchRegistry_ContextCancelFunc(t *testing.T) {
+	r := newCommunityHistoryFetchRegistry()
+	ctx, cancel := context.WithCancel(context.Background())
+	_ = r.register("communityA", cancel)
+
+	require.NoError(t, ctx.Err())
+	r.cancel("communityA")
+	require.ErrorIs(t, ctx.Err(), context.Canceled)
+}

--- a/protocol/messenger_store_node_request_manager.go
+++ b/protocol/messenger_store_node_request_manager.go
@@ -407,6 +407,26 @@ func (r *storeNodeRequest) shouldFetchNextPageUncapped(envelopesCount int) (bool
 		}
 
 		if community == nil {
+			// The community is absent from the community table, but it may already
+			// be in hand and merely withheld pending on-chain owner validation. In
+			// that state the description has been fetched and only verification is
+			// blocking persistence; verification retries out-of-band on the
+			// owner-verification loop. Fetching more store-node pages cannot make a
+			// failed verification succeed — it only floods the network and starves
+			// the very RPC calls whose success would end the request (issue
+			// #21470-hf). So once the description is queued for validation, stop.
+			queuedClock, qErr := r.manager.messenger.communitiesManager.HighestQueuedValidationClock(communityID)
+			if qErr != nil {
+				logger.Warn("failed to read community validation queue; continuing to page",
+					zap.String("communityID", r.requestID.DataID),
+					zap.Error(qErr))
+			} else if gateNextPageByValidationQueue(false, queuedClock, r.minimumDataClock) {
+				logger.Info("community description queued for owner validation; stopping pagination (verification retries out-of-band)",
+					zap.Uint64("queuedClock", queuedClock),
+					zap.Uint64("minimumDataClock", r.minimumDataClock))
+				return false, 0
+			}
+
 			// community not found in the database, request next page
 			logger.Debug("community still not fetched")
 			return true, r.config.FurtherPageSize

--- a/protocol/messenger_store_node_request_manager.go
+++ b/protocol/messenger_store_node_request_manager.go
@@ -75,7 +75,7 @@ func NewStoreNodeRequestManager(m *Messenger) *StoreNodeRequestManager {
 // Automatically waits for an available store node.
 // When a `nil` community and `nil` error is returned, that means the community wasn't found at the store node.
 func (m *StoreNodeRequestManager) FetchCommunity(ctx context.Context, communityID string, opts []StoreNodeRequestOption) (*communities.Community, StoreNodeRequestStats, error) {
-	cfg := buildStoreNodeRequestConfig(opts)
+	cfg := buildCommunityStoreNodeRequestConfig(opts)
 
 	m.logger.Info("requesting community from store node",
 		zap.String("community", communityID),
@@ -381,7 +381,21 @@ func (r *storeNodeRequest) shouldFetchNextPageUncapped(envelopesCount int) (bool
 	// Force all received envelopes to be processed. We keep the resulting
 	// response so a community request can tell whether this page actually
 	// carried a description for the target community (issue #21470-hf).
-	response := r.manager.messenger.ProcessAllMessages()
+	//
+	// Skip the walk entirely for an empty page: ProcessAllMessages traverses the
+	// messenger's whole pending backlog, but its only job here is to flush THIS
+	// page's envelopes into the DB before the GetByID check. With zero envelopes
+	// there is nothing of ours to flush, and during a channel backfill re-walking
+	// that fat queue on every empty page — to the cap, per dead id — is the CPU/GC
+	// storm behind the device overheat (issue #21470-hf). The DB check below still
+	// runs, so a description delivered by a parallel channel-sync page is not
+	// missed; only the redundant processing is dropped.
+	var response *MessengerResponse
+	if shouldProcessStoreNodePage(envelopesCount) {
+		response = r.manager.messenger.ProcessAllMessages()
+	} else {
+		logger.Debug("skipping ProcessAllMessages for empty store node page")
+	}
 
 	// Try to get community from database
 	switch r.requestID.RequestType {

--- a/protocol/messenger_store_node_request_manager.go
+++ b/protocol/messenger_store_node_request_manager.go
@@ -1,6 +1,7 @@
 package protocol
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"sync"
@@ -270,6 +271,13 @@ type storeNodeRequest struct {
 	minimumDataClock uint64
 	config           StoreNodeRequestConfig
 
+	// descriptionSeen latches true once a description for the requested community
+	// has been processed in this request. Store-node history is paged
+	// newest-first, so any later page can only carry an older description; once
+	// this is set, further paging cannot yield a newer one and is stopped by
+	// gateNextPageByDescriptionSeen (issue #21470-hf).
+	descriptionSeen bool
+
 	// request corresponding metadata to be used in finalize
 	filterToForget *types2.ChatFilter
 
@@ -342,6 +350,14 @@ func (r *storeNodeRequest) finalize() {
 func (r *storeNodeRequest) shouldFetchNextPage(envelopesCount int) (bool, uint64) {
 	fetchNext, pageSize := r.shouldFetchNextPageUncapped(envelopesCount)
 
+	fetchNext, descriptionGateTripped := r.config.gateNextPageByDescriptionSeen(fetchNext, r.descriptionSeen)
+	if descriptionGateTripped {
+		r.manager.logger.Info("community description seen and not newer; stopping pagination (older pages cannot contain newer descriptions)",
+			zap.Any("requestID", r.requestID),
+			zap.Int("fetchedPagesCount", r.result.stats.FetchedPagesCount),
+			zap.Int("fetchedEnvelopesCount", r.result.stats.FetchedEnvelopesCount))
+	}
+
 	fetchNext, pageSize, capTripped := r.config.gateNextPageByCap(fetchNext, pageSize, r.result.stats.FetchedPagesCount)
 	if capTripped {
 		r.manager.logger.Warn("store node request reached page cap; stopping pagination to bound runaway fetch",
@@ -362,8 +378,10 @@ func (r *storeNodeRequest) shouldFetchNextPageUncapped(envelopesCount int) (bool
 	r.result.stats.FetchedEnvelopesCount += envelopesCount
 	r.result.stats.FetchedPagesCount++
 
-	// Force all received envelopes to be processed
-	r.manager.messenger.ProcessAllMessages()
+	// Force all received envelopes to be processed. We keep the resulting
+	// response so a community request can tell whether this page actually
+	// carried a description for the target community (issue #21470-hf).
+	response := r.manager.messenger.ProcessAllMessages()
 
 	// Try to get community from database
 	switch r.requestID.RequestType {
@@ -378,6 +396,14 @@ func (r *storeNodeRequest) shouldFetchNextPageUncapped(envelopesCount int) (bool
 				err:       fmt.Errorf("failed to decode community ID: %w", err),
 			}
 			return false, 0 // failed to decode community ID, no sense to continue the procedure
+		}
+
+		// Store-node history is paged newest-first, so the first page that carries
+		// a description for this community carries the newest available one. Latch
+		// that here; once set, gateNextPageByDescriptionSeen stops paging because
+		// older pages cannot contain a newer description (issue #21470-hf).
+		if !r.descriptionSeen && communityDescriptionSeen(response, communityID) {
+			r.descriptionSeen = true
 		}
 
 		// check if community is waiting for a verification and do a verification manually
@@ -531,4 +557,25 @@ func (r *storeNodeRequest) routine() {
 
 func (r *storeNodeRequest) start() {
 	go r.routine()
+}
+
+// communityDescriptionSeen reports whether the processed-messages response
+// carries a description for the given community. A processed community
+// description surfaces the community in the MessengerResponse via
+// handleCommunityResponse -> AddCommunity — including the equal-clock
+// re-processing that drives issue #21470-hf (UpdateCommunityDescription only
+// rejects strictly-older clocks, so a re-fetched identical description still
+// flows through and is added). Its presence is therefore the request-scoped
+// "a description for this community was processed this page" signal used by
+// gateNextPageByDescriptionSeen.
+func communityDescriptionSeen(response *MessengerResponse, communityID []byte) bool {
+	if response == nil {
+		return false
+	}
+	for _, c := range response.Communities() {
+		if c != nil && bytes.Equal(c.ID(), communityID) {
+			return true
+		}
+	}
+	return false
 }

--- a/protocol/messenger_store_node_request_manager.go
+++ b/protocol/messenger_store_node_request_manager.go
@@ -329,7 +329,32 @@ func (r *storeNodeRequest) finalize() {
 	}
 }
 
+// shouldFetchNextPage decides whether the store-node pager should request
+// another page. It wraps the natural per-page decision with a hard page ceiling
+// (issue #21470-hf): once a request has processed config.MaxPageCount pages
+// without resolving, pagination is stopped even if the natural decision would
+// keep going. This bounds requests that can never terminate (e.g. a token-owned
+// community stuck in owner validation) so they don't drain the full store-node
+// window and overheat the device. Requests that resolve before the cap are
+// completely unaffected. On a cap-forced stop we return false, which drives the
+// request through the same finalize() path as an ordinary "not found" result,
+// so the UI's loading state clears normally.
 func (r *storeNodeRequest) shouldFetchNextPage(envelopesCount int) (bool, uint64) {
+	fetchNext, pageSize := r.shouldFetchNextPageUncapped(envelopesCount)
+
+	fetchNext, pageSize, capTripped := r.config.gateNextPageByCap(fetchNext, pageSize, r.result.stats.FetchedPagesCount)
+	if capTripped {
+		r.manager.logger.Warn("store node request reached page cap; stopping pagination to bound runaway fetch",
+			zap.Any("requestID", r.requestID),
+			zap.Int("fetchedPagesCount", r.result.stats.FetchedPagesCount),
+			zap.Int("fetchedEnvelopesCount", r.result.stats.FetchedEnvelopesCount),
+			zap.Int("maxPageCount", r.config.MaxPageCount))
+	}
+
+	return fetchNext, pageSize
+}
+
+func (r *storeNodeRequest) shouldFetchNextPageUncapped(envelopesCount int) (bool, uint64) {
 	logger := r.manager.logger.With(
 		zap.Any("requestID", r.requestID),
 		zap.Int("envelopesCount", envelopesCount))

--- a/protocol/messenger_store_node_request_manager_config.go
+++ b/protocol/messenger_store_node_request_manager_config.go
@@ -60,6 +60,35 @@ func gateNextPageByValidationQueue(communityInDB bool, queuedClock, minimumDataC
 	return queuedClock > minimumDataClock
 }
 
+// gateNextPageByDescriptionSeen decides whether store-node pagination for a
+// community request should stop because a description for the target community
+// has already been processed in this request (issue #21470-hf).
+//
+// Store-node history is paged newest-first: the go-waku HistoryRetriever builds
+// each StoreQueryRequest with PaginationForward unset (proto3 default false =
+// backward) and walks the time window from newest to oldest. So the first
+// description encountered for the community is the newest available, and every
+// later page can only carry an older one. Once any description has been
+// processed, continuing to page cannot yield a newer description; each extra
+// page merely re-unmarshals and re-preprocesses the (large, ~1.4MB) description,
+// driving a GC storm that overheats the device. This is the flood that remains
+// after the page-cap and validation-queue gates: the "community persisted but
+// not newer than minimumDataClock" branch keeps paging to the cap and is
+// re-issued perpetually as the spectated community's description is re-fetched.
+//
+// Like the other gates it only ever converts a "fetch next page" decision into a
+// stop; it never forces paging. When StopWhenDataFound is false the caller wants
+// a full-window walk regardless of what is found (mirroring the success-path
+// `!StopWhenDataFound` return), so this gate is disabled and returns the natural
+// decision unchanged. gateTripped reports whether this gate forced the stop, so
+// the caller can log it distinctly from an ordinary completion.
+func (c StoreNodeRequestConfig) gateNextPageByDescriptionSeen(fetchNext, descriptionSeen bool) (shouldFetch, gateTripped bool) {
+	if fetchNext && c.StopWhenDataFound && descriptionSeen {
+		return false, true
+	}
+	return fetchNext, false
+}
+
 type StoreNodeRequestOption func(*StoreNodeRequestConfig)
 
 func defaultStoreNodeRequestConfig() StoreNodeRequestConfig {

--- a/protocol/messenger_store_node_request_manager_config.go
+++ b/protocol/messenger_store_node_request_manager_config.go
@@ -9,6 +9,19 @@ package protocol
 // full 31-day store-node window and burns CPU/battery on the device.
 const maxStoreNodeRequestPageCount = 30
 
+// maxCommunityStoreNodeRequestPageCount caps community fetches far more tightly
+// than the generic contact cap (issue #21470-hf). Store queries page newest-first
+// (verified in go-waku history.go: PaginationForward unset => proto3 default false
+// => backward) and community descriptions are republished periodically, so a live
+// community's description lands within the first pages; the description-seen gate
+// (6cd6ced1a) then stops the request on that hit. Deeper paging can therefore only
+// ever chew empty/irrelevant history — exactly the device failure mode: dead
+// curated ids each cost a ~minutes-long 30-page run finalizing with
+// fetchedEnvelopesCount=0. 3 pages keeps a healthy fetch (1-2 pages) untouched
+// while collapsing a dead-id run to a fraction of its former cost. Applied only at
+// the community construction site; the contact/default cap stays at 30.
+const maxCommunityStoreNodeRequestPageCount = 3
+
 type StoreNodeRequestConfig struct {
 	WaitForResponse   bool
 	StopWhenDataFound bool
@@ -89,6 +102,19 @@ func (c StoreNodeRequestConfig) gateNextPageByDescriptionSeen(fetchNext, descrip
 	return fetchNext, false
 }
 
+// shouldProcessStoreNodePage reports whether the forced per-page
+// Messenger.ProcessAllMessages should run for a page that carried envelopesCount
+// envelopes (issue #21470-hf). ProcessAllMessages walks the messenger's whole
+// pending backlog; the store-node pager only forces it to flush THIS request's
+// just-fetched envelopes into the DB before the GetByID check. A page with zero
+// envelopes has nothing of ours to flush, so processing it only re-walks the
+// (possibly fat) backfill queue for no gain — the CPU/GC amplification observed on
+// device. Skip it; the subsequent DB check still runs so a description delivered
+// by a parallel channel-sync page is not missed.
+func shouldProcessStoreNodePage(envelopesCount int) bool {
+	return envelopesCount > 0
+}
+
 type StoreNodeRequestOption func(*StoreNodeRequestConfig)
 
 func defaultStoreNodeRequestConfig() StoreNodeRequestConfig {
@@ -101,14 +127,34 @@ func defaultStoreNodeRequestConfig() StoreNodeRequestConfig {
 	}
 }
 
-func buildStoreNodeRequestConfig(opts []StoreNodeRequestOption) StoreNodeRequestConfig {
+// defaultCommunityStoreNodeRequestConfig is the base config for community fetches.
+// It matches the shared default in every field except the page cap, which is
+// tightened to maxCommunityStoreNodeRequestPageCount (issue #21470-hf).
+func defaultCommunityStoreNodeRequestConfig() StoreNodeRequestConfig {
 	cfg := defaultStoreNodeRequestConfig()
+	cfg.MaxPageCount = maxCommunityStoreNodeRequestPageCount
+	return cfg
+}
 
+func applyStoreNodeRequestOptions(cfg StoreNodeRequestConfig, opts []StoreNodeRequestOption) StoreNodeRequestConfig {
 	for _, opt := range opts {
 		opt(&cfg)
 	}
 
 	return cfg
+}
+
+// buildStoreNodeRequestConfig builds the config for a contact fetch (the generic
+// default, 30-page cap). Caller options are folded on top.
+func buildStoreNodeRequestConfig(opts []StoreNodeRequestOption) StoreNodeRequestConfig {
+	return applyStoreNodeRequestOptions(defaultStoreNodeRequestConfig(), opts)
+}
+
+// buildCommunityStoreNodeRequestConfig builds the config for a community fetch,
+// starting from the tighter community default (3-page cap). Caller options are
+// still folded on top and can override the cap (issue #21470-hf).
+func buildCommunityStoreNodeRequestConfig(opts []StoreNodeRequestOption) StoreNodeRequestConfig {
+	return applyStoreNodeRequestOptions(defaultCommunityStoreNodeRequestConfig(), opts)
 }
 
 func WithWaitForResponseOption(waitForResponse bool) StoreNodeRequestOption {

--- a/protocol/messenger_store_node_request_manager_config.go
+++ b/protocol/messenger_store_node_request_manager_config.go
@@ -1,10 +1,35 @@
 package protocol
 
+// maxStoreNodeRequestPageCount is a hard ceiling on the number of store-node
+// response pages a single storeNodeRequest may process before giving up (issue
+// #21470-hf). Normal community/contact fetches resolve in 1-2 pages; this is
+// deliberately generous (~15x) so it never affects healthy requests, while
+// still bounding a request that can never terminate — e.g. a token-owned
+// community whose owner validation keeps failing, which otherwise drains the
+// full 31-day store-node window and burns CPU/battery on the device.
+const maxStoreNodeRequestPageCount = 30
+
 type StoreNodeRequestConfig struct {
 	WaitForResponse   bool
 	StopWhenDataFound bool
 	InitialPageSize   uint64
 	FurtherPageSize   uint64
+	// MaxPageCount caps how many pages a single request may process. A value
+	// of 0 disables the cap.
+	MaxPageCount int
+}
+
+// gateNextPageByCap applies the per-request page ceiling to a natural
+// pagination decision. It only ever converts a "fetch next page" decision into
+// a stop; it never forces additional paging, and it is a no-op both when the
+// natural decision is already to stop and when the cap is disabled
+// (MaxPageCount <= 0). capTripped reports whether the cap itself forced the
+// stop, so the caller can log it distinctly from an ordinary completion.
+func (c StoreNodeRequestConfig) gateNextPageByCap(fetchNext bool, nextPageSize uint64, fetchedPagesCount int) (shouldFetch bool, pageSize uint64, capTripped bool) {
+	if fetchNext && c.MaxPageCount > 0 && fetchedPagesCount >= c.MaxPageCount {
+		return false, 0, true
+	}
+	return fetchNext, nextPageSize, false
 }
 
 type StoreNodeRequestOption func(*StoreNodeRequestConfig)
@@ -15,6 +40,7 @@ func defaultStoreNodeRequestConfig() StoreNodeRequestConfig {
 		StopWhenDataFound: true,
 		InitialPageSize:   initialStoreNodeRequestPageSize,
 		FurtherPageSize:   defaultStoreNodeRequestPageSize,
+		MaxPageCount:      maxStoreNodeRequestPageCount,
 	}
 }
 
@@ -49,5 +75,11 @@ func WithInitialPageSize(initialPageSize uint64) StoreNodeRequestOption {
 func WithFurtherPageSize(furtherPageSize uint64) StoreNodeRequestOption {
 	return func(c *StoreNodeRequestConfig) {
 		c.FurtherPageSize = furtherPageSize
+	}
+}
+
+func WithMaxPageCount(maxPageCount int) StoreNodeRequestOption {
+	return func(c *StoreNodeRequestConfig) {
+		c.MaxPageCount = maxPageCount
 	}
 }

--- a/protocol/messenger_store_node_request_manager_config.go
+++ b/protocol/messenger_store_node_request_manager_config.go
@@ -32,6 +32,34 @@ func (c StoreNodeRequestConfig) gateNextPageByCap(fetchNext bool, nextPageSize u
 	return fetchNext, nextPageSize, false
 }
 
+// gateNextPageByValidationQueue decides whether store-node pagination for a
+// community request should stop because the community's description is already
+// in hand and only blocked on owner validation (issue #21470-hf).
+//
+// For a token-owned community the pager stops when the community is persisted,
+// but persistence is withheld until on-chain owner verification succeeds. On a
+// transport failure (RPC timeout, dead proxy, rate limit) verification neither
+// succeeds nor rejects, so the pager — which only knows "community not in the
+// table yet" — wrongly requests another page. A new page cannot revive a dead
+// RPC; it only floods the network and starves the very verification calls whose
+// success would end the request. Once we hold the description (it is queued for
+// validation), fetching more pages is pointless: verification retries out-of-band
+// on the owner-verification loop and publishes once it eventually succeeds.
+//
+// queuedClock is the highest clock among the descriptions queued for validation
+// for this community (0 if none are queued). A queued description only supersedes
+// further paging when it is newer than the clock we already hold
+// (minimumDataClock) — mirroring the "is this description newer" test the pager
+// applies when the community IS found. communityInDB short-circuits to false so
+// the found path (with its own clock check) remains solely responsible for that
+// case.
+func gateNextPageByValidationQueue(communityInDB bool, queuedClock, minimumDataClock uint64) bool {
+	if communityInDB {
+		return false
+	}
+	return queuedClock > minimumDataClock
+}
+
 type StoreNodeRequestOption func(*StoreNodeRequestConfig)
 
 func defaultStoreNodeRequestConfig() StoreNodeRequestConfig {

--- a/protocol/messenger_store_node_request_manager_config.go
+++ b/protocol/messenger_store_node_request_manager_config.go
@@ -9,18 +9,18 @@ package protocol
 // full 31-day store-node window and burns CPU/battery on the device.
 const maxStoreNodeRequestPageCount = 30
 
-// maxCommunityStoreNodeRequestPageCount caps community fetches far more tightly
-// than the generic contact cap (issue #21470-hf). Store queries page newest-first
-// (verified in go-waku history.go: PaginationForward unset => proto3 default false
-// => backward) and community descriptions are republished periodically, so a live
-// community's description lands within the first pages; the description-seen gate
-// (6cd6ced1a) then stops the request on that hit. Deeper paging can therefore only
-// ever chew empty/irrelevant history — exactly the device failure mode: dead
-// curated ids each cost a ~minutes-long 30-page run finalizing with
-// fetchedEnvelopesCount=0. 3 pages keeps a healthy fetch (1-2 pages) untouched
-// while collapsing a dead-id run to a fraction of its former cost. Applied only at
-// the community construction site; the contact/default cap stays at 30.
-const maxCommunityStoreNodeRequestPageCount = 3
+// maxCommunityStoreNodeRequestPageCount caps community fetches (issue #21470-hf).
+// Store queries page newest-first, but on a HIGH-TRAFFIC community the universal
+// content topic carries all channels' messages, so the periodically-republished
+// description can sit well below the newest pages: on-device (Samsung S21FE, dev
+// fleet) a 3-page cap made the Status community's 1.4MB description UNREACHABLE —
+// 62 capped fetch attempts, zero resolves, community permanently absent from
+// Discover — while low-traffic communities resolved in 1-2 pages. 30 pages
+// (~1500 envelopes) reliably reached it in every measured run. Deep pages are
+// affordable now that undecryptable envelopes drop early (keyless gate,
+// 36dd3cf7f) and empty pages skip processing; the description-seen gate
+// (6cd6ced1a) still stops a request the moment the description appears.
+const maxCommunityStoreNodeRequestPageCount = 30
 
 type StoreNodeRequestConfig struct {
 	WaitForResponse   bool

--- a/protocol/messenger_store_node_request_manager_config_test.go
+++ b/protocol/messenger_store_node_request_manager_config_test.go
@@ -100,3 +100,89 @@ func TestGateNextPageByValidationQueue(t *testing.T) {
 		require.False(t, gateNextPageByValidationQueue(false, 90, 100))
 	})
 }
+
+// TestGateNextPageByDescriptionSeen verifies the decision that stops store-node
+// pagination for a community request once a description for the target community
+// has already been processed in this request (issue #21470-hf). Store-node
+// history is paged newest-first, so the first description encountered is the
+// newest available and every later page can only carry an older one. Continuing
+// to page therefore cannot yield a newer description; it only re-unmarshals and
+// re-preprocesses the (large) description on each page, driving a GC storm and
+// overheating the device. This is the remaining flood after the page cap and
+// validation-queue gates: the "community persisted but not newer" branch
+// (messenger_store_node_request_manager.go, community.Clock() <= minimumDataClock)
+// which today keeps paging to the cap and is re-issued perpetually.
+func TestGateNextPageByDescriptionSeen(t *testing.T) {
+	t.Run("description not seen keeps the natural decision", func(t *testing.T) {
+		// No description for this community has been processed yet, so paging must
+		// continue up to the cap exactly as before.
+		cfg := StoreNodeRequestConfig{StopWhenDataFound: true}
+		fetch, tripped := cfg.gateNextPageByDescriptionSeen(true, false)
+		require.True(t, fetch)
+		require.False(t, tripped)
+	})
+
+	t.Run("description seen stops paging and reports the trip", func(t *testing.T) {
+		// The core #21470-hf bug: a spectated community is re-fetched,
+		// minimumDataClock == its clock, so every page hits the "not newer" branch
+		// and would keep paging. Once the description was processed this request,
+		// older pages cannot beat it, so we stop and report the trip so the caller
+		// can log it distinctly.
+		cfg := StoreNodeRequestConfig{StopWhenDataFound: true}
+		fetch, tripped := cfg.gateNextPageByDescriptionSeen(true, true)
+		require.False(t, fetch)
+		require.True(t, tripped)
+	})
+
+	t.Run("natural stop is never overridden and never reports a trip", func(t *testing.T) {
+		// The uncapped decision is already "stop" (e.g. found-and-newer, or a
+		// decode/validate error). Even with the description seen, this gate must
+		// not claim responsibility for the stop.
+		cfg := StoreNodeRequestConfig{StopWhenDataFound: true}
+		fetch, tripped := cfg.gateNextPageByDescriptionSeen(false, true)
+		require.False(t, fetch)
+		require.False(t, tripped)
+	})
+
+	t.Run("full-window walk (StopWhenDataFound=false) is never cut short", func(t *testing.T) {
+		// Mirrors the success-path `!StopWhenDataFound` return: a caller that
+		// wants the entire window must keep paging even after the description is
+		// seen. The gate is disabled and returns the natural decision unchanged.
+		cfg := StoreNodeRequestConfig{StopWhenDataFound: false}
+		fetch, tripped := cfg.gateNextPageByDescriptionSeen(true, true)
+		require.True(t, fetch)
+		require.False(t, tripped)
+	})
+}
+
+// TestCommunityDescriptionSeen verifies the request-scoped signal that feeds the
+// description-seen gate: whether the messages processed for a store-node page
+// carried a description for the target community. A processed description
+// surfaces the community in the MessengerResponse (handleCommunityResponse ->
+// AddCommunity), including the equal-clock re-processing that drives issue
+// #21470-hf, so its presence in the response is the "a description for this
+// community was processed this page" signal.
+func TestCommunityDescriptionSeen(t *testing.T) {
+	community := createTestCommunityWithImage(t)
+
+	t.Run("nil response is not seen", func(t *testing.T) {
+		require.False(t, communityDescriptionSeen(nil, community.ID()))
+	})
+
+	t.Run("empty response is not seen", func(t *testing.T) {
+		require.False(t, communityDescriptionSeen(&MessengerResponse{}, community.ID()))
+	})
+
+	t.Run("response carrying the community is seen", func(t *testing.T) {
+		response := &MessengerResponse{}
+		response.AddCommunity(community)
+		require.True(t, communityDescriptionSeen(response, community.ID()))
+	})
+
+	t.Run("response carrying a different community is not seen", func(t *testing.T) {
+		other := createTestCommunityWithImage(t)
+		response := &MessengerResponse{}
+		response.AddCommunity(other)
+		require.False(t, communityDescriptionSeen(response, community.ID()))
+	})
+}

--- a/protocol/messenger_store_node_request_manager_config_test.go
+++ b/protocol/messenger_store_node_request_manager_config_test.go
@@ -64,6 +64,67 @@ func TestStoreNodeRequestPageCap(t *testing.T) {
 	})
 }
 
+// TestCommunityStoreNodeRequestPageCap verifies that community fetches get a much
+// tighter page cap than contact fetches (issue #21470-hf). Store queries page
+// newest-first (go-waku history.go: PaginationForward unset = backward) and
+// community descriptions are republished periodically, so a live community's
+// description appears within the first few pages; with the description-seen gate
+// (6cd6ced1a) a hit stops the request anyway, so deep paging can only ever chew
+// empty/irrelevant history. The device evidence: dead curated ids each cost a
+// ~minutes-long 30-page run with fetchedEnvelopesCount=0 at cap-trip. Contact
+// fetches keep the generous 30-page cap; only the community construction site is
+// tightened, never the shared default.
+func TestCommunityStoreNodeRequestPageCap(t *testing.T) {
+	t.Run("community construction caps at 3 pages", func(t *testing.T) {
+		require.Equal(t, 3, maxCommunityStoreNodeRequestPageCount)
+		cfg := buildCommunityStoreNodeRequestConfig(nil)
+		require.Equal(t, maxCommunityStoreNodeRequestPageCount, cfg.MaxPageCount)
+	})
+
+	t.Run("contact construction keeps the generous 30-page cap", func(t *testing.T) {
+		require.Equal(t, 30, maxStoreNodeRequestPageCount)
+		cfg := buildStoreNodeRequestConfig(nil)
+		require.Equal(t, maxStoreNodeRequestPageCount, cfg.MaxPageCount)
+	})
+
+	t.Run("community construction is tighter than contact construction", func(t *testing.T) {
+		community := buildCommunityStoreNodeRequestConfig(nil)
+		contact := buildStoreNodeRequestConfig(nil)
+		require.Less(t, community.MaxPageCount, contact.MaxPageCount)
+	})
+
+	t.Run("community construction inherits the shared non-cap defaults", func(t *testing.T) {
+		cfg := buildCommunityStoreNodeRequestConfig(nil)
+		base := defaultStoreNodeRequestConfig()
+		require.Equal(t, base.WaitForResponse, cfg.WaitForResponse)
+		require.Equal(t, base.StopWhenDataFound, cfg.StopWhenDataFound)
+		require.Equal(t, base.InitialPageSize, cfg.InitialPageSize)
+		require.Equal(t, base.FurtherPageSize, cfg.FurtherPageSize)
+	})
+
+	t.Run("caller options still override the community cap", func(t *testing.T) {
+		cfg := buildCommunityStoreNodeRequestConfig([]StoreNodeRequestOption{WithMaxPageCount(7)})
+		require.Equal(t, 7, cfg.MaxPageCount)
+	})
+}
+
+// TestShouldProcessStoreNodePage verifies the decision that skips the forced
+// per-page Messenger.ProcessAllMessages when the just-fetched page carried zero
+// envelopes (issue #21470-hf). That call exists solely to flush THIS request's
+// envelopes into the DB before the GetByID check; with zero envelopes there is
+// nothing of ours to flush, yet ProcessAllMessages still walks the messenger's
+// whole pending backlog. During the legitimate channel backfill that means
+// re-walking a fat queue on every empty page — up to the page cap, continuously,
+// for each dead curated id — the CPU/GC storm seen on device (GC 67%, service
+// 320-370%). Skipping the walk on empty pages removes that amplification; the DB
+// check still runs (a parallel channel-sync page may have delivered the
+// description).
+func TestShouldProcessStoreNodePage(t *testing.T) {
+	require.False(t, shouldProcessStoreNodePage(0), "empty page has nothing of ours to flush")
+	require.True(t, shouldProcessStoreNodePage(1), "a page with envelopes must be processed")
+	require.True(t, shouldProcessStoreNodePage(50), "a full page must be processed")
+}
+
 // TestGateNextPageByValidationQueue verifies the decision that stops store-node
 // pagination for a community request once the community's description is already
 // in hand and only blocked on owner validation (issue #21470-hf). For a

--- a/protocol/messenger_store_node_request_manager_config_test.go
+++ b/protocol/messenger_store_node_request_manager_config_test.go
@@ -75,8 +75,8 @@ func TestStoreNodeRequestPageCap(t *testing.T) {
 // fetches keep the generous 30-page cap; only the community construction site is
 // tightened, never the shared default.
 func TestCommunityStoreNodeRequestPageCap(t *testing.T) {
-	t.Run("community construction caps at 3 pages", func(t *testing.T) {
-		require.Equal(t, 3, maxCommunityStoreNodeRequestPageCount)
+	t.Run("community construction caps at 30 pages", func(t *testing.T) {
+		require.Equal(t, 30, maxCommunityStoreNodeRequestPageCount)
 		cfg := buildCommunityStoreNodeRequestConfig(nil)
 		require.Equal(t, maxCommunityStoreNodeRequestPageCount, cfg.MaxPageCount)
 	})
@@ -87,10 +87,10 @@ func TestCommunityStoreNodeRequestPageCap(t *testing.T) {
 		require.Equal(t, maxStoreNodeRequestPageCount, cfg.MaxPageCount)
 	})
 
-	t.Run("community construction is tighter than contact construction", func(t *testing.T) {
+	t.Run("community construction is not looser than contact construction", func(t *testing.T) {
 		community := buildCommunityStoreNodeRequestConfig(nil)
 		contact := buildStoreNodeRequestConfig(nil)
-		require.Less(t, community.MaxPageCount, contact.MaxPageCount)
+		require.LessOrEqual(t, community.MaxPageCount, contact.MaxPageCount)
 	})
 
 	t.Run("community construction inherits the shared non-cap defaults", func(t *testing.T) {

--- a/protocol/messenger_store_node_request_manager_config_test.go
+++ b/protocol/messenger_store_node_request_manager_config_test.go
@@ -63,3 +63,40 @@ func TestStoreNodeRequestPageCap(t *testing.T) {
 		require.GreaterOrEqual(t, cfg.MaxPageCount, 20, "cap must be generous vs the 1-2 page normal fetch")
 	})
 }
+
+// TestGateNextPageByValidationQueue verifies the decision that stops store-node
+// pagination for a community request once the community's description is already
+// in hand and only blocked on owner validation (issue #21470-hf). For a
+// token-owned community the store-node pager's natural stop condition is
+// "community persisted", but persistence is withheld until on-chain owner
+// verification succeeds. A transport failure during verification is
+// indistinguishable, to the pager, from "not fetched yet", so it wrongly fetches
+// another page — which cannot make a dead RPC succeed and only floods the
+// network. Once the description is queued for validation, more pages genuinely
+// cannot help: verification retries out-of-band on the owner-verification loop.
+func TestGateNextPageByValidationQueue(t *testing.T) {
+	t.Run("community already in DB never stops for validation", func(t *testing.T) {
+		// The found path (clock check) owns this case; the validation gate must
+		// not interfere regardless of what is queued.
+		require.False(t, gateNextPageByValidationQueue(true, 100, 0))
+	})
+
+	t.Run("nothing queued keeps paging (genuine not-found)", func(t *testing.T) {
+		require.False(t, gateNextPageByValidationQueue(false, 0, 0))
+	})
+
+	t.Run("queued description newer than what we hold stops paging", func(t *testing.T) {
+		// Description is in hand, only owner verification is pending; the
+		// verification loop will retry it. More pages cannot help.
+		require.True(t, gateNextPageByValidationQueue(false, 100, 0))
+		require.True(t, gateNextPageByValidationQueue(false, 101, 100))
+	})
+
+	t.Run("queued description not newer than what we hold keeps paging", func(t *testing.T) {
+		// The queued description is stale relative to the clock we already have;
+		// a newer page could still legitimately arrive. Mirrors the found-path
+		// "is this newer" test (community.Clock() <= minimumDataClock).
+		require.False(t, gateNextPageByValidationQueue(false, 100, 100))
+		require.False(t, gateNextPageByValidationQueue(false, 90, 100))
+	})
+}

--- a/protocol/messenger_store_node_request_manager_config_test.go
+++ b/protocol/messenger_store_node_request_manager_config_test.go
@@ -1,0 +1,65 @@
+package protocol
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestStoreNodeRequestPageCap verifies the per-request page ceiling that bounds
+// a runaway store-node history fetch (issue #21470-hf). The cap must only ever
+// turn a "fetch next page" decision into a stop; it must never force extra
+// paging, and it must be a no-op when the natural decision is already to stop
+// (e.g. StopWhenDataFound with the data found) or when the cap is disabled.
+func TestStoreNodeRequestPageCap(t *testing.T) {
+	const cap = 30
+
+	t.Run("disabled cap (MaxPageCount==0) never trips", func(t *testing.T) {
+		cfg := StoreNodeRequestConfig{MaxPageCount: 0, FurtherPageSize: 50}
+		fetch, size, tripped := cfg.gateNextPageByCap(true, cfg.FurtherPageSize, 1_000_000)
+		require.True(t, fetch)
+		require.Equal(t, uint64(50), size)
+		require.False(t, tripped)
+	})
+
+	t.Run("below cap keeps paging", func(t *testing.T) {
+		cfg := StoreNodeRequestConfig{MaxPageCount: cap, FurtherPageSize: 50}
+		fetch, size, tripped := cfg.gateNextPageByCap(true, cfg.FurtherPageSize, cap-1)
+		require.True(t, fetch)
+		require.Equal(t, uint64(50), size)
+		require.False(t, tripped)
+	})
+
+	t.Run("exactly at cap trips and stops", func(t *testing.T) {
+		cfg := StoreNodeRequestConfig{MaxPageCount: cap, FurtherPageSize: 50}
+		fetch, size, tripped := cfg.gateNextPageByCap(true, cfg.FurtherPageSize, cap)
+		require.False(t, fetch)
+		require.Equal(t, uint64(0), size)
+		require.True(t, tripped)
+	})
+
+	t.Run("above cap trips and stops", func(t *testing.T) {
+		cfg := StoreNodeRequestConfig{MaxPageCount: cap, FurtherPageSize: 50}
+		fetch, size, tripped := cfg.gateNextPageByCap(true, cfg.FurtherPageSize, cap+5)
+		require.False(t, fetch)
+		require.Equal(t, uint64(0), size)
+		require.True(t, tripped)
+	})
+
+	t.Run("natural stop is never overridden and never reports a trip", func(t *testing.T) {
+		// Models StopWhenDataFound with the community found, or the decode/validate
+		// error branches: the uncapped decision is already "stop". Even past the
+		// cap, the cap must not claim responsibility for the stop.
+		cfg := StoreNodeRequestConfig{MaxPageCount: cap, FurtherPageSize: 50}
+		fetch, size, tripped := cfg.gateNextPageByCap(false, 0, cap+100)
+		require.False(t, fetch)
+		require.Equal(t, uint64(0), size)
+		require.False(t, tripped)
+	})
+
+	t.Run("default config ships a generous, enabled cap", func(t *testing.T) {
+		cfg := defaultStoreNodeRequestConfig()
+		require.Greater(t, cfg.MaxPageCount, 1, "cap must be enabled by default")
+		require.GreaterOrEqual(t, cfg.MaxPageCount, 20, "cap must be generous vs the 1-2 page normal fetch")
+	})
+}


### PR DESCRIPTION
## Fix Android overheating on community spectate — minimal hotfix (status-app#21470)

Minimal, ablation-verified subset of the #21470 investigation: **17 commits, 1,245 code lines (excl. tests), 16 files**. Every commit ships a concretely measured CPU/memory/storage reduction for the reported scenario; everything larger (the hash-first fetch subsystem, the global-sync change) is deferred to a develop-targeted follow-up (#7626 documents the full investigation).

### Problem
status-im/status-app#21470 — fresh profile → spectate the Status community → open `#general` → Samsung device reaches 50–52 °C skin, permanent loading spinner. Measured baseline: service process 275% CPU sustained (peak 743%, GC 60–72% of it), 3.9 MB/s network indefinitely, battery draining on the charger, RSS 876 MB, DB growing by GB.

### Root causes fixed here (each device-verified)
1. **Unbounded store-node pager** for token-owned communities whose on-chain owner verification fails (transport failure treated as "fetch more pages") → drains the full sync window re-processing the 1.4 MB description per page.
2. **Delivery starvation** (v10.34 regression): the retrieve loop's quiet-debounce never fires under floods → messages persist but never render.
3. **Keyless processing waste**: spectators hold no community keys, yet every encrypted envelope paid segmentation + per-key ratchet probes and was parked in SQLCipher for replay.
4. **Description redelivery tax**: ~40 re-encrypted republishes per description version each re-paid the full pipeline (~10 s each at 9-day volume) before any clock check; segment reassembly was O(N²).
5. **Mobile Go memory limit of 150 MB** — ~3× below the working set → permanent GC maximum-aggression mode (the single largest multiplier: A/B showed 61% GC share / 150–390% CPU vs GC-out-of-profile / 46–127% with a sane limit).

### Commits and their measured effect
| Commit | Change | Measured |
|---|---|---|
| pager cap (30 pages/request) | bounds any runaway walk | 275% → ~24% between re-issues (as sole fix) |
| retrieve-loop max-latency flush | spinner fix | permanent spinner → clears |
| stop-paging-when-queued-for-validation + out-of-band verify retries | root cause 1 | full-window drain → ~1 page/tick |
| stop-once-description-seen | newest-first invariant | update re-checks 30 pages → 1 |
| async community-token fetch (cherry-pick from develop) | was 35 s blocking per save | first-open latency |
| skip empty-page processing (+cap correction) | dead-id pages stopped re-walking ingest | GC amplification removed |
| keyless early-drop gates + enable | decrypt spam 7,188 → **0** | RSS **876→480 MB**; data dir 144 MB after 3 GB ingested (was GB growth) |
| spectate = community-scoped 9-day sync, cancellable on leave/background | headless drain fix | UI-death: 78–89% CPU + 3 MB/s forever → cancelled |
| description clock/hash gate (+latch fix) + keyless equal-clock skip + cached community | redelivery tax | 1,643 × ~10 s passes → short-circuit |
| segmentation O(N) | 26% of allocations were O(N²) SQL blob re-reads | eliminated |
| **memory limit 150 MB → 1 GB (mobile)** | GC thrash fix | A/B: GC 61% of CPU → out of top consumers; svc 150–390% → 46–127% |

### Ablation verification (this exact commit set, Samsung S21FE, fresh spectate of Status, 9-day window)
- `#general` opens in **2 m 41 s**, spinner clears, messages render
- Service CPU **14–33%** through the sync and after; GC absent from the profile's top consumers
- RSS peak **591 MB** (no balloon; classic fetch is store-paced); no pathological DB growth
- Downloaded 1.84 GB — the known remaining cost; the bandwidth reduction work (hash-first fetching, ~800 LOC of new subsystem) is intentionally deferred to develop where it can soak properly. The heat complaint is resolved without it.

### Deferred to develop (tracked)
Hash-first spectate + general-sync fetching (bandwidth: 42% dup downloads + description-republish redundancy), not-found fetch backoff, ingest backpressure (only needed with hash-first), and the protocol issue: description republishes are re-encrypted per heartbeat → unique hashes → dedup-proof store growth (~1,245 copies of a 1.4 MB description downloaded per fresh 9-day sync). Also tracked: join-path measurement, MMV scoping, pause coverage for history sync.

### Methodology
Dev-only auto-repro driver (fresh account → spectate → `#general`, compile-gated, desktop repo) + adb sampler + on-device Go pprof. All fixes TDD (red→green on pure seams), full regression battery green at every commit, each fix independently audited, this exact commit set re-verified end-to-end on device.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
