### PR TITLE
perf: community-scoped, cancellable spectate history sync (#21470, HF 4)

### DIFF
--- a/protocol/messenger.go
+++ b/protocol/messenger.go
@@ -153,6 +153,10 @@ type Messenger struct {
 	historicSyncInFlight      bool
 	lastHistoricSyncRequestAt time.Time
 
+	// communityHistoryFetches tracks cancellable, per-community spectate backfills
+	// so they can be aborted on leave / app-background (issue #21470-hf).
+	communityHistoryFetches *communityHistoryFetchRegistry
+
 	connectionStateMutex  sync.RWMutex
 	connectionState       connection.State
 	contractMaker         *contracts.ContractMaker
@@ -424,21 +428,22 @@ func NewMessenger(
 			logger: logger,
 			me:     selfContact,
 		},
-		allInstallations:      new(installationMap),
-		installationID:        installationID,
-		modifiedInstallations: new(stringBoolMap),
-		database:              database,
-		multiAccounts:         c.multiAccount,
-		settings:              settings,
-		verificationDatabase:  verification.NewPersistence(database),
-		mailserversDatabase:   c.mailserversDatabase,
-		account:               c.account,
-		quit:                  make(chan struct{}),
-		ctx:                   ctx,
-		cancel:                cancel,
-		importingCommunities:  make(map[string]bool),
-		importingChannels:     make(map[string]bool),
-		importRateLimiter:     rate.NewLimiter(rate.Every(importSlowRate), 1),
+		allInstallations:        new(installationMap),
+		installationID:          installationID,
+		modifiedInstallations:   new(stringBoolMap),
+		database:                database,
+		multiAccounts:           c.multiAccount,
+		settings:                settings,
+		verificationDatabase:    verification.NewPersistence(database),
+		mailserversDatabase:     c.mailserversDatabase,
+		account:                 c.account,
+		quit:                    make(chan struct{}),
+		ctx:                     ctx,
+		cancel:                  cancel,
+		importingCommunities:    make(map[string]bool),
+		importingChannels:       make(map[string]bool),
+		communityHistoryFetches: newCommunityHistoryFetchRegistry(),
+		importRateLimiter:       rate.NewLimiter(rate.Every(importSlowRate), 1),
 		importDelayer: struct {
 			wait chan struct{}
 			once sync.Once
@@ -553,6 +558,11 @@ func (m *Messenger) processSentMessage(id string) error {
 
 func (m *Messenger) SetPaused(paused bool) {
 	m.paused.Store(paused)
+	if paused {
+		// Backgrounding stops any in-flight scoped community history backfills, which
+		// on device were measured continuing headless after the UI died (#21470-hf).
+		m.communityHistoryFetches.cancelAll()
+	}
 	if m.ensVerifier != nil {
 		m.ensVerifier.SetPaused(paused)
 	}

--- a/protocol/messenger.go
+++ b/protocol/messenger.go
@@ -153,8 +153,8 @@ type Messenger struct {
 	historicSyncInFlight      bool
 	lastHistoricSyncRequestAt time.Time
 
-	// communityHistoryFetches tracks cancellable, per-community spectate backfills
-	// so they can be aborted on leave / app-background (issue #21470-hf).
+	// communityHistoryFetches tracks cancellable, per-community spectate
+	// backfills so leave / app-background can abort them.
 	communityHistoryFetches *communityHistoryFetchRegistry
 
 	connectionStateMutex  sync.RWMutex
@@ -559,8 +559,7 @@ func (m *Messenger) processSentMessage(id string) error {
 func (m *Messenger) SetPaused(paused bool) {
 	m.paused.Store(paused)
 	if paused {
-		// Backgrounding stops any in-flight scoped community history backfills, which
-		// on device were measured continuing headless after the UI died (#21470-hf).
+		// Backgrounding stops any in-flight scoped community history backfills.
 		m.communityHistoryFetches.cancelAll()
 	}
 	if m.ensVerifier != nil {

--- a/protocol/messenger_communities.go
+++ b/protocol/messenger_communities.go
@@ -958,13 +958,10 @@ func (m *Messenger) SpectatedCommunities() ([]*communities.Community, error) {
 	return m.communitiesManager.Spectated()
 }
 
-// initCommunityChats initialises a community's chats and filters. When spectated is
-// true the broad, full-period history sync is NOT scheduled here — the caller
-// (SpectateCommunity) drives a scoped 24h backfill instead (issue #21470-hf). A
-// keyless spectator's full-period backfill of the community's single universal
-// content topic ingests gigabytes of undecryptable payloads; the broad sync scheduled
-// here would race the scoped one for the topic watermark and defeat the scoping.
-// Joining keeps today's behavior (the broad sync runs).
+// initCommunityChats initialises a community's chats and filters. For a
+// spectated community the broad full-period history sync is not scheduled here
+// — it would race the caller's scoped backfill for the topic watermark;
+// joining keeps the broad sync.
 func (m *Messenger) initCommunityChats(community *communities.Community, spectated bool) ([]*Chat, error) {
 	logger := m.logger.Named("initCommunityChats")
 
@@ -991,7 +988,7 @@ func (m *Messenger) initCommunityChats(community *communities.Community, spectat
 	}
 
 	willSync := false
-	if scoped, _ := communityInitialHistorySync(spectated); !scoped {
+	if !spectated {
 		willSync, err = m.scheduleSyncFilters(filters)
 		if err != nil {
 			logger.Debug("m.scheduleSyncFilters error", zap.Error(err))
@@ -1171,11 +1168,6 @@ func (m *Messenger) SpectateCommunity(communityID types3.HexBytes) (*MessengerRe
 
 	response.AddCommunity(community)
 
-	// #21470-hf: a spectator holds no community keys, so the previous global
-	// full-period backfill of every filter pulled the community's single universal
-	// content topic as gigabytes of undecryptable payloads (measured ~2-3GB/11min at
-	// ~330% service CPU). Backfill ONLY this community's filters over a scoped 24h
-	// window, cancellable on leave / app-background.
 	m.asyncSyncSpectatedCommunity(community)
 
 	return response, nil
@@ -2260,8 +2252,6 @@ func (m *Messenger) LeaveCommunity(communityID types3.HexBytes) (*MessengerRespo
 func (m *Messenger) leaveCommunity(communityID types3.HexBytes) (*MessengerResponse, error) {
 	response := &MessengerResponse{}
 
-	// Leaving (or unspectating) a community stops any in-flight scoped history
-	// backfill for it (issue #21470-hf).
 	m.communityHistoryFetches.cancel(communityID.String())
 
 	community, err := m.communitiesManager.LeaveCommunity(communityID)

--- a/protocol/messenger_communities.go
+++ b/protocol/messenger_communities.go
@@ -958,7 +958,14 @@ func (m *Messenger) SpectatedCommunities() ([]*communities.Community, error) {
 	return m.communitiesManager.Spectated()
 }
 
-func (m *Messenger) initCommunityChats(community *communities.Community) ([]*Chat, error) {
+// initCommunityChats initialises a community's chats and filters. When spectated is
+// true the broad, full-period history sync is NOT scheduled here — the caller
+// (SpectateCommunity) drives a scoped 24h backfill instead (issue #21470-hf). A
+// keyless spectator's full-period backfill of the community's single universal
+// content topic ingests gigabytes of undecryptable payloads; the broad sync scheduled
+// here would race the scoped one for the topic watermark and defeat the scoping.
+// Joining keeps today's behavior (the broad sync runs).
+func (m *Messenger) initCommunityChats(community *communities.Community, spectated bool) ([]*Chat, error) {
 	logger := m.logger.Named("initCommunityChats")
 
 	chats := CreateCommunityChats(community, m.getTimesource())
@@ -983,10 +990,13 @@ func (m *Messenger) initCommunityChats(community *communities.Community) ([]*Cha
 		filters = append(filters, communityFilters...)
 	}
 
-	willSync, err := m.scheduleSyncFilters(filters)
-	if err != nil {
-		logger.Debug("m.scheduleSyncFilters error", zap.Error(err))
-		return nil, err
+	willSync := false
+	if scoped, _ := communityInitialHistorySync(spectated); !scoped {
+		willSync, err = m.scheduleSyncFilters(filters)
+		if err != nil {
+			logger.Debug("m.scheduleSyncFilters error", zap.Error(err))
+			return nil, err
+		}
 	}
 
 	if !willSync {
@@ -1062,7 +1072,7 @@ func (m *Messenger) joinCommunity(ctx context.Context, communityID types3.HexByt
 
 	// chats and settings are already initialized for spectated communities
 	if !community.Spectated() {
-		chats, err := m.initCommunityChats(community)
+		chats, err := m.initCommunityChats(community, false)
 		if err != nil {
 			return nil, err
 		}
@@ -1147,7 +1157,7 @@ func (m *Messenger) SpectateCommunity(communityID types3.HexBytes) (*MessengerRe
 		return nil, err
 	}
 
-	chats, err := m.initCommunityChats(community)
+	chats, err := m.initCommunityChats(community, true)
 	if err != nil {
 		return nil, err
 	}
@@ -1161,8 +1171,12 @@ func (m *Messenger) SpectateCommunity(communityID types3.HexBytes) (*MessengerRe
 
 	response.AddCommunity(community)
 
-	// sync community
-	m.asyncRequestAllHistoricMessages()
+	// #21470-hf: a spectator holds no community keys, so the previous global
+	// full-period backfill of every filter pulled the community's single universal
+	// content topic as gigabytes of undecryptable payloads (measured ~2-3GB/11min at
+	// ~330% service CPU). Backfill ONLY this community's filters over a scoped 24h
+	// window, cancellable on leave / app-background.
+	m.asyncSyncSpectatedCommunity(community)
 
 	return response, nil
 }
@@ -2245,6 +2259,10 @@ func (m *Messenger) LeaveCommunity(communityID types3.HexBytes) (*MessengerRespo
 
 func (m *Messenger) leaveCommunity(communityID types3.HexBytes) (*MessengerResponse, error) {
 	response := &MessengerResponse{}
+
+	// Leaving (or unspectating) a community stops any in-flight scoped history
+	// backfill for it (issue #21470-hf).
+	m.communityHistoryFetches.cancel(communityID.String())
 
 	community, err := m.communitiesManager.LeaveCommunity(communityID)
 	if err != nil {
@@ -3633,7 +3651,7 @@ func (m *Messenger) InitHistoryArchiveTasks(communities []*communities.Community
 			}
 
 			// Request possibly missed waku messages for community
-			_, err = m.syncFiltersFrom(peerInfo, filters, uint32(latestWakuMessageTimestamp))
+			_, err = m.syncFiltersFrom(m.ctx, peerInfo, filters, uint32(latestWakuMessageTimestamp))
 			if err != nil {
 				m.logger.Error("failed to request missing messages", zap.Error(err))
 				continue

--- a/protocol/messenger_mailserver.go
+++ b/protocol/messenger_mailserver.go
@@ -1,6 +1,7 @@
 package protocol
 
 import (
+	"context"
 	"fmt"
 	"sort"
 	"time"
@@ -419,7 +420,7 @@ func getPrioritizedBatches() []int {
 	return []int{1, 5, 10}
 }
 
-func (m *Messenger) syncFiltersFrom(peerInfo peer.AddrInfo, filters types2.ChatFilters, lastRequest uint32) (*MessengerResponse, error) {
+func (m *Messenger) syncFiltersFrom(ctx context.Context, peerInfo peer.AddrInfo, filters types2.ChatFilters, lastRequest uint32) (*MessengerResponse, error) {
 	canSync, err := m.canSyncWithStoreNodes()
 	if err != nil {
 		return nil, err
@@ -558,7 +559,7 @@ func (m *Messenger) syncFiltersFrom(peerInfo peer.AddrInfo, filters types2.ChatF
 		batchKeys := maps.Keys(batches[pubsubTopic])
 		sort.Ints(batchKeys)
 		for _, k := range batchKeys {
-			err := m.processMailserverBatch(peerInfo, batches[pubsubTopic][k])
+			err := m.processMailserverBatchWithContext(ctx, peerInfo, batches[pubsubTopic][k])
 			if err != nil {
 				m.logger.Error("error syncing topics", zap.Error(err))
 				return nil, err
@@ -618,7 +619,7 @@ func (m *Messenger) syncFiltersFrom(peerInfo peer.AddrInfo, filters types2.ChatF
 }
 
 func (m *Messenger) syncFilters(peerInfo peer.AddrInfo, filters types2.ChatFilters) (*MessengerResponse, error) {
-	return m.syncFiltersFrom(peerInfo, filters, 0)
+	return m.syncFiltersFrom(m.ctx, peerInfo, filters, 0)
 }
 
 func (m *Messenger) calculateGapForChat(chat *Chat, from uint32) (*common.Message, error) {
@@ -684,6 +685,16 @@ func (m *Messenger) ConnectionChanged(state connection.State) {
 }
 
 func (m *Messenger) processMailserverBatch(peerInfo peer.AddrInfo, batch types2.StoreNodeBatch) error {
+	return m.processMailserverBatchWithContext(m.ctx, peerInfo, batch)
+}
+
+// processMailserverBatchWithContext is processMailserverBatch with a caller-supplied
+// context, so a request can be cancelled independently of the messenger lifetime
+// (used by the cancellable spectate backfill, issue #21470-hf). The go-waku history
+// paging loop checks ctx.Done() between pages, so cancelling ctx aborts an in-flight
+// request; watermarks are advanced only after a batch completes, so an aborted batch
+// leaves them untouched.
+func (m *Messenger) processMailserverBatchWithContext(ctx context.Context, peerInfo peer.AddrInfo, batch types2.StoreNodeBatch) error {
 	canSync, err := m.canSyncWithStoreNodes()
 	if err != nil {
 		return err
@@ -692,7 +703,7 @@ func (m *Messenger) processMailserverBatch(peerInfo peer.AddrInfo, batch types2.
 		return nil
 	}
 
-	return m.messaging.ProcessMailserverBatch(m.ctx, batch, peerInfo, defaultStoreNodeRequestPageSize, nil, false)
+	return m.messaging.ProcessMailserverBatch(ctx, batch, peerInfo, defaultStoreNodeRequestPageSize, nil, false)
 }
 
 func (m *Messenger) processMailserverBatchWithOptions(peerInfo peer.AddrInfo, batch types2.StoreNodeBatch, pageLimit uint64, shouldProcessNextPage func(int) (bool, uint64), processEnvelopes bool) error {

--- a/protocol/messenger_spectate_history_sync.go
+++ b/protocol/messenger_spectate_history_sync.go
@@ -19,14 +19,16 @@ import (
 // spectatedCommunityInitialSyncPeriod bounds the history backfill triggered when a
 // user spectates a community (issue #21470-hf).
 //
-// A spectator holds no community decryption keys, and every channel in a community
-// rides ONE universal content topic, so a full default-period (9-day) backfill pulls
-// the entire community's traffic as undecryptable payloads. Device measurement
-// (Samsung S21FE, fresh account spectating the Status community): ~2-3GB ingested in
-// ~11min at ~330% service CPU, GC-bound. Because all channels share one content
-// topic, per-channel scoping is impossible — the WINDOW is the only byte-cutting
-// lever, so spectate is bounded to 24h.
-const spectatedCommunityInitialSyncPeriod = 24 * time.Hour
+// History: this was briefly 24h as a byte-mitigation when the backfill fetched full
+// bodies for the whole universal topic (measured ~2-3GB / ~11min at ~330% service
+// CPU on a Samsung S21FE). With the backfill now hash-first (bodies fetched only
+// for unknown hashes), keyless spectators skipping undecryptable bodies entirely,
+// and the early-drop gates making residual bodies cheap, the full default sync
+// period is affordable again — so spectators get the same 9-day history horizon as
+// everyone else. The real wins of this path are retained: the sync is scoped to the
+// community's own filters (not the global all-filters sync), cancellable on
+// leave/background, and watermark-seeded.
+const spectatedCommunityInitialSyncPeriod = 9 * 24 * time.Hour
 
 // spectatedCommunitySyncFrom returns the store-node "from" timestamp (unix seconds)
 // for a spectator's scoped backfill: now minus the spectate window.
@@ -35,9 +37,9 @@ func spectatedCommunitySyncFrom(nowUnixSeconds uint32) uint32 {
 }
 
 // communityInitialHistorySync decides how a community's FIRST history backfill is
-// scoped. Spectators get the tight 24h window (deeper history is undecryptable heat);
-// joiners keep today's behavior — a full default-period backfill — because they hold
-// keys and legitimately want the history.
+// scoped. Spectators get a community-scoped default-period window (fetched
+// hash-first); joiners keep today's behavior — the full global backfill — because
+// they hold keys and legitimately want everything.
 func communityInitialHistorySync(spectated bool) (scoped bool, window time.Duration) {
 	if spectated {
 		return true, spectatedCommunityInitialSyncPeriod

--- a/protocol/messenger_spectate_history_sync.go
+++ b/protocol/messenger_spectate_history_sync.go
@@ -19,15 +19,15 @@ import (
 // spectatedCommunityInitialSyncPeriod bounds the history backfill triggered when a
 // user spectates a community (issue #21470-hf).
 //
-// History: this was briefly 24h as a byte-mitigation when the backfill fetched full
-// bodies for the whole universal topic (measured ~2-3GB / ~11min at ~330% service
-// CPU on a Samsung S21FE). With the backfill now hash-first (bodies fetched only
-// for unknown hashes), keyless spectators skipping undecryptable bodies entirely,
-// and the early-drop gates making residual bodies cheap, the full default sync
-// period is affordable again — so spectators get the same 9-day history horizon as
-// everyone else. The real wins of this path are retained: the sync is scoped to the
-// community's own filters (not the global all-filters sync), cancellable on
-// leave/background, and watermark-seeded.
+// The window matches the app-wide default sync period so spectators keep the
+// same history horizon as everyone else. What makes it affordable are the
+// processing fixes shipped alongside: undecryptable payloads drop early
+// instead of being ratchet-probed and parked (keyless gates), redelivered
+// descriptions short-circuit before the expensive pipeline (clock/hash gate),
+// segment reassembly is O(N), and the Go memory limit no longer forces
+// permanent GC thrash. The wins of this path itself: the sync is scoped to
+// the community's own filters (not the global all-filters sync), cancellable
+// on leave/background, and watermark-seeded.
 const spectatedCommunityInitialSyncPeriod = 9 * 24 * time.Hour
 
 // spectatedCommunitySyncFrom returns the store-node "from" timestamp (unix seconds)

--- a/protocol/messenger_spectate_history_sync.go
+++ b/protocol/messenger_spectate_history_sync.go
@@ -1,0 +1,289 @@
+package protocol
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"go.uber.org/zap"
+
+	"github.com/waku-org/go-waku/waku/v2/api/history"
+
+	gocommon "github.com/status-im/status-go/common"
+	types2 "github.com/status-im/status-go/pkg/messaging/types"
+	"github.com/status-im/status-go/protocol/communities"
+	"github.com/status-im/status-go/services/mailservers"
+)
+
+// spectatedCommunityInitialSyncPeriod bounds the history backfill triggered when a
+// user spectates a community (issue #21470-hf).
+//
+// A spectator holds no community decryption keys, and every channel in a community
+// rides ONE universal content topic, so a full default-period (9-day) backfill pulls
+// the entire community's traffic as undecryptable payloads. Device measurement
+// (Samsung S21FE, fresh account spectating the Status community): ~2-3GB ingested in
+// ~11min at ~330% service CPU, GC-bound. Because all channels share one content
+// topic, per-channel scoping is impossible — the WINDOW is the only byte-cutting
+// lever, so spectate is bounded to 24h.
+const spectatedCommunityInitialSyncPeriod = 24 * time.Hour
+
+// spectatedCommunitySyncFrom returns the store-node "from" timestamp (unix seconds)
+// for a spectator's scoped backfill: now minus the spectate window.
+func spectatedCommunitySyncFrom(nowUnixSeconds uint32) uint32 {
+	return nowUnixSeconds - uint32(spectatedCommunityInitialSyncPeriod/time.Second)
+}
+
+// communityInitialHistorySync decides how a community's FIRST history backfill is
+// scoped. Spectators get the tight 24h window (deeper history is undecryptable heat);
+// joiners keep today's behavior — a full default-period backfill — because they hold
+// keys and legitimately want the history.
+func communityInitialHistorySync(spectated bool) (scoped bool, window time.Duration) {
+	if spectated {
+		return true, spectatedCommunityInitialSyncPeriod
+	}
+	return false, 0
+}
+
+// mailserverTopicRef identifies a store-node topic (its pubsub + content topic).
+type mailserverTopicRef struct {
+	pubsubTopic  string
+	contentTopic string
+}
+
+// mailserverTopicKey is the map key syncFiltersFrom uses to look topics up; the seed
+// path must match it so a seeded topic is recognised as "already tracked".
+func mailserverTopicKey(pubsubTopic, contentTopic string) string {
+	return fmt.Sprintf("%s-%s", pubsubTopic, contentTopic)
+}
+
+// communityHistorySeedTopics returns the watermark rows to insert so a spectator's
+// first backfill of the given topics is bounded to lastRequest.
+//
+// syncFiltersFrom ignores its lastRequest argument for topics not yet present in the
+// mailserver DB (it hardcodes the default sync period for fresh topics), so without a
+// pre-seeded watermark a spectate would refetch the full default period. Topics
+// already tracked are skipped — AddTopics is INSERT-OR-REPLACE, and rewinding a good
+// watermark would refetch history we already have. Each topic is seeded at most once.
+func communityHistorySeedTopics(refs []mailserverTopicRef, existing map[string]struct{}, lastRequest int) []mailservers.MailserverTopic {
+	seeded := make(map[string]struct{}, len(refs))
+	var seeds []mailservers.MailserverTopic
+	for _, ref := range refs {
+		key := mailserverTopicKey(ref.pubsubTopic, ref.contentTopic)
+		if _, ok := existing[key]; ok {
+			continue
+		}
+		if _, ok := seeded[key]; ok {
+			continue
+		}
+		seeded[key] = struct{}{}
+		seeds = append(seeds, mailservers.MailserverTopic{
+			PubsubTopic:  ref.pubsubTopic,
+			ContentTopic: ref.contentTopic,
+			LastRequest:  lastRequest,
+		})
+	}
+	return seeds
+}
+
+// communitySyncFilters returns the transport filters that carry a community's
+// traffic: its single universal content topic plus the community-level filters. It
+// resolves the community's DefaultFilters chat ids to the live filters created when
+// the community was initialised. Every channel rides the one universal (community-id)
+// content topic, so this set covers all of the community's store-node bytes.
+func (m *Messenger) communitySyncFilters(community *communities.Community) types2.ChatFilters {
+	var filters types2.ChatFilters
+	seen := make(map[string]struct{})
+	for _, spec := range m.DefaultFilters(community) {
+		filter := m.messaging.ChatFilterByChatID(spec.ChatID)
+		if filter == nil {
+			continue
+		}
+		if _, ok := seen[filter.ChatID()]; ok {
+			continue
+		}
+		seen[filter.ChatID()] = struct{}{}
+		filters = append(filters, filter)
+	}
+	return filters
+}
+
+// seedCommunityHistoryWatermarks pre-seeds the mailserver watermark for each of the
+// given filters' topics that is not already tracked, so the spectate backfill's first
+// fetch is bounded to lastRequest instead of the full default sync period.
+func (m *Messenger) seedCommunityHistoryWatermarks(filters types2.ChatFilters, lastRequest int) error {
+	if m.mailserversDatabase == nil {
+		return nil
+	}
+
+	existingTopics, err := m.mailserversDatabase.Topics()
+	if err != nil {
+		return err
+	}
+	existing := make(map[string]struct{}, len(existingTopics))
+	for _, t := range existingTopics {
+		existing[mailserverTopicKey(t.PubsubTopic, t.ContentTopic)] = struct{}{}
+	}
+
+	refs := make([]mailserverTopicRef, 0, len(filters))
+	for _, filter := range filters {
+		refs = append(refs, mailserverTopicRef{
+			pubsubTopic:  filter.PubsubTopic(),
+			contentTopic: filter.ContentTopic().String(),
+		})
+	}
+
+	seeds := communityHistorySeedTopics(refs, existing, lastRequest)
+	if len(seeds) == 0 {
+		return nil
+	}
+	return m.mailserversDatabase.AddTopics(seeds)
+}
+
+// asyncSyncSpectatedCommunity backfills a freshly-spectated community's history over
+// the scoped 24h window (issue #21470-hf), replacing the global all-filters,
+// full-period backfill that spectating previously triggered. The fetch runs under a
+// per-community cancellable context registered on the messenger, so it stops when the
+// user leaves the community or the app is backgrounded.
+//
+// No message loss: skipped (older or cancelled) history stays on the store node; each
+// completed batch advances the per-topic watermark so later syncs resume exactly where
+// this one stopped; live relay delivery is unaffected; and the missing-message
+// verifier remains a net for anything not covered. A cancelled batch advances no
+// watermark, so nothing is marked fetched that was not.
+func (m *Messenger) asyncSyncSpectatedCommunity(community *communities.Community) {
+	shouldSync, err := m.shouldSync()
+	if err != nil {
+		m.logger.Error("failed to get shouldSync for spectated community", zap.Error(err))
+		return
+	}
+	if !shouldSync {
+		return
+	}
+
+	filters := m.communitySyncFilters(community)
+	if len(filters) == 0 {
+		return
+	}
+
+	communityID := community.IDString()
+	from := spectatedCommunitySyncFrom(uint32(m.getTimesource().GetCurrentTime() / 1000))
+
+	ctx, cancel := context.WithCancel(m.ctx)
+	token := m.communityHistoryFetches.register(communityID, cancel)
+
+	m.shutdownWaitGroup.Add(1)
+	go func() {
+		defer gocommon.LogOnPanic()
+		defer m.shutdownWaitGroup.Done()
+		defer cancel()
+		defer m.communityHistoryFetches.finish(communityID, token)
+
+		if err := m.seedCommunityHistoryWatermarks(filters, int(from)); err != nil {
+			m.logger.Warn("failed to seed spectated community history watermarks",
+				zap.String("communityID", communityID), zap.Error(err))
+			return
+		}
+
+		peerInfo := m.messaging.GetActiveStorenode()
+		_, err := m.performStorenodeTask(func() (*MessengerResponse, error) {
+			response, err := m.syncFiltersFrom(ctx, peerInfo, filters, from)
+			if err != nil {
+				if ctx.Err() != nil {
+					// Cancelled by leave / background: stop cleanly, without retrying
+					// or penalising the storenode's failure accounting.
+					m.logger.Debug("spectated community history sync cancelled",
+						zap.String("communityID", communityID))
+					return nil, nil
+				}
+				m.logger.Error("failed to sync spectated community history",
+					zap.String("communityID", communityID), zap.Error(err))
+				return nil, err
+			}
+			if m.config.messengerSignalsHandler != nil {
+				m.config.messengerSignalsHandler.MessengerResponse(response)
+			}
+			return response, nil
+		}, history.WithPeerID(peerInfo.ID))
+		if err != nil {
+			m.logger.Error("failed to perform spectated community history request",
+				zap.String("communityID", communityID), zap.Error(err))
+		}
+	}()
+}
+
+// communityHistoryFetchRegistry tracks the cancellable, per-community spectate
+// backfill goroutines so they can be aborted when the user leaves the community or
+// the app is backgrounded (issue #21470-hf, part B). On device the backfill was
+// measured continuing headless after the UI process died; cancellation stops it.
+//
+// Each registration is tagged with a monotonic token so a goroutine finishing on its
+// own only removes the map entry it still owns, never a fresher registration that
+// replaced it (context.CancelFunc values are not comparable, hence the token).
+type communityHistoryFetchRegistry struct {
+	mu      sync.Mutex
+	seq     uint64
+	entries map[string]communityHistoryFetchEntry
+}
+
+type communityHistoryFetchEntry struct {
+	token  uint64
+	cancel context.CancelFunc
+}
+
+func newCommunityHistoryFetchRegistry() *communityHistoryFetchRegistry {
+	return &communityHistoryFetchRegistry{
+		entries: make(map[string]communityHistoryFetchEntry),
+	}
+}
+
+// register records a new in-flight fetch for communityID, cancelling and replacing
+// any fetch already registered for it (e.g. a rapid re-spectate). It returns a token
+// identifying this registration, to be passed to finish.
+func (r *communityHistoryFetchRegistry) register(communityID string, cancel context.CancelFunc) uint64 {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if existing, ok := r.entries[communityID]; ok {
+		existing.cancel()
+	}
+	r.seq++
+	token := r.seq
+	r.entries[communityID] = communityHistoryFetchEntry{token: token, cancel: cancel}
+	return token
+}
+
+// cancel aborts the in-flight fetch for communityID (leave / unspectate path). It is
+// a no-op if none is registered.
+func (r *communityHistoryFetchRegistry) cancel(communityID string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if entry, ok := r.entries[communityID]; ok {
+		entry.cancel()
+		delete(r.entries, communityID)
+	}
+}
+
+// cancelAll aborts every in-flight fetch (app backgrounded).
+func (r *communityHistoryFetchRegistry) cancelAll() {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	for communityID, entry := range r.entries {
+		entry.cancel()
+		delete(r.entries, communityID)
+	}
+}
+
+// finish removes the registration for communityID IFF token still identifies the
+// current entry. A goroutine calls this on natural completion; if a newer fetch has
+// since replaced it, the entry is left untouched so the newer fetch stays cancellable.
+func (r *communityHistoryFetchRegistry) finish(communityID string, token uint64) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if entry, ok := r.entries[communityID]; ok && entry.token == token {
+		delete(r.entries, communityID)
+	}
+}

--- a/protocol/messenger_spectate_history_sync.go
+++ b/protocol/messenger_spectate_history_sync.go
@@ -16,57 +16,29 @@ import (
 	"github.com/status-im/status-go/services/mailservers"
 )
 
-// spectatedCommunityInitialSyncPeriod bounds the history backfill triggered when a
-// user spectates a community (issue #21470-hf).
-//
-// The window matches the app-wide default sync period so spectators keep the
-// same history horizon as everyone else. What makes it affordable are the
-// processing fixes shipped alongside: undecryptable payloads drop early
-// instead of being ratchet-probed and parked (keyless gates), redelivered
-// descriptions short-circuit before the expensive pipeline (clock/hash gate),
-// segment reassembly is O(N), and the Go memory limit no longer forces
-// permanent GC thrash. The wins of this path itself: the sync is scoped to
-// the community's own filters (not the global all-filters sync), cancellable
-// on leave/background, and watermark-seeded.
+// spectatedCommunityInitialSyncPeriod matches the app-wide default sync period
+// so spectators keep the same history horizon as everyone else.
 const spectatedCommunityInitialSyncPeriod = 9 * 24 * time.Hour
 
-// spectatedCommunitySyncFrom returns the store-node "from" timestamp (unix seconds)
-// for a spectator's scoped backfill: now minus the spectate window.
 func spectatedCommunitySyncFrom(nowUnixSeconds uint32) uint32 {
 	return nowUnixSeconds - uint32(spectatedCommunityInitialSyncPeriod/time.Second)
 }
 
-// communityInitialHistorySync decides how a community's FIRST history backfill is
-// scoped. Spectators get a community-scoped default-period window (fetched
-// hash-first); joiners keep today's behavior — the full global backfill — because
-// they hold keys and legitimately want everything.
-func communityInitialHistorySync(spectated bool) (scoped bool, window time.Duration) {
-	if spectated {
-		return true, spectatedCommunityInitialSyncPeriod
-	}
-	return false, 0
-}
-
-// mailserverTopicRef identifies a store-node topic (its pubsub + content topic).
 type mailserverTopicRef struct {
 	pubsubTopic  string
 	contentTopic string
 }
 
-// mailserverTopicKey is the map key syncFiltersFrom uses to look topics up; the seed
-// path must match it so a seeded topic is recognised as "already tracked".
+// mailserverTopicKey must match the key format syncFiltersFrom uses, so a
+// seeded topic is recognised as already tracked.
 func mailserverTopicKey(pubsubTopic, contentTopic string) string {
 	return fmt.Sprintf("%s-%s", pubsubTopic, contentTopic)
 }
 
-// communityHistorySeedTopics returns the watermark rows to insert so a spectator's
-// first backfill of the given topics is bounded to lastRequest.
-//
-// syncFiltersFrom ignores its lastRequest argument for topics not yet present in the
-// mailserver DB (it hardcodes the default sync period for fresh topics), so without a
-// pre-seeded watermark a spectate would refetch the full default period. Topics
-// already tracked are skipped — AddTopics is INSERT-OR-REPLACE, and rewinding a good
-// watermark would refetch history we already have. Each topic is seeded at most once.
+// communityHistorySeedTopics returns watermark rows for topics not yet tracked:
+// syncFiltersFrom hardcodes the full default sync period for topics missing
+// from the mailserver DB, and already-tracked topics must not be rewound
+// (AddTopics is INSERT-OR-REPLACE).
 func communityHistorySeedTopics(refs []mailserverTopicRef, existing map[string]struct{}, lastRequest int) []mailservers.MailserverTopic {
 	seeded := make(map[string]struct{}, len(refs))
 	var seeds []mailservers.MailserverTopic
@@ -88,11 +60,9 @@ func communityHistorySeedTopics(refs []mailserverTopicRef, existing map[string]s
 	return seeds
 }
 
-// communitySyncFilters returns the transport filters that carry a community's
-// traffic: its single universal content topic plus the community-level filters. It
-// resolves the community's DefaultFilters chat ids to the live filters created when
-// the community was initialised. Every channel rides the one universal (community-id)
-// content topic, so this set covers all of the community's store-node bytes.
+// communitySyncFilters resolves the community's DefaultFilters chat ids to live
+// transport filters; every channel rides the community's one universal content
+// topic, so this set covers all of its store-node traffic.
 func (m *Messenger) communitySyncFilters(community *communities.Community) types2.ChatFilters {
 	var filters types2.ChatFilters
 	seen := make(map[string]struct{})
@@ -110,9 +80,6 @@ func (m *Messenger) communitySyncFilters(community *communities.Community) types
 	return filters
 }
 
-// seedCommunityHistoryWatermarks pre-seeds the mailserver watermark for each of the
-// given filters' topics that is not already tracked, so the spectate backfill's first
-// fetch is bounded to lastRequest instead of the full default sync period.
 func (m *Messenger) seedCommunityHistoryWatermarks(filters types2.ChatFilters, lastRequest int) error {
 	if m.mailserversDatabase == nil {
 		return nil
@@ -142,17 +109,11 @@ func (m *Messenger) seedCommunityHistoryWatermarks(filters types2.ChatFilters, l
 	return m.mailserversDatabase.AddTopics(seeds)
 }
 
-// asyncSyncSpectatedCommunity backfills a freshly-spectated community's history over
-// the scoped 24h window (issue #21470-hf), replacing the global all-filters,
-// full-period backfill that spectating previously triggered. The fetch runs under a
-// per-community cancellable context registered on the messenger, so it stops when the
-// user leaves the community or the app is backgrounded.
-//
-// No message loss: skipped (older or cancelled) history stays on the store node; each
-// completed batch advances the per-topic watermark so later syncs resume exactly where
-// this one stopped; live relay delivery is unaffected; and the missing-message
-// verifier remains a net for anything not covered. A cancelled batch advances no
-// watermark, so nothing is marked fetched that was not.
+// asyncSyncSpectatedCommunity backfills a freshly-spectated community's history
+// over the scoped window, replacing the global all-filters backfill spectating
+// previously triggered. The fetch is cancellable per community (leave /
+// background); a cancelled batch advances no watermark, so later syncs resume
+// where it stopped.
 func (m *Messenger) asyncSyncSpectatedCommunity(community *communities.Community) {
 	shouldSync, err := m.shouldSync()
 	if err != nil {
@@ -192,8 +153,8 @@ func (m *Messenger) asyncSyncSpectatedCommunity(community *communities.Community
 			response, err := m.syncFiltersFrom(ctx, peerInfo, filters, from)
 			if err != nil {
 				if ctx.Err() != nil {
-					// Cancelled by leave / background: stop cleanly, without retrying
-					// or penalising the storenode's failure accounting.
+					// Cancelled by leave/background — don't retry or penalise the
+					// storenode's failure accounting.
 					m.logger.Debug("spectated community history sync cancelled",
 						zap.String("communityID", communityID))
 					return nil, nil
@@ -214,14 +175,10 @@ func (m *Messenger) asyncSyncSpectatedCommunity(community *communities.Community
 	}()
 }
 
-// communityHistoryFetchRegistry tracks the cancellable, per-community spectate
-// backfill goroutines so they can be aborted when the user leaves the community or
-// the app is backgrounded (issue #21470-hf, part B). On device the backfill was
-// measured continuing headless after the UI process died; cancellation stops it.
-//
-// Each registration is tagged with a monotonic token so a goroutine finishing on its
-// own only removes the map entry it still owns, never a fresher registration that
-// replaced it (context.CancelFunc values are not comparable, hence the token).
+// communityHistoryFetchRegistry tracks the in-flight per-community backfills so
+// leave/background can cancel them. Registrations carry a monotonic token so a
+// goroutine finishing on its own removes only the entry it still owns, never a
+// fresher registration that replaced it.
 type communityHistoryFetchRegistry struct {
 	mu      sync.Mutex
 	seq     uint64
@@ -239,9 +196,7 @@ func newCommunityHistoryFetchRegistry() *communityHistoryFetchRegistry {
 	}
 }
 
-// register records a new in-flight fetch for communityID, cancelling and replacing
-// any fetch already registered for it (e.g. a rapid re-spectate). It returns a token
-// identifying this registration, to be passed to finish.
+// register cancels and replaces any fetch already registered for communityID.
 func (r *communityHistoryFetchRegistry) register(communityID string, cancel context.CancelFunc) uint64 {
 	r.mu.Lock()
 	defer r.mu.Unlock()
@@ -255,8 +210,6 @@ func (r *communityHistoryFetchRegistry) register(communityID string, cancel cont
 	return token
 }
 
-// cancel aborts the in-flight fetch for communityID (leave / unspectate path). It is
-// a no-op if none is registered.
 func (r *communityHistoryFetchRegistry) cancel(communityID string) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
@@ -267,7 +220,6 @@ func (r *communityHistoryFetchRegistry) cancel(communityID string) {
 	}
 }
 
-// cancelAll aborts every in-flight fetch (app backgrounded).
 func (r *communityHistoryFetchRegistry) cancelAll() {
 	r.mu.Lock()
 	defer r.mu.Unlock()
@@ -278,9 +230,8 @@ func (r *communityHistoryFetchRegistry) cancelAll() {
 	}
 }
 
-// finish removes the registration for communityID IFF token still identifies the
-// current entry. A goroutine calls this on natural completion; if a newer fetch has
-// since replaced it, the entry is left untouched so the newer fetch stays cancellable.
+// finish removes the registration only if token still identifies the current
+// entry, so a newer fetch that replaced it stays cancellable.
 func (r *communityHistoryFetchRegistry) finish(communityID string, token uint64) {
 	r.mu.Lock()
 	defer r.mu.Unlock()

--- a/protocol/messenger_spectate_history_sync_test.go
+++ b/protocol/messenger_spectate_history_sync_test.go
@@ -8,42 +8,16 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestSpectatedCommunitySyncFrom verifies the spectate backfill window computation
-// (issue #21470-hf). A keyless spectator's full default-period backfill of a
-// community's single universal content topic ingests gigabytes of undecryptable
-// payloads (measured ~2-3GB/11min at ~330% service CPU on a Samsung S21FE). The
-// only byte-cutting lever is the WINDOW, because every channel rides one content
-// topic so per-channel scoping is impossible. Spectate is therefore bounded to a
-// scoped window matching the app's default sync period (9 days).
 func TestSpectatedCommunitySyncFrom(t *testing.T) {
 	require.Equal(t, 9*24*time.Hour, spectatedCommunityInitialSyncPeriod,
-		"spectate window matches the 9-day default sync period — affordable since hash-first + keyless-skip")
+		"spectate window matches the 9-day default sync period")
 
 	const now = uint32(1_700_000_000)
 	require.Equal(t, now-uint32(9*24*60*60), spectatedCommunitySyncFrom(now))
 }
 
-// TestCommunityInitialHistorySync verifies the spectate-vs-join scoping decision
-// (issue #21470-hf). A spectator holds no decryption keys, so deeper history is
-// pure heat and is scoped to 24h. A joiner holds keys and legitimately wants the
-// full default-period backfill, so joining must KEEP today's behavior (unscoped).
-func TestCommunityInitialHistorySync(t *testing.T) {
-	scoped, window := communityInitialHistorySync(true /* spectated */)
-	require.True(t, scoped, "spectators must use the scoped window")
-	require.Equal(t, spectatedCommunityInitialSyncPeriod, window)
-
-	scoped, window = communityInitialHistorySync(false /* joined */)
-	require.False(t, scoped, "joining must keep today's unscoped full-period backfill")
-	require.Equal(t, time.Duration(0), window)
-}
-
-// TestCommunityHistorySeedTopics verifies the watermark seeding that bounds a
-// spectator's FIRST backfill to the scoped window (issue #21470-hf). syncFiltersFrom
-// ignores its `lastRequest` argument for topics not yet tracked — a fresh topic
-// always defaults to the full sync period. So before syncing we seed each of the
-// community's topics with a `now-24h` watermark. Topics already tracked must be
-// SKIPPED (INSERT-OR-REPLACE would otherwise rewind a good watermark and refetch),
-// and each topic is seeded at most once.
+// Fresh topics get a seeded watermark; already-tracked topics must be skipped
+// (INSERT-OR-REPLACE would rewind a good watermark); each seeded at most once.
 func TestCommunityHistorySeedTopics(t *testing.T) {
 	const from = 1_699_913_600 // now - 24h
 
@@ -84,10 +58,6 @@ type fakeCancel struct {
 
 func (f fakeCancel) cancel() { *f.calls++ }
 
-// TestCommunityHistoryFetchRegistry_LeaveAndBackground verifies the cancel-registry
-// semantics that make the spectate backfill cancellable (issue #21470-hf, part B):
-// the device-measured backfill continues headless after the UI dies, so leaving a
-// community and backgrounding the app must both stop it.
 func TestCommunityHistoryFetchRegistry_LeaveAndBackground(t *testing.T) {
 	r := newCommunityHistoryFetchRegistry()
 

--- a/protocol/messenger_spectate_history_sync_test.go
+++ b/protocol/messenger_spectate_history_sync_test.go
@@ -14,13 +14,13 @@ import (
 // payloads (measured ~2-3GB/11min at ~330% service CPU on a Samsung S21FE). The
 // only byte-cutting lever is the WINDOW, because every channel rides one content
 // topic so per-channel scoping is impossible. Spectate is therefore bounded to a
-// tight 24h window; `from = now - 24h`.
+// scoped window matching the app's default sync period (9 days).
 func TestSpectatedCommunitySyncFrom(t *testing.T) {
-	require.Equal(t, 24*time.Hour, spectatedCommunityInitialSyncPeriod,
-		"spectate window must stay 24h — the measured heat lever")
+	require.Equal(t, 9*24*time.Hour, spectatedCommunityInitialSyncPeriod,
+		"spectate window matches the 9-day default sync period — affordable since hash-first + keyless-skip")
 
 	const now = uint32(1_700_000_000)
-	require.Equal(t, now-uint32(24*60*60), spectatedCommunitySyncFrom(now))
+	require.Equal(t, now-uint32(9*24*60*60), spectatedCommunitySyncFrom(now))
 }
 
 // TestCommunityInitialHistorySync verifies the spectate-vs-join scoping decision

--- a/protocol/messenger_spectate_history_sync_test.go
+++ b/protocol/messenger_spectate_history_sync_test.go
@@ -1,0 +1,162 @@
+package protocol
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestSpectatedCommunitySyncFrom verifies the spectate backfill window computation
+// (issue #21470-hf). A keyless spectator's full default-period backfill of a
+// community's single universal content topic ingests gigabytes of undecryptable
+// payloads (measured ~2-3GB/11min at ~330% service CPU on a Samsung S21FE). The
+// only byte-cutting lever is the WINDOW, because every channel rides one content
+// topic so per-channel scoping is impossible. Spectate is therefore bounded to a
+// tight 24h window; `from = now - 24h`.
+func TestSpectatedCommunitySyncFrom(t *testing.T) {
+	require.Equal(t, 24*time.Hour, spectatedCommunityInitialSyncPeriod,
+		"spectate window must stay 24h — the measured heat lever")
+
+	const now = uint32(1_700_000_000)
+	require.Equal(t, now-uint32(24*60*60), spectatedCommunitySyncFrom(now))
+}
+
+// TestCommunityInitialHistorySync verifies the spectate-vs-join scoping decision
+// (issue #21470-hf). A spectator holds no decryption keys, so deeper history is
+// pure heat and is scoped to 24h. A joiner holds keys and legitimately wants the
+// full default-period backfill, so joining must KEEP today's behavior (unscoped).
+func TestCommunityInitialHistorySync(t *testing.T) {
+	scoped, window := communityInitialHistorySync(true /* spectated */)
+	require.True(t, scoped, "spectators must use the scoped window")
+	require.Equal(t, spectatedCommunityInitialSyncPeriod, window)
+
+	scoped, window = communityInitialHistorySync(false /* joined */)
+	require.False(t, scoped, "joining must keep today's unscoped full-period backfill")
+	require.Equal(t, time.Duration(0), window)
+}
+
+// TestCommunityHistorySeedTopics verifies the watermark seeding that bounds a
+// spectator's FIRST backfill to the scoped window (issue #21470-hf). syncFiltersFrom
+// ignores its `lastRequest` argument for topics not yet tracked — a fresh topic
+// always defaults to the full sync period. So before syncing we seed each of the
+// community's topics with a `now-24h` watermark. Topics already tracked must be
+// SKIPPED (INSERT-OR-REPLACE would otherwise rewind a good watermark and refetch),
+// and each topic is seeded at most once.
+func TestCommunityHistorySeedTopics(t *testing.T) {
+	const from = 1_699_913_600 // now - 24h
+
+	refs := []mailserverTopicRef{
+		{pubsubTopic: "pubA", contentTopic: "0x01"}, // fresh -> seed
+		{pubsubTopic: "pubA", contentTopic: "0x02"}, // already tracked -> skip
+		{pubsubTopic: "pubA", contentTopic: "0x01"}, // duplicate of the first -> seed once
+	}
+	existing := map[string]struct{}{
+		mailserverTopicKey("pubA", "0x02"): {},
+	}
+
+	seeds := communityHistorySeedTopics(refs, existing, from)
+
+	require.Len(t, seeds, 1, "only the fresh topic is seeded, exactly once")
+	require.Equal(t, "pubA", seeds[0].PubsubTopic)
+	require.Equal(t, "0x01", seeds[0].ContentTopic)
+	require.Equal(t, from, seeds[0].LastRequest)
+}
+
+// TestCommunityHistorySeedTopics_AllTracked verifies that when every topic is already
+// tracked, nothing is seeded (leaving each topic's existing watermark to drive an
+// incremental, already-bounded sync).
+func TestCommunityHistorySeedTopics_AllTracked(t *testing.T) {
+	refs := []mailserverTopicRef{{pubsubTopic: "pubA", contentTopic: "0x01"}}
+	existing := map[string]struct{}{mailserverTopicKey("pubA", "0x01"): {}}
+
+	require.Empty(t, communityHistorySeedTopics(refs, existing, 123))
+}
+
+// --- cancel registry -------------------------------------------------------
+
+// fakeCancel records how many times it was invoked, standing in for a
+// context.CancelFunc without needing a live context.
+type fakeCancel struct {
+	calls *int
+}
+
+func (f fakeCancel) cancel() { *f.calls++ }
+
+// TestCommunityHistoryFetchRegistry_LeaveAndBackground verifies the cancel-registry
+// semantics that make the spectate backfill cancellable (issue #21470-hf, part B):
+// the device-measured backfill continues headless after the UI dies, so leaving a
+// community and backgrounding the app must both stop it.
+func TestCommunityHistoryFetchRegistry_LeaveAndBackground(t *testing.T) {
+	r := newCommunityHistoryFetchRegistry()
+
+	aCalls, bCalls := 0, 0
+	a := fakeCancel{&aCalls}
+	b := fakeCancel{&bCalls}
+
+	// register two in-flight community fetches
+	_ = r.register("communityA", a.cancel)
+	_ = r.register("communityB", b.cancel)
+
+	// leaving communityA cancels only its fetch
+	r.cancel("communityA")
+	require.Equal(t, 1, aCalls)
+	require.Equal(t, 0, bCalls)
+
+	// cancelling an already-cancelled / unknown id is a no-op
+	r.cancel("communityA")
+	r.cancel("unknown")
+	require.Equal(t, 1, aCalls)
+
+	// backgrounding cancels everything still in flight
+	r.cancelAll()
+	require.Equal(t, 1, bCalls)
+	require.Equal(t, 1, aCalls, "A was already removed by leave, must not be re-cancelled")
+}
+
+// TestCommunityHistoryFetchRegistry_ReplaceAndFinish verifies that re-spectating the
+// same community cancels the stale in-flight fetch, and that a fetch which finishes
+// on its own only cleans up the map entry it still owns (never a newer one's).
+func TestCommunityHistoryFetchRegistry_ReplaceAndFinish(t *testing.T) {
+	r := newCommunityHistoryFetchRegistry()
+
+	firstCalls, secondCalls := 0, 0
+	first := fakeCancel{&firstCalls}
+	second := fakeCancel{&secondCalls}
+
+	tok1 := r.register("communityA", first.cancel)
+
+	// re-spectating communityA replaces (and cancels) the stale fetch
+	tok2 := r.register("communityA", second.cancel)
+	require.Equal(t, 1, firstCalls, "stale fetch must be cancelled on re-register")
+	require.NotEqual(t, tok1, tok2, "each registration gets a distinct token")
+
+	// the FIRST fetch's goroutine now finishes and tries to clean up. It must NOT
+	// remove the second fetch's entry (it no longer owns the slot).
+	r.finish("communityA", tok1)
+
+	// cancelling communityA must still reach the second (current) fetch
+	r.cancel("communityA")
+	require.Equal(t, 1, secondCalls, "current fetch must remain cancellable after a stale finish")
+
+	// a fetch that finishes on its own removes its entry, so a later cancel is a no-op
+	thirdCalls := 0
+	third := fakeCancel{&thirdCalls}
+	tok3 := r.register("communityA", third.cancel)
+	r.finish("communityA", tok3)
+	r.cancel("communityA")
+	require.Equal(t, 0, thirdCalls, "finish removed the entry, so cancel must not reach the completed fetch")
+}
+
+// TestCommunityHistoryFetchRegistry_ContextCancelFunc is a light integration check
+// that a real context.CancelFunc registered in the registry cancels its context.
+func TestCommunityHistoryFetchRegistry_ContextCancelFunc(t *testing.T) {
+	r := newCommunityHistoryFetchRegistry()
+	ctx, cancel := context.WithCancel(context.Background())
+	_ = r.register("communityA", cancel)
+
+	require.NoError(t, ctx.Err())
+	r.cancel("communityA")
+	require.ErrorIs(t, ctx.Err(), context.Canceled)
+}


### PR DESCRIPTION
## HF 4: spectate history sync scoping (status-app#21470)

Stacked on #7634. Spectating a community previously fired the GLOBAL all-filters, full-period history backfill — twice via racing paths — and it kept running headless after the UI process died.

**Change (4 commits):** spectate triggers a sync scoped to the community's own filters over the 9-day default window (same horizon as everyone else), watermark-seeded so fresh topics don't default to a full-period walk, and registered in a per-community cancel registry: leaving the community or backgrounding the app aborts it. A cancelled batch advances no watermark, so later syncs resume where it stopped. Joining keeps today's unscoped behavior.

**Measured on device:** UI-process kill during an active sync drops the service from ~60% mean CPU to **3–20% within a minute** (base behavior: 78–89% CPU + ~3MB/s indefinitely, forever). In-protocol CPU is neutral (61% mean vs 60% — the sync itself still runs); the win is the lifecycle: no double sync, no headless drain.

Umbrella PR with the full per-stage accountability table: #7632.

🤖 Generated with [Claude Code](https://claude.com/claude-code)