### PR TITLE
fix(chats): only increase the unviewed count when the chat is accessible

### DIFF
--- a/protocol/communities/community.go
+++ b/protocol/communities/community.go
@@ -106,6 +106,7 @@ type Community struct {
 type ReadonlyCommunity interface {
 	ID() types.HexBytes
 	IsControlNode() bool
+	CanView(pk *ecdsa.PublicKey, chatID string) bool
 	CanPost(pk *ecdsa.PublicKey, chatID string, messageType protobuf.ApplicationMetadataMessage_Type) (bool, error)
 	IsBanned(pk *ecdsa.PublicKey) bool
 }

--- a/protocol/communities_messenger_token_permissions_test.go
+++ b/protocol/communities_messenger_token_permissions_test.go
@@ -826,6 +826,10 @@ func (s *MessengerCommunitiesTokenPermissionsSuite) testViewChannelPermissions(v
 	s.Require().Len(response.Messages(), 1)
 	s.Require().Equal(msg.Text, response.Messages()[0].Text)
 
+	bobChat, ok := s.bob.allChats.Load(chat.ID)
+	s.Require().True(ok)
+	unreadBeforeRestrictedMessage := bobChat.UnviewedMessagesCount
+
 	waitOnBobToBeKickedFromChannel := waitOnCommunitiesEvent(s.owner, func(sub *communities.Subscription) bool {
 		channel, ok := sub.Community.Chats()[chat.CommunityChatID()]
 		return ok && len(channel.Members) == 0
@@ -892,6 +896,17 @@ func (s *MessengerCommunitiesTokenPermissionsSuite) testViewChannelPermissions(v
 	s.Require().True(community.ChannelHasPermissions(chat.CommunityChatID()))
 	s.Require().NoError(err)
 	s.Require().False(community.IsMemberLikelyInChat(chat.CommunityChatID()))
+
+	// Send a message while Bob cannot view the channel.
+	// Even if transport delivers it, unread count must not increase.
+	_ = s.sendChatMessage(s.owner, chat.ID, "message while bob cannot view channel")
+
+	_, err = s.bob.RetrieveAll()
+	s.Require().NoError(err)
+
+	bobChat, ok = s.bob.allChats.Load(chat.ID)
+	s.Require().True(ok)
+	s.Require().Equal(unreadBeforeRestrictedMessage, bobChat.UnviewedMessagesCount)
 
 	// make bob satisfy channel criteria
 	s.makeAddressSatisfyTheCriteria(testChainID1, bobAddress, channelPermissionRequest.TokenCriteria[0])

--- a/protocol/messenger_handler.go
+++ b/protocol/messenger_handler.go
@@ -2145,6 +2145,7 @@ func (m *Messenger) handleChatMessage(ctx context.Context, state *ReceivedMessag
 		return ErrMessageNotAllowed
 	}
 
+	var communityChatAccessible = true
 	if chat.ChatType == ChatTypeCommunityChat {
 		communityID, err := types3.DecodeHex(chat.CommunityID)
 		if err != nil {
@@ -2176,6 +2177,9 @@ func (m *Messenger) handleChatMessage(ctx context.Context, state *ReceivedMessag
 				zap.String("communityID", chat.CommunityID))
 			return errors.New("received a messaged from banned user")
 		}
+
+		communityChatID := chat.CommunityChatID()
+		communityChatAccessible = community.CanView(&m.identity.PublicKey, communityChatID)
 	}
 
 	// It looks like status-mobile created profile chats as public chats
@@ -2209,7 +2213,7 @@ func (m *Messenger) handleChatMessage(ctx context.Context, state *ReceivedMessag
 	// Our own message, mark as sent
 	if isSyncMessage {
 		receivedMessage.OutgoingStatus = common.OutgoingStatusSent
-	} else if !receivedMessage.Seen {
+	} else if !receivedMessage.Seen && communityChatAccessible {
 		// Increase unviewed count
 		skipUpdateUnviewedCountForAlbums := false
 		if receivedMessage.ContentType == protobuf.ChatMessage_IMAGE {


### PR DESCRIPTION
Fixes https://github.com/status-im/status-app/issues/21599
status-app PR: https://github.com/status-im/status-app/pull/21647

The problem was that we still process messages even in channels we do not have access to. This guard makes sure we do not increase the unviewed count if the channel cannot be read.
