### PR TITLE
fix: nil-guards for community collectible metadata and channel bloom filters (#7630)

### DIFF
--- a/protocol/communities/community_bloom_filter.go
+++ b/protocol/communities/community_bloom_filter.go
@@ -13,6 +13,14 @@ import (
 )
 
 func generateBloomFiltersForChannels(description *protobuf.CommunityDescription, privateKey *ecdsa.PrivateKey) error {
+	// Bloom filters require the community private key to derive the shared secret.
+	// It is absent on devices that don't control the community (e.g. a freshly
+	// profile-synced device), which is expected, so skip generation instead of
+	// dereferencing a nil key.
+	if privateKey == nil {
+		return nil
+	}
+
 	for channelID, channel := range description.Chats {
 		if !channelEncrypted(ChatID(description.ID, channelID), description.TokenPermissions) {
 			continue

--- a/protocol/communities/community_bloom_filter_test.go
+++ b/protocol/communities/community_bloom_filter_test.go
@@ -65,3 +65,42 @@ func (s *CommunityBloomFilterSuite) TestBasic() {
 	s.Require().True(verifyMembershipWithBloomFilter(filter, memberIdentity, &ownerIdentity.PublicKey, encryptedChannelID, description.Clock))
 	s.Require().False(verifyMembershipWithBloomFilter(filter, nonMemberIdentity, &ownerIdentity.PublicKey, encryptedChannelID, description.Clock))
 }
+
+// Regression test: on a device that does not hold the community private key
+// (e.g. right after a profile sync), the publish path can still reach
+// generateBloomFiltersForChannels with a nil key. Filter generation must be
+// skipped so the description is marshaled without filters, instead of crashing
+// the node in ECDH.
+func (s *CommunityBloomFilterSuite) TestNilPrivateKey() {
+	memberIdentity, err := crypto.GenerateKey()
+	s.Require().NoError(err)
+
+	communityID := "cid"
+	encryptedChannelID := "enc"
+
+	description := &protobuf.CommunityDescription{
+		ID:    communityID,
+		Clock: 1,
+		Chats: map[string]*protobuf.CommunityChat{
+			encryptedChannelID: {
+				Members: map[string]*protobuf.CommunityMember{
+					crypto.PubkeyToHex(&memberIdentity.PublicKey): {},
+				},
+			},
+		},
+		TokenPermissions: map[string]*protobuf.CommunityTokenPermission{
+			"permissionID": {
+				Id:            "permissionID",
+				Type:          protobuf.CommunityTokenPermission_CAN_VIEW_CHANNEL,
+				TokenCriteria: []*protobuf.TokenCriteria{{}},
+				ChatIds:       []string{ChatID(communityID, encryptedChannelID)},
+			},
+		},
+	}
+
+	s.Require().NotPanics(func() {
+		err = generateBloomFiltersForChannels(description, nil)
+	})
+	s.Require().NoError(err)
+	s.Require().Nil(description.Chats[encryptedChannelID].MembersList)
+}

--- a/services/ext/service.go
+++ b/services/ext/service.go
@@ -496,6 +496,25 @@ func (s *Service) FillCollectibleMetadata(community *communities.Community, coll
 
 	permission := fetchCommunityCollectiblePermission(community, id)
 
+	fillCollectibleMetadata(collectible, community, tokenMetadata, communityToken, permission)
+
+	return nil
+}
+
+// fillCollectibleMetadata enriches collectible from the community description
+// token metadata. communityToken may be nil: the community_tokens table is
+// populated by a separate sync path and can lag behind the community
+// description (e.g. right after a profile sync on a fresh device).
+func fillCollectibleMetadata(
+	collectible *thirdparty.FullCollectibleData,
+	community *communities.Community,
+	tokenMetadata *protobuf.CommunityTokenMetadata,
+	communityToken *communitiestoken.CommunityToken,
+	permission *communities.CommunityTokenPermission,
+) {
+	id := collectible.CollectibleData.ID
+	communityID := collectible.CollectibleData.CommunityID
+
 	privilegesLevel := communitiestoken.CommunityLevel
 	if permission != nil {
 		privilegesLevel = permissionTypeToPrivilegesLevel(permission.GetType())
@@ -509,7 +528,9 @@ func (s *Service) FillCollectibleMetadata(community *communities.Community, coll
 	collectible.CollectibleData.Description = tokenMetadata.GetDescription()
 	collectible.CollectibleData.ImagePayload = imagePayload
 	collectible.CollectibleData.Traits = getCollectibleCommunityTraits(communityToken)
-	collectible.CollectibleData.Soulbound = !communityToken.Transferable
+	if communityToken != nil {
+		collectible.CollectibleData.Soulbound = !communityToken.Transferable
+	}
 
 	if collectible.CollectionData == nil {
 		collectible.CollectionData = &thirdparty.CollectionData{
@@ -527,8 +548,6 @@ func (s *Service) FillCollectibleMetadata(community *communities.Community, coll
 	collectible.CollectibleCommunityInfo = &thirdparty.CollectibleCommunityInfo{
 		PrivilegesLevel: privilegesLevel,
 	}
-
-	return nil
 }
 
 func permissionTypeToPrivilegesLevel(permissionType protobuf.CommunityTokenPermission_Type) communitiestoken.PrivilegesLevel {

--- a/services/ext/service_test.go
+++ b/services/ext/service_test.go
@@ -7,6 +7,8 @@ import (
 
 	"github.com/status-im/status-go/common"
 	"github.com/status-im/status-go/protocol"
+	"github.com/status-im/status-go/protocol/protobuf"
+	"github.com/status-im/status-go/services/wallet/thirdparty"
 )
 
 func TestServicePauseResumeBackgroundWithNilMessenger(t *testing.T) {
@@ -25,4 +27,28 @@ func TestServicePauseResumeBackgroundWithMessenger(t *testing.T) {
 	require.Equal(t, common.ServiceStatePaused, svc.PausableState())
 	require.NoError(t, svc.Resume())
 	require.Equal(t, common.ServiceStateRunning, svc.PausableState())
+}
+
+// Regression test: right after a profile sync the community description
+// (token metadata) can arrive before the community_tokens rows are synced,
+// so the community token lookup legitimately returns nil. Filling metadata
+// must tolerate that instead of crashing the node.
+func TestFillCollectibleMetadataWithMissingCommunityToken(t *testing.T) {
+	collectible := &thirdparty.FullCollectibleData{
+		CollectibleData: thirdparty.CollectibleData{
+			CommunityID: "0x0123",
+		},
+	}
+	tokenMetadata := &protobuf.CommunityTokenMetadata{
+		Name:        "Community Collectible",
+		Description: "desc",
+	}
+
+	require.NotPanics(t, func() {
+		fillCollectibleMetadata(collectible, nil, tokenMetadata, nil, nil)
+	})
+
+	require.Equal(t, "Community Collectible", collectible.CollectibleData.Name)
+	require.False(t, collectible.CollectibleData.Soulbound)
+	require.NotNil(t, collectible.CollectionData)
 }


### PR DESCRIPTION
cherry-pick from #7630