### PR TITLE
perf: gate redelivered community descriptions; O(N) segment reassembly (#21470, HF 5)

### DIFF
--- a/pkg/messaging/layers/segmentation/persistence.go
+++ b/pkg/messaging/layers/segmentation/persistence.go
@@ -7,6 +7,12 @@ import (
 type Persistence interface {
 	IsMessageAlreadyCompleted(hash []byte) (bool, error)
 	SaveMessageSegment(segment *Message, sigPubKey *ecdsa.PublicKey, timestamp int64) error
+	// GetMessageSegmentsCompletionInfo returns the number of stored segments for a
+	// message and the SegmentsCount its data segments advertise (0 if none stored
+	// yet). It is a cheap aggregate (COUNT + MAX, no payload blobs copied) used to
+	// avoid loading every stored segment via GetMessageSegments until the message
+	// can actually be reassembled (issue #21470-hf).
+	GetMessageSegmentsCompletionInfo(hash []byte, sigPubKey *ecdsa.PublicKey) (storedCount int, segmentsCount uint32, err error)
 	GetMessageSegments(hash []byte, sigPubKey *ecdsa.PublicKey) ([]*Message, error)
 	CompleteMessageSegments(hash []byte, sigPubKey *ecdsa.PublicKey, timestamp int64) error
 	RemoveMessageSegmentsOlderThan(timestamp int64) error

--- a/pkg/messaging/layers/segmentation/persistence.go
+++ b/pkg/messaging/layers/segmentation/persistence.go
@@ -7,11 +7,9 @@ import (
 type Persistence interface {
 	IsMessageAlreadyCompleted(hash []byte) (bool, error)
 	SaveMessageSegment(segment *Message, sigPubKey *ecdsa.PublicKey, timestamp int64) error
-	// GetMessageSegmentsCompletionInfo returns the number of stored segments for a
-	// message and the SegmentsCount its data segments advertise (0 if none stored
-	// yet). It is a cheap aggregate (COUNT + MAX, no payload blobs copied) used to
-	// avoid loading every stored segment via GetMessageSegments until the message
-	// can actually be reassembled (issue #21470-hf).
+	// GetMessageSegmentsCompletionInfo returns the number of stored segments
+	// and the SegmentsCount the data segments advertise (0 if none stored yet),
+	// without copying payload blobs.
 	GetMessageSegmentsCompletionInfo(hash []byte, sigPubKey *ecdsa.PublicKey) (storedCount int, segmentsCount uint32, err error)
 	GetMessageSegments(hash []byte, sigPubKey *ecdsa.PublicKey) ([]*Message, error)
 	CompleteMessageSegments(hash []byte, sigPubKey *ecdsa.PublicKey, timestamp int64) error

--- a/pkg/messaging/layers/segmentation/segmenter.go
+++ b/pkg/messaging/layers/segmentation/segmenter.go
@@ -153,13 +153,9 @@ func (s *Segmenter) Reconstruct(payload []byte, sigPubKey *ecdsa.PublicKey, tran
 		return nil, nil, err
 	}
 
-	// Cheap completion precheck (issue #21470-hf): a message can only be reassembled
-	// once at least SegmentsCount segments (data + parity) are stored. Until then,
-	// skip the expensive GetMessageSegments below, which copies every stored payload
-	// blob out of sqlcipher — for an N-segment message arriving one segment at a time
-	// that full read would otherwise run on every arrival (O(N^2) blob copies).
-	// This is a NECESSARY-condition filter only; the authoritative completeness and
-	// hash checks still run on the fully loaded segments below.
+	// Necessary-condition precheck: skip the full segment load until at least
+	// SegmentsCount segments are stored; the authoritative completeness and
+	// hash checks still run on the loaded segments below.
 	storedCount, expectedCount, err := s.persistence.GetMessageSegmentsCompletionInfo(segmentMessage.EntireMessageHash, sigPubKey)
 	if err != nil {
 		return nil, nil, err

--- a/pkg/messaging/layers/segmentation/segmenter.go
+++ b/pkg/messaging/layers/segmentation/segmenter.go
@@ -153,6 +153,21 @@ func (s *Segmenter) Reconstruct(payload []byte, sigPubKey *ecdsa.PublicKey, tran
 		return nil, nil, err
 	}
 
+	// Cheap completion precheck (issue #21470-hf): a message can only be reassembled
+	// once at least SegmentsCount segments (data + parity) are stored. Until then,
+	// skip the expensive GetMessageSegments below, which copies every stored payload
+	// blob out of sqlcipher — for an N-segment message arriving one segment at a time
+	// that full read would otherwise run on every arrival (O(N^2) blob copies).
+	// This is a NECESSARY-condition filter only; the authoritative completeness and
+	// hash checks still run on the fully loaded segments below.
+	storedCount, expectedCount, err := s.persistence.GetMessageSegmentsCompletionInfo(segmentMessage.EntireMessageHash, sigPubKey)
+	if err != nil {
+		return nil, nil, err
+	}
+	if expectedCount == 0 || storedCount < int(expectedCount) {
+		return nil, nil, ErrIncomplete
+	}
+
 	segments, err := s.persistence.GetMessageSegments(segmentMessage.EntireMessageHash, sigPubKey)
 	if err != nil {
 		return nil, nil, err

--- a/pkg/messaging/layers/segmentation/segmenter_test.go
+++ b/pkg/messaging/layers/segmentation/segmenter_test.go
@@ -188,10 +188,8 @@ func (s *MessageSegmentationSuite) TestProtobufMissDecoding() {
 	s.Require().False(segmentedMessage.IsValid())
 }
 
-// countingPersistence wraps a real Persistence and counts GetMessageSegments
-// calls, so tests can assert the expensive full-segment read (which copies every
-// stored payload blob out of sqlcipher) happens only once, on completion —
-// instead of on every arriving segment (the O(N^2) behavior, issue #21470-hf).
+// countingPersistence counts GetMessageSegments calls so tests can assert the
+// full-segment read happens only once, on completion.
 type countingPersistence struct {
 	Persistence
 	getSegmentsCalls int
@@ -214,9 +212,6 @@ func (s *MessageSegmentationSuite) newCountingSegmenter() (*Segmenter, *counting
 	return NewSegmenter(counting, zap.Must(zap.NewDevelopment())), counting
 }
 
-// TestReadsAllSegmentsOnlyOnCompletion (no parity) verifies that arriving segments
-// before the last do NOT trigger a full read of every stored segment, and the last
-// one triggers exactly one such read (issue #21470-hf: O(N) instead of O(N^2)).
 func (s *MessageSegmentationSuite) TestReadsAllSegmentsOnlyOnCompletion() {
 	segmenter, counting := s.newCountingSegmenter()
 
@@ -241,9 +236,6 @@ func (s *MessageSegmentationSuite) TestReadsAllSegmentsOnlyOnCompletion() {
 	s.Require().Equal(1, counting.getSegmentsCalls, "reads all segments exactly once, on completion")
 }
 
-// TestReadsAllSegmentsOnlyOnCompletionOutOfOrder verifies the completion precheck
-// is order-independent: the full read still fires exactly once, on the arrival that
-// brings the stored count up to SegmentsCount.
 func (s *MessageSegmentationSuite) TestReadsAllSegmentsOnlyOnCompletionOutOfOrder() {
 	segmenter, counting := s.newCountingSegmenter()
 
@@ -269,9 +261,7 @@ func (s *MessageSegmentationSuite) TestReadsAllSegmentsOnlyOnCompletionOutOfOrde
 	}
 }
 
-// TestDuplicateSegmentDoesNotTriggerRead verifies a duplicate arrival (which
-// REPLACEs its row and leaves the stored count unchanged) neither completes the
-// message nor triggers a full read.
+// A duplicate arrival REPLACEs its row and leaves the stored count unchanged.
 func (s *MessageSegmentationSuite) TestDuplicateSegmentDoesNotTriggerRead() {
 	segmenter, counting := s.newCountingSegmenter()
 
@@ -290,9 +280,6 @@ func (s *MessageSegmentationSuite) TestDuplicateSegmentDoesNotTriggerRead() {
 	s.Require().Equal(0, counting.getSegmentsCalls, "duplicate must not trigger a full read")
 }
 
-// TestParityCompletionReadsOnce verifies the completion precheck fires the single
-// full read even when the completing segment is a parity segment (reedsolomon
-// reconstruction with one data segment missing).
 func (s *MessageSegmentationSuite) TestParityCompletionReadsOnce() {
 	segmenter, counting := s.newCountingSegmenter()
 

--- a/pkg/messaging/layers/segmentation/segmenter_test.go
+++ b/pkg/messaging/layers/segmentation/segmenter_test.go
@@ -1,6 +1,7 @@
 package segmentation
 
 import (
+	"crypto/ecdsa"
 	_ "embed"
 	"testing"
 
@@ -185,4 +186,137 @@ func (s *MessageSegmentationSuite) TestProtobufMissDecoding() {
 
 	// Ensure that the sanity check for the segmented message fails, as expected.
 	s.Require().False(segmentedMessage.IsValid())
+}
+
+// countingPersistence wraps a real Persistence and counts GetMessageSegments
+// calls, so tests can assert the expensive full-segment read (which copies every
+// stored payload blob out of sqlcipher) happens only once, on completion —
+// instead of on every arriving segment (the O(N^2) behavior, issue #21470-hf).
+type countingPersistence struct {
+	Persistence
+	getSegmentsCalls int
+}
+
+func (c *countingPersistence) GetMessageSegments(hash []byte, sigPubKey *ecdsa.PublicKey) ([]*Message, error) {
+	c.getSegmentsCalls++
+	return c.Persistence.GetMessageSegments(hash, sigPubKey)
+}
+
+func (s *MessageSegmentationSuite) newCountingSegmenter() (*Segmenter, *countingPersistence) {
+	db, err := testutils.SetupTestMemorySQLDB(testutils.NewTestDBInitializer([]*bindata.AssetSource{
+		{
+			Names:     migrations.AssetNames(),
+			AssetFunc: migrations.Asset,
+		},
+	}))
+	s.Require().NoError(err)
+	counting := &countingPersistence{Persistence: NewSQLitePersistence(db)}
+	return NewSegmenter(counting, zap.Must(zap.NewDevelopment())), counting
+}
+
+// TestReadsAllSegmentsOnlyOnCompletion (no parity) verifies that arriving segments
+// before the last do NOT trigger a full read of every stored segment, and the last
+// one triggers exactly one such read (issue #21470-hf: O(N) instead of O(N^2)).
+func (s *MessageSegmentationSuite) TestReadsAllSegmentsOnlyOnCompletion() {
+	segmenter, counting := s.newCountingSegmenter()
+
+	signer, err := crypto.GenerateKey()
+	s.Require().NoError(err)
+
+	segmentsCount := 5 // floor(5*0.125)=0 parity segments
+	segSize := (len(s.testPayload) + segmentsCount - 1) / segmentsCount
+	segs, err := segmenter.Segment(s.testPayload, segSize)
+	s.Require().NoError(err)
+	s.Require().Len(segs, segmentsCount)
+
+	for i := 0; i < segmentsCount-1; i++ {
+		_, _, err := segmenter.Reconstruct(segs[i], &signer.PublicKey, nil)
+		s.Require().ErrorIs(err, ErrIncomplete)
+	}
+	s.Require().Equal(0, counting.getSegmentsCalls, "must not read all segments before completion")
+
+	payload, _, err := segmenter.Reconstruct(segs[segmentsCount-1], &signer.PublicKey, nil)
+	s.Require().NoError(err)
+	s.Require().ElementsMatch(s.testPayload, payload)
+	s.Require().Equal(1, counting.getSegmentsCalls, "reads all segments exactly once, on completion")
+}
+
+// TestReadsAllSegmentsOnlyOnCompletionOutOfOrder verifies the completion precheck
+// is order-independent: the full read still fires exactly once, on the arrival that
+// brings the stored count up to SegmentsCount.
+func (s *MessageSegmentationSuite) TestReadsAllSegmentsOnlyOnCompletionOutOfOrder() {
+	segmenter, counting := s.newCountingSegmenter()
+
+	signer, err := crypto.GenerateKey()
+	s.Require().NoError(err)
+
+	segmentsCount := 5
+	segSize := (len(s.testPayload) + segmentsCount - 1) / segmentsCount
+	segs, err := segmenter.Segment(s.testPayload, segSize)
+	s.Require().NoError(err)
+
+	order := []int{3, 0, 4, 1, 2}
+	for i, idx := range order {
+		payload, _, err := segmenter.Reconstruct(segs[idx], &signer.PublicKey, nil)
+		if i < segmentsCount-1 {
+			s.Require().ErrorIs(err, ErrIncomplete)
+			s.Require().Equal(0, counting.getSegmentsCalls)
+		} else {
+			s.Require().NoError(err)
+			s.Require().ElementsMatch(s.testPayload, payload)
+			s.Require().Equal(1, counting.getSegmentsCalls)
+		}
+	}
+}
+
+// TestDuplicateSegmentDoesNotTriggerRead verifies a duplicate arrival (which
+// REPLACEs its row and leaves the stored count unchanged) neither completes the
+// message nor triggers a full read.
+func (s *MessageSegmentationSuite) TestDuplicateSegmentDoesNotTriggerRead() {
+	segmenter, counting := s.newCountingSegmenter()
+
+	signer, err := crypto.GenerateKey()
+	s.Require().NoError(err)
+
+	segmentsCount := 5
+	segSize := (len(s.testPayload) + segmentsCount - 1) / segmentsCount
+	segs, err := segmenter.Segment(s.testPayload, segSize)
+	s.Require().NoError(err)
+
+	_, _, err = segmenter.Reconstruct(segs[0], &signer.PublicKey, nil)
+	s.Require().ErrorIs(err, ErrIncomplete)
+	_, _, err = segmenter.Reconstruct(segs[0], &signer.PublicKey, nil) // duplicate
+	s.Require().ErrorIs(err, ErrIncomplete)
+	s.Require().Equal(0, counting.getSegmentsCalls, "duplicate must not trigger a full read")
+}
+
+// TestParityCompletionReadsOnce verifies the completion precheck fires the single
+// full read even when the completing segment is a parity segment (reedsolomon
+// reconstruction with one data segment missing).
+func (s *MessageSegmentationSuite) TestParityCompletionReadsOnce() {
+	segmenter, counting := s.newCountingSegmenter()
+
+	signer, err := crypto.GenerateKey()
+	s.Require().NoError(err)
+
+	segmentsCount := 8 // floor(8*0.125)=1 parity segment
+	segSize := (len(s.testPayload) + segmentsCount - 1) / segmentsCount
+	segs, err := segmenter.Segment(s.testPayload, segSize)
+	s.Require().NoError(err)
+	s.Require().Len(segs, segmentsCount+1) // 8 data + 1 parity
+
+	// Deliver 7 of the 8 data segments (index 0..6), then the parity segment
+	// (index 8) which brings the stored count to 8 and completes via parity.
+	arrival := []int{0, 1, 2, 3, 4, 5, 6, 8}
+	for i, idx := range arrival {
+		payload, _, err := segmenter.Reconstruct(segs[idx], &signer.PublicKey, nil)
+		if i < segmentsCount-1 {
+			s.Require().ErrorIs(err, ErrIncomplete)
+			s.Require().Equal(0, counting.getSegmentsCalls)
+		} else {
+			s.Require().NoError(err)
+			s.Require().ElementsMatch(s.testPayload, payload)
+			s.Require().Equal(1, counting.getSegmentsCalls)
+		}
+	}
 }

--- a/pkg/messaging/layers/segmentation/sqlite_persistence.go
+++ b/pkg/messaging/layers/segmentation/sqlite_persistence.go
@@ -36,6 +36,26 @@ func (s *SQLitePersistence) SaveMessageSegment(segment *Message, sigPubKey *ecds
 	return err
 }
 
+// GetMessageSegmentsCompletionInfo returns how many segments are stored for the
+// message and the SegmentsCount its data segments advertise. Data segments carry
+// segments_count = N (> 0); parity segments carry 0, so MAX(segments_count) is N
+// once any data segment is stored, and 0 while only parity has arrived. This is a
+// cheap aggregate over just this message's rows (via the primary-key prefix
+// hash+sig_pub_key) that copies no payload blobs (issue #21470-hf).
+func (s *SQLitePersistence) GetMessageSegmentsCompletionInfo(hash []byte, sigPubKey *ecdsa.PublicKey) (int, uint32, error) {
+	sigPubKeyBlob := crypto.CompressPubkey(sigPubKey)
+
+	var storedCount int
+	var segmentsCount uint32
+	err := s.db.QueryRow(
+		"SELECT COUNT(*), COALESCE(MAX(segments_count), 0) FROM message_segments WHERE hash = ? AND sig_pub_key = ?",
+		hash, sigPubKeyBlob).Scan(&storedCount, &segmentsCount)
+	if err != nil {
+		return 0, 0, err
+	}
+	return storedCount, segmentsCount, nil
+}
+
 // Get ordered message segments for given hash
 func (s *SQLitePersistence) GetMessageSegments(hash []byte, sigPubKey *ecdsa.PublicKey) ([]*Message, error) {
 	sigPubKeyBlob := crypto.CompressPubkey(sigPubKey)

--- a/pkg/messaging/layers/segmentation/sqlite_persistence.go
+++ b/pkg/messaging/layers/segmentation/sqlite_persistence.go
@@ -36,12 +36,9 @@ func (s *SQLitePersistence) SaveMessageSegment(segment *Message, sigPubKey *ecds
 	return err
 }
 
-// GetMessageSegmentsCompletionInfo returns how many segments are stored for the
-// message and the SegmentsCount its data segments advertise. Data segments carry
-// segments_count = N (> 0); parity segments carry 0, so MAX(segments_count) is N
-// once any data segment is stored, and 0 while only parity has arrived. This is a
-// cheap aggregate over just this message's rows (via the primary-key prefix
-// hash+sig_pub_key) that copies no payload blobs (issue #21470-hf).
+// Data segments carry segments_count = N (> 0); parity segments carry 0, so
+// MAX(segments_count) is N once any data segment is stored and 0 while only
+// parity has arrived.
 func (s *SQLitePersistence) GetMessageSegmentsCompletionInfo(hash []byte, sigPubKey *ecdsa.PublicKey) (int, uint32, error) {
 	sigPubKeyBlob := crypto.CompressPubkey(sigPubKey)
 

--- a/protocol/communities/community_description_gate.go
+++ b/protocol/communities/community_description_gate.go
@@ -5,48 +5,17 @@ import (
 	"sync"
 )
 
-// descriptionGateEntry records, for one community, the last community description
-// this node FULLY processed: its clock and a content hash of the raw description
-// payload bytes that were handled.
 type descriptionGateEntry struct {
 	clock       uint64
 	contentHash [32]byte
 }
 
-// communityDescriptionGate short-circuits the expensive per-description pipeline
-// for redelivered community descriptions that cannot change local state
-// (issue #21470-hf).
-//
-// status-go re-publishes each community description into every fetch/spectate
-// window, so the same byte-identical ~1.4MB blob is handed to
-// Manager.HandleCommunityDescriptionMessage hundreds of times over a long history
-// sync. Each of those calls otherwise pays, before any clock comparison:
-// proto.Unmarshal of the blob, GetDecryptedCommunityDescription (read) +
-// SaveDecryptedCommunityDescription (write) in preprocessDescription, and GetByID,
-// which re-reads and re-unmarshals the stored community blob — ~10s of CPU per
-// redelivered copy.
-//
-// The gate remembers, per community, the clock+content-hash of the last
-// description that was fully processed, and lets the handler return early for:
-//   - strictly-older clocks (can never win the downstream clock comparison in
-//     Community.UpdateCommunityDescription, which rejects them as outdated), and
-//   - the byte-identical same-clock redelivery (a guaranteed no-op).
-//
-// For a KEYS-HELD community it deliberately does NOT gate a same-clock description
-// whose content differs: Community.UpdateCommunityDescription intentionally
-// reprocesses identical clocks so a previously-encrypted description can be
-// re-evaluated once the decryption key arrives. For a KEYLESS spectator that
-// exception is dropped — an equal-clock re-encrypted republish is useless to a node
-// with no keys, so it is skipped regardless of content (see shouldSkip). For both
-// cases the gate is cleared when new hash-ratchet keys arrive
-// (Manager.NewHashRatchetKeys) and when a community is deleted
-// (Manager.DeleteCommunity), so those legitimate reprocessing paths are never
-// starved.
-//
-// A community that has only ever been QUEUED for owner validation (never fully
-// processed) has no gate entry, so validateCommunity's re-entry into the handler
-// is never blocked. The gate fails OPEN: any state it does not positively know to
-// be a redelivery proceeds to full processing.
+// communityDescriptionGate short-circuits reprocessing of redelivered community
+// descriptions that cannot change local state. It remembers the clock and
+// content hash of the last fully processed description per community and fails
+// open — anything it does not positively know to be a redelivery proceeds.
+// Entries are cleared on key arrival (forgetAll) and community deletion
+// (forget) so legitimate reprocessing is never starved.
 type communityDescriptionGate struct {
 	mu      sync.Mutex
 	entries map[string]descriptionGateEntry // communityID(hex) -> last processed
@@ -58,38 +27,16 @@ func newCommunityDescriptionGate() *communityDescriptionGate {
 	}
 }
 
-// hashDescriptionPayload returns a content hash of the raw community description
-// payload bytes. SHA-256 makes a collision astronomically unlikely, so a matching
-// (clock, hash) pair is safely treated as a byte-identical redelivery.
 func hashDescriptionPayload(payload []byte) [32]byte {
 	return sha256.Sum256(payload)
 }
 
-// shouldSkip reports whether a description with the given clock and content hash
-// can be skipped because it can neither advance nor change local state. holdsKeys
-// says whether this node holds ANY hash-ratchet decryption key for the community;
-// it must be fail-open (true) on any entitlement-lookup error so a transient DB
-// issue never turns into a dropped description.
-//
-// A strictly-older clock is always skippable (it can never win the downstream clock
-// comparison in Community.UpdateCommunityDescription). For an EQUAL clock the rule
-// depends on whether keys are held:
-//
-//   - keys held (member, or fail-open): skip only the byte-identical redelivery.
-//     A same-clock description with DIFFERENT content still proceeds, because
-//     community.go intentionally reprocesses identical clocks so a previously
-//     encrypted description is re-evaluated once the decryption key arrives — the
-//     member key-rotation path. This preserves the pre-refinement behaviour exactly.
-//
-//   - keyless (spectator): skip an equal-clock description REGARDLESS of content
-//     hash. status-go re-encrypts each logical description version ~40 times, so a
-//     keyless node is handed the same clock with different payload bytes over and
-//     over; it can gain nothing from a re-encrypted copy (its encrypted inner fields
-//     are skipped anyway, and key ARRIVAL lifts the whole gate via forgetAll), so
-//     reprocessing only burns CPU. Issue #21470-hf.
-//
-// Everything else (unknown community, newer clock) returns false so the handler
-// proceeds.
+// shouldSkip reports whether a description can be skipped: older clocks always,
+// equal clocks only when byte-identical for a keys-held node (a same-clock,
+// different-content description must reprocess so it can be re-evaluated once a
+// decryption key arrives), and regardless of content for a keyless node
+// (re-encrypted republishes carry the same clock with different bytes).
+// holdsKeys must be fail-open (true) on entitlement-lookup errors.
 func (g *communityDescriptionGate) shouldSkip(id string, clock uint64, hash [32]byte, holdsKeys bool) bool {
 	g.mu.Lock()
 	defer g.mu.Unlock()
@@ -109,9 +56,8 @@ func (g *communityDescriptionGate) shouldSkip(id string, clock uint64, hash [32]
 	return false
 }
 
-// recordProcessed advances the gate for a community after a description was fully
-// and successfully processed. It only ever moves the recorded clock forward, so an
-// out-of-order older success can never shadow a newer one.
+// recordProcessed only ever moves the recorded clock forward, so an
+// out-of-order older success cannot shadow a newer one.
 func (g *communityDescriptionGate) recordProcessed(id string, clock uint64, hash [32]byte) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
@@ -121,17 +67,14 @@ func (g *communityDescriptionGate) recordProcessed(id string, clock uint64, hash
 	g.entries[id] = descriptionGateEntry{clock: clock, contentHash: hash}
 }
 
-// forget drops the gate entry for a single community so its next description is
-// fully reprocessed. Called when the community is deleted.
 func (g *communityDescriptionGate) forget(id string) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
 	delete(g.entries, id)
 }
 
-// forgetAll clears every gate entry. Called when new hash-ratchet key material
-// arrives (which may be community- or channel-scoped) so every community's next
-// description is reprocessed and can decrypt now-available private data.
+// forgetAll is called when new hash-ratchet key material arrives (community- or
+// channel-scoped) so every community's next description is reprocessed.
 func (g *communityDescriptionGate) forgetAll() {
 	g.mu.Lock()
 	defer g.mu.Unlock()

--- a/protocol/communities/community_description_gate.go
+++ b/protocol/communities/community_description_gate.go
@@ -1,0 +1,114 @@
+package communities
+
+import (
+	"crypto/sha256"
+	"sync"
+)
+
+// descriptionGateEntry records, for one community, the last community description
+// this node FULLY processed: its clock and a content hash of the raw description
+// payload bytes that were handled.
+type descriptionGateEntry struct {
+	clock       uint64
+	contentHash [32]byte
+}
+
+// communityDescriptionGate short-circuits the expensive per-description pipeline
+// for redelivered community descriptions that cannot change local state
+// (issue #21470-hf).
+//
+// status-go re-publishes each community description into every fetch/spectate
+// window, so the same byte-identical ~1.4MB blob is handed to
+// Manager.HandleCommunityDescriptionMessage hundreds of times over a long history
+// sync. Each of those calls otherwise pays, before any clock comparison:
+// proto.Unmarshal of the blob, GetDecryptedCommunityDescription (read) +
+// SaveDecryptedCommunityDescription (write) in preprocessDescription, and GetByID,
+// which re-reads and re-unmarshals the stored community blob — ~10s of CPU per
+// redelivered copy.
+//
+// The gate remembers, per community, the clock+content-hash of the last
+// description that was fully processed, and lets the handler return early for:
+//   - strictly-older clocks (can never win the downstream clock comparison in
+//     Community.UpdateCommunityDescription, which rejects them as outdated), and
+//   - the byte-identical same-clock redelivery (a guaranteed no-op).
+//
+// It deliberately does NOT gate a same-clock description whose content differs:
+// Community.UpdateCommunityDescription intentionally reprocesses identical clocks
+// so a previously-encrypted description can be re-evaluated once the decryption key
+// arrives. For that same reason the gate is cleared when new hash-ratchet keys
+// arrive (Manager.NewHashRatchetKeys) and when a community is deleted
+// (Manager.DeleteCommunity), so those legitimate reprocessing paths are never
+// starved.
+//
+// A community that has only ever been QUEUED for owner validation (never fully
+// processed) has no gate entry, so validateCommunity's re-entry into the handler
+// is never blocked. The gate fails OPEN: any state it does not positively know to
+// be a redelivery proceeds to full processing.
+type communityDescriptionGate struct {
+	mu      sync.Mutex
+	entries map[string]descriptionGateEntry // communityID(hex) -> last processed
+}
+
+func newCommunityDescriptionGate() *communityDescriptionGate {
+	return &communityDescriptionGate{
+		entries: make(map[string]descriptionGateEntry),
+	}
+}
+
+// hashDescriptionPayload returns a content hash of the raw community description
+// payload bytes. SHA-256 makes a collision astronomically unlikely, so a matching
+// (clock, hash) pair is safely treated as a byte-identical redelivery.
+func hashDescriptionPayload(payload []byte) [32]byte {
+	return sha256.Sum256(payload)
+}
+
+// shouldSkip reports whether a description with the given clock and content hash
+// can be skipped because it can neither advance nor change local state. It returns
+// true only for a strictly-older clock, or an equal clock whose content hash matches
+// the last fully-processed description for this community. Everything else (unknown
+// community, newer clock, equal clock with different content) returns false so the
+// handler proceeds.
+func (g *communityDescriptionGate) shouldSkip(id string, clock uint64, hash [32]byte) bool {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	entry, ok := g.entries[id]
+	if !ok {
+		return false
+	}
+	if clock < entry.clock {
+		return true
+	}
+	if clock == entry.clock && hash == entry.contentHash {
+		return true
+	}
+	return false
+}
+
+// recordProcessed advances the gate for a community after a description was fully
+// and successfully processed. It only ever moves the recorded clock forward, so an
+// out-of-order older success can never shadow a newer one.
+func (g *communityDescriptionGate) recordProcessed(id string, clock uint64, hash [32]byte) {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	if entry, ok := g.entries[id]; ok && clock < entry.clock {
+		return
+	}
+	g.entries[id] = descriptionGateEntry{clock: clock, contentHash: hash}
+}
+
+// forget drops the gate entry for a single community so its next description is
+// fully reprocessed. Called when the community is deleted.
+func (g *communityDescriptionGate) forget(id string) {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	delete(g.entries, id)
+}
+
+// forgetAll clears every gate entry. Called when new hash-ratchet key material
+// arrives (which may be community- or channel-scoped) so every community's next
+// description is reprocessed and can decrypt now-available private data.
+func (g *communityDescriptionGate) forgetAll() {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	g.entries = make(map[string]descriptionGateEntry)
+}

--- a/protocol/communities/community_description_gate.go
+++ b/protocol/communities/community_description_gate.go
@@ -32,11 +32,14 @@ type descriptionGateEntry struct {
 //     Community.UpdateCommunityDescription, which rejects them as outdated), and
 //   - the byte-identical same-clock redelivery (a guaranteed no-op).
 //
-// It deliberately does NOT gate a same-clock description whose content differs:
-// Community.UpdateCommunityDescription intentionally reprocesses identical clocks
-// so a previously-encrypted description can be re-evaluated once the decryption key
-// arrives. For that same reason the gate is cleared when new hash-ratchet keys
-// arrive (Manager.NewHashRatchetKeys) and when a community is deleted
+// For a KEYS-HELD community it deliberately does NOT gate a same-clock description
+// whose content differs: Community.UpdateCommunityDescription intentionally
+// reprocesses identical clocks so a previously-encrypted description can be
+// re-evaluated once the decryption key arrives. For a KEYLESS spectator that
+// exception is dropped — an equal-clock re-encrypted republish is useless to a node
+// with no keys, so it is skipped regardless of content (see shouldSkip). For both
+// cases the gate is cleared when new hash-ratchet keys arrive
+// (Manager.NewHashRatchetKeys) and when a community is deleted
 // (Manager.DeleteCommunity), so those legitimate reprocessing paths are never
 // starved.
 //
@@ -63,12 +66,31 @@ func hashDescriptionPayload(payload []byte) [32]byte {
 }
 
 // shouldSkip reports whether a description with the given clock and content hash
-// can be skipped because it can neither advance nor change local state. It returns
-// true only for a strictly-older clock, or an equal clock whose content hash matches
-// the last fully-processed description for this community. Everything else (unknown
-// community, newer clock, equal clock with different content) returns false so the
-// handler proceeds.
-func (g *communityDescriptionGate) shouldSkip(id string, clock uint64, hash [32]byte) bool {
+// can be skipped because it can neither advance nor change local state. holdsKeys
+// says whether this node holds ANY hash-ratchet decryption key for the community;
+// it must be fail-open (true) on any entitlement-lookup error so a transient DB
+// issue never turns into a dropped description.
+//
+// A strictly-older clock is always skippable (it can never win the downstream clock
+// comparison in Community.UpdateCommunityDescription). For an EQUAL clock the rule
+// depends on whether keys are held:
+//
+//   - keys held (member, or fail-open): skip only the byte-identical redelivery.
+//     A same-clock description with DIFFERENT content still proceeds, because
+//     community.go intentionally reprocesses identical clocks so a previously
+//     encrypted description is re-evaluated once the decryption key arrives — the
+//     member key-rotation path. This preserves the pre-refinement behaviour exactly.
+//
+//   - keyless (spectator): skip an equal-clock description REGARDLESS of content
+//     hash. status-go re-encrypts each logical description version ~40 times, so a
+//     keyless node is handed the same clock with different payload bytes over and
+//     over; it can gain nothing from a re-encrypted copy (its encrypted inner fields
+//     are skipped anyway, and key ARRIVAL lifts the whole gate via forgetAll), so
+//     reprocessing only burns CPU. Issue #21470-hf.
+//
+// Everything else (unknown community, newer clock) returns false so the handler
+// proceeds.
+func (g *communityDescriptionGate) shouldSkip(id string, clock uint64, hash [32]byte, holdsKeys bool) bool {
 	g.mu.Lock()
 	defer g.mu.Unlock()
 	entry, ok := g.entries[id]
@@ -78,8 +100,11 @@ func (g *communityDescriptionGate) shouldSkip(id string, clock uint64, hash [32]
 	if clock < entry.clock {
 		return true
 	}
-	if clock == entry.clock && hash == entry.contentHash {
-		return true
+	if clock == entry.clock {
+		if !holdsKeys {
+			return true
+		}
+		return hash == entry.contentHash
 	}
 	return false
 }

--- a/protocol/communities/community_description_gate_test.go
+++ b/protocol/communities/community_description_gate_test.go
@@ -17,13 +17,9 @@ const (
 	keyless  = false
 )
 
-// TestDescriptionGateTruthTable exercises the redelivery gate decision across the
-// whole truth table (issue #21470-hf) for a KEYS-HELD community (member): unknown
-// community, strictly-older clock, byte-identical same-clock redelivery,
-// same-clock-different-content, and a newer clock. Only a strictly-older clock or a
-// byte-identical same-clock redelivery may be skipped; everything else must proceed
-// to full processing. The same-clock-different-content rule is what keeps key
-// rotation working for members, so it must survive.
+// Keys-held: only a strictly-older clock or a byte-identical same-clock
+// redelivery may be skipped; same-clock-different-content must proceed (key
+// rotation).
 func TestDescriptionGateTruthTable(t *testing.T) {
 	const id = "0xcommunity"
 	payloadA := []byte("description-bytes-A")
@@ -61,14 +57,8 @@ func TestDescriptionGateTruthTable(t *testing.T) {
 	require.False(t, g.shouldSkip("0xother", 1, hashA, keysHeld), "other community must proceed")
 }
 
-// TestDescriptionGateKeylessTruthTable exercises the gate for a KEYLESS spectator
-// (holds no decryption keys). status-go re-encrypts each logical description ~40
-// times per version, so a keyless node sees the same clock with DIFFERENT payload
-// bytes over and over. A keyless spectator can gain nothing from a re-encrypted
-// equal-clock copy (its encrypted inner fields are skipped anyway, and key ARRIVAL
-// is handled by forgetAll), so the gate must skip equal-clock republishes
-// REGARDLESS of content hash — the one behaviour that differs from a keys-held
-// community (issue #21470-hf).
+// Keyless: equal-clock republishes are skipped regardless of content hash —
+// the one behaviour that differs from keys-held.
 func TestDescriptionGateKeylessTruthTable(t *testing.T) {
 	const id = "0xcommunity"
 	hashA := hashOf([]byte("description-bytes-A"))
@@ -97,11 +87,8 @@ func TestDescriptionGateKeylessTruthTable(t *testing.T) {
 	require.False(t, g.shouldSkip(id, 11, hashB, keyless), "keyless newer clock must proceed regardless of content")
 }
 
-// TestDescriptionGateFailOpenTreatedAsKeysHeld documents that the fail-open case
-// (entitlement lookup errored, so the Manager reports holdsKeys=true) is exactly the
-// keys-held branch: an equal-clock DIFFERENT-content description still proceeds, so a
-// transient DB error can never make a keyless-style skip drop a description that a
-// member would have reprocessed.
+// Fail-open (holdsKeys=true on lookup error) must behave exactly like the
+// keys-held branch.
 func TestDescriptionGateFailOpenTreatedAsKeysHeld(t *testing.T) {
 	const id = "0xcommunity"
 	hashA := hashOf([]byte("A"))
@@ -114,9 +101,6 @@ func TestDescriptionGateFailOpenTreatedAsKeysHeld(t *testing.T) {
 	require.False(t, g.shouldSkip(id, 10, hashB, keysHeld), "fail-open (keys-held) equal-clock different-content must proceed")
 }
 
-// TestDescriptionGateRecordIsMonotonic verifies recordProcessed never moves the
-// recorded clock backwards, so an out-of-order older success cannot shadow a newer
-// one and cause a newer redelivery to be wrongly skipped.
 func TestDescriptionGateRecordIsMonotonic(t *testing.T) {
 	const id = "0xcommunity"
 	hash := hashOf([]byte("x"))
@@ -130,8 +114,6 @@ func TestDescriptionGateRecordIsMonotonic(t *testing.T) {
 	require.True(t, g.shouldSkip(id, 4, hash, keysHeld), "older than recorded 20 skips")
 }
 
-// TestDescriptionGateForget verifies a single-community invalidation (community
-// delete) forces the next description to be fully reprocessed.
 func TestDescriptionGateForget(t *testing.T) {
 	const id = "0xcommunity"
 	hash := hashOf([]byte("x"))
@@ -144,9 +126,6 @@ func TestDescriptionGateForget(t *testing.T) {
 	require.False(t, g.shouldSkip(id, 10, hash, keysHeld), "after forget, identical redelivery reprocesses")
 }
 
-// TestDescriptionGateForgetAll verifies key-arrival invalidation lifts the gate for
-// every community so a byte-identical description can be reprocessed and decrypt
-// now-available private data.
 func TestDescriptionGateForgetAll(t *testing.T) {
 	hash := hashOf([]byte("x"))
 	g := newCommunityDescriptionGate()

--- a/protocol/communities/community_description_gate_test.go
+++ b/protocol/communities/community_description_gate_test.go
@@ -10,11 +10,20 @@ func hashOf(b []byte) [32]byte {
 	return hashDescriptionPayload(b)
 }
 
+// keysHeld/keyless make the holdsKeys argument to shouldSkip read as intent at
+// the call site.
+const (
+	keysHeld = true
+	keyless  = false
+)
+
 // TestDescriptionGateTruthTable exercises the redelivery gate decision across the
-// whole truth table (issue #21470-hf): unknown community, strictly-older clock,
-// byte-identical same-clock redelivery, same-clock-different-content, and a newer
-// clock. Only a strictly-older clock or a byte-identical same-clock redelivery may
-// be skipped; everything else must proceed to full processing.
+// whole truth table (issue #21470-hf) for a KEYS-HELD community (member): unknown
+// community, strictly-older clock, byte-identical same-clock redelivery,
+// same-clock-different-content, and a newer clock. Only a strictly-older clock or a
+// byte-identical same-clock redelivery may be skipped; everything else must proceed
+// to full processing. The same-clock-different-content rule is what keeps key
+// rotation working for members, so it must survive.
 func TestDescriptionGateTruthTable(t *testing.T) {
 	const id = "0xcommunity"
 	payloadA := []byte("description-bytes-A")
@@ -28,28 +37,81 @@ func TestDescriptionGateTruthTable(t *testing.T) {
 	// also the queued-validation guarantee: a community that has only ever been
 	// queued (never fully processed) has no gate entry, so validateCommunity's
 	// re-entry is never blocked.
-	require.False(t, g.shouldSkip(id, 10, hashA), "unknown community must proceed")
+	require.False(t, g.shouldSkip(id, 10, hashA, keysHeld), "unknown community must proceed")
 
 	// Record clock 10 / content A as fully processed.
 	g.recordProcessed(id, 10, hashA)
 
 	// Byte-identical same-clock redelivery: skip.
-	require.True(t, g.shouldSkip(id, 10, hashA), "byte-identical same-clock redelivery must skip")
+	require.True(t, g.shouldSkip(id, 10, hashA, keysHeld), "byte-identical same-clock redelivery must skip")
 
 	// Same clock, different content: MUST proceed (community.go intentionally
 	// reprocesses identical clocks so a previously-encrypted description can be
-	// re-evaluated once keys arrive).
-	require.False(t, g.shouldSkip(id, 10, hashB), "same-clock different-content must proceed")
+	// re-evaluated once keys arrive — this is the member key-rotation path).
+	require.False(t, g.shouldSkip(id, 10, hashB, keysHeld), "same-clock different-content must proceed for a keys-held community")
 
 	// Strictly-older clock: skip (can never win the downstream clock comparison).
-	require.True(t, g.shouldSkip(id, 9, hashA), "older clock must skip")
-	require.True(t, g.shouldSkip(id, 9, hashB), "older clock must skip regardless of content")
+	require.True(t, g.shouldSkip(id, 9, hashA, keysHeld), "older clock must skip")
+	require.True(t, g.shouldSkip(id, 9, hashB, keysHeld), "older clock must skip regardless of content")
 
 	// Newer clock: proceed.
-	require.False(t, g.shouldSkip(id, 11, hashA), "newer clock must proceed")
+	require.False(t, g.shouldSkip(id, 11, hashA, keysHeld), "newer clock must proceed")
 
 	// A different community is unaffected by this one's entry.
-	require.False(t, g.shouldSkip("0xother", 1, hashA), "other community must proceed")
+	require.False(t, g.shouldSkip("0xother", 1, hashA, keysHeld), "other community must proceed")
+}
+
+// TestDescriptionGateKeylessTruthTable exercises the gate for a KEYLESS spectator
+// (holds no decryption keys). status-go re-encrypts each logical description ~40
+// times per version, so a keyless node sees the same clock with DIFFERENT payload
+// bytes over and over. A keyless spectator can gain nothing from a re-encrypted
+// equal-clock copy (its encrypted inner fields are skipped anyway, and key ARRIVAL
+// is handled by forgetAll), so the gate must skip equal-clock republishes
+// REGARDLESS of content hash — the one behaviour that differs from a keys-held
+// community (issue #21470-hf).
+func TestDescriptionGateKeylessTruthTable(t *testing.T) {
+	const id = "0xcommunity"
+	hashA := hashOf([]byte("description-bytes-A"))
+	hashB := hashOf([]byte("description-bytes-B"))
+
+	g := newCommunityDescriptionGate()
+
+	// Unknown community: never skip, even keyless (nothing recorded yet).
+	require.False(t, g.shouldSkip(id, 10, hashA, keyless), "unknown community must proceed")
+
+	g.recordProcessed(id, 10, hashA)
+
+	// Equal clock, same content: skip (same as keys-held).
+	require.True(t, g.shouldSkip(id, 10, hashA, keyless), "keyless equal-clock same-content must skip")
+
+	// Equal clock, DIFFERENT content: skip — this is the refinement. A re-encrypted
+	// republish at the same clock is useless to a keyless spectator.
+	require.True(t, g.shouldSkip(id, 10, hashB, keyless), "keyless equal-clock different-content must skip")
+
+	// Strictly-older clock: skip regardless of content.
+	require.True(t, g.shouldSkip(id, 9, hashA, keyless), "keyless older clock must skip")
+	require.True(t, g.shouldSkip(id, 9, hashB, keyless), "keyless older clock must skip regardless of content")
+
+	// Newer clock: proceed — a genuinely newer description must always be processed.
+	require.False(t, g.shouldSkip(id, 11, hashA, keyless), "keyless newer clock must proceed")
+	require.False(t, g.shouldSkip(id, 11, hashB, keyless), "keyless newer clock must proceed regardless of content")
+}
+
+// TestDescriptionGateFailOpenTreatedAsKeysHeld documents that the fail-open case
+// (entitlement lookup errored, so the Manager reports holdsKeys=true) is exactly the
+// keys-held branch: an equal-clock DIFFERENT-content description still proceeds, so a
+// transient DB error can never make a keyless-style skip drop a description that a
+// member would have reprocessed.
+func TestDescriptionGateFailOpenTreatedAsKeysHeld(t *testing.T) {
+	const id = "0xcommunity"
+	hashA := hashOf([]byte("A"))
+	hashB := hashOf([]byte("B"))
+
+	g := newCommunityDescriptionGate()
+	g.recordProcessed(id, 10, hashA)
+
+	// holdsKeys=true is what communityHoldsAnyDecryptionKey returns on any error.
+	require.False(t, g.shouldSkip(id, 10, hashB, keysHeld), "fail-open (keys-held) equal-clock different-content must proceed")
 }
 
 // TestDescriptionGateRecordIsMonotonic verifies recordProcessed never moves the
@@ -63,9 +125,9 @@ func TestDescriptionGateRecordIsMonotonic(t *testing.T) {
 	g.recordProcessed(id, 20, hash)
 	g.recordProcessed(id, 5, hash) // stale, must not overwrite the newer record
 
-	require.True(t, g.shouldSkip(id, 20, hash), "recorded clock is still 20, identical redelivery skips")
-	require.False(t, g.shouldSkip(id, 21, hash), "a genuinely newer clock still proceeds")
-	require.True(t, g.shouldSkip(id, 4, hash), "older than recorded 20 skips")
+	require.True(t, g.shouldSkip(id, 20, hash, keysHeld), "recorded clock is still 20, identical redelivery skips")
+	require.False(t, g.shouldSkip(id, 21, hash, keysHeld), "a genuinely newer clock still proceeds")
+	require.True(t, g.shouldSkip(id, 4, hash, keysHeld), "older than recorded 20 skips")
 }
 
 // TestDescriptionGateForget verifies a single-community invalidation (community
@@ -76,10 +138,10 @@ func TestDescriptionGateForget(t *testing.T) {
 
 	g := newCommunityDescriptionGate()
 	g.recordProcessed(id, 10, hash)
-	require.True(t, g.shouldSkip(id, 10, hash))
+	require.True(t, g.shouldSkip(id, 10, hash, keysHeld))
 
 	g.forget(id)
-	require.False(t, g.shouldSkip(id, 10, hash), "after forget, identical redelivery reprocesses")
+	require.False(t, g.shouldSkip(id, 10, hash, keysHeld), "after forget, identical redelivery reprocesses")
 }
 
 // TestDescriptionGateForgetAll verifies key-arrival invalidation lifts the gate for
@@ -90,10 +152,10 @@ func TestDescriptionGateForgetAll(t *testing.T) {
 	g := newCommunityDescriptionGate()
 	g.recordProcessed("0xa", 10, hash)
 	g.recordProcessed("0xb", 10, hash)
-	require.True(t, g.shouldSkip("0xa", 10, hash))
-	require.True(t, g.shouldSkip("0xb", 10, hash))
+	require.True(t, g.shouldSkip("0xa", 10, hash, keysHeld))
+	require.True(t, g.shouldSkip("0xb", 10, hash, keysHeld))
 
 	g.forgetAll()
-	require.False(t, g.shouldSkip("0xa", 10, hash))
-	require.False(t, g.shouldSkip("0xb", 10, hash))
+	require.False(t, g.shouldSkip("0xa", 10, hash, keysHeld))
+	require.False(t, g.shouldSkip("0xb", 10, hash, keysHeld))
 }

--- a/protocol/communities/community_description_gate_test.go
+++ b/protocol/communities/community_description_gate_test.go
@@ -1,0 +1,99 @@
+package communities
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func hashOf(b []byte) [32]byte {
+	return hashDescriptionPayload(b)
+}
+
+// TestDescriptionGateTruthTable exercises the redelivery gate decision across the
+// whole truth table (issue #21470-hf): unknown community, strictly-older clock,
+// byte-identical same-clock redelivery, same-clock-different-content, and a newer
+// clock. Only a strictly-older clock or a byte-identical same-clock redelivery may
+// be skipped; everything else must proceed to full processing.
+func TestDescriptionGateTruthTable(t *testing.T) {
+	const id = "0xcommunity"
+	payloadA := []byte("description-bytes-A")
+	payloadB := []byte("description-bytes-B")
+	hashA := hashOf(payloadA)
+	hashB := hashOf(payloadB)
+
+	g := newCommunityDescriptionGate()
+
+	// Unknown community: never skip (fail open — nothing recorded yet). This is
+	// also the queued-validation guarantee: a community that has only ever been
+	// queued (never fully processed) has no gate entry, so validateCommunity's
+	// re-entry is never blocked.
+	require.False(t, g.shouldSkip(id, 10, hashA), "unknown community must proceed")
+
+	// Record clock 10 / content A as fully processed.
+	g.recordProcessed(id, 10, hashA)
+
+	// Byte-identical same-clock redelivery: skip.
+	require.True(t, g.shouldSkip(id, 10, hashA), "byte-identical same-clock redelivery must skip")
+
+	// Same clock, different content: MUST proceed (community.go intentionally
+	// reprocesses identical clocks so a previously-encrypted description can be
+	// re-evaluated once keys arrive).
+	require.False(t, g.shouldSkip(id, 10, hashB), "same-clock different-content must proceed")
+
+	// Strictly-older clock: skip (can never win the downstream clock comparison).
+	require.True(t, g.shouldSkip(id, 9, hashA), "older clock must skip")
+	require.True(t, g.shouldSkip(id, 9, hashB), "older clock must skip regardless of content")
+
+	// Newer clock: proceed.
+	require.False(t, g.shouldSkip(id, 11, hashA), "newer clock must proceed")
+
+	// A different community is unaffected by this one's entry.
+	require.False(t, g.shouldSkip("0xother", 1, hashA), "other community must proceed")
+}
+
+// TestDescriptionGateRecordIsMonotonic verifies recordProcessed never moves the
+// recorded clock backwards, so an out-of-order older success cannot shadow a newer
+// one and cause a newer redelivery to be wrongly skipped.
+func TestDescriptionGateRecordIsMonotonic(t *testing.T) {
+	const id = "0xcommunity"
+	hash := hashOf([]byte("x"))
+
+	g := newCommunityDescriptionGate()
+	g.recordProcessed(id, 20, hash)
+	g.recordProcessed(id, 5, hash) // stale, must not overwrite the newer record
+
+	require.True(t, g.shouldSkip(id, 20, hash), "recorded clock is still 20, identical redelivery skips")
+	require.False(t, g.shouldSkip(id, 21, hash), "a genuinely newer clock still proceeds")
+	require.True(t, g.shouldSkip(id, 4, hash), "older than recorded 20 skips")
+}
+
+// TestDescriptionGateForget verifies a single-community invalidation (community
+// delete) forces the next description to be fully reprocessed.
+func TestDescriptionGateForget(t *testing.T) {
+	const id = "0xcommunity"
+	hash := hashOf([]byte("x"))
+
+	g := newCommunityDescriptionGate()
+	g.recordProcessed(id, 10, hash)
+	require.True(t, g.shouldSkip(id, 10, hash))
+
+	g.forget(id)
+	require.False(t, g.shouldSkip(id, 10, hash), "after forget, identical redelivery reprocesses")
+}
+
+// TestDescriptionGateForgetAll verifies key-arrival invalidation lifts the gate for
+// every community so a byte-identical description can be reprocessed and decrypt
+// now-available private data.
+func TestDescriptionGateForgetAll(t *testing.T) {
+	hash := hashOf([]byte("x"))
+	g := newCommunityDescriptionGate()
+	g.recordProcessed("0xa", 10, hash)
+	g.recordProcessed("0xb", 10, hash)
+	require.True(t, g.shouldSkip("0xa", 10, hash))
+	require.True(t, g.shouldSkip("0xb", 10, hash))
+
+	g.forgetAll()
+	require.False(t, g.shouldSkip("0xa", 10, hash))
+	require.False(t, g.shouldSkip("0xb", 10, hash))
+}

--- a/protocol/communities/manager.go
+++ b/protocol/communities/manager.go
@@ -1519,12 +1519,9 @@ func (m *Manager) DeleteCommunity(id types3.HexBytes) error {
 	if err != nil {
 		return err
 	}
-	// Drop any redelivery-gate entry so a re-fetched description of a deleted
-	// community is fully reprocessed rather than skipped (#21470-hf).
 	if m.descriptionGate != nil {
 		m.descriptionGate.forget(id.String())
 	}
-	// Drop the cached community so a redelivery skip can never surface a deleted one.
 	m.cache.Delete(id.String())
 	return m.persistence.DeleteCommunitySettings(id)
 }
@@ -2081,32 +2078,13 @@ func (m *Manager) HandleCommunityDescriptionMessage(signer *ecdsa.PublicKey, des
 		id = crypto.CompressPubkey(signer)
 	}
 
-	// #21470-hf: fast-path redelivered descriptions before any expensive work.
-	// status-go re-publishes the same ~1.4MB description into every fetch window,
-	// and each redelivered copy otherwise pays proto.Unmarshal + preprocessDescription
-	// (decrypted-cache read+write) + GetByID (re-read/re-unmarshal of the stored
-	// blob) BEFORE the downstream clock comparison rejects it. The gate skips only
-	// strictly-older clocks and byte-identical same-clock redeliveries; it is
-	// cleared when keys arrive or a community is deleted (see communityDescriptionGate).
 	gateKey := types3.HexBytes(id).String()
 	payloadHash := hashDescriptionPayload(payload)
-	// holdsKeys drives the equal-clock gate rule: a keyless spectator skips ALL
-	// equal-clock republishes (status-go re-encrypts each version ~40 times, useless
-	// to a keyless node), while a keys-held community keeps the byte-identical-only
-	// rule so key rotation still reprocesses. communityHoldsAnyDecryptionKey is
-	// cached and fails open (reports true) on any lookup error, so an entitlement
-	// error degrades safely to the keys-held rule (#21470-hf).
 	holdsKeys := m.communityHoldsAnyDecryptionKey(id, description.Chats)
 	if m.descriptionGate != nil && m.descriptionGate.shouldSkip(gateKey, description.Clock, payloadHash, holdsKeys) {
-		// Skip the expensive pipeline (preprocessDescription's decrypted-cache
-		// read+write and handleCommunityDescriptionMessageCommon's ~1.4MB re-save),
-		// but still SURFACE the already-known community with empty changes. The
-		// store-node pager latches "description seen" from the community appearing
-		// in the handled response and stops paging once it holds the newest
-		// description (issue #21470-hf, commit 6cd6ced1a); returning nil here would
-		// hide the redelivery from that latch and make the pager run to its page
-		// cap. Fail open: if the community is not readable, fall through to full
-		// processing rather than fabricate a skip.
+		// A skipped redelivery must still surface the known community: the
+		// store-node pager latches "description seen" from the community
+		// appearing in the handled response. Fail open if it is not readable.
 		if community := m.cachedCommunityForRedelivery(id); community != nil {
 			m.logger.Debug("surfacing redelivered community description without reprocessing",
 				zap.String("communityID", gateKey), zap.Uint64("clock", description.Clock))
@@ -2199,37 +2177,22 @@ func (m *Manager) HandleCommunityDescriptionMessage(signer *ecdsa.PublicKey, des
 	if err != nil {
 		return nil, err
 	}
-	// Advance the redelivery gate only after fully successful processing, so a
-	// byte-identical same-clock redelivery of THIS description can be skipped.
-	// Deliberately NOT advanced on the queue path or the FailedToDecrypt early
-	// return, so validateCommunity's later re-entry and key-arrival reprocessing
-	// are never blocked (#21470-hf).
+	// Advance the gate only after fully successful processing — never on the
+	// queue path or the FailedToDecrypt early return, so validateCommunity's
+	// re-entry and key-arrival reprocessing are not blocked.
 	if m.descriptionGate != nil {
 		m.descriptionGate.recordProcessed(gateKey, processedDescription.Clock, payloadHash)
 	}
-	// Warm the redelivery cache with the freshly-processed community so the next
-	// gated redelivery is served without a ~1.4MB GetByID. handleCommunityDescription-
-	// MessageCommon already deleted the stale entry via SaveCommunity, so this sets the
-	// current one (#21470-hf).
 	m.cache.Set(gateKey, ReadonlyCommunity(community), ttlcache.DefaultTTL)
 	r.FailedToDecrypt = failedToDecrypt
 	return r, nil
 }
 
-// cachedCommunityForRedelivery returns the community for a gated (skipped) description
-// redelivery. It serves the shared readonly community cache first — the whole point of
-// the gate is to avoid the ~1.4MB GetByID (SQLite read + proto.Unmarshal) that each
-// skip would otherwise pay — and falls back to a single GetByID on a cache miss,
-// populating the cache so subsequent skips are free. Returns nil (caller falls through
-// to full processing) if the community cannot be read.
-//
-// The cache is coherent for this use: every persisted community mutation funnels
-// through Manager.SaveCommunity, which deletes the entry, so a hit can never be staler
-// than the last persisted description. The skip path only needs the community to
-// (a) trip the store-node description-seen latch, which keys off the community ID alone
-// (communityDescriptionSeen), and (b) be surfaced with empty changes. The store-node
-// pager's minimumDataClock comparison reads the PERSISTED clock via its own GetByID,
-// never this cached copy, so a slightly-stale clock here cannot change pager behaviour.
+// cachedCommunityForRedelivery returns the community for a gated (skipped)
+// description redelivery, from the readonly cache or a single GetByID on a
+// miss. Returns nil if the community cannot be read (caller falls through to
+// full processing). Cache coherence: every persisted mutation funnels through
+// SaveCommunity, which deletes the entry.
 func (m *Manager) cachedCommunityForRedelivery(id types3.HexBytes) *Community {
 	idString := id.String()
 	if item := m.cache.Get(idString); item != nil {
@@ -2249,23 +2212,15 @@ func (m *Manager) cachedCommunityForRedelivery(id types3.HexBytes) *Community {
 
 func (m *Manager) NewHashRatchetKeys(keys []*types.HashRatchetInfo) error {
 	// New keys may be community- or channel-scoped and cannot be mapped back to
-	// a single community cheaply, so clear all cached entitlements: the next
-	// description must re-evaluate.
-	if m.keyEntitlement != nil && len(keys) > 0 {
-		m.keyEntitlement.forgetAll()
-	}
-	// Lift the redelivery gate too: a description that was byte-identical to one
-	// already processed may now decrypt previously-encrypted private data, so it
-	// must be reprocessed rather than skipped as a redelivery (#21470-hf).
-	if m.descriptionGate != nil && len(keys) > 0 {
-		m.descriptionGate.forgetAll()
-	}
-	// Drop cached communities too: a community processed while keyless was cached
-	// without its decrypted private data, so the cached copy must not be reused once
-	// keys arrive. Keys may be channel-scoped and cannot be mapped back to a single
-	// community cheaply, so clear all — the same reason descriptionGate.forgetAll does
-	// (#21470-hf). Cleared entries simply re-read from the DB on next access.
+	// a single community cheaply, so lift all gates and cached copies: the next
+	// description must re-evaluate entitlement and reprocess.
 	if len(keys) > 0 {
+		if m.keyEntitlement != nil {
+			m.keyEntitlement.forgetAll()
+		}
+		if m.descriptionGate != nil {
+			m.descriptionGate.forgetAll()
+		}
 		m.cache.DeleteAll()
 	}
 	return m.persistence.InvalidateDecryptedCommunityCacheForKeys(keys)

--- a/protocol/communities/manager.go
+++ b/protocol/communities/manager.go
@@ -2089,9 +2089,23 @@ func (m *Manager) HandleCommunityDescriptionMessage(signer *ecdsa.PublicKey, des
 	gateKey := types3.HexBytes(id).String()
 	payloadHash := hashDescriptionPayload(payload)
 	if m.descriptionGate != nil && m.descriptionGate.shouldSkip(gateKey, description.Clock, payloadHash) {
-		m.logger.Debug("skipping redelivered community description",
-			zap.String("communityID", gateKey), zap.Uint64("clock", description.Clock))
-		return nil, nil
+		// Skip the expensive pipeline (preprocessDescription's decrypted-cache
+		// read+write and handleCommunityDescriptionMessageCommon's ~1.4MB re-save),
+		// but still SURFACE the already-known community with empty changes. The
+		// store-node pager latches "description seen" from the community appearing
+		// in the handled response and stops paging once it holds the newest
+		// description (issue #21470-hf, commit 6cd6ced1a); returning nil here would
+		// hide the redelivery from that latch and make the pager run to its page
+		// cap. Fail open: if the community is not readable, fall through to full
+		// processing rather than fabricate a skip.
+		m.communityLock.Lock(id)
+		community, err := m.GetByID(id)
+		m.communityLock.Unlock(id)
+		if err == nil && community != nil {
+			m.logger.Debug("surfacing redelivered community description without reprocessing",
+				zap.String("communityID", gateKey), zap.Uint64("clock", description.Clock))
+			return &CommunityResponse{Community: community, Changes: community.emptyCommunityChanges()}, nil
+		}
 	}
 
 	failedToDecrypt, processedDescription, err := m.preprocessDescription(id, description)

--- a/protocol/communities/manager.go
+++ b/protocol/communities/manager.go
@@ -1524,6 +1524,8 @@ func (m *Manager) DeleteCommunity(id types3.HexBytes) error {
 	if m.descriptionGate != nil {
 		m.descriptionGate.forget(id.String())
 	}
+	// Drop the cached community so a redelivery skip can never surface a deleted one.
+	m.cache.Delete(id.String())
 	return m.persistence.DeleteCommunitySettings(id)
 }
 
@@ -2088,7 +2090,14 @@ func (m *Manager) HandleCommunityDescriptionMessage(signer *ecdsa.PublicKey, des
 	// cleared when keys arrive or a community is deleted (see communityDescriptionGate).
 	gateKey := types3.HexBytes(id).String()
 	payloadHash := hashDescriptionPayload(payload)
-	if m.descriptionGate != nil && m.descriptionGate.shouldSkip(gateKey, description.Clock, payloadHash) {
+	// holdsKeys drives the equal-clock gate rule: a keyless spectator skips ALL
+	// equal-clock republishes (status-go re-encrypts each version ~40 times, useless
+	// to a keyless node), while a keys-held community keeps the byte-identical-only
+	// rule so key rotation still reprocesses. communityHoldsAnyDecryptionKey is
+	// cached and fails open (reports true) on any lookup error, so an entitlement
+	// error degrades safely to the keys-held rule (#21470-hf).
+	holdsKeys := m.communityHoldsAnyDecryptionKey(id, description.Chats)
+	if m.descriptionGate != nil && m.descriptionGate.shouldSkip(gateKey, description.Clock, payloadHash, holdsKeys) {
 		// Skip the expensive pipeline (preprocessDescription's decrypted-cache
 		// read+write and handleCommunityDescriptionMessageCommon's ~1.4MB re-save),
 		// but still SURFACE the already-known community with empty changes. The
@@ -2098,10 +2107,7 @@ func (m *Manager) HandleCommunityDescriptionMessage(signer *ecdsa.PublicKey, des
 		// hide the redelivery from that latch and make the pager run to its page
 		// cap. Fail open: if the community is not readable, fall through to full
 		// processing rather than fabricate a skip.
-		m.communityLock.Lock(id)
-		community, err := m.GetByID(id)
-		m.communityLock.Unlock(id)
-		if err == nil && community != nil {
+		if community := m.cachedCommunityForRedelivery(id); community != nil {
 			m.logger.Debug("surfacing redelivered community description without reprocessing",
 				zap.String("communityID", gateKey), zap.Uint64("clock", description.Clock))
 			return &CommunityResponse{Community: community, Changes: community.emptyCommunityChanges()}, nil
@@ -2201,8 +2207,44 @@ func (m *Manager) HandleCommunityDescriptionMessage(signer *ecdsa.PublicKey, des
 	if m.descriptionGate != nil {
 		m.descriptionGate.recordProcessed(gateKey, processedDescription.Clock, payloadHash)
 	}
+	// Warm the redelivery cache with the freshly-processed community so the next
+	// gated redelivery is served without a ~1.4MB GetByID. handleCommunityDescription-
+	// MessageCommon already deleted the stale entry via SaveCommunity, so this sets the
+	// current one (#21470-hf).
+	m.cache.Set(gateKey, ReadonlyCommunity(community), ttlcache.DefaultTTL)
 	r.FailedToDecrypt = failedToDecrypt
 	return r, nil
+}
+
+// cachedCommunityForRedelivery returns the community for a gated (skipped) description
+// redelivery. It serves the shared readonly community cache first — the whole point of
+// the gate is to avoid the ~1.4MB GetByID (SQLite read + proto.Unmarshal) that each
+// skip would otherwise pay — and falls back to a single GetByID on a cache miss,
+// populating the cache so subsequent skips are free. Returns nil (caller falls through
+// to full processing) if the community cannot be read.
+//
+// The cache is coherent for this use: every persisted community mutation funnels
+// through Manager.SaveCommunity, which deletes the entry, so a hit can never be staler
+// than the last persisted description. The skip path only needs the community to
+// (a) trip the store-node description-seen latch, which keys off the community ID alone
+// (communityDescriptionSeen), and (b) be surfaced with empty changes. The store-node
+// pager's minimumDataClock comparison reads the PERSISTED clock via its own GetByID,
+// never this cached copy, so a slightly-stale clock here cannot change pager behaviour.
+func (m *Manager) cachedCommunityForRedelivery(id types3.HexBytes) *Community {
+	idString := id.String()
+	if item := m.cache.Get(idString); item != nil {
+		if community, ok := item.Value().(*Community); ok {
+			return community
+		}
+	}
+	m.communityLock.Lock(id)
+	defer m.communityLock.Unlock(id)
+	community, err := m.GetByID(id)
+	if err != nil || community == nil {
+		return nil
+	}
+	m.cache.Set(idString, ReadonlyCommunity(community), ttlcache.DefaultTTL)
+	return community
 }
 
 func (m *Manager) NewHashRatchetKeys(keys []*types.HashRatchetInfo) error {
@@ -2217,6 +2259,14 @@ func (m *Manager) NewHashRatchetKeys(keys []*types.HashRatchetInfo) error {
 	// must be reprocessed rather than skipped as a redelivery (#21470-hf).
 	if m.descriptionGate != nil && len(keys) > 0 {
 		m.descriptionGate.forgetAll()
+	}
+	// Drop cached communities too: a community processed while keyless was cached
+	// without its decrypted private data, so the cached copy must not be reused once
+	// keys arrive. Keys may be channel-scoped and cannot be mapped back to a single
+	// community cheaply, so clear all — the same reason descriptionGate.forgetAll does
+	// (#21470-hf). Cleared entries simply re-read from the DB on next access.
+	if len(keys) > 0 {
+		m.cache.DeleteAll()
 	}
 	return m.persistence.InvalidateDecryptedCommunityCacheForKeys(keys)
 }

--- a/protocol/communities/manager.go
+++ b/protocol/communities/manager.go
@@ -114,6 +114,7 @@ type Manager struct {
 	PermissionChecker        PermissionChecker
 	keyDistributor           KeyDistributor
 	keyEntitlement           *communityKeyEntitlement
+	descriptionGate          *communityDescriptionGate
 	communityLock            *CommunityLock
 	mediaServer              server.MediaServerInterface
 	communityImageVersions   map[string]uint32
@@ -324,6 +325,7 @@ func NewManager(
 		timesource:             timesource,
 		keyDistributor:         keyDistributor,
 		keyEntitlement:         newCommunityKeyEntitlement(),
+		descriptionGate:        newCommunityDescriptionGate(),
 		communityLock:          NewCommunityLock(logger),
 		mediaServer:            mediaServer,
 		communityImageVersions: make(map[string]uint32),
@@ -1517,6 +1519,11 @@ func (m *Manager) DeleteCommunity(id types3.HexBytes) error {
 	if err != nil {
 		return err
 	}
+	// Drop any redelivery-gate entry so a re-fetched description of a deleted
+	// community is fully reprocessed rather than skipped (#21470-hf).
+	if m.descriptionGate != nil {
+		m.descriptionGate.forget(id.String())
+	}
 	return m.persistence.DeleteCommunitySettings(id)
 }
 
@@ -2072,6 +2079,21 @@ func (m *Manager) HandleCommunityDescriptionMessage(signer *ecdsa.PublicKey, des
 		id = crypto.CompressPubkey(signer)
 	}
 
+	// #21470-hf: fast-path redelivered descriptions before any expensive work.
+	// status-go re-publishes the same ~1.4MB description into every fetch window,
+	// and each redelivered copy otherwise pays proto.Unmarshal + preprocessDescription
+	// (decrypted-cache read+write) + GetByID (re-read/re-unmarshal of the stored
+	// blob) BEFORE the downstream clock comparison rejects it. The gate skips only
+	// strictly-older clocks and byte-identical same-clock redeliveries; it is
+	// cleared when keys arrive or a community is deleted (see communityDescriptionGate).
+	gateKey := types3.HexBytes(id).String()
+	payloadHash := hashDescriptionPayload(payload)
+	if m.descriptionGate != nil && m.descriptionGate.shouldSkip(gateKey, description.Clock, payloadHash) {
+		m.logger.Debug("skipping redelivered community description",
+			zap.String("communityID", gateKey), zap.Uint64("clock", description.Clock))
+		return nil, nil
+	}
+
 	failedToDecrypt, processedDescription, err := m.preprocessDescription(id, description)
 	if err != nil {
 		return nil, err
@@ -2157,6 +2179,14 @@ func (m *Manager) HandleCommunityDescriptionMessage(signer *ecdsa.PublicKey, des
 	if err != nil {
 		return nil, err
 	}
+	// Advance the redelivery gate only after fully successful processing, so a
+	// byte-identical same-clock redelivery of THIS description can be skipped.
+	// Deliberately NOT advanced on the queue path or the FailedToDecrypt early
+	// return, so validateCommunity's later re-entry and key-arrival reprocessing
+	// are never blocked (#21470-hf).
+	if m.descriptionGate != nil {
+		m.descriptionGate.recordProcessed(gateKey, processedDescription.Clock, payloadHash)
+	}
 	r.FailedToDecrypt = failedToDecrypt
 	return r, nil
 }
@@ -2167,6 +2197,12 @@ func (m *Manager) NewHashRatchetKeys(keys []*types.HashRatchetInfo) error {
 	// description must re-evaluate.
 	if m.keyEntitlement != nil && len(keys) > 0 {
 		m.keyEntitlement.forgetAll()
+	}
+	// Lift the redelivery gate too: a description that was byte-identical to one
+	// already processed may now decrypt previously-encrypted private data, so it
+	// must be reprocessed rather than skipped as a redelivery (#21470-hf).
+	if m.descriptionGate != nil && len(keys) > 0 {
+		m.descriptionGate.forgetAll()
 	}
 	return m.persistence.InvalidateDecryptedCommunityCacheForKeys(keys)
 }

--- a/protocol/communities/manager_test.go
+++ b/protocol/communities/manager_test.go
@@ -1845,12 +1845,9 @@ func (s *ManagerSuite) TestCommunityIDIsHydratedWhenMarshaling() {
 	s.Require().Equal(community.IDString(), community.config.CommunityDescription.ID)
 }
 
-// TestHandleCommunityDescriptionRedeliveryGate verifies the redelivery gate
-// (issue #21470-hf). A byte-identical redelivery of an already-processed community
-// description must skip the expensive pipeline yet still SURFACE the already-known
-// community, so the store-node pager's description-seen latch (commit 6cd6ced1a)
-// trips exactly as it would for a fully-processed redelivery. Newer clocks are
-// still processed, and new hash-ratchet key material lifts the gate.
+// A skipped redelivery must still surface the known community (the pager's
+// description-seen latch depends on it); newer clocks process; key arrival
+// lifts the gate.
 func (s *ManagerSuite) TestHandleCommunityDescriptionRedeliveryGate() {
 	// s.manager is the control node that authors the community; m is a separate
 	// receiver (spectator) node that ingests the published description.
@@ -1924,12 +1921,8 @@ func (s *ManagerSuite) TestHandleCommunityDescriptionRedeliveryGate() {
 	s.Require().NotNil(resp5)
 }
 
-// TestHandleCommunityDescriptionRedeliveryCache verifies the redelivery skip path is
-// served from the in-memory community cache instead of a 1.4MB GetByID per skip
-// (issue #21470-hf). It exercises the cache lifecycle at the Manager seam:
-// populate-on-successful-processing, and invalidation on both NewHashRatchetKeys and
-// DeleteCommunity. Description-update invalidation is already covered by SaveCommunity
-// (every successful processing deletes then repopulates the cache entry).
+// Cache lifecycle at the Manager seam: populate on successful processing,
+// invalidate on NewHashRatchetKeys and DeleteCommunity.
 func (s *ManagerSuite) TestHandleCommunityDescriptionRedeliveryCache() {
 	m, _ := s.buildManagers(nil)
 

--- a/protocol/communities/manager_test.go
+++ b/protocol/communities/manager_test.go
@@ -1844,3 +1844,70 @@ func (s *ManagerSuite) TestCommunityIDIsHydratedWhenMarshaling() {
 	s.Require().NoError(err)
 	s.Require().Equal(community.IDString(), community.config.CommunityDescription.ID)
 }
+
+// TestHandleCommunityDescriptionRedeliveryGate verifies the redelivery gate
+// (issue #21470-hf): a byte-identical redelivery of an already-processed
+// community description is short-circuited (nil response, no error), while newer
+// clocks are still processed, and new hash-ratchet key material lifts the gate so
+// the same description is reprocessed (it may then decrypt private data).
+func (s *ManagerSuite) TestHandleCommunityDescriptionRedeliveryGate() {
+	// s.manager is the control node that authors the community; m is a separate
+	// receiver (spectator) node that ingests the published description.
+	m, _ := s.buildManagers(nil)
+
+	signer, err := crypto.GenerateKey()
+	s.Require().NoError(err)
+
+	createRequest := &requests.CreateCommunity{
+		Name:        "status",
+		Description: "status community description",
+		Membership:  protobuf.CommunityPermissions_AUTO_ACCEPT,
+	}
+	community, err := s.manager.CreateCommunity(createRequest, true)
+	s.Require().NoError(err)
+
+	description := community.config.CommunityDescription
+	// Plain community: no token ownership, so it is processed immediately (not queued).
+	s.Require().Equal(uint64(0), CommunityDescriptionTokenOwnerChainID(description))
+
+	buildPayload := func() []byte {
+		payload, err := community.MarshaledDescription()
+		s.Require().NoError(err)
+		payload, err = v.WrapIntoAppLayerMessage(payload, protobuf.ApplicationMetadataMessage_COMMUNITY_DESCRIPTION, signer)
+		s.Require().NoError(err)
+		return payload
+	}
+
+	payload := buildPayload()
+
+	// First delivery is fully processed and yields a response.
+	resp1, err := m.HandleCommunityDescriptionMessage(&signer.PublicKey, description, payload, nil)
+	s.Require().NoError(err)
+	s.Require().NotNil(resp1)
+
+	// Byte-identical redelivery is short-circuited by the gate (nil response, no error).
+	resp2, err := m.HandleCommunityDescriptionMessage(&signer.PublicKey, description, payload, nil)
+	s.Require().NoError(err)
+	s.Require().Nil(resp2)
+
+	// A genuinely newer clock still gets processed.
+	community.config.CommunityDescription.Clock++
+	newerPayload := buildPayload()
+	resp3, err := m.HandleCommunityDescriptionMessage(&signer.PublicKey, description, newerPayload, nil)
+	s.Require().NoError(err)
+	s.Require().NotNil(resp3)
+
+	// Its identical redelivery is skipped again.
+	resp4, err := m.HandleCommunityDescriptionMessage(&signer.PublicKey, description, newerPayload, nil)
+	s.Require().NoError(err)
+	s.Require().Nil(resp4)
+
+	// New hash-ratchet keys arriving must lift the gate so the same description is
+	// reprocessed (it may now decrypt previously-encrypted private data).
+	err = m.NewHashRatchetKeys([]*types.HashRatchetInfo{{GroupID: community.ID(), KeyID: []byte("key-id")}})
+	s.Require().NoError(err)
+
+	resp5, err := m.HandleCommunityDescriptionMessage(&signer.PublicKey, description, newerPayload, nil)
+	s.Require().NoError(err)
+	s.Require().NotNil(resp5, "gate must be lifted after new keys arrive")
+}

--- a/protocol/communities/manager_test.go
+++ b/protocol/communities/manager_test.go
@@ -1883,7 +1883,7 @@ func (s *ManagerSuite) TestHandleCommunityDescriptionRedeliveryGate() {
 	payload := buildPayload()
 
 	// The gate starts empty: the first delivery must not be skipped.
-	s.Require().False(m.descriptionGate.shouldSkip(gateKey, description.Clock, hashDescriptionPayload(payload)))
+	s.Require().False(m.descriptionGate.shouldSkip(gateKey, description.Clock, hashDescriptionPayload(payload), keysHeld))
 
 	// First delivery is fully processed and yields a response.
 	resp1, err := m.HandleCommunityDescriptionMessage(&signer.PublicKey, description, payload, nil)
@@ -1891,7 +1891,7 @@ func (s *ManagerSuite) TestHandleCommunityDescriptionRedeliveryGate() {
 	s.Require().NotNil(resp1)
 
 	// The gate now records this description, so a byte-identical redelivery is a skip.
-	s.Require().True(m.descriptionGate.shouldSkip(gateKey, description.Clock, hashDescriptionPayload(payload)))
+	s.Require().True(m.descriptionGate.shouldSkip(gateKey, description.Clock, hashDescriptionPayload(payload), keysHeld))
 
 	// Byte-identical redelivery is short-circuited but STILL surfaces the community
 	// (non-nil, matching ID, empty changes) so downstream description-seen latches.
@@ -1910,16 +1910,81 @@ func (s *ManagerSuite) TestHandleCommunityDescriptionRedeliveryGate() {
 	resp3, err := m.HandleCommunityDescriptionMessage(&signer.PublicKey, description, newerPayload, nil)
 	s.Require().NoError(err)
 	s.Require().NotNil(resp3)
-	s.Require().True(m.descriptionGate.shouldSkip(gateKey, description.Clock, hashDescriptionPayload(newerPayload)))
+	s.Require().True(m.descriptionGate.shouldSkip(gateKey, description.Clock, hashDescriptionPayload(newerPayload), keysHeld))
 
 	// New hash-ratchet keys arriving must lift the gate so the same description can
 	// be reprocessed (it may now decrypt previously-encrypted private data).
 	err = m.NewHashRatchetKeys([]*types.HashRatchetInfo{{GroupID: community.ID(), KeyID: []byte("key-id")}})
 	s.Require().NoError(err)
-	s.Require().False(m.descriptionGate.shouldSkip(gateKey, description.Clock, hashDescriptionPayload(newerPayload)),
+	s.Require().False(m.descriptionGate.shouldSkip(gateKey, description.Clock, hashDescriptionPayload(newerPayload), keysHeld),
 		"gate must be lifted after new keys arrive")
 
 	resp5, err := m.HandleCommunityDescriptionMessage(&signer.PublicKey, description, newerPayload, nil)
 	s.Require().NoError(err)
 	s.Require().NotNil(resp5)
+}
+
+// TestHandleCommunityDescriptionRedeliveryCache verifies the redelivery skip path is
+// served from the in-memory community cache instead of a 1.4MB GetByID per skip
+// (issue #21470-hf). It exercises the cache lifecycle at the Manager seam:
+// populate-on-successful-processing, and invalidation on both NewHashRatchetKeys and
+// DeleteCommunity. Description-update invalidation is already covered by SaveCommunity
+// (every successful processing deletes then repopulates the cache entry).
+func (s *ManagerSuite) TestHandleCommunityDescriptionRedeliveryCache() {
+	m, _ := s.buildManagers(nil)
+
+	signer, err := crypto.GenerateKey()
+	s.Require().NoError(err)
+
+	createRequest := &requests.CreateCommunity{
+		Name:        "status",
+		Description: "status community description",
+		Membership:  protobuf.CommunityPermissions_AUTO_ACCEPT,
+	}
+	community, err := s.manager.CreateCommunity(createRequest, true)
+	s.Require().NoError(err)
+
+	description := community.config.CommunityDescription
+	gateKey := community.IDString()
+	buildPayload := func() []byte {
+		payload, err := community.MarshaledDescription()
+		s.Require().NoError(err)
+		payload, err = v.WrapIntoAppLayerMessage(payload, protobuf.ApplicationMetadataMessage_COMMUNITY_DESCRIPTION, signer)
+		s.Require().NoError(err)
+		return payload
+	}
+	payload := buildPayload()
+
+	// The cache starts empty for an unseen community.
+	s.Require().Nil(m.cache.Get(gateKey), "cache must be empty before first processing")
+
+	// POPULATE-ON-PROCESS: after a successful full processing the just-processed
+	// community is cached so the first redelivery skip serves it without a GetByID.
+	_, err = m.HandleCommunityDescriptionMessage(&signer.PublicKey, description, payload, nil)
+	s.Require().NoError(err)
+	cached := m.cache.Get(gateKey)
+	s.Require().NotNil(cached, "community must be cached after successful processing")
+	s.Require().True(bytes.Equal(community.ID(), cached.Value().ID()), "cached community must match")
+
+	// The redelivery skip surfaces the community (from cache) with empty changes.
+	resp, err := m.HandleCommunityDescriptionMessage(&signer.PublicKey, description, payload, nil)
+	s.Require().NoError(err)
+	s.Require().NotNil(resp)
+	s.Require().NotNil(resp.Community)
+	s.Require().Equal(community.IDString(), resp.Community.IDString())
+
+	// INVALIDATE on NewHashRatchetKeys: keys arriving must drop the cached community
+	// (its next read reflects any now-decryptable state after reprocessing).
+	err = m.NewHashRatchetKeys([]*types.HashRatchetInfo{{GroupID: community.ID(), KeyID: []byte("key-id")}})
+	s.Require().NoError(err)
+	s.Require().Nil(m.cache.Get(gateKey), "new keys must invalidate the cached community")
+
+	// Reprocess to repopulate, then INVALIDATE on DeleteCommunity.
+	_, err = m.HandleCommunityDescriptionMessage(&signer.PublicKey, description, payload, nil)
+	s.Require().NoError(err)
+	s.Require().NotNil(m.cache.Get(gateKey), "reprocessing must repopulate the cache")
+
+	err = m.DeleteCommunity(community.ID())
+	s.Require().NoError(err)
+	s.Require().Nil(m.cache.Get(gateKey), "deleting the community must invalidate the cached community")
 }

--- a/protocol/communities/manager_test.go
+++ b/protocol/communities/manager_test.go
@@ -1846,10 +1846,11 @@ func (s *ManagerSuite) TestCommunityIDIsHydratedWhenMarshaling() {
 }
 
 // TestHandleCommunityDescriptionRedeliveryGate verifies the redelivery gate
-// (issue #21470-hf): a byte-identical redelivery of an already-processed
-// community description is short-circuited (nil response, no error), while newer
-// clocks are still processed, and new hash-ratchet key material lifts the gate so
-// the same description is reprocessed (it may then decrypt private data).
+// (issue #21470-hf). A byte-identical redelivery of an already-processed community
+// description must skip the expensive pipeline yet still SURFACE the already-known
+// community, so the store-node pager's description-seen latch (commit 6cd6ced1a)
+// trips exactly as it would for a fully-processed redelivery. Newer clocks are
+// still processed, and new hash-ratchet key material lifts the gate.
 func (s *ManagerSuite) TestHandleCommunityDescriptionRedeliveryGate() {
 	// s.manager is the control node that authors the community; m is a separate
 	// receiver (spectator) node that ingests the published description.
@@ -1870,6 +1871,7 @@ func (s *ManagerSuite) TestHandleCommunityDescriptionRedeliveryGate() {
 	// Plain community: no token ownership, so it is processed immediately (not queued).
 	s.Require().Equal(uint64(0), CommunityDescriptionTokenOwnerChainID(description))
 
+	gateKey := community.IDString()
 	buildPayload := func() []byte {
 		payload, err := community.MarshaledDescription()
 		s.Require().NoError(err)
@@ -1880,15 +1882,27 @@ func (s *ManagerSuite) TestHandleCommunityDescriptionRedeliveryGate() {
 
 	payload := buildPayload()
 
+	// The gate starts empty: the first delivery must not be skipped.
+	s.Require().False(m.descriptionGate.shouldSkip(gateKey, description.Clock, hashDescriptionPayload(payload)))
+
 	// First delivery is fully processed and yields a response.
 	resp1, err := m.HandleCommunityDescriptionMessage(&signer.PublicKey, description, payload, nil)
 	s.Require().NoError(err)
 	s.Require().NotNil(resp1)
 
-	// Byte-identical redelivery is short-circuited by the gate (nil response, no error).
+	// The gate now records this description, so a byte-identical redelivery is a skip.
+	s.Require().True(m.descriptionGate.shouldSkip(gateKey, description.Clock, hashDescriptionPayload(payload)))
+
+	// Byte-identical redelivery is short-circuited but STILL surfaces the community
+	// (non-nil, matching ID, empty changes) so downstream description-seen latches.
 	resp2, err := m.HandleCommunityDescriptionMessage(&signer.PublicKey, description, payload, nil)
 	s.Require().NoError(err)
-	s.Require().Nil(resp2)
+	s.Require().NotNil(resp2)
+	s.Require().NotNil(resp2.Community)
+	s.Require().Equal(community.IDString(), resp2.Community.IDString())
+	s.Require().NotNil(resp2.Changes)
+	s.Require().Empty(resp2.Changes.MembersAdded)
+	s.Require().Empty(resp2.Changes.ChatsAdded)
 
 	// A genuinely newer clock still gets processed.
 	community.config.CommunityDescription.Clock++
@@ -1896,18 +1910,16 @@ func (s *ManagerSuite) TestHandleCommunityDescriptionRedeliveryGate() {
 	resp3, err := m.HandleCommunityDescriptionMessage(&signer.PublicKey, description, newerPayload, nil)
 	s.Require().NoError(err)
 	s.Require().NotNil(resp3)
+	s.Require().True(m.descriptionGate.shouldSkip(gateKey, description.Clock, hashDescriptionPayload(newerPayload)))
 
-	// Its identical redelivery is skipped again.
-	resp4, err := m.HandleCommunityDescriptionMessage(&signer.PublicKey, description, newerPayload, nil)
-	s.Require().NoError(err)
-	s.Require().Nil(resp4)
-
-	// New hash-ratchet keys arriving must lift the gate so the same description is
-	// reprocessed (it may now decrypt previously-encrypted private data).
+	// New hash-ratchet keys arriving must lift the gate so the same description can
+	// be reprocessed (it may now decrypt previously-encrypted private data).
 	err = m.NewHashRatchetKeys([]*types.HashRatchetInfo{{GroupID: community.ID(), KeyID: []byte("key-id")}})
 	s.Require().NoError(err)
+	s.Require().False(m.descriptionGate.shouldSkip(gateKey, description.Clock, hashDescriptionPayload(newerPayload)),
+		"gate must be lifted after new keys arrive")
 
 	resp5, err := m.HandleCommunityDescriptionMessage(&signer.PublicKey, description, newerPayload, nil)
 	s.Require().NoError(err)
-	s.Require().NotNil(resp5, "gate must be lifted after new keys arrive")
+	s.Require().NotNil(resp5)
 }


### PR DESCRIPTION
## HF 5: description redelivery gate + segmentation (status-app#21470)

Stacked on #7635; completes the hotfix stack (= #7632's content).

**Problem:** each community description version is republished ~40× re-encrypted; over a 9-day sync a spectator is handed the same ~1.4MB blob hundreds of times, each copy paying proto.Unmarshal + decrypted-cache read/write + a full GetByID before the clock comparison rejects it (~10s each at Status-community volume). Segment reassembly additionally re-read every stored segment from SQLCipher on every arriving segment — O(N²) blob copies, 26% of all allocations.

**Changes (5 commits):**
- Clock/content-hash gate in `HandleCommunityDescriptionMessage`: strictly-older clocks and byte-identical same-clock redeliveries short-circuit; a keyless node also skips re-encrypted equal-clock republishes (useless without keys). Keys-held nodes keep the same-clock-different-content reprocess (member key rotation). Fail-open everywhere; gate cleared on key arrival and community deletion.
- Skipped redeliveries still surface the known community (from the readonly cache, one GetByID per miss) so the store-node pager's description-seen latch keeps working.
- Segmentation: COUNT/MAX completion precheck — the full segment load runs once, on completion.

**Measured on device (final-stack verification run):** redelivery_skips=370 in one 9-day sync; service CPU tail **31%, settling to 13–23%** (best of the staged series); rx 2.26GB; battery 38–39°C. Per-stage table in #7632.

🤖 Generated with [Claude Code](https://claude.com/claude-code)