### PR TITLE
fix(server): rebind in Start() when the listener died silently

### DIFF
--- a/server/lifecycle_test.go
+++ b/server/lifecycle_test.go
@@ -129,3 +129,33 @@ func TestServerToBackgroundReturnsPromptlyAndStopsAcceptingConnections(t *testin
 		t.Fatal("timed out waiting for blocked request to finish")
 	}
 }
+
+// Simulates the iOS suspension failure: the OS kills the listening socket
+// without the accept loop returning (running stays true), so a later Start()
+// must detect the dead listener and rebind instead of early-returning.
+func TestStartRebindsWhenListenerDiesSilently(t *testing.T) {
+	s := NewServer(zap.NewNop(), &Config{
+		AddrPort: netip.MustParseAddrPort("127.0.0.1:0"),
+	})
+
+	require.NoError(t, s.Start())
+	require.Eventually(t, func() bool {
+		return s.GetPort() != 0 && s.listenerAlive()
+	}, time.Second, 10*time.Millisecond)
+	firstPort := s.GetPort()
+
+	// Kill the listener out from under the server; Serve returns an error and
+	// the serve goroutine exits, but on iOS running can remain true — force
+	// that state to model it.
+	require.NoError(t, s.listener.Close())
+	s.serveWg.Wait()
+	s.running.Store(true)
+	require.False(t, s.listenerAlive())
+
+	require.NoError(t, s.Start())
+	require.Eventually(t, func() bool {
+		return s.IsRunning() && s.listenerAlive()
+	}, time.Second, 10*time.Millisecond)
+	require.Equal(t, firstPort, s.GetPort())
+	require.NoError(t, s.Stop())
+}

--- a/server/server.go
+++ b/server/server.go
@@ -246,12 +246,39 @@ func (s *Server) applyHandlers() {
 	s.server.Handler = mux
 }
 
+// listenerAlive verifies the bound listener actually accepts connections.
+// On iOS a process suspension can kill the listening socket without the accept
+// loop ever returning an error, leaving `running` true while every client
+// connect is refused (observed when the app is suspended on the login screen,
+// before the pausable-services bridge has anything to drive).
+func (s *Server) listenerAlive() bool {
+	addr := s.GetListeningAddrPort()
+	if addr == "" {
+		return false
+	}
+	conn, err := net.DialTimeout("tcp", addr, time.Second)
+	if err != nil {
+		return false
+	}
+	_ = conn.Close()
+	return true
+}
+
 func (s *Server) Start() error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
 	if s.running.Load() {
-		return nil
+		if s.listenerAlive() {
+			return nil
+		}
+		s.logger.Warn("server marked running but listener is dead; rebinding")
+		currentServer := s.server
+		s.running.Store(false)
+		s.mu.Unlock()
+		_ = currentServer.Close()
+		s.serveWg.Wait()
+		s.mu.Lock()
 	}
 
 	// Once Shutdown has been called on a server, it may not be reused;

--- a/server/server.go
+++ b/server/server.go
@@ -74,6 +74,12 @@ type Server struct {
 	// when rebinding the same cached ephemeral port).
 	serveWg sync.WaitGroup
 
+	// serveDone is closed when the current serve goroutine has fully exited.
+	// The dead-listener rebind path waits on the instance it captured — never
+	// on serveWg, which a concurrent Start could grow while the mutex is
+	// released, making the wait block on an unrelated healthy server.
+	serveDone chan struct{}
+
 	*timeoutManager
 }
 
@@ -251,6 +257,11 @@ func (s *Server) applyHandlers() {
 // loop ever returning an error, leaving `running` true while every client
 // connect is refused (observed when the app is suspended on the login screen,
 // before the pausable-services bridge has anything to drive).
+//
+// A raw TCP dial is sufficient and safe with a TLS listener: crypto/tls only
+// handshakes on the first read/write of an accepted conn, and net/http runs
+// that in a per-connection goroutine — an immediate close surfaces (at most) a
+// per-conn handshake error, never an Accept error, so Serve keeps running.
 func (s *Server) listenerAlive() bool {
 	addr := s.GetListeningAddrPort()
 	if addr == "" {
@@ -274,11 +285,22 @@ func (s *Server) Start() error {
 		}
 		s.logger.Warn("server marked running but listener is dead; rebinding")
 		currentServer := s.server
+		done := s.serveDone
 		s.running.Store(false)
-		s.mu.Unlock()
 		_ = currentServer.Close()
-		s.serveWg.Wait()
+		// The serve goroutine's deferred cleanup takes s.mu — release it while
+		// waiting, and wait only on the captured instance, never on serveWg
+		// (a concurrent Start could grow it with a healthy new server).
+		s.mu.Unlock()
+		if done != nil {
+			<-done
+		}
 		s.mu.Lock()
+		// Re-validate after the unlocked window: a concurrent Start may have
+		// already rebound — in that case this call's work is done.
+		if s.running.Load() {
+			return nil
+		}
 	}
 
 	// Once Shutdown has been called on a server, it may not be reused;
@@ -293,9 +315,12 @@ func (s *Server) Start() error {
 	// Mark running synchronously to avoid pause/play races where ToBackground
 	// can run before serve() goroutine has a chance to set the state.
 	s.running.Store(true)
+	done := make(chan struct{})
+	s.serveDone = done
 	s.serveWg.Add(1)
 	go func() {
 		defer common.LogOnPanic()
+		defer close(done)
 		defer s.serveWg.Done()
 		s.serve(s.server, s.listener)
 	}()


### PR DESCRIPTION
## Problem

On iOS, a process suspension can kill the media server's listening socket without the Go accept loop ever returning an error — `Server.running` stays `true` while every client connect is refused.

The damaging case is a suspension **before login** (phone locked on the login screen, or the app cold-started in the background): the pausable-services lifecycle has nothing registered to drive yet, so nothing calls `ToForeground()`, and the login-time `MediaServer.Start()` early-returns on the stale `running` flag. Result: every `https://localhost:<port>/` media URL (avatars, chat images, community logos) is dead for the entire session. Reproduced and validated on an iPhone 15 Pro Max.

## Fix

`Server.Start()` now verifies that a listener it believes is running actually accepts connections (1s self-dial to the bound address). If the listener is dead, it force-closes the old `http.Server`, waits for the serve goroutine, and proceeds with a normal bind — reusing the cached ephemeral port, so existing URLs stay valid. After the rebind the `mediaserver.started` signal fires again, driving the client-side URL refresh for the (rare) port-change case.

## Testing

- New unit test `TestStartRebindsWhenListenerDiesSilently` simulates the OS-killed listener (close the listener out from under the server, force `running=true`) and asserts `Start()` detects it and rebinds on the same port.
- Full `./server` package passes.
- Device-validated on iOS: launch → lock before login → unlock → login now logs `server marked running but listener is dead; rebinding` and images load; without this change the session's media URLs stay dead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)