### PR TITLE
fix(ci): use absolute path to bash and set GOPROXY to direct as fallback

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -96,6 +96,8 @@ else ifeq ($(detected_OS),Linux)
 endif
 export GOPATH ?= $(HOME)/go
 
+export GOPROXY ?= https://proxy.golang.org|direct
+
 GIT_ROOT ?= $(dir $(realpath $(lastword $(MAKEFILE_LIST))))
 GIT_COMMIT ?= $(shell git rev-parse --short HEAD)
 GIT_AUTHOR ?= $(shell git config user.email || echo $$USER)

--- a/_assets/ci/Jenkinsfile.desktop
+++ b/_assets/ci/Jenkinsfile.desktop
@@ -154,7 +154,8 @@ def make(target) {
   if (env.PLATFORM.startsWith('windows')) {
     bat """
       call "C:\\BuildTools\\VC\\Auxiliary\\Build\\vcvars64.bat"
-      bash -c "make ${target} make=/bin/sh MINGW_PATH=C:/ProgramData/scoop/apps/msys2/current/mingw64"
+      REM Absolute path, because system32 precedes Git in PATH and also has a bash.exe once WSL is enabled.
+      "C:\\ProgramData\\scoop\\apps\\git\\current\\bin\\bash.exe" -c "make ${target} make=/bin/sh MINGW_PATH=C:/ProgramData/scoop/apps/msys2/current/mingw64"
     """
   } else { /* Use Nix for Linux/macOS. */
     nix.develop("make ${target}", pure: false)


### PR DESCRIPTION
Otherwise CI jobs may fail like this :
```
[2026-07-27T08:27:40.261Z] J:\Users\jenkins\workspace\_prs_windows_x86_64_main_PR-7652>call
"C:\BuildTools\VC\Auxiliary\Build\vcvars64.bat"
[2026-07-27T08:27:40.262Z]
**********************************************************************
[2026-07-27T08:27:40.262Z] ** Visual Studio 2022 Developer Command Prompt v17.14.31
[2026-07-27T08:27:40.262Z] ** Copyright (c) 2025 Microsoft Corporation
[2026-07-27T08:27:40.262Z]
**********************************************************************
[2026-07-27T08:27:41.547Z] [vcvarsall.bat] Environment initialized for: 'x64'
[2026-07-27T08:27:41.547Z] Windows Subsystem for Linux has no installed distributions.
[2026-07-27T08:27:41.547Z]
[2026-07-27T08:27:41.547Z] You can resolve this by installing a distribution with the instructions below:
[2026-07-27T08:27:41.547Z]
[2026-07-27T08:27:41.547Z]
[2026-07-27T08:27:41.547Z]
[2026-07-27T08:27:41.547Z] Use 'wsl.exe --list --online' to list available distributions
[2026-07-27T08:27:41.547Z]
[2026-07-27T08:27:41.547Z] and 'wsl.exe --install <Distro>' to install.
[2026-07-27T08:27:41.547Z]
[2026-07-27T08:27:41.640Z] script returned exit code 1
```

`GOPROXY` fallback helps when we get timeouts from go proxy like this : 

```
[2026-07-30T10:12:14.541Z] go: downloading golang.org/x/mod v0.29.0

[2026-07-30T10:13:25.561Z] golang.org/x/mod/semver: ../o_prs_macos_aarch64_main_PR-7659@tmp/go/pkg/mod/golang.org/x/tools@v0.38.0/internal/gocommand/vendor.go:17:2: golang.org/x/mod@v0.29.0: read "https://proxy.golang.org/golang.org/x/mod/@v/v0.29.0.zip": stream error: stream ID 65; INTERNAL_ERROR; received from peer

[2026-07-30T10:13:25.561Z] golang.org/x/mod/module: ../o_prs_macos_aarch64_main_PR-7659@tmp/go/pkg/mod/golang.org/x/tools@v0.38.0/internal/imports/mod.go:21:2: golang.org/x/mod@v0.29.0: read "https://proxy.golang.org/golang.org/x/mod/@v/v0.29.0.zip": stream error: stream ID 65; INTERNAL_ERROR; received from peer

[2026-07-30T10:13:25.561Z] make: *** [Makefile:515: generate] Error 1

script returned exit code 2
```