### PR TITLE
perf: exclude the description topic from the spectate history sweep (#21470, HF 6)

### DIFF
--- a/protocol/messenger_spectate_history_sync.go
+++ b/protocol/messenger_spectate_history_sync.go
@@ -124,13 +124,28 @@ func (m *Messenger) asyncSyncSpectatedCommunity(community *communities.Community
 		return
 	}
 
-	filters := m.communitySyncFilters(community)
-	if len(filters) == 0 {
+	communityID := community.IDString()
+	now := uint32(m.getTimesource().GetCurrentTime() / 1000)
+	from := spectatedCommunitySyncFrom(now)
+
+	// The community-ID topic carries only re-published CommunityDescriptions —
+	// ~99.8% of a full sweep's bytes for one useful blob. The newest description
+	// is already fetched by FetchCommunity and live delivery stays subscribed,
+	// so that topic is excluded from the history sweep and its watermark is
+	// seeded at now — otherwise the next general sync would find it untracked
+	// and sweep the full window anyway.
+	allFilters := m.communitySyncFilters(community)
+	var sweepFilters, descriptionFilters types2.ChatFilters
+	for _, filter := range allFilters {
+		if filter.ChatID() == communityID {
+			descriptionFilters = append(descriptionFilters, filter)
+			continue
+		}
+		sweepFilters = append(sweepFilters, filter)
+	}
+	if len(sweepFilters) == 0 {
 		return
 	}
-
-	communityID := community.IDString()
-	from := spectatedCommunitySyncFrom(uint32(m.getTimesource().GetCurrentTime() / 1000))
 
 	ctx, cancel := context.WithCancel(m.ctx)
 	token := m.communityHistoryFetches.register(communityID, cancel)
@@ -142,15 +157,20 @@ func (m *Messenger) asyncSyncSpectatedCommunity(community *communities.Community
 		defer cancel()
 		defer m.communityHistoryFetches.finish(communityID, token)
 
-		if err := m.seedCommunityHistoryWatermarks(filters, int(from)); err != nil {
+		if err := m.seedCommunityHistoryWatermarks(sweepFilters, int(from)); err != nil {
 			m.logger.Warn("failed to seed spectated community history watermarks",
+				zap.String("communityID", communityID), zap.Error(err))
+			return
+		}
+		if err := m.seedCommunityHistoryWatermarks(descriptionFilters, int(now)); err != nil {
+			m.logger.Warn("failed to seed description-topic watermark",
 				zap.String("communityID", communityID), zap.Error(err))
 			return
 		}
 
 		peerInfo := m.messaging.GetActiveStorenode()
 		_, err := m.performStorenodeTask(func() (*MessengerResponse, error) {
-			response, err := m.syncFiltersFrom(ctx, peerInfo, filters, from)
+			response, err := m.syncFiltersFrom(ctx, peerInfo, sweepFilters, from)
 			if err != nil {
 				if ctx.Err() != nil {
 					// Cancelled by leave/background — don't retry or penalise the


### PR DESCRIPTION
## HF 6: don't sweep 9 days of a topic that carries only stale descriptions (status-app#21498 / #21470)

Stacked on #7636; completes the stack. Based on the store-node-side analysis in status-app#21498 (thanks @Ivansete-status): the community-ID content topic carries **only** re-published `CommunityDescription`s — ~99.8% of a spectator's 9-day sweep bytes (~2,000 copies of a ~2.4MB blob) — for exactly one useful copy, the newest, which `FetchCommunity` already delivers with a correct early stop.

**Change (1 commit, ~15 lines):** the spectate backfill sweeps only the chat (universal/memberUpdate) and control topics; the description topic is excluded and its watermark is **seeded at now** — without the seed, the next general sync would find the topic untracked and sweep the full default window anyway, merely deferring the cost. Live delivery keeps the filter subscribed; future description updates arrive via relay and `FetchCommunity`. Historical copies are strictly-older clocks the handler would discard after paying full unmarshal — skipping the download is behaviorally identical, minus the gigabytes.

### Measured (same fresh-profile → spectate Status → #general protocol as the whole series, Samsung S21FE, 9-day window)
| | previous stack tip (HF 1-5) | **+ this PR** |
|---|---|---|
| time to #general | 7m12s (series range 3m51s+) | **1m23s** |
| service CPU @ +5 / +10 min | 42% / 15% | **3.6% / 3.4%** |
| service CPU mean / tail (17-min window) | 45% / 31% | **21% / 4%** |
| resident memory during soak | 507-725MB | **106MB** (peak 477MB) |
| battery | 38-39°C | 38-39°C |

Remaining download (~1.8GB in this protocol) is the Communities Portal curated-directory `FetchCommunity` walk — page-cap-bounded, one-time, and a separate concern from the spectate path.

The deeper issue — the protocol re-publishing a full-member-list description re-encrypted ~229×/day into permanent store growth — is untouched here and tracked for upstream (also affects store nodes: it is most of `status.prod`'s community bytes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)