### PR TITLE
fix(makefile): enforce git switch to not recurse submodules

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -189,7 +189,7 @@ ifeq ($(LOGOS_STORAGE_BUILD_FROM_SOURCE),true)
 		cd "$(LOGOS_STORAGE_SOURCE_DIR)" && git fetch --tags; \
 	fi
 	cd "$(LOGOS_STORAGE_SOURCE_DIR)" && \
-		git switch --force --detach "$(LOGOS_STORAGE_VERSION)" && \
+		git switch --no-recurse-submodules --force --detach "$(LOGOS_STORAGE_VERSION)" && \
 		git clean -fdx && \
 		git submodule update --init --recursive --force
 endif
@@ -338,7 +338,7 @@ ifeq ($(NIM_SDS_BUILD_FROM_SOURCE),true)
 		cd "$(NIM_SDS_SOURCE_DIR)" && git fetch --tags; \
 	fi
 	cd "$(NIM_SDS_SOURCE_DIR)" && \
-		git switch --force --detach "$(NIM_SDS_VERSION)" && \
+		git switch --no-recurse-submodules --force --detach "$(NIM_SDS_VERSION)" && \
 		git clean -fdx && \
 		git submodule update --init --recursive --force
 endif


### PR DESCRIPTION
Otherwise `submodule.recurse=true` breaks it.

```
❯ git config list | grep submodule.recurse
submodule.recurse=true

❯ NIM_SDS_SOURCE_DIR="/Users/status/work/status-app/vendor/nim-sds" make build-libsds --trace
Makefile:332: update target 'clone-nim-sds' due to: target is .PHONY
...
Cloning or updating nim-sds ...
if [ ! -d "/Users/status/work/status-app/vendor/nim-sds" ]; then \
	git clone --recurse-submodules https://github.com/waku-org/nim-sds.git "/Users/status/work/status-app/vendor/nim-sds"; \
else \
	cd "/Users/status/work/status-app/vendor/nim-sds" && git fetch --tags; \
fi
Cloning into '/Users/status/work/status-app/vendor/nim-sds'...
...
cd "/Users/status/work/status-app/vendor/nim-sds" && \
	git switch --force --detach "v0.3.3" && \
	git clean -fdx && \
	git submodule update --init --recursive --force
fatal: not a git repository: ../../.git/modules/vendor/nim-chronicles
fatal: could not reset submodule index
make: *** [Makefile:334: clone-nim-sds] Error 128
```

Failed while testing https://github.com/status-im/status-app/pull/20019
