### PR TITLE
chore: guards added to some key pair related functions

### DIFF
--- a/internal/accounts-management/manager_test.go
+++ b/internal/accounts-management/manager_test.go
@@ -619,6 +619,62 @@ func (s *ManagerTestSuite) TestDeleteKeypair() {
 	s.Equal(0, len(files))
 }
 
+// Regression: CreateKeypairFromMnemonicAndStore documents that accounts are
+// stored to the keystore only when the keypair is not a cold wallet / keycard,
+// but the implementation always calls storeKeystoreFilesForAccounts.
+func (s *ManagerTestSuite) TestCreateKeypairFromMnemonicAndStoreDoesNotWriteKeystoreWhenCold() {
+	s.persistence.EXPECT().GetKeypairByKeyUID(s.masterAccount.KeyUID()).Return(
+		nil, types.ErrDbKeypairNotFound,
+	).Times(1)
+
+	s.persistence.EXPECT().GetPositionForNextNewAccount().Return(int64(0), nil).Times(1)
+
+	s.persistence.EXPECT().SaveOrUpdateKeypair(gomock.Any()).DoAndReturn(
+		func(kp *types.Keypair) error {
+			s.Require().Equal(types.ColdWalletTypeStatusKeycard, kp.ColdWallet)
+			return nil
+		},
+	).Times(1)
+
+	s.persistence.EXPECT().GetProfileKeypair().Return(
+		&types.Keypair{
+			KeyUID: s.masterAccount.KeyUID(),
+		},
+		nil,
+	).Times(1)
+
+	walletAccount := &types.AccountCreationDetails{
+		Path: common.PathDefaultWalletAccount,
+	}
+
+	keypair, err := s.accManager.CreateKeypairFromMnemonicAndStore(
+		s.mnemonic, s.password, "kp-name", types.ColdWalletTypeStatusKeycard, walletAccount, true, 0)
+	s.Require().NoError(err)
+	s.Require().NotNil(keypair)
+	s.Require().Equal(types.ColdWalletTypeStatusKeycard, keypair.ColdWallet)
+
+	files, err := os.ReadDir(s.getKeyDir())
+	s.Require().NoError(err)
+	s.Require().Empty(files, "cold wallet keypair must not persist private keys in the local keystore")
+}
+
+// Regression: MigrateKeypairToColdWallet must refuse an empty password instead of
+// silently flipping cold_wallet while leaving keystore files on disk.
+func (s *ManagerTestSuite) TestMigrateKeypairToColdWalletRequiresPassword() {
+	keypair := s.createAndStoreProfileKeypair()
+	keypair.Type = types.KeypairTypeSeed
+
+	s.persistence.EXPECT().GetKeypairByKeyUID(keypair.KeyUID).Return(keypair, nil).Times(1)
+
+	err := s.accManager.MigrateKeypairToColdWallet(keypair.KeyUID, "", types.ColdWalletTypeStatusKeycard, 1)
+	s.Require().Error(err)
+	s.Require().ErrorIs(err, ErrNoPasswordProvided)
+
+	files, err := os.ReadDir(s.getKeyDir())
+	s.Require().NoError(err)
+	s.Require().Len(files, 3, "keystore files must remain until a password-backed wipe runs")
+}
+
 func (s *ManagerTestSuite) TestCleanKeystoreFiles() {
 	testCases := []struct {
 		name                     string

--- a/internal/accounts-management/persistence_operations.go
+++ b/internal/accounts-management/persistence_operations.go
@@ -93,10 +93,12 @@ func (m *AccountsManager) CreateKeypairFromMnemonicAndStore(mnemonic string, pas
 		return
 	}
 
-	// store accounts to keystore
-	err = m.storeKeystoreFilesForAccounts(masterAccount, derivedAccounts, password)
-	if err != nil {
-		return
+	// store accounts to keystore, unless the keypair lives on a cold wallet device
+	if coldWallet == types.ColdWalletTypeNone {
+		err = m.storeKeystoreFilesForAccounts(masterAccount, derivedAccounts, password)
+		if err != nil {
+			return
+		}
 	}
 
 	// set the chat account if it's a profile keypair
@@ -547,7 +549,11 @@ func (m *AccountsManager) MigrateKeypairToColdWallet(keyUID string, password str
 		return err
 	}
 
-	if !kpDb.MigratedToColdWallet() && password != "" {
+	if !kpDb.MigratedToColdWallet() {
+		if password == "" {
+			return ErrNoPasswordProvided
+		}
+
 		err = m.deleteKeystoreFilesForKeypairInternally(kpDb, password)
 		if err != nil {
 			return err

--- a/protocol/messenger_handler.go
+++ b/protocol/messenger_handler.go
@@ -3273,6 +3273,10 @@ func (m *Messenger) handleSyncKeypair(message *protobuf.SyncKeypair, fromLocalPa
 			oldAddresses[acc.Address] = !acc.Removed
 		}
 
+		if message.Xpub == "" {
+			kp.XPub = dbKeypair.XPub
+		}
+
 		// Keep this device's signing method (auto-apply disabled, or a profile conversion
 		// flow is pending): preserve the local cold wallet state instead of adopting the
 		// wire value; all other fields still apply. For keypairs unknown locally there is

--- a/protocol/messenger_sync_keypairs_auto_apply_test.go
+++ b/protocol/messenger_sync_keypairs_auto_apply_test.go
@@ -258,3 +258,30 @@ func (s *MessengerSyncKeypairsAutoApplySuite) TestProfileMigrationNeededNotSetWh
 		s.Require().Equal(accsmanagementtypes.AccountFullyOperable, acc.Operable)
 	}
 }
+
+// Regression: SaveOrUpdateKeypair writes xpub unconditionally, so an empty wire
+// xpub must not wipe a previously stored wallet xpub. UpdateKeypairXPub already
+// treats empty xpub as "leave unchanged"; the sync path should match.
+func (s *MessengerSyncKeypairsAutoApplySuite) TestEmptyWireXPubDoesNotWipeStoredXPub() {
+	const storedXPub = "xpub6BugbotRegressionWalletXPubDoNotWipeOnEmptySyncMessage"
+
+	kp, _, _, err := accounts.GetSeedImportedKeypair1ForTest()
+	s.Require().NoError(err)
+	kp.Clock = 1
+	kp.XPub = storedXPub
+	kp.ColdWallet = accsmanagementtypes.ColdWalletTypeStatusKeycard
+	for _, acc := range kp.Accounts {
+		acc.Operable = accsmanagementtypes.AccountFullyOperable
+	}
+	s.Require().NoError(s.m.settings.SaveOrUpdateKeypair(kp))
+
+	message := s.syncMessageFor(kp, 2, "Renamed On Paired Device", accsmanagementtypes.ColdWalletTypeStatusKeycard)
+	message.Xpub = ""
+
+	s.handleSync(message, false)
+
+	dbKp := s.dbKeypair(kp.KeyUID)
+	s.Require().Equal("Renamed On Paired Device", dbKp.Name)
+	s.Require().Equal(accsmanagementtypes.ColdWalletTypeStatusKeycard, dbKp.ColdWallet)
+	s.Require().Equal(storedXPub, dbKp.XPub, "empty SyncKeypair.xpub must leave the stored wallet xpub unchanged")
+}


### PR DESCRIPTION
Affected functions:
- `handleSyncKeypair`,
- `MigrateKeypairToColdWallet`
- `CreateKeypairFromMnemonicAndStore`