### PR TITLE
perf: skip decryption of encrypted description fields for keyless spectators (#21470, HF 3)

### DIFF
--- a/protocol/communities/community_key_entitlement.go
+++ b/protocol/communities/community_key_entitlement.go
@@ -2,33 +2,22 @@ package communities
 
 import "sync"
 
-// dropLogInterval is how often (in gated descriptions) a per-community DEBUG
-// checkpoint is emitted after the initial INFO line.
-const dropLogInterval = 1000
-
-// communityKeyEntitlement caches, per community, whether this node holds ANY
-// hash-ratchet decryption key material for that community. A keyless (spectator)
-// node uses the cache to skip the per-key decryption attempts that a re-published
-// community description would otherwise trigger on every fetch — each of which is
-// a guaranteed "no ratchet key" failure (issue #21470). The cache is invalidated
-// when new keys are saved (Manager.NewHashRatchetKeys), so the gate lifts the
-// moment the node acquires keys.
+// communityKeyEntitlement caches, per community, whether this node holds any
+// hash-ratchet decryption key material. Invalidated when new keys are saved so
+// the gate lifts the moment the node acquires keys.
 type communityKeyEntitlement struct {
-	mu      sync.Mutex
-	holds   map[string]bool   // communityID(hex) -> holds any decryption key
-	dropped map[string]uint64 // communityID(hex) -> count of gated descriptions
-	logged  map[string]bool   // communityID(hex) -> INFO already emitted this session
+	mu     sync.Mutex
+	holds  map[string]bool // communityID(hex) -> holds any decryption key
+	logged map[string]bool // communityID(hex) -> skip already logged this session
 }
 
 func newCommunityKeyEntitlement() *communityKeyEntitlement {
 	return &communityKeyEntitlement{
-		holds:   make(map[string]bool),
-		dropped: make(map[string]uint64),
-		logged:  make(map[string]bool),
+		holds:  make(map[string]bool),
+		logged: make(map[string]bool),
 	}
 }
 
-// known reports the cached entitlement for id and whether it was cached at all.
 func (c *communityKeyEntitlement) known(id string) (holds bool, ok bool) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
@@ -36,62 +25,28 @@ func (c *communityKeyEntitlement) known(id string) (holds bool, ok bool) {
 	return holds, ok
 }
 
-// remember stores the entitlement result for id.
 func (c *communityKeyEntitlement) remember(id string, holds bool) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	c.holds[id] = holds
 }
 
-// forget drops the cached entitlement for the given ids, forcing a fresh lookup.
-// Called when new keys are saved for a community so the gate re-evaluates and lifts.
-func (c *communityKeyEntitlement) forget(ids ...string) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	for _, id := range ids {
-		delete(c.holds, id)
-	}
-}
-
-// forgetAll clears every cached entitlement. Called when new key material arrives
-// (which may be community- or channel-scoped) so all gates re-evaluate and lift.
+// forgetAll is called when new key material arrives (community- or
+// channel-scoped) so all gates re-evaluate.
 func (c *communityKeyEntitlement) forgetAll() {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	c.holds = make(map[string]bool)
 }
 
-// dropLogDecision tells the caller what (if anything) to log for a gated description.
-type dropLogDecision struct {
-	logInfo  bool   // first drop for this community this session
-	logDebug bool   // periodic checkpoint (every dropLogInterval drops)
-	count    uint64 // total gated descriptions for this community this session
-}
-
-// recordDrop increments the gated-description counter for id and returns what to
-// log: an INFO line on the first drop of the session, then a DEBUG checkpoint
-// every dropLogInterval drops. Never logs per envelope.
-func (c *communityKeyEntitlement) recordDrop(id string) dropLogDecision {
+// shouldLogDrop reports true once per community per session — the skip fires
+// per redelivered description, far too often to log each time.
+func (c *communityKeyEntitlement) shouldLogDrop(id string) bool {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	c.dropped[id]++
-	count := c.dropped[id]
-	d := dropLogDecision{count: count}
-	switch {
-	case !c.logged[id]:
-		c.logged[id] = true
-		d.logInfo = true
-	case count%dropLogInterval == 0:
-		d.logDebug = true
+	if c.logged[id] {
+		return false
 	}
-	return d
-}
-
-// shouldSkipPrivateDataDecryption reports whether the per-key decryption attempts
-// over a community description's PrivateData should be skipped. They are skipped
-// only when there is encrypted private data to attempt AND the node holds no key
-// material for the community — i.e. a keyless spectator, for whom every attempt is
-// a guaranteed "no ratchet key" failure.
-func shouldSkipPrivateDataDecryption(hasPrivateData, holdsKeys bool) bool {
-	return hasPrivateData && !holdsKeys
+	c.logged[id] = true
+	return true
 }

--- a/protocol/communities/community_key_entitlement.go
+++ b/protocol/communities/community_key_entitlement.go
@@ -1,0 +1,97 @@
+package communities
+
+import "sync"
+
+// dropLogInterval is how often (in gated descriptions) a per-community DEBUG
+// checkpoint is emitted after the initial INFO line.
+const dropLogInterval = 1000
+
+// communityKeyEntitlement caches, per community, whether this node holds ANY
+// hash-ratchet decryption key material for that community. A keyless (spectator)
+// node uses the cache to skip the per-key decryption attempts that a re-published
+// community description would otherwise trigger on every fetch — each of which is
+// a guaranteed "no ratchet key" failure (issue #21470). The cache is invalidated
+// when new keys are saved (Manager.NewHashRatchetKeys), so the gate lifts the
+// moment the node acquires keys.
+type communityKeyEntitlement struct {
+	mu      sync.Mutex
+	holds   map[string]bool   // communityID(hex) -> holds any decryption key
+	dropped map[string]uint64 // communityID(hex) -> count of gated descriptions
+	logged  map[string]bool   // communityID(hex) -> INFO already emitted this session
+}
+
+func newCommunityKeyEntitlement() *communityKeyEntitlement {
+	return &communityKeyEntitlement{
+		holds:   make(map[string]bool),
+		dropped: make(map[string]uint64),
+		logged:  make(map[string]bool),
+	}
+}
+
+// known reports the cached entitlement for id and whether it was cached at all.
+func (c *communityKeyEntitlement) known(id string) (holds bool, ok bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	holds, ok = c.holds[id]
+	return holds, ok
+}
+
+// remember stores the entitlement result for id.
+func (c *communityKeyEntitlement) remember(id string, holds bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.holds[id] = holds
+}
+
+// forget drops the cached entitlement for the given ids, forcing a fresh lookup.
+// Called when new keys are saved for a community so the gate re-evaluates and lifts.
+func (c *communityKeyEntitlement) forget(ids ...string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	for _, id := range ids {
+		delete(c.holds, id)
+	}
+}
+
+// forgetAll clears every cached entitlement. Called when new key material arrives
+// (which may be community- or channel-scoped) so all gates re-evaluate and lift.
+func (c *communityKeyEntitlement) forgetAll() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.holds = make(map[string]bool)
+}
+
+// dropLogDecision tells the caller what (if anything) to log for a gated description.
+type dropLogDecision struct {
+	logInfo  bool   // first drop for this community this session
+	logDebug bool   // periodic checkpoint (every dropLogInterval drops)
+	count    uint64 // total gated descriptions for this community this session
+}
+
+// recordDrop increments the gated-description counter for id and returns what to
+// log: an INFO line on the first drop of the session, then a DEBUG checkpoint
+// every dropLogInterval drops. Never logs per envelope.
+func (c *communityKeyEntitlement) recordDrop(id string) dropLogDecision {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.dropped[id]++
+	count := c.dropped[id]
+	d := dropLogDecision{count: count}
+	switch {
+	case !c.logged[id]:
+		c.logged[id] = true
+		d.logInfo = true
+	case count%dropLogInterval == 0:
+		d.logDebug = true
+	}
+	return d
+}
+
+// shouldSkipPrivateDataDecryption reports whether the per-key decryption attempts
+// over a community description's PrivateData should be skipped. They are skipped
+// only when there is encrypted private data to attempt AND the node holds no key
+// material for the community — i.e. a keyless spectator, for whom every attempt is
+// a guaranteed "no ratchet key" failure.
+func shouldSkipPrivateDataDecryption(hasPrivateData, holdsKeys bool) bool {
+	return hasPrivateData && !holdsKeys
+}

--- a/protocol/communities/community_key_entitlement_test.go
+++ b/protocol/communities/community_key_entitlement_test.go
@@ -1,0 +1,77 @@
+package communities
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestShouldSkipPrivateDataDecryption(t *testing.T) {
+	// Skip only when there is encrypted private data AND the node holds no keys.
+	require.True(t, shouldSkipPrivateDataDecryption(true, false), "keyless node with private data must skip")
+	require.False(t, shouldSkipPrivateDataDecryption(true, true), "node holding keys must attempt")
+	require.False(t, shouldSkipPrivateDataDecryption(false, false), "no private data means nothing to skip")
+	require.False(t, shouldSkipPrivateDataDecryption(false, true), "no private data means nothing to skip")
+}
+
+func TestCommunityKeyEntitlementCache(t *testing.T) {
+	c := newCommunityKeyEntitlement()
+
+	// Unknown until remembered.
+	_, ok := c.known("comm-a")
+	require.False(t, ok)
+
+	// Remembered values are returned.
+	c.remember("comm-a", false)
+	holds, ok := c.known("comm-a")
+	require.True(t, ok)
+	require.False(t, holds)
+
+	c.remember("comm-b", true)
+	holds, ok = c.known("comm-b")
+	require.True(t, ok)
+	require.True(t, holds)
+
+	// forget invalidates only the named id, forcing a fresh lookup (gate lift on key arrival).
+	c.forget("comm-a")
+	_, ok = c.known("comm-a")
+	require.False(t, ok)
+	_, ok = c.known("comm-b")
+	require.True(t, ok, "forget must not touch other communities")
+
+	// forgetAll clears every cached entitlement (used when any new key arrives).
+	c.remember("comm-a", false)
+	c.forgetAll()
+	_, ok = c.known("comm-a")
+	require.False(t, ok)
+	_, ok = c.known("comm-b")
+	require.False(t, ok)
+}
+
+func TestCommunityKeyEntitlementDropLogging(t *testing.T) {
+	c := newCommunityKeyEntitlement()
+
+	// First drop for a community => INFO, count 1.
+	d := c.recordDrop("comm-a")
+	require.True(t, d.logInfo)
+	require.False(t, d.logDebug)
+	require.Equal(t, uint64(1), d.count)
+
+	// Subsequent drops below the interval => silent, counting up.
+	for i := 2; i < dropLogInterval; i++ {
+		d = c.recordDrop("comm-a")
+		require.False(t, d.logInfo, "only the first drop logs INFO")
+		require.False(t, d.logDebug)
+	}
+
+	// Every dropLogInterval-th drop => DEBUG checkpoint, never a second INFO.
+	d = c.recordDrop("comm-a")
+	require.False(t, d.logInfo)
+	require.True(t, d.logDebug)
+	require.Equal(t, uint64(dropLogInterval), d.count)
+
+	// A different community gets its own first-drop INFO and independent count.
+	d = c.recordDrop("comm-b")
+	require.True(t, d.logInfo)
+	require.Equal(t, uint64(1), d.count)
+}

--- a/protocol/communities/community_key_entitlement_test.go
+++ b/protocol/communities/community_key_entitlement_test.go
@@ -6,14 +6,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestShouldSkipPrivateDataDecryption(t *testing.T) {
-	// Skip only when there is encrypted private data AND the node holds no keys.
-	require.True(t, shouldSkipPrivateDataDecryption(true, false), "keyless node with private data must skip")
-	require.False(t, shouldSkipPrivateDataDecryption(true, true), "node holding keys must attempt")
-	require.False(t, shouldSkipPrivateDataDecryption(false, false), "no private data means nothing to skip")
-	require.False(t, shouldSkipPrivateDataDecryption(false, true), "no private data means nothing to skip")
-}
-
 func TestCommunityKeyEntitlementCache(t *testing.T) {
 	c := newCommunityKeyEntitlement()
 
@@ -32,15 +24,7 @@ func TestCommunityKeyEntitlementCache(t *testing.T) {
 	require.True(t, ok)
 	require.True(t, holds)
 
-	// forget invalidates only the named id, forcing a fresh lookup (gate lift on key arrival).
-	c.forget("comm-a")
-	_, ok = c.known("comm-a")
-	require.False(t, ok)
-	_, ok = c.known("comm-b")
-	require.True(t, ok, "forget must not touch other communities")
-
 	// forgetAll clears every cached entitlement (used when any new key arrives).
-	c.remember("comm-a", false)
 	c.forgetAll()
 	_, ok = c.known("comm-a")
 	require.False(t, ok)
@@ -51,27 +35,9 @@ func TestCommunityKeyEntitlementCache(t *testing.T) {
 func TestCommunityKeyEntitlementDropLogging(t *testing.T) {
 	c := newCommunityKeyEntitlement()
 
-	// First drop for a community => INFO, count 1.
-	d := c.recordDrop("comm-a")
-	require.True(t, d.logInfo)
-	require.False(t, d.logDebug)
-	require.Equal(t, uint64(1), d.count)
-
-	// Subsequent drops below the interval => silent, counting up.
-	for i := 2; i < dropLogInterval; i++ {
-		d = c.recordDrop("comm-a")
-		require.False(t, d.logInfo, "only the first drop logs INFO")
-		require.False(t, d.logDebug)
-	}
-
-	// Every dropLogInterval-th drop => DEBUG checkpoint, never a second INFO.
-	d = c.recordDrop("comm-a")
-	require.False(t, d.logInfo)
-	require.True(t, d.logDebug)
-	require.Equal(t, uint64(dropLogInterval), d.count)
-
-	// A different community gets its own first-drop INFO and independent count.
-	d = c.recordDrop("comm-b")
-	require.True(t, d.logInfo)
-	require.Equal(t, uint64(1), d.count)
+	// One log per community per session.
+	require.True(t, c.shouldLogDrop("comm-a"))
+	require.False(t, c.shouldLogDrop("comm-a"))
+	require.True(t, c.shouldLogDrop("comm-b"))
+	require.False(t, c.shouldLogDrop("comm-a"))
 }

--- a/protocol/communities/manager.go
+++ b/protocol/communities/manager.go
@@ -113,6 +113,7 @@ type Manager struct {
 	stopped                  bool
 	PermissionChecker        PermissionChecker
 	keyDistributor           KeyDistributor
+	keyEntitlement           *communityKeyEntitlement
 	communityLock            *CommunityLock
 	mediaServer              server.MediaServerInterface
 	communityImageVersions   map[string]uint32
@@ -322,6 +323,7 @@ func NewManager(
 		messaging:              messaging,
 		timesource:             timesource,
 		keyDistributor:         keyDistributor,
+		keyEntitlement:         newCommunityKeyEntitlement(),
 		communityLock:          NewCommunityLock(logger),
 		mediaServer:            mediaServer,
 		communityImageVersions: make(map[string]uint32),
@@ -2160,7 +2162,53 @@ func (m *Manager) HandleCommunityDescriptionMessage(signer *ecdsa.PublicKey, des
 }
 
 func (m *Manager) NewHashRatchetKeys(keys []*types.HashRatchetInfo) error {
+	// Lift the keyless-spectator gate now that key material has arrived, so the next
+	// description fetch re-evaluates entitlement and attempts decryption. Keys may be
+	// community- or channel-scoped, so clear all cached entitlements rather than map
+	// each group id back to a community.
+	if m.keyEntitlement != nil && len(keys) > 0 {
+		m.keyEntitlement.forgetAll()
+	}
 	return m.persistence.InvalidateDecryptedCommunityCacheForKeys(keys)
+}
+
+// communityHoldsAnyDecryptionKey reports whether this node holds any hash-ratchet
+// key material for the community (its community-level group or any of its channel
+// groups). The result is cached per community and invalidated when new keys arrive
+// (NewHashRatchetKeys). On any lookup error it fails open (reports true) so a
+// transient DB issue can never cause legitimate data to be dropped.
+func (m *Manager) communityHoldsAnyDecryptionKey(id types3.HexBytes, chats map[string]*protobuf.CommunityChat) bool {
+	if m.messaging == nil || m.keyEntitlement == nil {
+		return true
+	}
+
+	cacheKey := id.String()
+	if holds, ok := m.keyEntitlement.known(cacheKey); ok {
+		return holds
+	}
+
+	holds := m.hasHashRatchetKeyForGroup(id)
+	if !holds {
+		for channelID := range chats {
+			if m.hasHashRatchetKeyForGroup(types3.HexBytes(id.String() + channelID)) {
+				holds = true
+				break
+			}
+		}
+	}
+
+	m.keyEntitlement.remember(cacheKey, holds)
+	return holds
+}
+
+func (m *Manager) hasHashRatchetKeyForGroup(groupID []byte) bool {
+	key, err := m.messaging.GetCurrentKeyForGroup(groupID)
+	if err != nil {
+		// Fail open: never drop decryptable data because of a lookup error.
+		return true
+	}
+	// GetCurrentKeyForGroup returns a non-nil, empty ratchet when no key exists.
+	return key != nil && len(key.Key) != 0
 }
 
 // NOTE: encrypted_community_description_cache is not a cache for the community description
@@ -2173,6 +2221,26 @@ func (m *Manager) preprocessDescription(id types3.HexBytes, description *protobu
 	}
 	if decryptedCommunity != nil {
 		return nil, decryptedCommunity, nil
+	}
+
+	// Keyless-spectator early drop (#21470): if the description carries encrypted
+	// private data but this node holds no decryption keys for the community, skip
+	// the per-key decryption attempts entirely — each would be a guaranteed
+	// "no ratchet key" failure. The plaintext outer description is still handled;
+	// only the encrypted inner fields are left encrypted (a spectator cannot see
+	// them anyway). The gate lifts automatically once keys arrive.
+	if len(description.PrivateData) > 0 &&
+		shouldSkipPrivateDataDecryption(true, m.communityHoldsAnyDecryptionKey(id, description.Chats)) {
+		decision := m.keyEntitlement.recordDrop(id.String())
+		if decision.logInfo {
+			m.logger.Info("dropping encrypted community payloads (no decryption keys held)",
+				zap.String("communityID", id.String()), zap.Uint64("droppedCount", decision.count))
+		} else if decision.logDebug {
+			m.logger.Debug("still dropping encrypted community payloads (no decryption keys held)",
+				zap.String("communityID", id.String()), zap.Uint64("droppedCount", decision.count))
+		}
+		upgradeTokenPermissions(description)
+		return nil, description, m.persistence.SaveDecryptedCommunityDescription(id, nil, description)
 	}
 
 	response, err := decryptDescription(id, m, description, m.logger)

--- a/protocol/communities/manager.go
+++ b/protocol/communities/manager.go
@@ -2162,21 +2162,19 @@ func (m *Manager) HandleCommunityDescriptionMessage(signer *ecdsa.PublicKey, des
 }
 
 func (m *Manager) NewHashRatchetKeys(keys []*types.HashRatchetInfo) error {
-	// Lift the keyless-spectator gate now that key material has arrived, so the next
-	// description fetch re-evaluates entitlement and attempts decryption. Keys may be
-	// community- or channel-scoped, so clear all cached entitlements rather than map
-	// each group id back to a community.
+	// New keys may be community- or channel-scoped and cannot be mapped back to
+	// a single community cheaply, so clear all cached entitlements: the next
+	// description must re-evaluate.
 	if m.keyEntitlement != nil && len(keys) > 0 {
 		m.keyEntitlement.forgetAll()
 	}
 	return m.persistence.InvalidateDecryptedCommunityCacheForKeys(keys)
 }
 
-// communityHoldsAnyDecryptionKey reports whether this node holds any hash-ratchet
-// key material for the community (its community-level group or any of its channel
-// groups). The result is cached per community and invalidated when new keys arrive
-// (NewHashRatchetKeys). On any lookup error it fails open (reports true) so a
-// transient DB issue can never cause legitimate data to be dropped.
+// communityHoldsAnyDecryptionKey reports whether this node holds any
+// hash-ratchet key material for the community or any of its channel groups.
+// Cached per community, invalidated on key arrival, fails open on lookup
+// errors.
 func (m *Manager) communityHoldsAnyDecryptionKey(id types3.HexBytes, chats map[string]*protobuf.CommunityChat) bool {
 	if m.messaging == nil || m.keyEntitlement == nil {
 		return true
@@ -2223,21 +2221,13 @@ func (m *Manager) preprocessDescription(id types3.HexBytes, description *protobu
 		return nil, decryptedCommunity, nil
 	}
 
-	// Keyless-spectator early drop (#21470): if the description carries encrypted
-	// private data but this node holds no decryption keys for the community, skip
-	// the per-key decryption attempts entirely — each would be a guaranteed
-	// "no ratchet key" failure. The plaintext outer description is still handled;
-	// only the encrypted inner fields are left encrypted (a spectator cannot see
-	// them anyway). The gate lifts automatically once keys arrive.
-	if len(description.PrivateData) > 0 &&
-		shouldSkipPrivateDataDecryption(true, m.communityHoldsAnyDecryptionKey(id, description.Chats)) {
-		decision := m.keyEntitlement.recordDrop(id.String())
-		if decision.logInfo {
+	// Keyless spectators skip the per-key decryption attempts; the plaintext
+	// outer description is still handled, only the encrypted inner fields stay
+	// encrypted. The gate lifts once keys arrive.
+	if len(description.PrivateData) > 0 && !m.communityHoldsAnyDecryptionKey(id, description.Chats) {
+		if m.keyEntitlement.shouldLogDrop(id.String()) {
 			m.logger.Info("dropping encrypted community payloads (no decryption keys held)",
-				zap.String("communityID", id.String()), zap.Uint64("droppedCount", decision.count))
-		} else if decision.logDebug {
-			m.logger.Debug("still dropping encrypted community payloads (no decryption keys held)",
-				zap.String("communityID", id.String()), zap.Uint64("droppedCount", decision.count))
+				zap.String("communityID", id.String()))
 		}
 		upgradeTokenPermissions(description)
 		return nil, description, m.persistence.SaveDecryptedCommunityDescription(id, nil, description)


### PR DESCRIPTION
## HF 3: keyless description-field skip (status-app#21470)

Stacked on #7631. A spectator holding no community decryption keys previously paid per-key hash-ratchet decrypt probes on the encrypted inner fields of every redelivered ~1.4MB community description — each a guaranteed "no ratchet key" failure, logged every time.

**Change (2 commits, gate 1 only):** `preprocessDescription` skips the private-data decryption attempts when the node holds no key material for the community or any of its channels (`communityHoldsAnyDecryptionKey`, cached, invalidated on key arrival, fail-open on lookup errors). The plaintext outer description is handled unchanged. Logged once per community per session.

**Measured on device** (staged series, Samsung S21FE, fresh spectate of Status, 9-day window): decrypt-failure log spam **8,389 → 0**; data dir bounded at ~114-121MB after ~2.5GB ingested. CPU-neutral in isolation (the CPU wins live in #7629/#7631); this slice's value is eliminating pointless crypto work, log spam, and the failed-decrypt bookkeeping.

Umbrella PR with the full per-stage accountability table: #7632.

🤖 Generated with [Claude Code](https://claude.com/claude-code)