### PR TITLE
fix(protocol): validate responseTo before sending a chat message

### DIFF
--- a/protocol/errors.go
+++ b/protocol/errors.go
@@ -5,10 +5,11 @@ import (
 )
 
 var (
-	ErrChatIDEmpty      = errors.New("chat ID is empty")
-	ErrChatNotFound     = errors.New("can't find chat")
-	ErrNotImplemented   = errors.New("not implemented")
-	ErrContactNotFound  = errors.New("contact not found")
-	ErrCommunityIDEmpty = errors.New("community ID is empty")
-	ErrUserNotMember    = errors.New("user not a member")
+	ErrChatIDEmpty       = errors.New("chat ID is empty")
+	ErrChatNotFound      = errors.New("can't find chat")
+	ErrNotImplemented    = errors.New("not implemented")
+	ErrContactNotFound   = errors.New("contact not found")
+	ErrCommunityIDEmpty  = errors.New("community ID is empty")
+	ErrUserNotMember     = errors.New("user not a member")
+	ErrInvalidResponseTo = errors.New("can't find message replied to")
 )

--- a/protocol/messenger.go
+++ b/protocol/messenger.go
@@ -2026,6 +2026,16 @@ func (m *Messenger) SendChatMessages(ctx context.Context, messages []*common.Mes
 
 // sendChatMessage takes a minimal message and sends it based on the corresponding chat
 func (m *Messenger) sendChatMessage(ctx context.Context, message *common.Message) (*MessengerResponse, error) {
+	if len(message.ResponseTo) != 0 {
+		exists, err := m.persistence.MessagesExist([]string{message.ResponseTo})
+		if err != nil {
+			return nil, err
+		}
+		if !exists[message.ResponseTo] {
+			return nil, ErrInvalidResponseTo
+		}
+	}
+
 	displayName, err := m.settings.DisplayName()
 	if err != nil {
 		return nil, err

--- a/protocol/messenger_reply_test.go
+++ b/protocol/messenger_reply_test.go
@@ -83,3 +83,22 @@ func (s *MessengerReplySuite) TestReceiveReply() {
 	// Verify that it's replied
 	s.Require().True(messageToCheck.Replied)
 }
+
+func (s *MessengerReplySuite) TestSendReplyToNonExistentMessage() {
+	alice := s.m
+
+	chatID := statusChatID
+	chat := CreatePublicChat(chatID, alice.getTimesource())
+
+	err := alice.SaveChat(chat)
+	s.Require().NoError(err)
+
+	_, err = alice.Join(chat)
+	s.Require().NoError(err)
+
+	// Reply to a message ID that was never sent or received
+	replyMessage := buildTestMessage(*chat)
+	replyMessage.ResponseTo = "non-existent-message-id"
+	_, err = alice.SendChatMessage(context.Background(), replyMessage)
+	s.Require().ErrorIs(err, ErrInvalidResponseTo)
+}


### PR DESCRIPTION
Validates the `responseTo` field before a chat message is sent, and returns a clear, specific error when it points at a message that doesn't exist locally.

## Description

Calling `SendChatMessage` (via `wakuext_sendChatMessage` over RPC, or directly) with `responseTo` set to a message ID that doesn't exist previously went through with no validation anywhere in `sendChatMessage`. Any resulting failure surfaced as an opaque error, with nothing pointing at `responseTo` as the actual problem.

I traced the send path (`services/ext/api.go` `PublicAPI.SendChatMessage` → `protocol/messenger.go` `Messenger.SendChatMessage`/`sendChatMessage`) and confirmed there's no check on `ResponseTo` anywhere before the message is encoded and dispatched — `extendMessageFromChat`, `encodeChatEntity`, and the persistence layer (`response_to` is a plain `VARCHAR` column with no foreign key) don't validate it either.

`sendChatMessage` now checks a non-empty `responseTo` against local storage using the existing `MessagesExist` helper (already used and tested elsewhere in `persistence_test.go`) before doing any other work, and returns a new `ErrInvalidResponseTo` sentinel error (`protocol/errors.go`, following the existing `ErrChatNotFound`/`ErrContactNotFound` naming convention) if the message can't be found. Since `SendChatMessages` (plural) calls `SendChatMessage` per message internally, this covers both entry points.

Important changes:
- [x] `protocol/errors.go`: new `ErrInvalidResponseTo` sentinel error
- [x] `protocol/messenger.go`: `sendChatMessage` validates `message.ResponseTo` up front via `MessagesExist`
- [x] `protocol/messenger_reply_test.go`: added `TestSendReplyToNonExistentMessage`, alongside the existing `TestReceiveReply`, asserting the new error via `ErrorIs`

## Note on prior discussion

@AysajanE expressed interest in this issue a couple of days ago and mentioned waiting for a core contributor's approval before starting. I don't see a PR from them yet, so I went ahead — happy to coordinate or step back if they're already partway through this.

## How I tested this

I traced the full send path by hand against the current `develop` branch and matched this fix to the existing patterns in `protocol/errors.go` and `protocol/messenger_reply_test.go`. I wasn't able to complete a full local `go build`/`go test` run in my environment — this module links against `libsds` (native, built from a separate Nim project) which the project's own docs point at the Nix dev shell for; standing that up from scratch outside Nix pulled in building a full Nim toolchain, which felt disproportionate for this change, so I stopped short of a local build/test run. `gofmt` confirms the diff is syntactically valid and correctly formatted. Happy to fix up anything CI catches.

Closes #7644