### PR TITLE
fix(communities): bound community fetching to stop the description-topic drain (#21470)

### DIFF
--- a/pkg/messaging/core_test_utils.go
+++ b/pkg/messaging/core_test_utils.go
@@ -54,6 +54,13 @@ func (f *TestMessagingEnvironment) SubscribePostEvents() chan *PostMessageSubscr
 	return f.waku.SubscribePostEvents()
 }
 
+// SetProcessMailserverBatchHook installs a hook that intercepts every store
+// (mailserver) batch request issued through this environment. Passing nil
+// restores the default behavior of forwarding to the underlying waku.
+func (f *TestMessagingEnvironment) SetProcessMailserverBatchHook(hook func(ctx context.Context, batch types.MailserverBatch, storenode peer.AddrInfo, pageLimit uint64, shouldProcessNextPage func(int) (bool, uint64), processEnvelopes bool) error) {
+	f.waku.processMailserverBatchHook = hook
+}
+
 func (f *TestMessagingEnvironment) SimulateOffline() func() {
 	f.waku.Waku.(*wakuv3.Waku).SkipPublishToTopic(true)
 	return func() {
@@ -65,6 +72,25 @@ func (f *TestMessagingEnvironment) SimulateOffline() func() {
 type testWakuWrapper struct {
 	types.Waku
 	api *testPublicWakuAPI
+
+	// processMailserverBatchHook, when set, intercepts every store (mailserver)
+	// batch request instead of forwarding it to the underlying waku. Used by
+	// tests to observe store queries without a real store node.
+	processMailserverBatchHook func(ctx context.Context, batch types.MailserverBatch, storenode peer.AddrInfo, pageLimit uint64, shouldProcessNextPage func(int) (bool, uint64), processEnvelopes bool) error
+}
+
+func (tw *testWakuWrapper) ProcessMailserverBatch(
+	ctx context.Context,
+	batch types.MailserverBatch,
+	storenode peer.AddrInfo,
+	pageLimit uint64,
+	shouldProcessNextPage func(int) (bool, uint64),
+	processEnvelopes bool,
+) error {
+	if tw.processMailserverBatchHook != nil {
+		return tw.processMailserverBatchHook(ctx, batch, storenode, pageLimit, shouldProcessNextPage, processEnvelopes)
+	}
+	return tw.Waku.ProcessMailserverBatch(ctx, batch, storenode, pageLimit, shouldProcessNextPage, processEnvelopes)
 }
 
 func (tw *testWakuWrapper) PublicWakuAPI() types.PublicWakuAPI {

--- a/protocol/common/code_control_flags.go
+++ b/protocol/common/code_control_flags.go
@@ -4,8 +4,4 @@ type CodeControlFlags struct {
 	// AutoRequestHistoricMessages indicates whether we should automatically request
 	// historic messages on getting online, connecting to store node, etc.
 	AutoRequestHistoricMessages bool
-
-	// CuratedCommunitiesUpdateLoopEnabled indicates whether we should disable the curated communities update loop.
-	// Usually should be disabled in tests.
-	CuratedCommunitiesUpdateLoopEnabled bool
 }

--- a/protocol/messenger.go
+++ b/protocol/messenger.go
@@ -142,6 +142,8 @@ type Messenger struct {
 	cancel            context.CancelFunc
 	shutdownWaitGroup sync.WaitGroup
 
+	curatedCommunitiesRefresh curatedCommunitiesRefresh
+
 	importingCommunities map[string]bool
 	importingChannels    map[string]bool
 	importRateLimiter    *rate.Limiter
@@ -653,9 +655,6 @@ func (m *Messenger) Start() (*MessengerResponse, error) {
 	m.startSyncSettingsLoop()
 	m.startSettingsChangesLoop()
 	m.startCommunityRekeyLoop()
-	if m.config.codeControlFlags.CuratedCommunitiesUpdateLoopEnabled {
-		m.startCuratedCommunitiesUpdateLoop()
-	}
 	m.startRequestMissingCommunityChannelsHRKeysLoop()
 
 	if err := m.cleanTopics(); err != nil {

--- a/protocol/messenger_builder_test.go
+++ b/protocol/messenger_builder_test.go
@@ -188,7 +188,6 @@ func newTestMessenger(t *testing.T, messagingEnv *messaging2.TestMessagingEnviro
 		WithMultiAccounts(madb),
 		WithAccount(multiAcc),
 		WithDatasync(),
-		WithCuratedCommunitiesUpdateLoop(false),
 		WithStubOnlineChecker(),
 		WithENSVerifier(ensVerifier),
 		WithMessageSigner(NewSignerStub()),

--- a/protocol/messenger_communities.go
+++ b/protocol/messenger_communities.go
@@ -1161,9 +1161,6 @@ func (m *Messenger) SpectateCommunity(communityID types3.HexBytes) (*MessengerRe
 
 	response.AddCommunity(community)
 
-	// sync community
-	m.asyncRequestAllHistoricMessages()
-
 	return response, nil
 }
 

--- a/protocol/messenger_config.go
+++ b/protocol/messenger_config.go
@@ -56,7 +56,9 @@ type MessengerSignalsHandler interface {
 	DiscordChannelImportCancelled(channelID string)
 	SendBackedUpProfile(response *backupsync.BackedUpDataResponse)
 	SendBackedUpSettings(response *backupsync.BackedUpDataResponse)
-	SendCuratedCommunitiesUpdate(response *communities.KnownCommunitiesResponse)
+	CuratedCommunitiesRefreshStarted()
+	CuratedCommunityResolved(communityID string, stored bool)
+	CuratedCommunitiesRefreshFinished(resolved, unresolved int, cancelled bool)
 }
 
 type config struct {
@@ -118,7 +120,6 @@ func messengerDefaultConfig() config {
 	}
 
 	c.codeControlFlags.AutoRequestHistoricMessages = true
-	c.codeControlFlags.CuratedCommunitiesUpdateLoopEnabled = true
 
 	c.tracer = trace.NewNoopTracer()
 

--- a/protocol/messenger_config_test.go
+++ b/protocol/messenger_config_test.go
@@ -4,13 +4,6 @@ import (
 	"github.com/status-im/status-go/protocol/communities"
 )
 
-func WithCuratedCommunitiesUpdateLoop(enabled bool) Option {
-	return func(c *config) error {
-		c.codeControlFlags.CuratedCommunitiesUpdateLoopEnabled = enabled
-		return nil
-	}
-}
-
 func WithCommunityManagerOptions(options []communities.ManagerOption) Option {
 	return func(c *config) error {
 		c.communityManagerOptions = options

--- a/protocol/messenger_curated_communities.go
+++ b/protocol/messenger_curated_communities.go
@@ -3,8 +3,7 @@ package protocol
 import (
 	"context"
 	"errors"
-	"reflect"
-	"time"
+	"sync"
 
 	"go.uber.org/zap"
 
@@ -15,85 +14,6 @@ import (
 	"github.com/status-im/status-go/protocol/communities"
 	"github.com/status-im/status-go/services/wallet/common"
 )
-
-const (
-	curatedCommunitiesUpdateInterval = time.Hour
-	communitiesUpdateFailureInterval = time.Minute
-)
-
-// Regularly gets list of curated communities and signals them to client
-func (m *Messenger) startCuratedCommunitiesUpdateLoop() {
-	logger := m.logger.Named("curatedCommunitiesUpdateLoop")
-
-	if m.contractMaker == nil {
-		logger.Warn("not starting curated communities loop: contract maker not initialized")
-		return
-	}
-
-	go func() {
-		defer gocommon.LogOnPanic()
-		// Initialize interval to 0 for immediate execution
-		var interval time.Duration = 0
-
-		cache, err := m.communitiesManager.GetCuratedCommunities()
-		if err != nil {
-			logger.Error("failed to start curated communities loop", zap.Error(err))
-			return
-		}
-
-		for {
-			select {
-			case <-time.After(interval):
-				if m.shouldPauseCuratedCommunitiesUpdateLoop() {
-					interval = curatedCommunitiesUpdateInterval
-					continue
-				}
-				// Immediate execution on first run, then set to regular interval
-				interval = curatedCommunitiesUpdateInterval
-
-				logger.Debug("updating curated communities")
-				curatedCommunities, err := m.getCuratedCommunitiesFromContract()
-				if err != nil {
-					interval = communitiesUpdateFailureInterval
-					logger.Error("failed to get curated communities from contract", zap.Error(err))
-					continue
-				}
-
-				if reflect.DeepEqual(cache.ContractCommunities, curatedCommunities.ContractCommunities) &&
-					reflect.DeepEqual(cache.ContractFeaturedCommunities, curatedCommunities.ContractFeaturedCommunities) {
-					// nothing changed
-					continue
-				}
-
-				err = m.communitiesManager.SetCuratedCommunities(curatedCommunities)
-				if err == nil {
-					cache = curatedCommunities
-				} else {
-					logger.Error("failed to save curated communities", zap.Error(err))
-				}
-
-				response, err := m.fetchCuratedCommunities(curatedCommunities)
-				if err != nil {
-					interval = communitiesUpdateFailureInterval
-					logger.Error("failed to fetch curated communities", zap.Error(err))
-					continue
-				}
-
-				m.config.messengerSignalsHandler.SendCuratedCommunitiesUpdate(response)
-
-			case <-m.quit:
-				return
-			}
-		}
-	}()
-}
-
-func (m *Messenger) shouldPauseCuratedCommunitiesUpdateLoop() bool {
-	// TODO when we implement back the setting for the user to select if they want to
-	// fetch on expensive networks, use canSyncWithStoreNodes()
-	// https://github.com/status-im/status-app/issues/18388
-	return m.isPaused() || m.getConnectionState().IsExpensive()
-}
 
 func (m *Messenger) getCuratedCommunitiesFromContract() (*communities.CuratedCommunities, error) {
 	if m.contractMaker == nil {
@@ -141,38 +61,172 @@ func (m *Messenger) getCuratedCommunitiesFromContract() (*communities.CuratedCom
 	}, nil
 }
 
-func (m *Messenger) fetchCuratedCommunities(curatedCommunities *communities.CuratedCommunities) (*communities.KnownCommunitiesResponse, error) {
+// CuratedCommunities returns the curated directory ids together with any
+// description already stored locally. It is a pure read: it never queries store
+// nodes. Use RefreshCuratedCommunities to resolve missing descriptions.
+func (m *Messenger) CuratedCommunities() (*communities.KnownCommunitiesResponse, error) {
+	curatedCommunities, err := m.communitiesManager.GetCuratedCommunities()
+	if err != nil {
+		return nil, err
+	}
+
 	response, err := m.communitiesManager.GetStoredDescriptionForCommunities(curatedCommunities.ContractCommunities)
 	if err != nil {
 		return nil, err
 	}
 	response.ContractFeaturedCommunities = curatedCommunities.ContractFeaturedCommunities
 
-	m.shutdownWaitGroup.Add(1)
-
-	go func() {
-		defer gocommon.LogOnPanic()
-		defer m.shutdownWaitGroup.Done()
-		m.logger.Debug("fetching unknown curated communities")
-
-		for _, communityID := range response.UnknownCommunities {
-			_, _, err := m.storeNodeRequestsManager.FetchCommunity(m.ctx, communityID, nil)
-			if err != nil {
-				m.logger.Error("failed to fetch curated community",
-					zap.String("communityID", communityID),
-					zap.Error(err),
-				)
-			}
-		}
-	}()
-
 	return response, nil
 }
 
-func (m *Messenger) CuratedCommunities() (*communities.KnownCommunitiesResponse, error) {
-	curatedCommunities, err := m.communitiesManager.GetCuratedCommunities()
-	if err != nil {
-		return nil, err
+// curatedCommunityResolver resolves a single curated directory entry against
+// store nodes and reports whether a description is now stored locally.
+type curatedCommunityResolver func(ctx context.Context, communityID string) bool
+
+// curatedCommunitiesRefresh tracks the single in-flight curated refresh so a
+// second refresh joins the running one instead of starting a new walk.
+type curatedCommunitiesRefresh struct {
+	mu      sync.Mutex
+	running bool
+	cancel  context.CancelFunc
+}
+
+// begin starts a new refresh derived from parent, unless one is already running.
+func (r *curatedCommunitiesRefresh) begin(parent context.Context) (context.Context, bool) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if r.running {
+		return nil, false
 	}
-	return m.fetchCuratedCommunities(curatedCommunities)
+
+	ctx, cancel := context.WithCancel(parent)
+	r.running = true
+	r.cancel = cancel
+	return ctx, true
+}
+
+func (r *curatedCommunitiesRefresh) end() {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if r.cancel != nil {
+		r.cancel()
+		r.cancel = nil
+	}
+	r.running = false
+}
+
+func (r *curatedCommunitiesRefresh) stop() {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if r.cancel != nil {
+		r.cancel()
+	}
+}
+
+// RefreshCuratedCommunities reads the curated directory and resolves every entry
+// (known and unknown) against store nodes. Progress is reported via signals. A
+// refresh started while one is already running joins the in-progress run.
+func (m *Messenger) RefreshCuratedCommunities() error {
+	return m.refreshCuratedCommunities(m.getCuratedCommunitiesFromContract, m.fetchAndStoreCuratedCommunity)
+}
+
+// StopCuratedCommunitiesRefresh cancels the in-flight refresh, if any.
+func (m *Messenger) StopCuratedCommunitiesRefresh() {
+	m.curatedCommunitiesRefresh.stop()
+}
+
+func (m *Messenger) refreshCuratedCommunities(directory func() (*communities.CuratedCommunities, error), resolve curatedCommunityResolver) error {
+	ctx, started := m.curatedCommunitiesRefresh.begin(m.ctx)
+	if !started {
+		return nil
+	}
+
+	m.shutdownWaitGroup.Add(1)
+	go func() {
+		defer gocommon.LogOnPanic()
+		defer m.shutdownWaitGroup.Done()
+		defer m.curatedCommunitiesRefresh.end()
+
+		m.config.messengerSignalsHandler.CuratedCommunitiesRefreshStarted()
+
+		var resolved, unresolved int
+		curatedCommunities, err := directory()
+		if err != nil {
+			m.logger.Error("failed to read curated communities directory", zap.Error(err))
+		} else {
+			if err := m.communitiesManager.SetCuratedCommunities(curatedCommunities); err != nil {
+				m.logger.Error("failed to store curated communities", zap.Error(err))
+			}
+			resolved, unresolved = m.resolveCuratedCommunities(ctx, curatedCommunities.ContractCommunities, resolve)
+		}
+
+		m.config.messengerSignalsHandler.CuratedCommunitiesRefreshFinished(resolved, unresolved, ctx.Err() != nil)
+	}()
+
+	return nil
+}
+
+func (m *Messenger) resolveCuratedCommunities(ctx context.Context, communityIDs []string, resolve curatedCommunityResolver) (resolved, unresolved int) {
+	const maxConcurrentResolves = 3
+
+	var (
+		wg sync.WaitGroup
+		mu sync.Mutex
+	)
+	sem := make(chan struct{}, maxConcurrentResolves)
+
+	for _, communityID := range communityIDs {
+		select {
+		case <-ctx.Done():
+			wg.Wait()
+			return resolved, unresolved
+		case sem <- struct{}{}:
+		}
+
+		wg.Add(1)
+		go func(communityID string) {
+			defer gocommon.LogOnPanic()
+			defer wg.Done()
+			defer func() { <-sem }()
+
+			stored := resolve(ctx, communityID)
+			m.config.messengerSignalsHandler.CuratedCommunityResolved(communityID, stored)
+
+			mu.Lock()
+			if stored {
+				resolved++
+			} else {
+				unresolved++
+			}
+			mu.Unlock()
+		}(communityID)
+	}
+
+	wg.Wait()
+	return resolved, unresolved
+}
+
+// fetchAndStoreCuratedCommunity resolves a single curated entry through the
+// bounded store node request manager and reports whether a description is now
+// stored locally.
+func (m *Messenger) fetchAndStoreCuratedCommunity(ctx context.Context, communityID string) bool {
+	_, _, err := m.storeNodeRequestsManager.FetchCommunity(ctx, communityID, nil)
+	if err != nil {
+		m.logger.Error("failed to resolve curated community",
+			zap.String("communityID", communityID),
+			zap.Error(err))
+	}
+
+	response, err := m.communitiesManager.GetStoredDescriptionForCommunities([]string{communityID})
+	if err != nil {
+		m.logger.Error("failed to check stored curated community description",
+			zap.String("communityID", communityID),
+			zap.Error(err))
+		return false
+	}
+
+	return len(response.Descriptions) > 0
 }

--- a/protocol/messenger_curated_communities.go
+++ b/protocol/messenger_curated_communities.go
@@ -150,7 +150,9 @@ func (m *Messenger) refreshCuratedCommunities(directory func() (*communities.Cur
 		defer m.shutdownWaitGroup.Done()
 		defer m.curatedCommunitiesRefresh.end()
 
-		m.config.messengerSignalsHandler.CuratedCommunitiesRefreshStarted()
+		if h := m.config.messengerSignalsHandler; h != nil {
+			h.CuratedCommunitiesRefreshStarted()
+		}
 
 		var resolved, unresolved int
 		curatedCommunities, err := directory()
@@ -163,7 +165,14 @@ func (m *Messenger) refreshCuratedCommunities(directory func() (*communities.Cur
 			resolved, unresolved = m.resolveCuratedCommunities(ctx, curatedCommunities.ContractCommunities, resolve)
 		}
 
-		m.config.messengerSignalsHandler.CuratedCommunitiesRefreshFinished(resolved, unresolved, ctx.Err() != nil)
+		// Clear the single-flight state before emitting finished so a refresh
+		// triggered right after is not dropped. Capture the cancelled flag first,
+		// because end() cancels ctx.
+		cancelled := ctx.Err() != nil
+		m.curatedCommunitiesRefresh.end()
+		if h := m.config.messengerSignalsHandler; h != nil {
+			h.CuratedCommunitiesRefreshFinished(resolved, unresolved, cancelled)
+		}
 	}()
 
 	return nil
@@ -193,7 +202,9 @@ func (m *Messenger) resolveCuratedCommunities(ctx context.Context, communityIDs 
 			defer func() { <-sem }()
 
 			stored := resolve(ctx, communityID)
-			m.config.messengerSignalsHandler.CuratedCommunityResolved(communityID, stored)
+			if h := m.config.messengerSignalsHandler; h != nil {
+				h.CuratedCommunityResolved(communityID, stored)
+			}
 
 			mu.Lock()
 			if stored {

--- a/protocol/messenger_curated_communities_test.go
+++ b/protocol/messenger_curated_communities_test.go
@@ -1,18 +1,287 @@
 package protocol
 
 import (
+	"context"
+	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
 
-	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
 
-	"github.com/status-im/status-go/internal/connection"
+	"github.com/status-im/status-go/pkg/messaging"
+	types2 "github.com/status-im/status-go/pkg/messaging/types"
+	"github.com/status-im/status-go/protocol/communities"
 )
 
-func TestShouldPauseCuratedCommunitiesUpdateLoop(t *testing.T) {
-	m := &Messenger{}
+func TestMessengerCuratedRefreshSuite(t *testing.T) {
+	suite.Run(t, new(MessengerCuratedRefreshSuite))
+}
 
-	require.False(t, m.shouldPauseCuratedCommunitiesUpdateLoop())
+type MessengerCuratedRefreshSuite struct {
+	suite.Suite
 
-	m.setConnectionState(connection.State{Expensive: true})
-	require.True(t, m.shouldPauseCuratedCommunitiesUpdateLoop())
+	messagingEnv *messaging.TestMessagingEnvironment
+	m            *Messenger
+}
+
+func (s *MessengerCuratedRefreshSuite) SetupTest() {
+	var err error
+	s.messagingEnv, err = messaging.NewTestMessagingEnvironment()
+	s.Require().NoError(err)
+	s.Require().NoError(s.messagingEnv.Setup(s.T()))
+
+	s.m, err = newTestMessenger(s.T(), s.messagingEnv, testMessengerConfig{})
+	s.Require().NoError(err)
+}
+
+// curatedRefreshSignals records the curated refresh signals in emission order.
+type curatedRefreshSignals struct {
+	MessengerSignalsHandler
+
+	mu              sync.Mutex
+	order           []string
+	resolved        map[string]bool
+	resolvedCount   int
+	unresolvedCount int
+	cancelled       bool
+	finished        chan struct{}
+}
+
+func newCuratedRefreshSignals() *curatedRefreshSignals {
+	return &curatedRefreshSignals{
+		resolved: map[string]bool{},
+		finished: make(chan struct{}, 1),
+	}
+}
+
+func (r *curatedRefreshSignals) CuratedCommunitiesRefreshStarted() {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.order = append(r.order, "started")
+}
+
+func (r *curatedRefreshSignals) CuratedCommunityResolved(communityID string, stored bool) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.order = append(r.order, "resolved")
+	r.resolved[communityID] = stored
+}
+
+func (r *curatedRefreshSignals) CuratedCommunitiesRefreshFinished(resolved, unresolved int, cancelled bool) {
+	r.mu.Lock()
+	r.order = append(r.order, "finished")
+	r.resolvedCount = resolved
+	r.unresolvedCount = unresolved
+	r.cancelled = cancelled
+	r.mu.Unlock()
+	r.finished <- struct{}{}
+}
+
+func (r *curatedRefreshSignals) count(event string) int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	n := 0
+	for _, e := range r.order {
+		if e == event {
+			n++
+		}
+	}
+	return n
+}
+
+func (s *MessengerCuratedRefreshSuite) waitFinished(mock *curatedRefreshSignals) {
+	select {
+	case <-mock.finished:
+	case <-time.After(5 * time.Second):
+		s.FailNow("refresh did not finish in time")
+	}
+}
+
+func curatedDirectory(ids ...string) func() (*communities.CuratedCommunities, error) {
+	return func() (*communities.CuratedCommunities, error) {
+		return &communities.CuratedCommunities{ContractCommunities: ids}, nil
+	}
+}
+
+// TestCuratedCommunitiesReadIsSideEffectFree verifies that reading the curated
+// communities returns stored data only and never triggers a store node request.
+func (s *MessengerCuratedRefreshSuite) TestCuratedCommunitiesReadIsSideEffectFree() {
+	var batches int32
+	s.m.storeNodeRequestsManager.onPerformingBatch = func(types2.StoreNodeBatch) {
+		atomic.AddInt32(&batches, 1)
+	}
+
+	s.Require().NoError(s.m.communitiesManager.SetCuratedCommunities(&communities.CuratedCommunities{
+		ContractCommunities:         []string{unknownCommunityID},
+		ContractFeaturedCommunities: []string{unknownCommunityID},
+	}))
+
+	response, err := s.m.CuratedCommunities()
+	s.Require().NoError(err)
+	s.Require().Contains(response.UnknownCommunities, unknownCommunityID)
+	s.Require().Equal([]string{unknownCommunityID}, response.ContractFeaturedCommunities)
+
+	s.Require().Equal(int32(0), atomic.LoadInt32(&batches), "a pure read must not issue store node requests")
+}
+
+// TestResolveRespectsParallelismAndCounts verifies bounded parallelism of 3
+// across entries, a per-community resolved signal for every entry, and correct
+// resolved/unresolved counts.
+func (s *MessengerCuratedRefreshSuite) TestResolveRespectsParallelismAndCounts() {
+	mock := newCuratedRefreshSignals()
+	s.m.config.messengerSignalsHandler = mock
+
+	ids := []string{"0x01", "0x02", "0x03", "0x04", "0x05", "0x06"}
+	stored := map[string]bool{"0x01": true, "0x03": true, "0x05": true, "0x06": true}
+
+	var (
+		mu      sync.Mutex
+		current int
+		maxSeen int
+	)
+	resolve := func(ctx context.Context, id string) bool {
+		mu.Lock()
+		current++
+		if current > maxSeen {
+			maxSeen = current
+		}
+		mu.Unlock()
+
+		time.Sleep(20 * time.Millisecond)
+
+		mu.Lock()
+		current--
+		mu.Unlock()
+		return stored[id]
+	}
+
+	resolved, unresolved := s.m.resolveCuratedCommunities(context.Background(), ids, resolve)
+
+	mu.Lock()
+	s.Require().LessOrEqual(maxSeen, 3, "must not resolve more than 3 entries concurrently")
+	mu.Unlock()
+
+	s.Require().Equal(4, resolved)
+	s.Require().Equal(2, unresolved)
+	s.Require().Equal(len(ids), mock.count("resolved"), "one resolved signal per entry")
+	for _, id := range ids {
+		got, ok := mock.resolved[id]
+		s.Require().True(ok, "missing resolved signal for %s", id)
+		s.Require().Equal(stored[id], got)
+	}
+}
+
+// TestRefreshIsSingleFlight verifies that a second refresh started while one is
+// in progress joins the running one: it starts no new run and no entry is
+// fetched twice.
+func (s *MessengerCuratedRefreshSuite) TestRefreshIsSingleFlight() {
+	mock := newCuratedRefreshSignals()
+	s.m.config.messengerSignalsHandler = mock
+
+	ids := []string{"0x01", "0x02", "0x03"}
+	release := make(chan struct{})
+	calls := &sync.Map{}
+	resolve := func(ctx context.Context, id string) bool {
+		c, _ := calls.LoadOrStore(id, new(int32))
+		atomic.AddInt32(c.(*int32), 1)
+		<-release
+		return true
+	}
+
+	s.Require().NoError(s.m.refreshCuratedCommunities(curatedDirectory(ids...), resolve))
+	// Second refresh while the first is still running must join it.
+	s.Require().NoError(s.m.refreshCuratedCommunities(curatedDirectory(ids...), resolve))
+
+	close(release)
+	s.waitFinished(mock)
+
+	s.Require().Equal(1, mock.count("started"), "only one run must start")
+	s.Require().Equal(3, mock.resolvedCount)
+	calls.Range(func(key, value any) bool {
+		s.Require().Equal(int32(1), atomic.LoadInt32(value.(*int32)), "entry %v must be fetched once", key)
+		return true
+	})
+}
+
+// TestStopCancelsRefresh verifies that stopping cancels the in-flight refresh:
+// no further entries are resolved and the finished signal reports cancelled.
+func (s *MessengerCuratedRefreshSuite) TestStopCancelsRefresh() {
+	mock := newCuratedRefreshSignals()
+	s.m.config.messengerSignalsHandler = mock
+
+	ids := []string{"0x01", "0x02", "0x03", "0x04", "0x05", "0x06"}
+	entered := make(chan struct{}, len(ids))
+	release := make(chan struct{})
+	resolve := func(ctx context.Context, id string) bool {
+		entered <- struct{}{}
+		<-release
+		return ctx.Err() == nil
+	}
+
+	s.Require().NoError(s.m.refreshCuratedCommunities(curatedDirectory(ids...), resolve))
+
+	// Wait until the first bounded batch is in flight, then cancel.
+	for i := 0; i < 3; i++ {
+		<-entered
+	}
+	s.m.StopCuratedCommunitiesRefresh()
+	close(release)
+
+	s.waitFinished(mock)
+
+	s.Require().True(mock.cancelled)
+	s.Require().Less(mock.resolvedCount+mock.unresolvedCount, len(ids), "cancel must stop launching new entries")
+}
+
+// TestRefreshEmitsSignalsInOrder verifies the started -> resolved -> finished
+// ordering and the finished counts for a successful refresh.
+func (s *MessengerCuratedRefreshSuite) TestRefreshEmitsSignalsInOrder() {
+	mock := newCuratedRefreshSignals()
+	s.m.config.messengerSignalsHandler = mock
+
+	ids := []string{"0x01", "0x02"}
+	resolve := func(ctx context.Context, id string) bool {
+		return id == "0x01"
+	}
+
+	s.Require().NoError(s.m.refreshCuratedCommunities(curatedDirectory(ids...), resolve))
+	s.waitFinished(mock)
+
+	mock.mu.Lock()
+	order := append([]string{}, mock.order...)
+	mock.mu.Unlock()
+
+	s.Require().Equal("started", order[0])
+	s.Require().Equal("finished", order[len(order)-1])
+	s.Require().Equal(2, mock.count("resolved"))
+	s.Require().Equal(1, mock.resolvedCount)
+	s.Require().Equal(1, mock.unresolvedCount)
+	s.Require().False(mock.cancelled)
+	s.Require().True(mock.resolved["0x01"])
+	s.Require().False(mock.resolved["0x02"])
+}
+
+// TestStartIssuesNoCuratedBatch pins that a started messenger never resolves the
+// curated directory on its own: with a curated directory containing an unknown
+// community, no store node batch is issued unless a refresh is requested.
+func (s *MessengerCuratedRefreshSuite) TestStartIssuesNoCuratedBatch() {
+	var batches int32
+	s.m.storeNodeRequestsManager.onPerformingBatch = func(types2.StoreNodeBatch) {
+		atomic.AddInt32(&batches, 1)
+	}
+
+	s.Require().NoError(s.m.communitiesManager.SetCuratedCommunities(&communities.CuratedCommunities{
+		ContractCommunities: []string{unknownCommunityID},
+	}))
+
+	s.Require().NoError(s.m.messaging.Start())
+	s.T().Cleanup(func() { s.Require().NoError(s.m.messaging.Stop()) })
+	_, err := s.m.Start()
+	s.Require().NoError(err)
+	s.T().Cleanup(func() { s.Require().NoError(s.m.Shutdown()) })
+
+	time.Sleep(200 * time.Millisecond)
+
+	s.Require().Equal(int32(0), atomic.LoadInt32(&batches), "start must not issue curated store node requests")
 }

--- a/protocol/messenger_mailserver.go
+++ b/protocol/messenger_mailserver.go
@@ -23,7 +23,6 @@ import (
 )
 
 const (
-	initialStoreNodeRequestPageSize = 4
 	defaultStoreNodeRequestPageSize = 50
 
 	// tolerance is how many seconds of potentially out-of-order messages we want to fetch
@@ -475,10 +474,6 @@ func (m *Messenger) syncFiltersFrom(peerInfo peer.AddrInfo, filters types2.ChatF
 		contentTopicsPerPubsubTopic[filter.PubsubTopic()] = contentTopics
 	}
 
-	communityDescriptionChatIDs, err := m.communityDescriptionChatIDs()
-	if err != nil {
-		return nil, err
-	}
 	var communityDescriptionFilters []*types2.ChatFilter
 
 	for pubsubTopic, contentTopics := range contentTopicsPerPubsubTopic {
@@ -501,7 +496,7 @@ func (m *Messenger) syncFiltersFrom(peerInfo peer.AddrInfo, filters types2.ChatF
 			// topic over the whole sync window downloads gigabytes of stale
 			// duplicates. Skip it here and fetch only the newest description
 			// (single page, newest-first) below. See status-im/status-app#21498.
-			if _, isCommunityDescription := communityDescriptionChatIDs[chatID]; isCommunityDescription {
+			if isCommunityDescriptionChatID(chatID) {
 				communityDescriptionFilters = append(communityDescriptionFilters, filter)
 				continue
 			}
@@ -641,21 +636,30 @@ func (m *Messenger) syncFilters(peerInfo peer.AddrInfo, filters types2.ChatFilte
 	return m.syncFiltersFrom(peerInfo, filters, 0)
 }
 
-// communityDescriptionChatIDs returns the set of chat IDs that correspond to
-// the community description content topics of joined and spectated communities.
-// These topics carry the full community description, which is republished many
-// times per day. They are fetched with a dedicated StopWhenDataFound request
-// instead of being swept over the whole historic sync window.
-func (m *Messenger) communityDescriptionChatIDs() (map[string]struct{}, error) {
-	communities, err := m.communitiesManager.JoinedOrSpectated()
-	if err != nil {
-		return nil, err
+// isCommunityDescriptionChatID reports whether chatID is a community description
+// content topic. Such a topic's chatID is a community ID: the hex encoding of a
+// compressed secp256k1 public key ("0x02"/"0x03" prefix + 64 lowercase hex
+// chars). This shape is unique to community descriptions in the filter set:
+// community channel topics carry a suffix (e.g. "-memberUpdate"), contact-code
+// topics derive from uncompressed ("0x04") keys with a suffix, and 1-1/personal
+// chat IDs are uncompressed keys or named strings. Matching by shape rather than
+// by membership also excludes description topics of communities that are neither
+// joined nor spectated (e.g. temporary filters installed while resolving a
+// community), which would otherwise be swept over the whole historic window.
+func isCommunityDescriptionChatID(chatID string) bool {
+	const compressedKeyHexLen = len("0x") + 33*2 // "0x" + 33-byte compressed key
+	if len(chatID) != compressedKeyHexLen {
+		return false
 	}
-	chatIDs := make(map[string]struct{}, len(communities))
-	for _, community := range communities {
-		chatIDs[community.IDString()] = struct{}{}
+	if chatID[:4] != "0x02" && chatID[:4] != "0x03" {
+		return false
 	}
-	return chatIDs, nil
+	for _, c := range chatID[4:] {
+		if !((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f')) {
+			return false
+		}
+	}
+	return true
 }
 
 // fetchLatestCommunityDescriptions fetches only the most recent description for

--- a/protocol/messenger_mailserver.go
+++ b/protocol/messenger_mailserver.go
@@ -475,6 +475,12 @@ func (m *Messenger) syncFiltersFrom(peerInfo peer.AddrInfo, filters types2.ChatF
 		contentTopicsPerPubsubTopic[filter.PubsubTopic()] = contentTopics
 	}
 
+	communityDescriptionChatIDs, err := m.communityDescriptionChatIDs()
+	if err != nil {
+		return nil, err
+	}
+	var communityDescriptionFilters []*types2.ChatFilter
+
 	for pubsubTopic, contentTopics := range contentTopicsPerPubsubTopic {
 		if _, ok := batches[pubsubTopic]; !ok {
 			batches[pubsubTopic] = make(map[int]types2.StoreNodeBatch)
@@ -487,6 +493,17 @@ func (m *Messenger) syncFiltersFrom(peerInfo peer.AddrInfo, filters types2.ChatF
 				chatID = filter.Identity()
 			} else {
 				chatID = filter.ChatID()
+			}
+
+			// The community description content topic republishes the full
+			// community description (including every member) many times per day.
+			// Only the most recent description is ever used, so sweeping this
+			// topic over the whole sync window downloads gigabytes of stale
+			// duplicates. Skip it here and fetch only the newest description
+			// (single page, newest-first) below. See status-im/status-app#21498.
+			if _, isCommunityDescription := communityDescriptionChatIDs[chatID]; isCommunityDescription {
+				communityDescriptionFilters = append(communityDescriptionFilters, filter)
+				continue
 			}
 
 			topicData, ok := topicsData[fmt.Sprintf("%s-%s", filter.PubsubTopic(), filter.ContentTopic())]
@@ -614,11 +631,68 @@ func (m *Messenger) syncFiltersFrom(peerInfo peer.AddrInfo, filters types2.ChatF
 			return nil, err
 		}
 	}
+
+	m.fetchLatestCommunityDescriptions(peerInfo, communityDescriptionFilters)
+
 	return response, nil
 }
 
 func (m *Messenger) syncFilters(peerInfo peer.AddrInfo, filters types2.ChatFilters) (*MessengerResponse, error) {
 	return m.syncFiltersFrom(peerInfo, filters, 0)
+}
+
+// communityDescriptionChatIDs returns the set of chat IDs that correspond to
+// the community description content topics of joined and spectated communities.
+// These topics carry the full community description, which is republished many
+// times per day. They are fetched with a dedicated StopWhenDataFound request
+// instead of being swept over the whole historic sync window.
+func (m *Messenger) communityDescriptionChatIDs() (map[string]struct{}, error) {
+	communities, err := m.communitiesManager.JoinedOrSpectated()
+	if err != nil {
+		return nil, err
+	}
+	chatIDs := make(map[string]struct{}, len(communities))
+	for _, community := range communities {
+		chatIDs[community.IDString()] = struct{}{}
+	}
+	return chatIDs, nil
+}
+
+// fetchLatestCommunityDescriptions fetches only the most recent description for
+// each of the given community description filters. The store node is queried
+// newest-first and paging stops after the first page, so we download the single
+// latest description instead of every historic copy that was republished over
+// the sync window.
+//
+// Note: we deliberately do not use FetchCommunity here. FetchCommunity keeps
+// paging until it finds a description newer than the one already stored
+// locally; for a community we are already up to date on (the common case while
+// spectating), no such newer copy exists and it would sweep the whole window.
+func (m *Messenger) fetchLatestCommunityDescriptions(peerInfo peer.AddrInfo, filters []*types2.ChatFilter) {
+	if len(filters) == 0 {
+		return
+	}
+
+	from, to := m.calculateMailserverTimeBounds(oneMonthDuration)
+	stopAfterFirstPage := func(int) (bool, uint64) {
+		return false, 0
+	}
+
+	for _, filter := range filters {
+		batch := types2.StoreNodeBatch{
+			From:        from,
+			To:          to,
+			PubsubTopic: filter.PubsubTopic(),
+			Topics:      []types2.ContentTopic{filter.ContentTopic()},
+			ChatIDs:     []string{filter.ChatID()},
+		}
+		err := m.processMailserverBatchWithOptions(peerInfo, batch, 1, stopAfterFirstPage, false)
+		if err != nil {
+			m.logger.Error("failed to fetch latest community description",
+				zap.String("chatID", filter.ChatID()),
+				zap.Error(err))
+		}
+	}
 }
 
 func (m *Messenger) calculateGapForChat(chat *Chat, from uint32) (*common.Message, error) {

--- a/protocol/messenger_mailserver_test.go
+++ b/protocol/messenger_mailserver_test.go
@@ -1,0 +1,113 @@
+package protocol
+
+import (
+	"context"
+	"testing"
+
+	"github.com/libp2p/go-libp2p/core/peer"
+	"github.com/stretchr/testify/suite"
+
+	"github.com/status-im/status-go/pkg/messaging"
+	types2 "github.com/status-im/status-go/pkg/messaging/types"
+	wakutypes "github.com/status-im/status-go/pkg/messaging/waku/types"
+)
+
+func TestMessengerFetchLatestCommunityDescriptionsSuite(t *testing.T) {
+	suite.Run(t, new(MessengerFetchLatestCommunityDescriptionsSuite))
+}
+
+type MessengerFetchLatestCommunityDescriptionsSuite struct {
+	suite.Suite
+
+	messagingEnv *messaging.TestMessagingEnvironment
+	m            *Messenger
+}
+
+func (s *MessengerFetchLatestCommunityDescriptionsSuite) SetupTest() {
+	var err error
+	s.messagingEnv, err = messaging.NewTestMessagingEnvironment()
+	s.Require().NoError(err)
+	s.Require().NoError(s.messagingEnv.Setup(s.T()))
+
+	// Use a non-running messenger so no background loop issues store queries and
+	// interferes with the intercepted batches.
+	s.m, err = newTestMessenger(s.T(), s.messagingEnv, testMessengerConfig{})
+	s.Require().NoError(err)
+}
+
+type recordedMailserverBatch struct {
+	batch             wakutypes.MailserverBatch
+	pageLimit         uint64
+	shouldProcessNext func(int) (bool, uint64)
+	processEnvelopes  bool
+}
+
+func (s *MessengerFetchLatestCommunityDescriptionsSuite) recordMailserverBatches() *[]recordedMailserverBatch {
+	recorded := &[]recordedMailserverBatch{}
+	s.messagingEnv.SetProcessMailserverBatchHook(func(ctx context.Context, batch wakutypes.MailserverBatch, storenode peer.AddrInfo, pageLimit uint64, shouldProcessNextPage func(int) (bool, uint64), processEnvelopes bool) error {
+		*recorded = append(*recorded, recordedMailserverBatch{
+			batch:             batch,
+			pageLimit:         pageLimit,
+			shouldProcessNext: shouldProcessNextPage,
+			processEnvelopes:  processEnvelopes,
+		})
+		return nil
+	})
+	s.T().Cleanup(func() {
+		s.messagingEnv.SetProcessMailserverBatchHook(nil)
+	})
+	return recorded
+}
+
+func descriptionFilter(chatID, pubsubTopic, contentTopic string) *types2.ChatFilter {
+	return types2.NewChatFilter(&types2.ChatFilterConfig{
+		ChatID:       chatID,
+		PubsubTopic:  pubsubTopic,
+		ContentTopic: types2.StringToContentTopic(contentTopic),
+		Listen:       true,
+	})
+}
+
+// TestFetchesOnlyNewestPagePerFilter verifies that fetchLatestCommunityDescriptions
+// issues exactly one store request per filter that fetches only the newest page
+// (pageLimit == 1) and stops immediately, instead of sweeping the whole window.
+func (s *MessengerFetchLatestCommunityDescriptionsSuite) TestFetchesOnlyNewestPagePerFilter() {
+	recorded := s.recordMailserverBatches()
+
+	filters := []*types2.ChatFilter{
+		descriptionFilter("0xcommunity1", "/waku/2/pubsub-a", "0xcontenttopic1"),
+		descriptionFilter("0xcommunity2", "/waku/2/pubsub-b", "0xcontenttopic2"),
+	}
+
+	s.m.fetchLatestCommunityDescriptions(peer.AddrInfo{}, filters)
+
+	s.Require().Len(*recorded, len(filters), "expected exactly one store request per filter")
+
+	for i, rec := range *recorded {
+		// Only the newest page must be fetched.
+		s.Require().Equal(uint64(1), rec.pageLimit, "page limit must be 1")
+		s.Require().False(rec.processEnvelopes)
+
+		// The paging callback must stop immediately, regardless of how many
+		// envelopes the first page returned (i.e. never fetch a second page).
+		s.Require().NotNil(rec.shouldProcessNext)
+		cont, next := rec.shouldProcessNext(1000)
+		s.Require().False(cont, "must not fetch a second page")
+		s.Require().Equal(uint64(0), next)
+
+		// Each batch must target exactly the filter's description topic.
+		s.Require().Len(rec.batch.Topics, 1)
+		s.Require().Equal(filters[i].PubsubTopic(), rec.batch.PubsubTopic)
+		s.Require().Equal([]string{filters[i].ChatID()}, rec.batch.ChatIDs)
+	}
+}
+
+// TestNoFiltersIsNoop verifies that no store request is made when there are no
+// community description filters to fetch.
+func (s *MessengerFetchLatestCommunityDescriptionsSuite) TestNoFiltersIsNoop() {
+	recorded := s.recordMailserverBatches()
+
+	s.m.fetchLatestCommunityDescriptions(peer.AddrInfo{}, nil)
+
+	s.Require().Empty(*recorded, "no store request should be made when there are no filters")
+}

--- a/protocol/messenger_mailserver_test.go
+++ b/protocol/messenger_mailserver_test.go
@@ -227,6 +227,24 @@ func (s *MessengerBoundedResolveSuite) createLocalCommunity() *communities.Commu
 	return response.Communities()[0]
 }
 
+// TestReusedFilterForgottenForNonMember verifies that a description filter
+// reused by a store-node request is forgotten for a community that is neither
+// joined nor spectated (so it does not leave a live subscription behind), and
+// kept for a joined/spectated community and for contact requests.
+func (s *MessengerBoundedResolveSuite) TestReusedFilterForgottenForNonMember() {
+	// A validly-shaped community id (compressed pubkey) that is not in the DB.
+	unknownID := "0x02b5bdaf5a25fcfe2ee14c501fab1836b8de57f61621080c3d52073d16de0d98d6"
+	s.Require().True(s.m.storeNodeRequestsManager.reusedFilterShouldForget(storeNodeCommunityRequest, unknownID),
+		"a community that is neither joined nor spectated must not keep a reused filter")
+
+	joined := s.createLocalCommunity()
+	s.Require().False(s.m.storeNodeRequestsManager.reusedFilterShouldForget(storeNodeCommunityRequest, joined.IDString()),
+		"a joined/spectated community keeps its live description subscription")
+
+	s.Require().False(s.m.storeNodeRequestsManager.reusedFilterShouldForget(storeNodeContactRequest, unknownID),
+		"contact requests are unaffected")
+}
+
 // TestStopsAtPageCapUnresolved verifies that a request whose description never
 // resolves (e.g. a description whose segments span past the page cap) stops at
 // the configured MaxPages and ends unresolved instead of sweeping the window.

--- a/protocol/messenger_mailserver_test.go
+++ b/protocol/messenger_mailserver_test.go
@@ -2,14 +2,20 @@ package protocol
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/libp2p/go-libp2p/core/peer"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/status-im/status-go/pkg/messaging"
 	types2 "github.com/status-im/status-go/pkg/messaging/types"
 	wakutypes "github.com/status-im/status-go/pkg/messaging/waku/types"
+	"github.com/status-im/status-go/protocol/communities"
+	"github.com/status-im/status-go/protocol/protobuf"
+	"github.com/status-im/status-go/protocol/requests"
+	mailserversDB "github.com/status-im/status-go/services/mailservers"
 )
 
 func TestMessengerFetchLatestCommunityDescriptionsSuite(t *testing.T) {
@@ -110,4 +116,181 @@ func (s *MessengerFetchLatestCommunityDescriptionsSuite) TestNoFiltersIsNoop() {
 	s.m.fetchLatestCommunityDescriptions(peer.AddrInfo{}, nil)
 
 	s.Require().Empty(*recorded, "no store request should be made when there are no filters")
+}
+
+// TestSweepExcludesDescriptionShapedTopics verifies that the historic sweep
+// diverts any description-shaped topic (a community ID, even for a community
+// that is not joined or spectated — e.g. a temporary filter installed by the
+// store node request manager) to the dedicated newest-page fetch instead of
+// sweeping it over the whole sync window.
+func (s *MessengerFetchLatestCommunityDescriptionsSuite) TestSweepExcludesDescriptionShapedTopics() {
+	s.m.mailserversDatabase = mailserversDB.NewDB(s.m.database)
+	recorded := s.recordMailserverBatches()
+
+	communityDescriptionChatID := "0x02" + strings.Repeat("a", 64)
+	publicChatID := "a-public-chat"
+
+	filters := []*types2.ChatFilter{
+		descriptionFilter(communityDescriptionChatID, "/waku/2/default", "0xdesc"),
+		descriptionFilter(publicChatID, "/waku/2/default", "0xpublic"),
+	}
+
+	_, err := s.m.syncFiltersFrom(peer.AddrInfo{}, filters, 0)
+	s.Require().NoError(err)
+
+	var sweptChatIDs, newestFetchChatIDs []string
+	for _, rec := range *recorded {
+		if rec.pageLimit == 1 {
+			newestFetchChatIDs = append(newestFetchChatIDs, rec.batch.ChatIDs...)
+		} else {
+			sweptChatIDs = append(sweptChatIDs, rec.batch.ChatIDs...)
+		}
+	}
+
+	s.Require().NotContains(sweptChatIDs, communityDescriptionChatID,
+		"description-shaped topic of a non-joined community must not be swept over the whole window")
+	s.Require().Contains(newestFetchChatIDs, communityDescriptionChatID,
+		"description-shaped topic must still get the dedicated newest-page fetch")
+	s.Require().Contains(sweptChatIDs, publicChatID,
+		"non-description topics must still be swept")
+}
+
+func TestIsCommunityDescriptionChatID(t *testing.T) {
+	compressed02 := "0x02" + strings.Repeat("a", 64)
+	compressed03 := "0x03" + strings.Repeat("f", 64)
+	uncompressed := "0x04" + strings.Repeat("a", 128)
+
+	cases := []struct {
+		name   string
+		chatID string
+		want   bool
+	}{
+		{"compressed 0x02 community id", compressed02, true},
+		{"compressed 0x03 community id", compressed03, true},
+		{"member update channel", compressed02 + "-memberUpdate", false},
+		{"ping channel", compressed02 + "-ping", false},
+		{"uncompressed 1-1 chat id", uncompressed, false},
+		{"contact code topic", uncompressed + "-contact-code", false},
+		{"uppercase hex", "0x02" + strings.Repeat("A", 64), false},
+		{"non-hex 68 chars", "0x02" + strings.Repeat("z", 64), false},
+		{"public chat name", "a-public-chat", false},
+		{"empty", "", false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, isCommunityDescriptionChatID(tc.chatID))
+		})
+	}
+}
+
+func TestMessengerBoundedResolveSuite(t *testing.T) {
+	suite.Run(t, new(MessengerBoundedResolveSuite))
+}
+
+type MessengerBoundedResolveSuite struct {
+	suite.Suite
+
+	messagingEnv *messaging.TestMessagingEnvironment
+	m            *Messenger
+}
+
+func (s *MessengerBoundedResolveSuite) SetupTest() {
+	var err error
+	s.messagingEnv, err = messaging.NewTestMessagingEnvironment()
+	s.Require().NoError(err)
+	s.Require().NoError(s.messagingEnv.Setup(s.T()))
+
+	s.m, err = newTestMessenger(s.T(), s.messagingEnv, testMessengerConfig{})
+	s.Require().NoError(err)
+}
+
+// a syntactically valid community id that is not present in the local database.
+const unknownCommunityID = "0x02" + "0000000000000000000000000000000000000000000000000000000000000000"
+
+func (s *MessengerBoundedResolveSuite) newCommunityRequest(cfg StoreNodeRequestConfig, communityID string) *storeNodeRequest {
+	r := s.m.storeNodeRequestsManager.newStoreNodeRequest(context.Background())
+	r.requestID = storeNodeRequestID{RequestType: storeNodeCommunityRequest, DataID: communityID}
+	r.config = cfg
+	return r
+}
+
+func (s *MessengerBoundedResolveSuite) createLocalCommunity() *communities.Community {
+	response, err := s.m.CreateCommunity(&requests.CreateCommunity{
+		Membership:  protobuf.CommunityPermissions_AUTO_ACCEPT,
+		Name:        "status",
+		Color:       "#ffffff",
+		Description: "status community description",
+	}, true)
+	s.Require().NoError(err)
+	s.Require().Len(response.Communities(), 1)
+	return response.Communities()[0]
+}
+
+// TestStopsAtPageCapUnresolved verifies that a request whose description never
+// resolves (e.g. a description whose segments span past the page cap) stops at
+// the configured MaxPages and ends unresolved instead of sweeping the window.
+func (s *MessengerBoundedResolveSuite) TestStopsAtPageCapUnresolved() {
+	cfg := defaultStoreNodeRequestConfig(storeNodeCommunityRequest)
+	s.Require().Equal(uint64(2), cfg.MaxPages)
+
+	r := s.newCommunityRequest(cfg, unknownCommunityID)
+
+	cont, next := r.shouldFetchNextPage(0)
+	s.Require().True(cont, "first page must allow a second page")
+	s.Require().Equal(cfg.FurtherPageSize, next)
+
+	cont, _ = r.shouldFetchNextPage(0)
+	s.Require().False(cont, "must stop once the page cap is reached")
+	s.Require().Equal(storeNodeRequestUnresolved, r.result.outcome)
+	s.Require().Nil(r.result.community)
+}
+
+// TestResolvedStopsImmediately verifies that once a newer description is
+// persisted the request stops and reports the resolved outcome.
+func (s *MessengerBoundedResolveSuite) TestResolvedStopsImmediately() {
+	community := s.createLocalCommunity()
+
+	r := s.newCommunityRequest(defaultStoreNodeRequestConfig(storeNodeCommunityRequest), community.IDString())
+
+	cont, _ := r.shouldFetchNextPage(0)
+	s.Require().False(cont, "must stop once the community is resolved")
+	s.Require().Equal(storeNodeRequestResolved, r.result.outcome)
+	s.Require().NotNil(r.result.community)
+}
+
+// TestAlreadyUpToDateIsSuccess verifies that when the newest fetched clock is
+// not newer than the locally stored one the request reports already-up-to-date
+// (a success) and never sets a resolved community.
+func (s *MessengerBoundedResolveSuite) TestAlreadyUpToDateIsSuccess() {
+	community := s.createLocalCommunity()
+
+	r := s.newCommunityRequest(defaultStoreNodeRequestConfig(storeNodeCommunityRequest), community.IDString())
+	r.minimumDataClock = community.Clock()
+
+	cont, _ := r.shouldFetchNextPage(0)
+	s.Require().True(cont, "up-to-date request keeps paging until the cap")
+	s.Require().Equal(storeNodeRequestAlreadyUpToDate, r.result.outcome)
+
+	cont, _ = r.shouldFetchNextPage(0)
+	s.Require().False(cont, "must stop at the page cap")
+	s.Require().Equal(storeNodeRequestAlreadyUpToDate, r.result.outcome)
+	s.Require().Nil(r.result.community)
+}
+
+// TestFetchWindowPerRequestType verifies communities use a 7-day window and
+// contacts a 31-day window, and that these windows are what the request feeds
+// into the batch From/To bounds.
+func (s *MessengerBoundedResolveSuite) TestFetchWindowPerRequestType() {
+	comCfg := defaultStoreNodeRequestConfig(storeNodeCommunityRequest)
+	s.Require().Equal(7*oneDayDuration, comCfg.FetchWindow)
+
+	contactCfg := defaultStoreNodeRequestConfig(storeNodeContactRequest)
+	s.Require().Equal(oneMonthDuration, contactCfg.FetchWindow)
+
+	from, to := s.m.calculateMailserverTimeBounds(comCfg.FetchWindow)
+	s.Require().Equal(7*oneDayDuration, to.Sub(from))
+
+	from, to = s.m.calculateMailserverTimeBounds(contactCfg.FetchWindow)
+	s.Require().Equal(oneMonthDuration, to.Sub(from))
 }

--- a/protocol/messenger_store_node_request_manager.go
+++ b/protocol/messenger_store_node_request_manager.go
@@ -74,7 +74,7 @@ func NewStoreNodeRequestManager(m *Messenger) *StoreNodeRequestManager {
 // Automatically waits for an available store node.
 // When a `nil` community and `nil` error is returned, that means the community wasn't found at the store node.
 func (m *StoreNodeRequestManager) FetchCommunity(ctx context.Context, communityID string, opts []StoreNodeRequestOption) (*communities.Community, StoreNodeRequestStats, error) {
-	cfg := buildStoreNodeRequestConfig(opts)
+	cfg := buildStoreNodeRequestConfig(storeNodeCommunityRequest, opts)
 
 	m.logger.Info("requesting community from store node",
 		zap.String("community", communityID),
@@ -110,7 +110,7 @@ func (m *StoreNodeRequestManager) FetchCommunity(ctx context.Context, communityI
 // If a `nil` contact and a `nil` error are returned, it means that the contact wasn't found at the store node.
 func (m *StoreNodeRequestManager) FetchContact(ctx context.Context, contactID string, opts []StoreNodeRequestOption) (*contacts.Contact, StoreNodeRequestStats, error) {
 
-	cfg := buildStoreNodeRequestConfig(opts)
+	cfg := buildStoreNodeRequestConfig(storeNodeContactRequest, opts)
 
 	m.logger.Info("requesting contact from store node",
 		zap.Any("contactID", contactID),
@@ -286,8 +286,9 @@ type storeNodeRequest struct {
 // If data wasn't found in store node, then a data will be set to `nil`.
 // stats will contain information about the performed request that might be useful for testing.
 type storeNodeRequestResult struct {
-	err   error
-	stats StoreNodeRequestStats
+	err     error
+	stats   StoreNodeRequestStats
+	outcome storeNodeRequestOutcome
 	// One of data fields (community or contact) will be present depending on request type
 	community *communities.Community
 	contact   *contacts.Contact
@@ -337,6 +338,9 @@ func (r *storeNodeRequest) shouldFetchNextPage(envelopesCount int) (bool, uint64
 	r.result.stats.FetchedEnvelopesCount += envelopesCount
 	r.result.stats.FetchedPagesCount++
 
+	// Store queries are newest-first; MaxPages bounds the drain.
+	capReached := r.config.MaxPages > 0 && uint64(r.result.stats.FetchedPagesCount) >= r.config.MaxPages
+
 	// Force all received envelopes to be processed
 	r.manager.messenger.ProcessAllMessages()
 
@@ -384,7 +388,7 @@ func (r *storeNodeRequest) shouldFetchNextPage(envelopesCount int) (bool, uint64
 		if community == nil {
 			// community not found in the database, request next page
 			logger.Debug("community still not fetched")
-			return true, r.config.FurtherPageSize
+			return !capReached, r.config.FurtherPageSize
 		}
 
 		// We check here if the community was fetched actually fetched and updated, because it
@@ -398,13 +402,15 @@ func (r *storeNodeRequest) shouldFetchNextPage(envelopesCount int) (bool, uint64
 				zap.Any("existingClock", community.Clock()),
 				zap.Any("minimumDataClock", r.minimumDataClock),
 			)
-			return true, r.config.FurtherPageSize
+			r.result.outcome = storeNodeRequestAlreadyUpToDate
+			return !capReached, r.config.FurtherPageSize
 		}
 
 		logger.Debug("community found",
 			zap.String("displayName", community.Name()))
 
 		r.result.community = community
+		r.result.outcome = storeNodeRequestResolved
 
 	case storeNodeContactRequest:
 		contact := r.manager.messenger.GetContactByID(r.requestID.DataID)
@@ -412,16 +418,17 @@ func (r *storeNodeRequest) shouldFetchNextPage(envelopesCount int) (bool, uint64
 		if contact == nil {
 			// contact not found in the database, request next page
 			logger.Debug("contact still not fetched")
-			return true, r.config.FurtherPageSize
+			return !capReached, r.config.FurtherPageSize
 		}
 
 		logger.Debug("contact found",
 			zap.String("displayName", contact.DisplayName))
 
 		r.result.contact = contact
+		r.result.outcome = storeNodeRequestResolved
 	}
 
-	return !r.config.StopWhenDataFound, r.config.FurtherPageSize
+	return !r.config.StopWhenDataFound && !capReached, r.config.FurtherPageSize
 }
 
 func (r *storeNodeRequest) routine() {
@@ -463,7 +470,7 @@ func (r *storeNodeRequest) routine() {
 	}
 
 	// Start store node request
-	from, to := r.manager.messenger.calculateMailserverTimeBounds(oneMonthDuration)
+	from, to := r.manager.messenger.calculateMailserverTimeBounds(r.config.FetchWindow)
 
 	storeNode := r.manager.messenger.messaging.GetActiveStorenode()
 	_, err := r.manager.messenger.performStorenodeTask(func() (*MessengerResponse, error) {

--- a/protocol/messenger_store_node_request_manager.go
+++ b/protocol/messenger_store_node_request_manager.go
@@ -150,11 +150,11 @@ func (m *StoreNodeRequestManager) subscribeToRequest(ctx context.Context, reques
 		// Create corresponding filter
 		var err error
 		var filter *types2.ChatFilter
-		filterCreated := false
+		filterShouldForget := false
 
-		filter, filterCreated, err = m.getFilter(requestType, dataID, shard)
+		filter, filterShouldForget, err = m.getFilter(requestType, dataID, shard)
 		if err != nil {
-			if filterCreated {
+			if filterShouldForget {
 				m.forgetFilter(filter)
 			}
 			return nil, fmt.Errorf("failed to create community filter: %w", err)
@@ -165,7 +165,7 @@ func (m *StoreNodeRequestManager) subscribeToRequest(ctx context.Context, reques
 		request.pubsubTopic = filter.PubsubTopic()
 		request.requestID = requestID
 		request.contentTopic = filter.ContentTopic()
-		if filterCreated {
+		if filterShouldForget {
 			request.filterToForget = filter
 		}
 
@@ -186,13 +186,16 @@ func (m *StoreNodeRequestManager) newStoreNodeRequest(ctx context.Context) *stor
 }
 
 // getFilter checks if a filter for a given community is already created and creates one of not found.
-// Returns the found/created filter, a flag if the filter was created by the function and an error.
+// Returns the found/created filter, a flag telling whether the filter must be
+// forgotten once the request finishes, and an error. A newly created filter is
+// always temporary. A reused filter is kept only for joined/spectated
+// communities (they keep a live description subscription); for any other
+// community it is a snapshot and must not outlive the request.
 func (m *StoreNodeRequestManager) getFilter(requestType storeNodeRequestType, dataID string, shard *types2.Shard) (*types2.ChatFilter, bool, error) {
 	// First check if such filter already exists.
 	filter := m.messenger.messaging.ChatFilterByChatID(dataID)
 	if filter != nil {
-		//we don't remember filter id associated with community because it was already installed
-		return filter, false, nil
+		return filter, m.reusedFilterShouldForget(requestType, dataID), nil
 	}
 
 	switch requestType {
@@ -241,6 +244,28 @@ func (m *StoreNodeRequestManager) getFilter(requestType storeNodeRequestType, da
 	}
 
 	return filter, true, nil
+}
+
+// reusedFilterShouldForget reports whether a pre-existing filter reused for a
+// request must be removed once the request finishes. Joined and spectated
+// communities keep their live description subscription; every other community is
+// a snapshot, so a stray description filter must not be left subscribed.
+func (m *StoreNodeRequestManager) reusedFilterShouldForget(requestType storeNodeRequestType, dataID string) bool {
+	if requestType != storeNodeCommunityRequest {
+		return false
+	}
+	communityID, err := types.DecodeHex(dataID)
+	if err != nil {
+		return false
+	}
+	community, err := m.messenger.communitiesManager.GetByID(communityID)
+	if err != nil && err != communities.ErrOrgNotFound {
+		return false
+	}
+	if community != nil && (community.Joined() || community.Spectated()) {
+		return false
+	}
+	return true
 }
 
 // forgetFilter uninstalls the given filter

--- a/protocol/messenger_store_node_request_manager_config.go
+++ b/protocol/messenger_store_node_request_manager_config.go
@@ -1,25 +1,61 @@
 package protocol
 
+import "time"
+
+const (
+	// storeNodeRequestMaxPages bounds how many pages a single request may drain.
+	// Store queries are newest-first, so the first pages carry the latest data.
+	storeNodeRequestMaxPages = 2
+
+	storeNodeRequestPageSize = 25
+
+	communityStoreNodeFetchWindow = 7 * oneDayDuration
+	contactStoreNodeFetchWindow   = oneMonthDuration
+)
+
+// storeNodeRequestOutcome describes how a store node request ended.
+type storeNodeRequestOutcome int
+
+const (
+	// storeNodeRequestUnresolved means nothing usable was fetched, or the fetched
+	// data could not be persisted (e.g. owner verification failure / missing keys).
+	storeNodeRequestUnresolved storeNodeRequestOutcome = iota
+	// storeNodeRequestResolved means newer data was fetched and persisted.
+	storeNodeRequestResolved
+	// storeNodeRequestAlreadyUpToDate means the newest fetched data was not newer
+	// than the locally stored one. This is a success, not a failure.
+	storeNodeRequestAlreadyUpToDate
+)
+
 type StoreNodeRequestConfig struct {
 	WaitForResponse   bool
 	StopWhenDataFound bool
 	InitialPageSize   uint64
 	FurtherPageSize   uint64
+	MaxPages          uint64
+	FetchWindow       time.Duration
 }
 
 type StoreNodeRequestOption func(*StoreNodeRequestConfig)
 
-func defaultStoreNodeRequestConfig() StoreNodeRequestConfig {
+func defaultStoreNodeRequestConfig(requestType storeNodeRequestType) StoreNodeRequestConfig {
+	fetchWindow := communityStoreNodeFetchWindow
+	if requestType == storeNodeContactRequest {
+		fetchWindow = contactStoreNodeFetchWindow
+	}
+
 	return StoreNodeRequestConfig{
 		WaitForResponse:   true,
 		StopWhenDataFound: true,
-		InitialPageSize:   initialStoreNodeRequestPageSize,
-		FurtherPageSize:   defaultStoreNodeRequestPageSize,
+		InitialPageSize:   storeNodeRequestPageSize,
+		FurtherPageSize:   storeNodeRequestPageSize,
+		MaxPages:          storeNodeRequestMaxPages,
+		FetchWindow:       fetchWindow,
 	}
 }
 
-func buildStoreNodeRequestConfig(opts []StoreNodeRequestOption) StoreNodeRequestConfig {
-	cfg := defaultStoreNodeRequestConfig()
+func buildStoreNodeRequestConfig(requestType storeNodeRequestType, opts []StoreNodeRequestOption) StoreNodeRequestConfig {
+	cfg := defaultStoreNodeRequestConfig(requestType)
 
 	for _, opt := range opts {
 		opt(&cfg)

--- a/services/ext/api.go
+++ b/services/ext/api.go
@@ -240,9 +240,9 @@ func (api *PublicAPI) CommunityTags(parent context.Context) map[string]string {
 	return requests.AvailableTagsEmojis()
 }
 
-// CuratedCommunities returns the list of curated communities stored in the smart contract. If a community is
-// already known by the node, its description will be returned and and will asynchronously retrieve the
-// description for the communities it does not know
+// CuratedCommunities returns the curated communities from the smart contract together with any description
+// already stored locally. It is a pure read and never queries store nodes; use RefreshCuratedCommunities to
+// resolve descriptions the node does not have.
 func (api *PublicAPI) CuratedCommunities(parent context.Context) (*communities.KnownCommunitiesResponse, error) {
 	return api.service.messenger.CuratedCommunities()
 }

--- a/services/ext/api.go
+++ b/services/ext/api.go
@@ -247,6 +247,18 @@ func (api *PublicAPI) CuratedCommunities(parent context.Context) (*communities.K
 	return api.service.messenger.CuratedCommunities()
 }
 
+// RefreshCuratedCommunities resolves the curated directory entries against store
+// nodes. Progress is reported via curated communities signals.
+func (api *PublicAPI) RefreshCuratedCommunities(parent context.Context) error {
+	return api.service.messenger.RefreshCuratedCommunities()
+}
+
+// StopCuratedCommunitiesRefresh cancels an in-flight curated communities refresh.
+func (api *PublicAPI) StopCuratedCommunitiesRefresh(parent context.Context) error {
+	api.service.messenger.StopCuratedCommunitiesRefresh()
+	return nil
+}
+
 // SpectateCommunity spectates community with the given ID
 // Meaning user is only a spectator, not a member
 func (api *PublicAPI) SpectateCommunity(parent context.Context, communityID types.HexBytes) (*protocol.MessengerResponse, error) {

--- a/services/ext/signal.go
+++ b/services/ext/signal.go
@@ -165,6 +165,14 @@ func (m *MessengerSignalsHandler) SendBackedUpSettings(response *backupsync.Back
 	signal.SendBackedUpSettings(response)
 }
 
-func (m *MessengerSignalsHandler) SendCuratedCommunitiesUpdate(response *communities.KnownCommunitiesResponse) {
-	signal.SendCuratedCommunitiesUpdate(response)
+func (m *MessengerSignalsHandler) CuratedCommunitiesRefreshStarted() {
+	signal.SendCuratedCommunitiesRefreshStarted()
+}
+
+func (m *MessengerSignalsHandler) CuratedCommunityResolved(communityID string, stored bool) {
+	signal.SendCuratedCommunityResolved(communityID, stored)
+}
+
+func (m *MessengerSignalsHandler) CuratedCommunitiesRefreshFinished(resolved, unresolved int, cancelled bool) {
+	signal.SendCuratedCommunitiesRefreshFinished(resolved, unresolved, cancelled)
 }

--- a/signal/events_messenger.go
+++ b/signal/events_messenger.go
@@ -14,8 +14,14 @@ const (
 	// EventStatusUpdatesTimedOut Event Automatic Status Updates Timed out
 	EventStatusUpdatesTimedOut = "status.updates.timedout"
 
-	// EventCuratedCommunitiesUpdate triggered when it is time to refresh the list of curated communities
-	EventCuratedCommunitiesUpdate = "curated.communities.update"
+	// EventCuratedCommunitiesRefreshStarted triggered when a curated communities refresh begins
+	EventCuratedCommunitiesRefreshStarted = "curated.communities.refresh.started"
+
+	// EventCuratedCommunityResolved triggered per curated community once its description resolution completes
+	EventCuratedCommunityResolved = "curated.communities.refresh.communityResolved"
+
+	// EventCuratedCommunitiesRefreshFinished triggered when a curated communities refresh ends
+	EventCuratedCommunitiesRefreshFinished = "curated.communities.refresh.finished"
 )
 
 // MessageDeliveredSignal specifies chat and message that was delivered
@@ -56,6 +62,31 @@ func SendStatusUpdatesTimedOut(statusUpdates interface{}) {
 	send(EventStatusUpdatesTimedOut, statusUpdates)
 }
 
-func SendCuratedCommunitiesUpdate(curatedCommunitiesUpdate interface{}) {
-	send(EventCuratedCommunitiesUpdate, curatedCommunitiesUpdate)
+// CuratedCommunityResolvedSignal reports a curated community whose description resolution finished
+type CuratedCommunityResolvedSignal struct {
+	CommunityID string `json:"communityId"`
+	Stored      bool   `json:"stored"`
+}
+
+// CuratedCommunitiesRefreshFinishedSignal reports the outcome counts of a curated communities refresh
+type CuratedCommunitiesRefreshFinishedSignal struct {
+	Resolved   int  `json:"resolved"`
+	Unresolved int  `json:"unresolved"`
+	Cancelled  bool `json:"cancelled"`
+}
+
+func SendCuratedCommunitiesRefreshStarted() {
+	send(EventCuratedCommunitiesRefreshStarted, nil)
+}
+
+func SendCuratedCommunityResolved(communityID string, stored bool) {
+	send(EventCuratedCommunityResolved, CuratedCommunityResolvedSignal{CommunityID: communityID, Stored: stored})
+}
+
+func SendCuratedCommunitiesRefreshFinished(resolved, unresolved int, cancelled bool) {
+	send(EventCuratedCommunitiesRefreshFinished, CuratedCommunitiesRefreshFinishedSignal{
+		Resolved:   resolved,
+		Unresolved: unresolved,
+		Cancelled:  cancelled,
+	})
 }

--- a/signal/events_messenger.go
+++ b/signal/events_messenger.go
@@ -18,7 +18,7 @@ const (
 	EventCuratedCommunitiesRefreshStarted = "curated.communities.refresh.started"
 
 	// EventCuratedCommunityResolved triggered per curated community once its description resolution completes
-	EventCuratedCommunityResolved = "curated.communities.refresh.communityResolved"
+	EventCuratedCommunityResolved = "curated.communities.refresh.resolved"
 
 	// EventCuratedCommunitiesRefreshFinished triggered when a curated communities refresh ends
 	EventCuratedCommunitiesRefreshFinished = "curated.communities.refresh.finished"
@@ -64,7 +64,7 @@ func SendStatusUpdatesTimedOut(statusUpdates interface{}) {
 
 // CuratedCommunityResolvedSignal reports a curated community whose description resolution finished
 type CuratedCommunityResolvedSignal struct {
-	CommunityID string `json:"communityId"`
+	CommunityID string `json:"communityID"`
 	Stored      bool   `json:"stored"`
 }
 


### PR DESCRIPTION
Stacked on #7638. Targets `fix/only-fetch-community-description-once`; retarget to the release branch once #7638 lands.

## Problem

A fresh client spectating a token-owned community (e.g. Status) downloads gigabytes and overheats (#21470). The community **description** topic is republished thousands of times; a joining client that cannot owner-verify the community keeps paging the whole archive trying to, on several code paths at once (the community pager, the curated directory walker, and the historic sweep). It also leaves live description subscriptions running for communities it only glanced at.

Root cause is publisher/network-side and quantified separately (see #7640): the description topic is flooded with external, self-signed copies (~0.5% are owner-signed, buried hundreds deep), and the store cannot filter by signer. **This PR does not try to establish such communities** — it bounds the download cost so the client stops overheating.

## What changes

- **Bound resolve paging.** A community/contact store-node request stops as soon as the community verifies, and in any case after a fixed page cap over a fixed window (community 7d, contact 31d) — instead of draining until the data verifies (which never happens for a community the client cannot owner-verify). `StopWhenDataFound` still short-circuits on success; the cap only bounds the not-found / not-newer / exhaustive cases. A resolved / already-up-to-date / unresolved outcome lets callers stop retrying.
- **Split curated read from fetch.** `getCuratedCommunities` becomes a pure read of stored data. Resolving missing descriptions moves to an explicit, single-flight, cancellable `RefreshCuratedCommunities` with progress signals — opening Discover no longer spawns a directory-wide fetch as a side effect.
- **Remove the background curated update loop** (and its expensive-network pause); the directory refreshes only when the UI asks (companion desktop/mobile PR wires this).
- **Exclude description topics from the historic sweep by shape.** A description topic's chatID is a community ID (compressed pubkey), so it is never swept over the multi-day window regardless of which filter installed it.
- **Forget reused description filters for non-member communities.** A request that reused a pre-existing description-topic filter left it subscribed after finishing; for a community that is neither joined nor spectated that is a stray live subscription. Measured on device, those subscriptions kept streaming ~0.9 GB/h. Reused filters are now forgotten once the request finishes unless the community is joined/spectated.

## Not included (deliberately)

The owner "hunt" (deep paging for a rare owner-signed copy) was prototyped and **dropped**: on the mobile light client the store peer returns no continuation cursor and errors, so an owner copy buried within a day is unreachable at any budget. Establishing flooded split-key communities is a publisher-side fix (#7640) — bounding is the client's job here.

## Results (device, fresh spectate → idle)

- Store traffic: a sustained ~7 GB/h flood becomes a one-time ~0.7 GB establishment, then flat (0 store bytes when idle).
- Overheat gone: CPU near-idle, skin temperature stays cool.
- The filter fix removes the ~0.9 GB/h stray live subscriptions to non-spectated communities.

## Testing

`go build ./...` clean. Protocol suites green: `TestMessengerBoundedResolveSuite`, `TestMessengerCuratedRefreshSuite`, `TestMessengerFetchLatestCommunityDescriptionsSuite`.

## Companion

status-app: UI-gated curated refresh + this status-go bump (stacked on #21513).