### PR TITLE
fix(community): fix issue where community spectators could publish the community description

### DIFF
--- a/protocol/communities/manager.go
+++ b/protocol/communities/manager.go
@@ -4481,8 +4481,10 @@ func (m *Manager) handleCommunityTokensMetadata(community *Community) error {
 }
 
 func (m *Manager) handleCommunityTokensMetadataAsync(communityID string) {
+	m.quitWg.Add(1)
 	go func() {
 		defer utils.LogOnPanic()
+		defer m.quitWg.Done()
 
 		select {
 		case <-m.quit:
@@ -4492,16 +4494,25 @@ func (m *Manager) handleCommunityTokensMetadataAsync(communityID string) {
 
 		community, err := m.GetByIDString(communityID)
 		if err != nil {
+			m.logger.Error("failed to get community for tokens metadata handling",
+				zap.String("communityID", communityID), zap.Error(err))
 			return
 		}
 
 		err = m.handleCommunityTokensMetadata(community)
 		if err != nil {
+			m.logger.Error("failed to handle community tokens metadata",
+				zap.String("communityID", communityID), zap.Error(err))
 			return
 		}
 
-		m.publish(&Subscription{Community: community})
+		select {
+		case <-m.quit:
+			return
+		default:
+		}
 
+		m.publish(&Subscription{Community: community})
 	}()
 }
 

--- a/protocol/communities/manager.go
+++ b/protocol/communities/manager.go
@@ -419,6 +419,7 @@ func (m *Manager) SetMediaServerProperties() {
 type Subscription struct {
 	archivetypes.HistoryArchiveSignals
 	Community                            *Community
+	CommunityTokensMetadataLoaded        *Community
 	CommunityEventsMessage               *CommunityEventsMessage
 	AcceptedRequestsToJoin               []types3.HexBytes
 	RejectedRequestsToJoin               []types3.HexBytes
@@ -4512,7 +4513,7 @@ func (m *Manager) handleCommunityTokensMetadataAsync(communityID string) {
 		default:
 		}
 
-		m.publish(&Subscription{Community: community})
+		m.publish(&Subscription{CommunityTokensMetadataLoaded: community})
 	}()
 }
 

--- a/protocol/communities/manager_test.go
+++ b/protocol/communities/manager_test.go
@@ -94,6 +94,27 @@ func (s *ManagerSuite) SetupTest() {
 	s.archiveManager = t
 }
 
+func (s *ManagerSuite) TestCommunityTokensMetadataLoadedDoesNotPublishCommunity() {
+	community, err := s.manager.CreateCommunity(&requests.CreateCommunity{
+		Name:        "status",
+		Description: "status community description",
+		Membership:  protobuf.CommunityPermissions_AUTO_ACCEPT,
+	}, false)
+	s.Require().NoError(err)
+
+	subscription := s.manager.Subscribe()
+	s.manager.handleCommunityTokensMetadataAsync(community.IDString())
+
+	select {
+	case event := <-subscription:
+		s.Require().Nil(event.Community)
+		s.Require().NotNil(event.CommunityTokensMetadataLoaded)
+		s.Require().Equal(community.IDString(), event.CommunityTokensMetadataLoaded.IDString())
+	case <-time.After(2 * time.Second):
+		s.FailNow("community token metadata completion was not signaled")
+	}
+}
+
 func intToBig(n int64) *hexutil.Big {
 	return (*hexutil.Big)(big.NewInt(n))
 }

--- a/protocol/messenger_communities.go
+++ b/protocol/messenger_communities.go
@@ -125,6 +125,9 @@ func (m *Messenger) publishOrg(org *communities.Community, shouldRekey bool) err
 	if org == nil {
 		return nil
 	}
+	if !org.IsControlNode() {
+		return communities.ErrNotControlNode
+	}
 
 	m.logger.Debug("publishing community",
 		zap.String("communityID", org.IDString()),
@@ -408,14 +411,17 @@ func (m *Messenger) handleCommunitiesSubscription(c chan *communities.Subscripti
 					return
 				}
 				if sub.Community != nil {
-					if sub.Community == nil {
-						continue
-					}
 					// NOTE: because we use a pointer here, there's a race condition where the community would be updated before it's compared to the previous one.
 					// This results in keys not being propagated as the copy would not see any changes
 					communityCopy := sub.Community.CreateDeepCopy()
 
 					publishOrgAndDistributeEncryptionKeys(communityCopy)
+				}
+				if sub.CommunityTokensMetadataLoaded != nil && m.config.messengerSignalsHandler != nil {
+					communityCopy := sub.CommunityTokensMetadataLoaded.CreateDeepCopy()
+					response := &MessengerResponse{}
+					response.AddCommunity(communityCopy)
+					m.config.messengerSignalsHandler.MessengerResponse(response)
 				}
 
 				if sub.CommunityEventsMessage != nil {

--- a/protocol/messenger_communities_publish_test.go
+++ b/protocol/messenger_communities_publish_test.go
@@ -1,0 +1,81 @@
+package protocol
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/status-im/status-go/internal/crypto"
+	"github.com/status-im/status-go/pkg/messaging"
+	"github.com/status-im/status-go/pkg/pubsub"
+	protocolcommon "github.com/status-im/status-go/protocol/common"
+	"github.com/status-im/status-go/protocol/communities"
+	"github.com/status-im/status-go/protocol/protobuf"
+)
+
+type publishOrgTimeSource struct{}
+
+func (publishOrgTimeSource) GetCurrentTime() uint64 {
+	return 0
+}
+
+func TestPublishOrgRejectsNonControlNode(t *testing.T) {
+	controlNode, err := crypto.GenerateKey()
+	require.NoError(t, err)
+	member, err := crypto.GenerateKey()
+	require.NoError(t, err)
+
+	community, err := communities.New(communities.Config{
+		ControlNode:          &controlNode.PublicKey,
+		ID:                   &controlNode.PublicKey,
+		MemberIdentity:       member,
+		CommunityDescription: &protobuf.CommunityDescription{},
+	}, publishOrgTimeSource{}, &communities.NoopDescriptionEncryptor{}, nil)
+	require.NoError(t, err)
+	require.False(t, community.IsControlNode())
+
+	require.ErrorIs(t, (&Messenger{}).publishOrg(community, false), communities.ErrNotControlNode)
+}
+
+func TestPublishOrgAllowsControlNode(t *testing.T) {
+	messagingEnv, err := messaging.NewTestMessagingEnvironment()
+	require.NoError(t, err)
+	require.NoError(t, messagingEnv.Setup(t))
+
+	m, err := newTestMessenger(t, messagingEnv, testMessengerConfig{})
+	require.NoError(t, err)
+
+	controlNode, err := crypto.GenerateKey()
+	require.NoError(t, err)
+	community, err := communities.New(communities.Config{
+		PrivateKey:           controlNode,
+		ControlNode:          &controlNode.PublicKey,
+		ControlDevice:        true,
+		ID:                   &controlNode.PublicKey,
+		MemberIdentity:       controlNode,
+		CommunityDescription: &protobuf.CommunityDescription{},
+	}, publishOrgTimeSource{}, &communities.NoopDescriptionEncryptor{}, nil)
+	require.NoError(t, err)
+	require.True(t, community.IsControlNode())
+
+	messageEvents, unsubscribe := pubsub.Subscribe[protocolcommon.MessageEvent](m.sender.Publisher(), 1)
+	defer unsubscribe()
+
+	require.NoError(t, m.publishOrg(community, false))
+
+	select {
+	case event := <-messageEvents:
+		require.NotNil(t, event.ScheduledMessage)
+		require.Nil(t, event.ScheduledMessage.Recipient)
+		rawMessage := event.ScheduledMessage.RawMessage
+		require.NotNil(t, rawMessage)
+		require.NotEmpty(t, rawMessage.ID)
+		require.Equal(t, protobuf.ApplicationMetadataMessage_COMMUNITY_DESCRIPTION, rawMessage.MessageType)
+		require.Equal(t, community.IDString(), rawMessage.ContentTopic)
+		require.Equal(t, []byte(community.ID()), rawMessage.CommunityID)
+		require.NotNil(t, rawMessage.Sender)
+		require.True(t, crypto.IsPubKeyEqual(&rawMessage.Sender.PublicKey, community.ControlNode()))
+	default:
+		require.Fail(t, "community description was not scheduled for publication")
+	}
+}


### PR DESCRIPTION
Part of https://github.com/status-im/status-app/issues/21514

status-app PR: https://github.com/status-im/status-app/pull/21526

The asynchronous community token-metadata handler reused `Subscription.Community` to notify the UI after loading token data, but that event is interpreted by the messenger as a request to publish the full community description. On non-control nodes, the missing community private key caused `SendPublic` to fall back to the client identity, producing the flood of externally self-signed descriptions. Use a dedicated UI-only subscription event for token-metadata updates and reject description publication from devices that are not the community control node.
