### PR TITLE
test(functional): fix reliability ipv4 port publishing and skip ip-change on ipv6 

### DIFF
--- a/tests-functional/clients/statusgo_container.py
+++ b/tests-functional/clients/statusgo_container.py
@@ -359,7 +359,7 @@ class StatusPortsMappings:
         return {f"{m.container_port}/tcp": ("::", None) for m in self._published()}
 
     def ipv4_ports(self):
-        return {f"{m.container_port}/tcp": None for m in self._published()}
+        return {f"{m.container_port}/tcp": ("127.0.0.1", None) for m in self._published()}
 
     def ports(self, ipv6: bool):
         return self.ipv6_ports() if ipv6 else self.ipv4_ports()

--- a/tests-functional/tests/reliability/test_join_leave_community.py
+++ b/tests-functional/tests/reliability/test_join_leave_community.py
@@ -1,6 +1,7 @@
 from time import sleep
 import pytest
 from steps import messenger
+from resources.constants import USE_IPV6
 
 
 @pytest.mark.reliability
@@ -56,6 +57,7 @@ class TestJoinLeaveCommunities:
         messenger.leave_the_community(community_member, community_id)
         messenger.check_node_joined_community(community_member, joined=False, community_id=community_id)
 
+    @pytest.mark.skipif(USE_IPV6 == "Yes", reason="Test works only with IPV4")
     def test_join_leave_community_with_ip_change(self, community_admin, community_member):
         community_id = messenger.create_community(community_admin)
         messenger.join_community(member=community_member, admin=community_admin, community_id=community_id)


### PR DESCRIPTION
## What

### 1. ipv4 backend port publishing (`clients/statusgo_container.py`)

Regression from #7561 (switch to Docker-assigned ephemeral host ports). In ipv4 mode the ports were published with an empty `HostIp`, so Docker created **two** bindings for `3333/tcp` — `0.0.0.0` and `::` — with **different** ephemeral host ports. `resolve_host_ports()` took `bindings[0]` (the `::` one on the CI daemon) and paired it with a hardcoded `127.0.0.1` connect host, so every request hit an unreachable port → connection refused for all backends.

Fix: publish the ipv4 ports on an explicit `("127.0.0.1", None)` host binding, so Docker creates a single IPv4 binding whose ephemeral port matches the `127.0.0.1` connect host. Mirrors the ipv6 path, which already publishes explicitly on `("::", None)`.

### 2. Missing ipv6 skip guard (`tests/reliability/test_join_leave_community.py`)

`test_join_leave_community_with_ip_change` was the only `*_with_ip_change` test without `@pytest.mark.skipif(USE_IPV6 == "Yes", reason="Test works only with IPV4")`. Its five siblings all have it. Container IP-change is unsupported under ipv6 in the harness (the IP swap disconnects the only IPv6-capable network endpoint and the IPv4-only `bridge` anchor cannot preserve the `[::1]:<port>` mapping), so the test failed deterministically on the ipv6 leg. Added the missing guard to match the siblings.

## Follow-up (not in this PR)

Making container IP-change actually work under ipv6 (so all six `*_with_ip_change` tests can run on the ipv6 leg) is a larger test-infra change tracked separately.
