### PR TITLE
fix(protocol): validate responseTo before sending a chat message

### DIFF
--- a/protocol/errors.go
+++ b/protocol/errors.go
@@ -5,10 +5,11 @@ import (
 )
 
 var (
-	ErrChatIDEmpty      = errors.New("chat ID is empty")
-	ErrChatNotFound     = errors.New("can't find chat")
-	ErrNotImplemented   = errors.New("not implemented")
-	ErrContactNotFound  = errors.New("contact not found")
-	ErrCommunityIDEmpty = errors.New("community ID is empty")
-	ErrUserNotMember    = errors.New("user not a member")
+	ErrChatIDEmpty       = errors.New("chat ID is empty")
+	ErrChatNotFound      = errors.New("can't find chat")
+	ErrNotImplemented    = errors.New("not implemented")
+	ErrContactNotFound   = errors.New("contact not found")
+	ErrCommunityIDEmpty  = errors.New("community ID is empty")
+	ErrUserNotMember     = errors.New("user not a member")
+	ErrInvalidResponseTo = errors.New("can't find message replied to")
 )

--- a/protocol/messenger.go
+++ b/protocol/messenger.go
@@ -2026,6 +2026,16 @@ func (m *Messenger) SendChatMessages(ctx context.Context, messages []*common.Mes
 
 // sendChatMessage takes a minimal message and sends it based on the corresponding chat
 func (m *Messenger) sendChatMessage(ctx context.Context, message *common.Message) (*MessengerResponse, error) {
+	if len(message.ResponseTo) != 0 {
+		exists, err := m.persistence.MessagesExist([]string{message.ResponseTo})
+		if err != nil {
+			return nil, err
+		}
+		if !exists[message.ResponseTo] {
+			return nil, ErrInvalidResponseTo
+		}
+	}
+
 	displayName, err := m.settings.DisplayName()
 	if err != nil {
 		return nil, err

--- a/protocol/messenger_reply_test.go
+++ b/protocol/messenger_reply_test.go
@@ -83,3 +83,22 @@ func (s *MessengerReplySuite) TestReceiveReply() {
 	// Verify that it's replied
 	s.Require().True(messageToCheck.Replied)
 }
+
+func (s *MessengerReplySuite) TestSendReplyToNonExistentMessage() {
+	alice := s.m
+
+	chatID := statusChatID
+	chat := CreatePublicChat(chatID, alice.getTimesource())
+
+	err := alice.SaveChat(chat)
+	s.Require().NoError(err)
+
+	_, err = alice.Join(chat)
+	s.Require().NoError(err)
+
+	// Reply to a message ID that was never sent or received
+	replyMessage := buildTestMessage(*chat)
+	replyMessage.ResponseTo = "non-existent-message-id"
+	_, err = alice.SendChatMessage(context.Background(), replyMessage)
+	s.Require().ErrorIs(err, ErrInvalidResponseTo)
+}


### PR DESCRIPTION
Same PR as https://github.com/status-im/status-go/pull/7646 to run the CI

Sending a chat message with a responseTo pointing at a message ID that does not exist in the local store previously went through with no validation, and any resulting failure surfaced as an opaque error with no indication of the actual cause.

sendChatMessage now checks the responseTo ID against local storage via the existing MessagesExist helper before doing any other work, and returns a new ErrInvalidResponseTo sentinel error when the message can't be found, so callers get a clear, specific error instead of a bare one.

Fixes #7644