### PR TITLE
perf(login): speed up login

### DIFF
--- a/internal/accounts-management/interface_keystore.go
+++ b/internal/accounts-management/interface_keystore.go
@@ -19,6 +19,8 @@ type KeyStore interface {
 	ImportSingleExtendedKey(extKey *extkeys.ExtendedKey, passphrase string) (keystore.KeystoreAccount, error)
 	// AccountDecryptedKey returns decrypted key for account (provided that password is correct).
 	AccountDecryptedKey(address cryptoypes.Address, passphrase string) (keystore.KeystoreAccount, *ecdsa.PrivateKey, *extkeys.ExtendedKey, error)
+	// AccountDecryptedPrivateKey returns only the decrypted private key for an account.
+	AccountDecryptedPrivateKey(address cryptoypes.Address, passphrase string) (keystore.KeystoreAccount, *ecdsa.PrivateKey, error)
 	// Delete deletes the key matched by account.
 	// If the account contains no filename, the address must match a unique key.
 	Delete(address cryptoypes.Address, passphrase string) error

--- a/internal/accounts-management/keystore/adapter.go
+++ b/internal/accounts-management/keystore/adapter.go
@@ -129,6 +129,27 @@ func (a *Adapter) AccountDecryptedKey(address cryptotypes.Address, passphrase st
 	return
 }
 
+func (a *Adapter) AccountDecryptedPrivateKey(address cryptotypes.Address, passphrase string) (account KeystoreAccount, privateKey *ecdsa.PrivateKey, err error) {
+	defer func() {
+		err = mapToKeystoreError(err)
+	}()
+
+	var gethAccount accounts.Account
+	gethAccount, err = a.find(address)
+	if err != nil {
+		return
+	}
+
+	ethKey, err := readKeystoreFileAndDecryptedPrivateKey(gethAccount.URL.Path, passphrase)
+	if err != nil {
+		return
+	}
+
+	account = keystoreAccountFrom(gethAccount)
+	privateKey = ethKey.PrivateKey
+	return
+}
+
 func (a *Adapter) Delete(address cryptotypes.Address, passphrase string) (err error) {
 	defer func() {
 		err = mapToKeystoreError(err)

--- a/internal/accounts-management/keystore/helper.go
+++ b/internal/accounts-management/keystore/helper.go
@@ -39,6 +39,15 @@ func readKeystoreFileAndDecryptedKey(path string, auth string) (*types.Key, erro
 	return geth.DecryptKey(keyjson, auth)
 }
 
+func readKeystoreFileAndDecryptedPrivateKey(path string, auth string) (*types.Key, error) {
+	keyjson, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+
+	return geth.DecryptPrivateKey(keyjson, auth)
+}
+
 func encryptKeyAndStoreToKeystoreFile(ethKey *types.Key, path string, scryptN int, scryptP int, passphrase string) error {
 	key := &types.Key{
 		ID:              ethKey.ID,

--- a/internal/accounts-management/keystore/internal/geth/decryption.go
+++ b/internal/accounts-management/keystore/internal/geth/decryption.go
@@ -69,6 +69,54 @@ type cipherparamsJSON struct {
 	IV string `json:"iv"`
 }
 
+// DecryptPrivateKey decrypts only the private key portion of a keystore JSON blob.
+func DecryptPrivateKey(keyjson []byte, auth string) (*types.Key, error) {
+	m := make(map[string]interface{})
+	if err := json.Unmarshal(keyjson, &m); err != nil {
+		return nil, err
+	}
+
+	var (
+		keyBytes, keyId []byte
+		err             error
+	)
+
+	subAccountIndex, ok := m["subaccountindex"].(float64)
+	if !ok {
+		subAccountIndex = 0
+	}
+
+	if version, ok := m["version"].(string); ok && version == "1" {
+		k := new(encryptedKeyJSONV1)
+		if err := json.Unmarshal(keyjson, k); err != nil {
+			return nil, err
+		}
+		keyBytes, keyId, err = decryptKeyV1(k, auth)
+	} else {
+		k := new(EncryptedKeyJSONV3)
+		if err := json.Unmarshal(keyjson, k); err != nil {
+			return nil, err
+		}
+		keyBytes, keyId, err = decryptKeyV3(k, auth)
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	privateKey := crypto.ToECDSAUnsafe(keyBytes)
+	id, err := uuid.FromBytes(keyId)
+	if err != nil {
+		return nil, err
+	}
+
+	return &types.Key{
+		ID:              id,
+		Address:         crypto.PubkeyToAddress(privateKey.PublicKey),
+		PrivateKey:      privateKey,
+		SubAccountIndex: uint32(subAccountIndex),
+	}, nil
+}
+
 // DecryptKey decrypts a key from a json blob, returning the private key itself.
 func DecryptKey(keyjson []byte, auth string) (*types.Key, error) {
 	// Parse the json into a simple map to fetch the key version

--- a/internal/accounts-management/keystore/internal/geth/decryption_test.go
+++ b/internal/accounts-management/keystore/internal/geth/decryption_test.go
@@ -1,0 +1,66 @@
+package geth
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/status-im/extkeys"
+	"github.com/stretchr/testify/require"
+
+	"github.com/status-im/status-go/internal/accounts-management/types"
+	"github.com/status-im/status-go/internal/crypto"
+)
+
+func TestDecryptPrivateKeySkipsExtendedKey(t *testing.T) {
+	const password = "password"
+
+	extendedKey, err := extkeys.NewMaster([]byte("01234567890123456789012345678901"))
+	require.NoError(t, err)
+
+	privateKey := extendedKey.ToECDSA()
+	key := &types.Key{
+		ID:              uuid.New(),
+		Address:         crypto.PubkeyToAddress(privateKey.PublicKey),
+		PrivateKey:      privateKey,
+		ExtendedKey:     extendedKey,
+		SubAccountIndex: 7,
+	}
+
+	keyJSON, err := EncryptKey(key, password, 2, 1)
+	require.NoError(t, err)
+
+	var encryptedKey encryptedKeyJSONV3
+	require.NoError(t, json.Unmarshal(keyJSON, &encryptedKey))
+	encryptedKey.ExtendedKey.MAC = "invalid"
+	keyJSON, err = json.Marshal(encryptedKey)
+	require.NoError(t, err)
+
+	_, err = DecryptKey(keyJSON, password)
+	require.Error(t, err)
+
+	decryptedKey, err := DecryptPrivateKey(keyJSON, password)
+	require.NoError(t, err)
+	require.Equal(t, key.ID, decryptedKey.ID)
+	require.Equal(t, key.Address, decryptedKey.Address)
+	require.Equal(t, key.PrivateKey.D, decryptedKey.PrivateKey.D)
+	require.Nil(t, decryptedKey.ExtendedKey)
+	require.Equal(t, key.SubAccountIndex, decryptedKey.SubAccountIndex)
+}
+
+func TestDecryptPrivateKeyRejectsWrongPassword(t *testing.T) {
+	extendedKey, err := extkeys.NewMaster([]byte("01234567890123456789012345678901"))
+	require.NoError(t, err)
+
+	privateKey := extendedKey.ToECDSA()
+	keyJSON, err := EncryptKey(&types.Key{
+		ID:          uuid.New(),
+		Address:     crypto.PubkeyToAddress(privateKey.PublicKey),
+		PrivateKey:  privateKey,
+		ExtendedKey: extendedKey,
+	}, "password", 2, 1)
+	require.NoError(t, err)
+
+	_, err = DecryptPrivateKey(keyJSON, "wrong password")
+	require.Error(t, err)
+}

--- a/internal/accounts-management/manager.go
+++ b/internal/accounts-management/manager.go
@@ -11,6 +11,7 @@ import (
 	accsmanagementerrors "github.com/status-im/status-go/internal/accounts-management/errors"
 	"github.com/status-im/status-go/internal/accounts-management/generator"
 	"github.com/status-im/status-go/internal/accounts-management/keystore"
+	accsmanagementtypes "github.com/status-im/status-go/internal/accounts-management/types"
 	cryptotypes "github.com/status-im/status-go/internal/crypto/types"
 )
 
@@ -117,8 +118,34 @@ func (m *AccountsManager) loadAccountInternally(address cryptotypes.Address, pas
 	return account, nil
 }
 
+func (m *AccountsManager) loadPrivateKeyInternally(address cryptotypes.Address, password string) (*generator.Account, error) {
+	if m.keystore == nil {
+		return nil, ErrKeystoreMissing
+	}
+
+	_, privateKey, err := m.keystore.AccountDecryptedPrivateKey(address, password)
+	if err != nil {
+		m.logger.Error("error loading account", zap.String("address", address.Hex()), zap.Error(err))
+		if errors.Is(err, keystore.ErrKeystoreFileMissing) {
+			m.logger.Error("cannot locate account for address", zap.String("address", address.Hex()))
+			return nil, keystore.ErrKeystoreFileMissing.Copy().WithContext("address", address.Hex())
+		}
+		return nil, err
+	}
+
+	return generator.NewAccount(privateKey, nil), nil
+}
+
 // SetChatAccount sets the chat account and keystore either by address and password or by private key
 func (m *AccountsManager) SetChatAccount(address cryptotypes.Address, password string, privateKey *ecdsa.PrivateKey) error {
+	return m.setChatAccount(address, password, privateKey, nil)
+}
+
+func (m *AccountsManager) SetChatAccountWithProfileKeypair(address cryptotypes.Address, password string, privateKey *ecdsa.PrivateKey, profileKeypair *accsmanagementtypes.Keypair) error {
+	return m.setChatAccount(address, password, privateKey, profileKeypair)
+}
+
+func (m *AccountsManager) setChatAccount(address cryptotypes.Address, password string, privateKey *ecdsa.PrivateKey, profileKeypair *accsmanagementtypes.Keypair) error {
 	if address == cryptotypes.ZeroAddress() && privateKey == nil {
 		return ErrAddressAndPasswordOrPrivateKeyRequired
 	}
@@ -131,7 +158,10 @@ func (m *AccountsManager) SetChatAccount(address cryptotypes.Address, password s
 		return nil
 	}
 
-	profileKeypair, err := m.persistence.GetProfileKeypair()
+	var err error
+	if profileKeypair == nil {
+		profileKeypair, err = m.persistence.GetProfileKeypair()
+	}
 	if err != nil {
 		return err
 	}
@@ -146,7 +176,7 @@ func (m *AccountsManager) SetChatAccount(address cryptotypes.Address, password s
 	if privateKey != nil {
 		selectedChatAccount = generator.NewAccount(privateKey, nil)
 	} else {
-		selectedChatAccount, err = m.loadAccountInternally(address, password)
+		selectedChatAccount, err = m.loadPrivateKeyInternally(address, password)
 		if err != nil {
 			return err
 		}

--- a/internal/accounts-management/manager_test.go
+++ b/internal/accounts-management/manager_test.go
@@ -412,6 +412,25 @@ func (s *ManagerTestSuite) TestSetChatAccountForExistingProfile() {
 	s.Require().NotNil(selectedChatAccount)
 	s.Equal(genAcc.PrivateKeyHex(), selectedChatAccount.PrivateKeyHex())
 	s.Equal(genAcc.Address(), selectedChatAccount.Address())
+	s.Nil(selectedChatAccount.ExtendedKey())
+}
+
+func (s *ManagerTestSuite) TestSetChatAccountWithProfileKeypairSkipsPersistenceLookup() {
+	profileKeypair := s.createAndStoreProfileKeypair()
+	s.accManager.setChatAccountAndProfileKeyUID(nil, "")
+
+	s.Require().NoError(s.accManager.SetChatAccountWithProfileKeypair(
+		s.chatAddress,
+		s.password,
+		nil,
+		profileKeypair,
+	))
+
+	selectedChatAccount, err := s.accManager.SelectedChatAccount()
+	s.Require().NoError(err)
+	s.Equal(s.chatAddress, selectedChatAccount.Address())
+	s.Nil(selectedChatAccount.ExtendedKey())
+	s.Equal(profileKeypair.KeyUID, s.accManager.profileKeyUID)
 }
 
 func (s *ManagerTestSuite) TestLogout() {

--- a/internal/db/appdatabase/database.go
+++ b/internal/db/appdatabase/database.go
@@ -82,6 +82,14 @@ func InitializeDB(path, password string, kdfIterationsNumber int) (*sql.DB, erro
 	return db, nil
 }
 
+func OpenDB(path, password string, kdfIterationsNumber int) (*sql.DB, error) {
+	return sqlite.OpenDB(path, password, kdfIterationsNumber)
+}
+
+func MigrateDB(db *sql.DB) error {
+	return doMigration(db)
+}
+
 func migrateEnsUsernames(sqlTx *sql.Tx) error {
 
 	// 1. Check if ens_usernames table already exist

--- a/internal/db/sqlite/open_test.go
+++ b/internal/db/sqlite/open_test.go
@@ -1,0 +1,45 @@
+package sqlite
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestOpenDBConcurrently(t *testing.T) {
+	const workers = 32
+
+	start := make(chan struct{})
+	errors := make(chan error, workers)
+	var waitGroup sync.WaitGroup
+	waitGroup.Add(workers)
+
+	for range workers {
+		go func() {
+			defer waitGroup.Done()
+			defer func() {
+				if recovered := recover(); recovered != nil {
+					errors <- fmt.Errorf("OpenDB panicked: %v", recovered)
+				}
+			}()
+
+			<-start
+			db, err := OpenDB(InMemoryPath, "password", 2)
+			if err != nil {
+				errors <- err
+				return
+			}
+			errors <- db.Close()
+		}()
+	}
+
+	close(start)
+	waitGroup.Wait()
+	close(errors)
+
+	for err := range errors {
+		require.NoError(t, err)
+	}
+}

--- a/internal/db/sqlite/sqlite.go
+++ b/internal/db/sqlite/sqlite.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"runtime"
 	"strings"
+	"sync/atomic"
 
 	sqlcipher "github.com/mutecomm/go-sqlcipher/v4" // We require go sqlcipher that overrides default implementation
 
@@ -29,6 +30,8 @@ const (
 	V3CipherPageSize = 1024
 	sqlMainDatabase  = "main"
 )
+
+var sqlcipherDriverID uint64
 
 // DecryptDB completely removes the encryption from the db
 func DecryptDB(oldPath string, newPath string, key string, kdfIterationsNumber int) error {
@@ -165,7 +168,7 @@ func buildSqlcipherDSN(path string) (string, error) {
 }
 
 func openDB(path string, key string, kdfIterationsNumber int, cipherPageSize int) (*sql.DB, error) {
-	driverName := fmt.Sprintf("sqlcipher_with_extensions-%d", len(sql.Drivers()))
+	driverName := fmt.Sprintf("sqlcipher_with_extensions-%d", atomic.AddUint64(&sqlcipherDriverID, 1))
 	sql.Register(driverName, &sqlcipher.SQLiteDriver{
 		ConnectHook: func(conn *sqlcipher.SQLiteConn) error {
 			if _, err := conn.Exec("PRAGMA foreign_keys=ON", []driver.Value{}); err != nil {

--- a/internal/db/walletdatabase/database.go
+++ b/internal/db/walletdatabase/database.go
@@ -35,3 +35,11 @@ func InitializeDB(path, password string, kdfIterationsNumber int) (*sql.DB, erro
 
 	return db, nil
 }
+
+func OpenDB(path, password string, kdfIterationsNumber int) (*sql.DB, error) {
+	return sqlite.OpenDB(path, password, kdfIterationsNumber)
+}
+
+func MigrateDB(db *sql.DB) error {
+	return doMigration(db)
+}

--- a/pkg/backend/backend_test.go
+++ b/pkg/backend/backend_test.go
@@ -134,6 +134,30 @@ func TestEnsureDBsOpenedEstablishedDatabasesRejectsWrongPassword(t *testing.T) {
 	require.Nil(t, backend.walletDB)
 }
 
+func TestEnsureDBsOpenedEstablishedDatabasesDoesNotRegisterDBsOnAccountsDBFailure(t *testing.T) {
+	testContext := setupTestContext(t, testPassword, true, true, true)
+	backend := testContext.backend
+
+	require.NoError(t, backend.closeDBs())
+	backend.statusNode.SetAppDB(nil)
+	backend.statusNode.SetWalletDB(nil)
+
+	previousNewAccountsDB := newAccountsDB
+	newAccountsDB = func(*sql.DB) (*accounts.Database, error) {
+		return nil, fmt.Errorf("failed to create accounts db")
+	}
+	t.Cleanup(func() {
+		newAccountsDB = previousNewAccountsDB
+	})
+
+	err := backend.ensureDBsOpened(*testContext.multiAcc, testPassword)
+	require.EqualError(t, err, "failed to create accounts db")
+	require.Nil(t, backend.appDB)
+	require.Nil(t, backend.walletDB)
+	require.Nil(t, backend.statusNode.GetAppDB())
+	require.Nil(t, backend.statusNode.GetWalletDB())
+}
+
 func handleError(t *testing.T, err error) {
 	if err != nil {
 		t.Logf("deferred function error: '%s'", err)

--- a/pkg/backend/backend_test.go
+++ b/pkg/backend/backend_test.go
@@ -99,6 +99,41 @@ func setupGethStatusBackend() (*StatusBackend, func() error, func() error, func(
 	return backend, stop1, stop2, stop3, err
 }
 
+func TestEnsureDBsOpenedReopensEstablishedDatabases(t *testing.T) {
+	testContext := setupTestContext(t, testPassword, true, true, true)
+	backend := testContext.backend
+
+	require.NoError(t, backend.closeDBs())
+	require.NoError(t, backend.ensureDBsOpened(*testContext.multiAcc, testPassword))
+	t.Cleanup(func() {
+		require.NoError(t, backend.closeDBs())
+	})
+
+	require.NotNil(t, backend.appDB)
+	require.NotNil(t, backend.walletDB)
+	require.NoError(t, backend.appDB.Ping())
+	require.NoError(t, backend.walletDB.Ping())
+	require.Same(t, backend.appDB, backend.statusNode.GetAppDB())
+	require.Same(t, backend.walletDB, backend.statusNode.GetWalletDB())
+
+	accountsDB, err := accounts.NewDB(backend.appDB)
+	require.NoError(t, err)
+	profileKeypair, err := accountsDB.GetProfileKeypair()
+	require.NoError(t, err)
+	require.Equal(t, testContext.profileKeypair.KeyUID, profileKeypair.KeyUID)
+}
+
+func TestEnsureDBsOpenedEstablishedDatabasesRejectsWrongPassword(t *testing.T) {
+	testContext := setupTestContext(t, testPassword, true, true, true)
+	backend := testContext.backend
+
+	require.NoError(t, backend.closeDBs())
+	err := backend.ensureDBsOpened(*testContext.multiAcc, "wrong password")
+	require.Error(t, err)
+	require.Nil(t, backend.appDB)
+	require.Nil(t, backend.walletDB)
+}
+
 func handleError(t *testing.T, err error) {
 	if err != nil {
 		t.Logf("deferred function error: '%s'", err)

--- a/pkg/backend/geth_backend.go
+++ b/pkg/backend/geth_backend.go
@@ -72,6 +72,7 @@ import (
 var (
 	// ErrDBNotAvailable is returned if a method is called before the DB is available for usage
 	ErrDBNotAvailable = errors.New("DB is unavailable")
+	newAccountsDB     = accounts.NewDB
 )
 
 type LoginParams struct {
@@ -496,19 +497,16 @@ func (b *StatusBackend) ensureEstablishedDBsOpened(account multiaccounts.Account
 		_ = appResult.db.Close()
 		return err
 	}
-	b.walletDB = walletResult.db
-	b.statusNode.SetWalletDB(b.walletDB)
-	b.appDB = appResult.db
-	b.statusNode.SetAppDB(b.appDB)
-
-	accountsDB, err := accounts.NewDB(b.appDB)
+	accountsDB, err := newAccountsDB(appResult.db)
 	if err != nil {
-		_ = b.walletDB.Close()
-		_ = b.appDB.Close()
-		b.walletDB = nil
-		b.appDB = nil
+		_ = walletResult.db.Close()
+		_ = appResult.db.Close()
 		return err
 	}
+	b.walletDB = walletResult.db
+	b.appDB = appResult.db
+	b.statusNode.SetWalletDB(b.walletDB)
+	b.statusNode.SetAppDB(b.appDB)
 	b.accountsManager.SetPersistence(accountsDB)
 
 	return nil

--- a/pkg/backend/geth_backend.go
+++ b/pkg/backend/geth_backend.go
@@ -75,10 +75,11 @@ var (
 )
 
 type LoginParams struct {
-	ChatAddress  types.Address          `json:"chatAddress"`
-	Password     string                 `json:"password"`
-	MainAccount  types.Address          `json:"mainAccount"` // TODO: remove this field
-	MultiAccount *multiaccounts.Account `json:"multiAccount"`
+	ChatAddress    types.Address                `json:"chatAddress"`
+	Password       string                       `json:"password"`
+	MainAccount    types.Address                `json:"mainAccount"` // TODO: remove this field
+	MultiAccount   *multiaccounts.Account       `json:"multiAccount"`
+	ProfileKeypair *accsmanagementtypes.Keypair `json:"-"`
 }
 
 // StatusBackend implements the Status.im service over go-ethereum
@@ -419,6 +420,101 @@ func (b *StatusBackend) runDBFileMigrations(account multiaccounts.Account, passw
 }
 
 func (b *StatusBackend) ensureDBsOpened(account multiaccounts.Account, password string) (err error) {
+	b.mu.Lock()
+	dbsUnset := b.walletDB == nil && b.appDB == nil
+	b.mu.Unlock()
+	if dbsUnset {
+		appDBPath, pathErr := b.getAppDBPath(account.KeyUID)
+		if pathErr == nil {
+			walletDBPath, walletPathErr := b.getWalletDBPath(account.KeyUID)
+			legacyAppDBPath := filepath.Join(b.rootDataDir, fmt.Sprintf("%s.db", account.KeyUID))
+			unsupportedAppDBPath := filepath.Join(b.rootDataDir, fmt.Sprintf("app-%x.sql", account.KeyUID))
+			if walletPathErr == nil && fileExists(walletDBPath) && fileExists(appDBPath) &&
+				!fileExists(legacyAppDBPath) && !fileExists(unsupportedAppDBPath) {
+				return b.ensureEstablishedDBsOpened(account, password, appDBPath, walletDBPath)
+			}
+		}
+	}
+
+	return b.ensureDBsOpenedSequential(account, password)
+}
+
+func (b *StatusBackend) ensureEstablishedDBsOpened(account multiaccounts.Account, password, appDBPath, walletDBPath string) (err error) {
+	b.mu.Lock()
+	if b.walletDB != nil || b.appDB != nil {
+		b.mu.Unlock()
+		return b.ensureDBsOpenedSequential(account, password)
+	}
+	defer b.mu.Unlock()
+
+	walletResultCh := make(chan struct {
+		db  *sql.DB
+		err error
+	}, 1)
+	appResultCh := make(chan struct {
+		db  *sql.DB
+		err error
+	}, 1)
+	go func() {
+		defer gocommon.LogOnPanic()
+		db, openErr := walletdatabase.OpenDB(walletDBPath, password, account.KDFIterations)
+		walletResultCh <- struct {
+			db  *sql.DB
+			err error
+		}{db: db, err: openErr}
+	}()
+	go func() {
+		defer gocommon.LogOnPanic()
+		db, openErr := appdatabase.OpenDB(appDBPath, password, account.KDFIterations)
+		appResultCh <- struct {
+			db  *sql.DB
+			err error
+		}{db: db, err: openErr}
+	}()
+
+	walletResult := <-walletResultCh
+	appResult := <-appResultCh
+	if walletResult.err != nil {
+		if appResult.db != nil {
+			_ = appResult.db.Close()
+		}
+		return walletResult.err
+	}
+	if appResult.err != nil {
+		_ = walletResult.db.Close()
+		return appResult.err
+	}
+
+	if err = walletdatabase.MigrateDB(walletResult.db); err != nil {
+		_ = walletResult.db.Close()
+		_ = appResult.db.Close()
+		return err
+	}
+	appdatabase.CurrentAppDBKeyUID = account.KeyUID
+	if err = appdatabase.MigrateDB(appResult.db); err != nil {
+		_ = walletResult.db.Close()
+		_ = appResult.db.Close()
+		return err
+	}
+	b.walletDB = walletResult.db
+	b.statusNode.SetWalletDB(b.walletDB)
+	b.appDB = appResult.db
+	b.statusNode.SetAppDB(b.appDB)
+
+	accountsDB, err := accounts.NewDB(b.appDB)
+	if err != nil {
+		_ = b.walletDB.Close()
+		_ = b.appDB.Close()
+		b.walletDB = nil
+		b.appDB = nil
+		return err
+	}
+	b.accountsManager.SetPersistence(accountsDB)
+
+	return nil
+}
+
+func (b *StatusBackend) ensureDBsOpenedSequential(account multiaccounts.Account, password string) (err error) {
 	// After wallet DB initial migration, the tables moved to wallet DB are removed from appDB
 	// so better migrate wallet DB first to avoid removal if wallet DB migration fails
 	if err = b.ensureWalletDBOpened(account, password); err != nil {
@@ -541,6 +637,9 @@ func (b *StatusBackend) StartNodeWithKey(acc multiaccounts.Account, password str
 	}
 	// get logged in
 	if b.LocalPairingStateManager.IsPairing() {
+		if err == nil {
+			b.statusNode.StartTokenManager()
+		}
 		return nil
 	}
 	return b.LoggedIn(acc.KeyUID, err)
@@ -595,6 +694,9 @@ func (b *StatusBackend) LoginAccount(request *requests.Login) error {
 		_ = b.StopNode()
 	}
 	if b.LocalPairingStateManager.IsPairing() {
+		if err == nil {
+			b.statusNode.StartTokenManager()
+		}
 		return nil
 	}
 	err = b.LoggedIn(request.KeyUID, err)
@@ -700,24 +802,32 @@ func (b *StatusBackend) loginAccount(request *requests.Login) error {
 	}
 	b.account = multiAccount
 
+	chatAddr, err := accountsDB.GetChatAddress()
+	if err != nil {
+		return errors.Wrap(err, "failed to get chat address")
+	}
+
+	walletAddr, err := accountsDB.GetWalletAddress()
+	if err != nil {
+		return errors.Wrap(err, "failed to get wallet address")
+	}
+
+	profileKeypair, err := accountsDB.GetProfileKeypair()
+	if err != nil {
+		return errors.Wrap(err, "failed to get profile keypair")
+	}
+
 	err = b.StartNode(b.config)
 	if err != nil {
 		b.logger.Info("failed to start node")
 		return errors.Wrap(err, "failed to start node")
 	}
 
-	chatAddr, err := accountsDB.GetChatAddress()
-	if err != nil {
-		return errors.Wrap(err, "failed to get chat address")
-	}
-	walletAddr, err := accountsDB.GetWalletAddress()
-	if err != nil {
-		return errors.Wrap(err, "failed to get wallet address")
-	}
 	login := LoginParams{
-		Password:    request.Password,
-		ChatAddress: chatAddr,
-		MainAccount: walletAddr,
+		Password:       request.Password,
+		ChatAddress:    chatAddr,
+		MainAccount:    walletAddr,
+		ProfileKeypair: profileKeypair,
 	}
 
 	err = b.SelectAccount(login, request.ChatPrivateKey())
@@ -888,7 +998,11 @@ func (b *StatusBackend) GetEnsUsernames() ([]*ens.UsernameDetail, error) {
 }
 
 func (b *StatusBackend) Login(keyUID, password string) error {
-	return b.startNodeWithAccount(multiaccounts.Account{KeyUID: keyUID}, password, nil, nil)
+	err := b.startNodeWithAccount(multiaccounts.Account{KeyUID: keyUID}, password, nil, nil)
+	if err == nil {
+		b.statusNode.StartTokenManager()
+	}
+	return err
 }
 
 func (b *StatusBackend) StartNodeWithAccount(acc multiaccounts.Account, password string, nodecfg *params.NodeConfig, chatKey *ecdsa.PrivateKey) error {
@@ -900,6 +1014,9 @@ func (b *StatusBackend) StartNodeWithAccount(acc multiaccounts.Account, password
 	// get logged in
 	if !b.LocalPairingStateManager.IsPairing() {
 		return b.LoggedIn(acc.KeyUID, err)
+	}
+	if err == nil {
+		b.statusNode.StartTokenManager()
 	}
 	return err
 }
@@ -913,6 +1030,7 @@ func (b *StatusBackend) LoggedIn(keyUID string, err error) error {
 	if err != nil {
 		return err
 	}
+
 	acc, err := b.getAccountByKeyUID(keyUID)
 	if err != nil {
 		return err
@@ -929,7 +1047,9 @@ func (b *StatusBackend) LoggedIn(keyUID string, err error) error {
 			return err
 		}
 	}
+
 	signal.SendLoggedIn(acc, s, ensUsernamesJSON, nil)
+	b.statusNode.StartTokenManager()
 	return nil
 }
 
@@ -1027,6 +1147,7 @@ func (b *StatusBackend) ChangeDatabasePassword(keyUID string, password string, n
 				b.logger.Error("failed to start node", zap.Error(err))
 				return
 			}
+			b.statusNode.StartTokenManager()
 		}
 	}
 	defer restartNode()
@@ -2212,7 +2333,7 @@ func (b *StatusBackend) SelectAccount(loginParams LoginParams, privateKey *ecdsa
 	b.mu.Lock()
 	defer b.mu.Unlock()
 
-	err := b.accountsManager.SetChatAccount(loginParams.ChatAddress, loginParams.Password, privateKey)
+	err := b.accountsManager.SetChatAccountWithProfileKeypair(loginParams.ChatAddress, loginParams.Password, privateKey, loginParams.ProfileKeypair)
 	if err != nil {
 		return err
 	}

--- a/pkg/backend/node/get_status_node.go
+++ b/pkg/backend/node/get_status_node.go
@@ -132,6 +132,8 @@ type StatusNode struct {
 
 	localBackup *backup.Controller
 
+	tokenManagerStartDone chan struct{}
+
 	serviceRegistry *ServiceRegistry
 }
 
@@ -363,7 +365,7 @@ func (n *StatusNode) startWithDB(config *params.NodeConfig) error {
 	}
 	n.mediaServer.SetDataProviders(n.appDB, n.walletDB, n.downloader)
 
-	if err := n.createAndStartTokenManager(); err != nil {
+	if err := n.createTokenManager(); err != nil {
 		return err
 	}
 
@@ -438,7 +440,7 @@ func (n *StatusNode) populateServiceRegistry() {
 	}
 }
 
-func (n *StatusNode) createAndStartTokenManager() error {
+func (n *StatusNode) createTokenManager() error {
 	const (
 		defaultAutoRefreshInterval      = 30 * time.Minute // interval after which we should fetch the token lists from the remote source (or use the default one if remote source is not set)
 		defaultAutoRefreshCheckInterval = 3 * time.Minute  // interval after which we should check if we should trigger the auto-refresh
@@ -475,7 +477,28 @@ func (n *StatusNode) createAndStartTokenManager() error {
 		}
 	}
 
-	return n.tokenManager.Start(context.Background())
+	return nil
+}
+
+func (n *StatusNode) StartTokenManager() {
+	n.mu.Lock()
+	if !n.running.Load() || n.tokenManager == nil || n.tokenManagerStartDone != nil {
+		n.mu.Unlock()
+		return
+	}
+
+	tokenManager := n.tokenManager
+	done := make(chan struct{})
+	n.tokenManagerStartDone = done
+	n.mu.Unlock()
+
+	go func() {
+		defer common.LogOnPanic()
+		defer close(done)
+		if err := tokenManager.Start(context.Background()); err != nil {
+			n.logger.Error("failed to start token manager", zap.Error(err))
+		}
+	}()
 }
 
 func (n *StatusNode) setupRPCClient() (err error) {
@@ -504,6 +527,10 @@ func (n *StatusNode) Stop() error {
 	}
 
 	var errs []error
+	if n.tokenManagerStartDone != nil {
+		<-n.tokenManagerStartDone
+		n.tokenManagerStartDone = nil
+	}
 	n.timeSourceSrvc.Stop()
 
 	for _, service := range n.services {

--- a/pkg/backend/node/get_status_node.go
+++ b/pkg/backend/node/get_status_node.go
@@ -368,6 +368,11 @@ func (n *StatusNode) startWithDB(config *params.NodeConfig) error {
 	if err := n.createTokenManager(); err != nil {
 		return err
 	}
+	if err := n.tokenManager.Start(context.Background()); err != nil {
+		return errorspkg.Wrap(err, "failed to start token manager")
+	}
+	n.tokenManagerStartDone = make(chan struct{})
+	close(n.tokenManagerStartDone)
 
 	if err := n.initServices(config, n.mediaServer); err != nil {
 		return err
@@ -530,6 +535,7 @@ func (n *StatusNode) Stop() error {
 	if n.tokenManagerStartDone != nil {
 		<-n.tokenManagerStartDone
 		n.tokenManagerStartDone = nil
+		n.tokenManager.Stop()
 	}
 	n.timeSourceSrvc.Stop()
 

--- a/pkg/backend/node/geth_status_node_test.go
+++ b/pkg/backend/node/geth_status_node_test.go
@@ -5,6 +5,7 @@ import (
 	"path"
 	"testing"
 
+	"github.com/ethereum/go-ethereum/common"
 	"go.uber.org/zap"
 
 	"github.com/stretchr/testify/require"
@@ -47,7 +48,10 @@ func TestStatusNodeStart(t *testing.T) {
 	require.NotNil(t, n.Config())
 	require.NotNil(t, n.RPCClient())
 	require.NotNil(t, n.TokenManager())
-	require.Nil(t, n.tokenManagerStartDone)
+	require.NotNil(t, n.tokenManagerStartDone)
+	nativeToken, err := n.TokenManager().GetTokenByChainAddress(walletcommon.EthereumMainnet, common.Address{})
+	require.NoError(t, err)
+	require.NotNil(t, nativeToken)
 
 	// try to start already started node
 	require.EqualError(t, n.Start(config), ErrNodeRunning.Error())

--- a/pkg/backend/node/geth_status_node_test.go
+++ b/pkg/backend/node/geth_status_node_test.go
@@ -19,7 +19,7 @@ func TestStatusNodeStart(t *testing.T) {
 	config, err := params.NewNodeConfig("", walletcommon.EthereumSepolia)
 	require.NoError(t, err)
 
-	// StatusNode startup always creates & starts TokenManager, which requires at least one active network.
+	// StatusNode startup creates TokenManager, which requires at least one active network.
 	config.Networks = testutil.MinimalActiveNetworks()
 
 	n := New(nil, nil, testutils.MustCreateTestLogger())
@@ -46,12 +46,23 @@ func TestStatusNodeStart(t *testing.T) {
 	require.True(t, n.IsRunning())
 	require.NotNil(t, n.Config())
 	require.NotNil(t, n.RPCClient())
+	require.NotNil(t, n.TokenManager())
+	require.Nil(t, n.tokenManagerStartDone)
 
 	// try to start already started node
 	require.EqualError(t, n.Start(config), ErrNodeRunning.Error())
 
+	n.StartTokenManager()
+	startDone := n.tokenManagerStartDone
+	require.NotNil(t, startDone)
+
+	n.StartTokenManager()
+	require.Equal(t, startDone, n.tokenManagerStartDone)
+	<-startDone
+
 	// stop node
 	require.NoError(t, n.Stop())
+	require.Nil(t, n.tokenManagerStartDone)
 	// try to stop already stopped node
 	require.EqualError(t, n.Stop(), ErrNoRunningNode.Error())
 
@@ -67,7 +78,7 @@ func TestStatusNodeWithDataDir(t *testing.T) {
 	err := os.MkdirAll(keyStoreDir, os.ModePerm)
 	require.NoError(t, err)
 
-	// Start requires at least one active network because TokenManager is started during node startup.
+	// Start requires at least one active network because TokenManager is created during node startup.
 	config := params.NodeConfig{
 		RootDataDir: dir,
 		Networks:    testutil.MinimalActiveNetworks(),

--- a/pkg/messaging/waku/gowaku_test.go
+++ b/pkg/messaging/waku/gowaku_test.go
@@ -1,9 +1,11 @@
 package wakuv2
 
 import (
+	"context"
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rand"
+	"errors"
 	"fmt"
 	"testing"
 
@@ -24,6 +26,47 @@ import (
 
 	gocommon "github.com/status-im/status-go/common"
 )
+
+type failingDNSResolver struct {
+	err    error
+	called chan struct{}
+}
+
+func (r *failingDNSResolver) LookupTXT(context.Context, string) ([]string, error) {
+	select {
+	case r.called <- struct{}{}:
+	default:
+	}
+	return nil, r.err
+}
+
+func TestNewRetrievesInitialDiscV5BootstrapNodes(t *testing.T) {
+	expectedErr := errors.New("DNS lookup failed")
+	resolver := &failingDNSResolver{
+		err:    expectedErr,
+		called: make(chan struct{}, 1),
+	}
+	cfg := &Config{
+		DiscV5BootstrapNodes: []string{
+			"enrtree://AIRVQ5DDA4FFWLRBCHJWUWOO6X6S4ZTZ5B667LQ6AJU6PEYDLRD5O@nodes.example.org",
+		},
+		Resolver: resolver,
+	}
+
+	waku, err := New(nil, cfg, nil, nil)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		waku.cancel()
+		waku.envelopeCache.Stop()
+		waku.wg.Wait()
+	})
+
+	select {
+	case <-resolver.called:
+	default:
+		t.Fatal("expected initial DiscV5 bootstrap nodes to be retrieved through DNS")
+	}
+}
 
 func TestWakuLifecycleState(t *testing.T) {
 	// New() alone is safe to call with nil params; Start()/Stop() are not used

--- a/services/wallet/leaderboard/service.go
+++ b/services/wallet/leaderboard/service.go
@@ -82,18 +82,20 @@ func NewMarketDataService(config ServiceConfig, walletDB *sql.DB, feed *event.Fe
 
 // Start begins the data refresh loops
 func (s *MarketDataService) Start(ctx context.Context) {
-	s.storage.Start()
+	s.storage.StartAsync()
 	s.fetcher.Start(ctx)
 }
 
 // Stop halts all data refresh operations
 func (s *MarketDataService) Stop() {
 	s.fetcher.Stop()
+	s.storage.WaitForStart()
 	s.UnsubscribeFromLeaderboard() //nolint:errcheck
 }
 
 // GetCombinedData returns cryptocurrency data with updated price information
 func (s *MarketDataService) GetCombinedData() []Cryptocurrency {
+	s.storage.WaitForStart()
 	return s.storage.GetCombinedData()
 }
 
@@ -156,6 +158,7 @@ func (s *MarketDataService) sendLeaderboardPageUpdate() {
 
 func (s *MarketDataService) FetchLeaderboardPageAsync(page, pageSize, sortOrder int, currency string) {
 	s.scheduler.Enqueue(fetchLeaderboardPageTask, func(ctx context.Context) (interface{}, error) {
+		s.storage.WaitForStart()
 		if s.storage.IsDataStale() {
 			s.fetcher.FetchMarkets(ctx) //nolint:errcheck
 		}

--- a/services/wallet/leaderboard/service_test.go
+++ b/services/wallet/leaderboard/service_test.go
@@ -26,6 +26,16 @@ type blockingMarketDataPersistence struct {
 	data    []Cryptocurrency
 }
 
+type startAttempt struct {
+	started chan struct{}
+	release chan struct{}
+}
+
+type restartableMarketDataPersistence struct {
+	attempts chan startAttempt
+	data     []Cryptocurrency
+}
+
 func (p *blockingMarketDataPersistence) UpsertCryptocurrencies([]Cryptocurrency) error {
 	return nil
 }
@@ -37,6 +47,21 @@ func (p *blockingMarketDataPersistence) GetCryptocurrencies() ([]Cryptocurrency,
 }
 
 func (p *blockingMarketDataPersistence) DeleteCryptocurrencies([]string) error {
+	return nil
+}
+
+func (p *restartableMarketDataPersistence) UpsertCryptocurrencies([]Cryptocurrency) error {
+	return nil
+}
+
+func (p *restartableMarketDataPersistence) GetCryptocurrencies() ([]Cryptocurrency, error) {
+	attempt := <-p.attempts
+	close(attempt.started)
+	<-attempt.release
+	return p.data, nil
+}
+
+func (p *restartableMarketDataPersistence) DeleteCryptocurrencies([]string) error {
 	return nil
 }
 
@@ -139,6 +164,52 @@ func TestServiceWaitsForAsyncStorageStart(t *testing.T) {
 	close(persistence.release)
 	require.Equal(t, mockCrypto, <-combinedData)
 	<-stopDone
+}
+
+func TestDataStorageStartDoesNotOverwriteFetchedData(t *testing.T) {
+	persistence := &blockingMarketDataPersistence{
+		started: make(chan struct{}),
+		release: make(chan struct{}),
+		data:    mockCrypto,
+	}
+	storage := &DataStorage{
+		priceData:             make(PriceMap),
+		marketDataPersistence: persistence,
+	}
+	fetchedData := []Cryptocurrency{{ID: "fresh-market-data"}}
+
+	storage.StartAsync()
+	<-persistence.started
+	require.True(t, storage.UpdateCryptoDataWithEtag(fetchedData, "fresh-etag"))
+
+	close(persistence.release)
+	storage.WaitForStart()
+
+	require.Equal(t, fetchedData, storage.GetCryptoData())
+}
+
+func TestDataStorageCanRestartAfterStart(t *testing.T) {
+	firstAttempt := startAttempt{
+		started: make(chan struct{}),
+		release: make(chan struct{}),
+	}
+	persistence := &restartableMarketDataPersistence{
+		attempts: make(chan startAttempt, 1),
+		data:     mockCrypto,
+	}
+	storage := &DataStorage{
+		priceData:             make(PriceMap),
+		marketDataPersistence: persistence,
+	}
+
+	persistence.attempts <- firstAttempt
+	storage.StartAsync()
+	<-firstAttempt.started
+	close(firstAttempt.release)
+	storage.WaitForStart()
+
+	storage.StartAsync()
+	storage.WaitForStart()
 }
 
 func TestUnsubscribeWhenNotSubscribed(t *testing.T) {

--- a/services/wallet/leaderboard/service_test.go
+++ b/services/wallet/leaderboard/service_test.go
@@ -20,6 +20,26 @@ type MockFetcher struct {
 	storage *DataStorage
 }
 
+type blockingMarketDataPersistence struct {
+	started chan struct{}
+	release chan struct{}
+	data    []Cryptocurrency
+}
+
+func (p *blockingMarketDataPersistence) UpsertCryptocurrencies([]Cryptocurrency) error {
+	return nil
+}
+
+func (p *blockingMarketDataPersistence) GetCryptocurrencies() ([]Cryptocurrency, error) {
+	close(p.started)
+	<-p.release
+	return p.data, nil
+}
+
+func (p *blockingMarketDataPersistence) DeleteCryptocurrencies([]string) error {
+	return nil
+}
+
 func NewMockFetcher(storage *DataStorage) *MockFetcher {
 	f := &MockFetcher{
 		storage: storage,
@@ -74,6 +94,51 @@ func TestServiceStartStop(t *testing.T) {
 
 	service.Start(context.Background())
 	service.Stop()
+}
+
+func TestServiceWaitsForAsyncStorageStart(t *testing.T) {
+	persistence := &blockingMarketDataPersistence{
+		started: make(chan struct{}),
+		release: make(chan struct{}),
+		data:    mockCrypto,
+	}
+	storage := &DataStorage{
+		priceData:             make(PriceMap),
+		marketDataPersistence: persistence,
+	}
+	service := &MarketDataService{
+		storage:             storage,
+		fetcher:             &MockFetcher{storage: storage},
+		subscriptionManager: NewSubscriptionManager(),
+	}
+
+	service.Start(context.Background())
+	<-persistence.started
+
+	combinedData := make(chan []Cryptocurrency, 1)
+	go func() {
+		combinedData <- service.GetCombinedData()
+	}()
+	stopDone := make(chan struct{})
+	go func() {
+		service.Stop()
+		close(stopDone)
+	}()
+
+	select {
+	case <-combinedData:
+		t.Fatal("GetCombinedData returned before storage initialization completed")
+	default:
+	}
+	select {
+	case <-stopDone:
+		t.Fatal("Stop returned before storage initialization completed")
+	default:
+	}
+
+	close(persistence.release)
+	require.Equal(t, mockCrypto, <-combinedData)
+	<-stopDone
 }
 
 func TestUnsubscribeWhenNotSubscribed(t *testing.T) {

--- a/services/wallet/leaderboard/storage.go
+++ b/services/wallet/leaderboard/storage.go
@@ -18,8 +18,10 @@ const DATA_STALE_THRESHOLD = 10 * time.Minute
 // DataStorage manages the storage and retrieval of market data
 type DataStorage struct {
 	// Data and synchronization
-	cryptoData []Cryptocurrency
-	startWG    sync.WaitGroup
+	cryptoData            []Cryptocurrency
+	cryptoDataInitialized bool
+	startMu               sync.Mutex
+	startDone             chan struct{}
 
 	marketDataPersistence MarketDataPersistenceInterface
 	priceData             PriceMap
@@ -40,22 +42,43 @@ func NewDataStorage(walletDB *sql.DB) *DataStorage {
 }
 
 func (s *DataStorage) Start() {
+	s.dataMutex.RLock()
+	if s.cryptoDataInitialized {
+		s.dataMutex.RUnlock()
+		return
+	}
+	s.dataMutex.RUnlock()
+
+	cryptoData, _ := s.marketDataPersistence.GetCryptocurrencies()
+
 	s.dataMutex.Lock()
 	defer s.dataMutex.Unlock()
-	s.cryptoData, _ = s.marketDataPersistence.GetCryptocurrencies()
+	if !s.cryptoDataInitialized {
+		s.cryptoData = cryptoData
+		s.cryptoDataInitialized = true
+	}
 }
 
 func (s *DataStorage) StartAsync() {
-	s.startWG.Add(1)
+	s.startMu.Lock()
+	startDone := make(chan struct{})
+	s.startDone = startDone
+	s.startMu.Unlock()
+
 	go func() {
 		defer common.LogOnPanic()
-		defer s.startWG.Done()
+		defer close(startDone)
 		s.Start()
 	}()
 }
 
 func (s *DataStorage) WaitForStart() {
-	s.startWG.Wait()
+	s.startMu.Lock()
+	startDone := s.startDone
+	s.startMu.Unlock()
+	if startDone != nil {
+		<-startDone
+	}
 }
 
 // UpdateCryptoDataWithEtag updates both cryptocurrency data and etag atomically
@@ -68,6 +91,7 @@ func (s *DataStorage) UpdateCryptoDataWithEtag(data []Cryptocurrency, etag strin
 	s.dataMutex.Lock()
 	defer s.dataMutex.Unlock()
 
+	s.cryptoDataInitialized = true
 	currentIds := s.extractCryptocurrencyIDs(s.cryptoData)
 	s.cryptoData = data
 	s.cryptoEtag = etag

--- a/services/wallet/leaderboard/storage.go
+++ b/services/wallet/leaderboard/storage.go
@@ -9,6 +9,7 @@ import (
 
 	"go.uber.org/zap"
 
+	"github.com/status-im/status-go/common"
 	"github.com/status-im/status-go/internal/logutils"
 )
 
@@ -18,6 +19,7 @@ const DATA_STALE_THRESHOLD = 10 * time.Minute
 type DataStorage struct {
 	// Data and synchronization
 	cryptoData []Cryptocurrency
+	startWG    sync.WaitGroup
 
 	marketDataPersistence MarketDataPersistenceInterface
 	priceData             PriceMap
@@ -41,6 +43,19 @@ func (s *DataStorage) Start() {
 	s.dataMutex.Lock()
 	defer s.dataMutex.Unlock()
 	s.cryptoData, _ = s.marketDataPersistence.GetCryptocurrencies()
+}
+
+func (s *DataStorage) StartAsync() {
+	s.startWG.Add(1)
+	go func() {
+		defer common.LogOnPanic()
+		defer s.startWG.Done()
+		s.Start()
+	}()
+}
+
+func (s *DataStorage) WaitForStart() {
+	s.startWG.Wait()
 }
 
 // UpdateCryptoDataWithEtag updates both cryptocurrency data and etag atomically

--- a/services/wallet/token/token.go
+++ b/services/wallet/token/token.go
@@ -251,15 +251,17 @@ func setUpTokenListsManager(mng *Manager, walletDB *sql.DB, enabledChains []uint
 }
 
 func (tm *Manager) Start(ctx context.Context) error {
-	tm.stopCh = make(chan struct{})
-	tm.startAccountsWatcher()
-	tm.startNetworksWatcher()
+	stopCh := make(chan struct{})
+	tm.stopCh = stopCh
+	tm.startAccountsWatcher(stopCh)
+	tm.startNetworksWatcher(stopCh)
 
-	tm.notifyCh = make(chan struct{}, 1)
-	return tm.startTokenListsNotifier(ctx)
+	notifyCh := make(chan struct{}, 1)
+	tm.notifyCh = notifyCh
+	return tm.startTokenListsNotifier(ctx, stopCh, notifyCh)
 }
 
-func (tm *Manager) startTokenListsNotifier(ctx context.Context) error {
+func (tm *Manager) startTokenListsNotifier(ctx context.Context, stopCh <-chan struct{}, notifyCh chan struct{}) error {
 	thirdpartyServicesEnabled, err := tm.settings.ThirdpartyServicesEnabled()
 	if err != nil {
 		logutils.ZapLogger().Error("failed to get if thirdparty services are enabled", zap.Error(err))
@@ -273,7 +275,7 @@ func (tm *Manager) startTokenListsNotifier(ctx context.Context) error {
 
 	autoRefresh := thirdpartyServicesEnabled && autoRefreshEnabled
 
-	err = tm.tokensManager.Start(ctx, autoRefresh, tm.notifyCh)
+	err = tm.tokensManager.Start(ctx, autoRefresh, notifyCh)
 	if err != nil {
 		logutils.ZapLogger().Error("failed to start token lists notifier", zap.Error(err))
 		return err
@@ -283,13 +285,13 @@ func (tm *Manager) startTokenListsNotifier(ctx context.Context) error {
 		defer gocommon.LogOnPanic()
 		for {
 			select {
-			case <-tm.stopCh:
+			case <-stopCh:
 				err := tm.tokensManager.Stop()
 				if err != nil {
 					logutils.ZapLogger().Error("failed to stop token lists notifier", zap.Error(err))
 				}
 				return
-			case <-tm.notifyCh:
+			case <-notifyCh:
 				err := tm.setLastTokenListsRefreshTime(time.Now().UTC())
 				if err != nil {
 					logutils.ZapLogger().Error("failed to set last tokens update", zap.Error(err))
@@ -311,7 +313,7 @@ func (tm *Manager) startTokenListsNotifier(ctx context.Context) error {
 	return nil
 }
 
-func (tm *Manager) startAccountsWatcher() {
+func (tm *Manager) startAccountsWatcher(stopCh <-chan struct{}) {
 	if tm.accountsPublisher == nil || tm.accountsDB == nil {
 		return
 	}
@@ -322,7 +324,7 @@ func (tm *Manager) startAccountsWatcher() {
 		defer unsubFn()
 		for {
 			select {
-			case <-tm.stopCh:
+			case <-stopCh:
 				return
 			case event, ok := <-ch:
 				if !ok {
@@ -334,7 +336,7 @@ func (tm *Manager) startAccountsWatcher() {
 	}()
 }
 
-func (tm *Manager) startNetworksWatcher() {
+func (tm *Manager) startNetworksWatcher(stopCh <-chan struct{}) {
 	if tm.networkManager == nil {
 		return
 	}
@@ -346,7 +348,7 @@ func (tm *Manager) startNetworksWatcher() {
 		defer unsubFn()
 		for {
 			select {
-			case <-tm.stopCh:
+			case <-stopCh:
 				return
 			case _, ok := <-ch:
 				if !ok {


### PR DESCRIPTION
Part of https://github.com/status-im/status-app/issues/21462
companion PR: https://github.com/status-im/status-app/pull/21596

- Open existing app and wallet SQLCipher databases concurrently, while preserving sequential initialization for new or legacy databases.
- Speed up account selection by preloading the profile keypair and decrypting only the chat private key instead of the full extended key.
- Defer token manager startup until after login completes and run it asynchronously outside the critical startup path.
- Load cached leaderboard market data asynchronously, waiting only when the data is accessed or the service stops.

Before: about 2.15 s for the backend login request
After: about 0.47–0.50 s
Improvement: roughly 1.65–1.70 s saved
Relative reduction: about 77–78%
Speed multiplier: approximately 4.3–4.5× faster
