### PR TITLE
feat: derive accounts from the extended public key without password

### DIFF
--- a/internal/accounts-management/README.md
+++ b/internal/accounts-management/README.md
@@ -362,7 +362,6 @@ type Persistence interface {
     AddressExists(address cryptotypes.Address) (bool, error)
     GetProfileKeypair() (*types.Keypair, error)
     GetWalletRootAddress() (cryptotypes.Address, error)
-    GetPath(address cryptotypes.Address) (string, error)
     GetKeypairByKeyUID(keyUID string) (*types.Keypair, error)
     GetActiveKeypairs() ([]*types.Keypair, error)
     GetAllKeypairs() ([]*types.Keypair, error)

--- a/internal/accounts-management/errors.go
+++ b/internal/accounts-management/errors.go
@@ -39,6 +39,8 @@ const (
 	ErrCodeWrongPasswordProvided
 	ErrCodeCannotRemoveProfileKeypair
 	ErrCodeNoPasswordProvided
+	ErrCodeNoPasswordProvidedAndNoXPubStored
+	ErrCodeCannotDeriveAccountFromXPub
 )
 
 var (
@@ -66,6 +68,8 @@ var (
 	ErrKeypairIsNotColdWallet                          = errors.NewError(ErrCodeKeypairIsNotColdWallet, "keypair is not a cold wallet keypair", getErrorCategory)
 	ErrCannotRemoveProfileKeypair                      = errors.NewError(ErrCodeCannotRemoveProfileKeypair, "cannot remove profile keypair", getErrorCategory)
 	ErrNoPasswordProvided                              = errors.NewError(ErrCodeNoPasswordProvided, "no password provided", getErrorCategory)
+	ErrNoPasswordProvidedAndNoXPubStored               = errors.NewError(ErrCodeNoPasswordProvidedAndNoXPubStored, "no password provided and no extended public key stored for the keypair", getErrorCategory)
+	ErrCannotDeriveAccountFromXPub                     = errors.NewError(ErrCodeCannotDeriveAccountFromXPub, "account path cannot be derived from the keypair's extended public key", getErrorCategory)
 )
 
 func ErrKeystoreDirectoryError(err error) *errors.AccountsError {
@@ -88,7 +92,7 @@ func getErrorCategory(code errors.ErrorCode) errors.ErrorCategory {
 		ErrCodeKeypairAlreadyAdded, ErrCodeAccountAlreadyAdded, ErrCodeChatAccountNotFoundInDerivedAccounts,
 		ErrCodeKeypairMustHaveAtLeastOneWalletAccount, ErrCodeCannotAddAccountsToKeypairImportedViaPrivateKey,
 		ErrCodeCannotMigrateProfileKeypair, ErrCodeKeypairIsNotColdWallet, ErrCodeWrongPasswordProvided,
-		ErrCodeNoPasswordProvided:
+		ErrCodeNoPasswordProvided, ErrCodeNoPasswordProvidedAndNoXPubStored, ErrCodeCannotDeriveAccountFromXPub:
 		return ErrorCategoryValidation
 	case ErrCodeCannotAddDefaultWalletAccount, ErrCodeCannotAddDefaultChatAccount, ErrCodeCannotRemoveDefaultWalletAccount,
 		ErrCodeCannotRemoveDefaultChatAccount, ErrCodeCannotRemoveProfileKeypair:

--- a/internal/accounts-management/interface_persistence.go
+++ b/internal/accounts-management/interface_persistence.go
@@ -14,8 +14,6 @@ type Persistence interface {
 	GetProfileKeypair() (*types.Keypair, error)
 	// GetWalletRootAddress returns the root address of the wallet
 	GetWalletRootAddress() (cryptotypes.Address, error)
-	// GetPath returns the derivation path of the address
-	GetPath(address cryptotypes.Address) (string, error)
 	// GetKeypairByKeyUID returns a keypair by its keyUID
 	GetKeypairByKeyUID(keyUID string) (*types.Keypair, error)
 	// GetActiveKeypairs returns all active keypairs

--- a/internal/accounts-management/keystore_operations.go
+++ b/internal/accounts-management/keystore_operations.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
-	"strings"
 
 	"go.uber.org/zap"
 
@@ -325,23 +324,17 @@ func (m *AccountsManager) generatePartialAccountKey(address cryptotypes.Address,
 		return nil, ErrPersistenceMissing
 	}
 
-	rootAddress, err := m.persistence.GetWalletRootAddress()
-	if err != nil {
-		return nil, err
-	}
-
 	acc, err := m.persistence.GetAccountByAddress(address)
 	if err != nil {
 		return nil, err
 	}
 
-	dbPath, err := m.persistence.GetPath(acc.Address)
+	kp, err := m.persistence.GetKeypairByKeyUID(acc.KeyUID)
 	if err != nil {
 		return nil, err
 	}
-	path := "m/" + dbPath[strings.LastIndex(dbPath, "/")+1:]
 
-	return m.deriveChildAccountForPathAndStore(rootAddress, path, password)
+	return m.deriveChildAccountForPathAndStore(cryptotypes.HexToAddress(kp.DerivedFrom), acc.Path, password)
 }
 
 func (m *AccountsManager) deriveChildAccountForPath(deriveFrom cryptotypes.Address, path string, password string) (*generator.Account, error) {

--- a/internal/accounts-management/keystore_operations.go
+++ b/internal/accounts-management/keystore_operations.go
@@ -164,16 +164,16 @@ func (m *AccountsManager) deleteKeystoreFileForAccountInternally(address cryptot
 	}
 
 	if acc.Type != types.AccountTypeWatch {
-		if password == "" {
-			return ErrNoPasswordProvided
-		}
-
 		kp, err := m.persistence.GetKeypairByKeyUID(acc.KeyUID)
 		if err != nil {
 			return err
 		}
 
 		if !kp.MigratedToColdWallet() {
+			if password == "" {
+				return ErrNoPasswordProvided
+			}
+
 			err = m.deleteAccountFromKeystoreIfExists(address, password)
 			if err != nil {
 				return err
@@ -198,16 +198,16 @@ func (m *AccountsManager) deleteKeystoreFileForAccountInternally(address cryptot
 // if the keypair is already migrated to keycard, it does nothing
 // trying to delete a non-existent keystore file does not result in an error
 func (m *AccountsManager) deleteKeystoreFilesForKeypairInternally(keypair *types.Keypair, password string) (err error) {
-	if password == "" {
-		return ErrNoPasswordProvided
-	}
-
 	if keypair == nil {
 		return ErrKeypairIsNil
 	}
 
 	if keypair.MigratedToColdWallet() {
 		return nil
+	}
+
+	if password == "" {
+		return ErrNoPasswordProvided
 	}
 
 	if m.persistence == nil {

--- a/internal/accounts-management/manager.go
+++ b/internal/accounts-management/manager.go
@@ -199,9 +199,8 @@ func (m *AccountsManager) Accounts() ([]cryptotypes.Address, error) {
 	return addresses, nil
 }
 
-// GetVerifiedWalletAccount gets a verified wallet account by address and password
-// If the account is not found, it tries to generate the account if there is an account this account can be derived from
-// TODO: need to check it that's needed at all, cause `generatePartialAccountKey` was used for the old mobile app - maybe we should remove it
+// GetVerifiedWalletAccount gets a verified wallet account by address and password.
+// If the account has no its own keystore file (partially operable account), then its key is derived from the master keystore file and stored.
 func (m *AccountsManager) GetVerifiedWalletAccount(address cryptotypes.Address, password string) (*generator.Account, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()

--- a/internal/accounts-management/manager_test.go
+++ b/internal/accounts-management/manager_test.go
@@ -619,6 +619,54 @@ func (s *ManagerTestSuite) TestDeleteKeypair() {
 	s.Equal(0, len(files))
 }
 
+func (s *ManagerTestSuite) TestDeleteAccountOfColdWalletKeypairWithoutPassword() {
+	acc := s.deriveTestAccountAtPath(common.PathDefaultWalletAccount)
+	keypair := &types.Keypair{
+		KeyUID:     s.masterAccount.KeyUID(),
+		Type:       types.KeypairTypeSeed,
+		ColdWallet: types.ColdWalletTypeStatusKeycard,
+		Accounts:   []*types.Account{acc},
+	}
+
+	s.persistence.EXPECT().GetAccountByAddress(acc.Address).Return(acc, nil).Times(2)
+	s.persistence.EXPECT().GetKeypairByKeyUID(acc.KeyUID).Return(keypair, nil).Times(1)
+	s.persistence.EXPECT().RemoveAccount(acc.Address, uint64(0)).Return(nil).Times(1)
+
+	deletedAcc, err := s.accManager.DeleteAccount(acc.Address, "", 0)
+	s.Require().NoError(err)
+	s.Require().NotNil(deletedAcc)
+	s.Require().Equal(acc.Address, deletedAcc.Address)
+}
+
+func (s *ManagerTestSuite) TestDeleteColdWalletKeypairWithoutPassword() {
+	keypair := &types.Keypair{
+		KeyUID:     s.masterAccount.KeyUID(),
+		Type:       types.KeypairTypeSeed,
+		ColdWallet: types.ColdWalletTypeStatusKeycard,
+	}
+
+	s.persistence.EXPECT().GetKeypairByKeyUID(keypair.KeyUID).Return(keypair, nil).Times(1)
+	s.persistence.EXPECT().RemoveKeypair(keypair.KeyUID, uint64(0)).Return(nil).Times(1)
+
+	deletedKp, err := s.accManager.DeleteKeypair(keypair.KeyUID, "", 0)
+	s.Require().NoError(err)
+	s.Require().NotNil(deletedKp)
+	s.Require().Equal(keypair.KeyUID, deletedKp.KeyUID)
+}
+
+func (s *ManagerTestSuite) TestDeleteRegularKeypairWithoutPasswordRejected() {
+	keypair := &types.Keypair{
+		KeyUID: s.masterAccount.KeyUID(),
+		Type:   types.KeypairTypeSeed,
+	}
+
+	s.persistence.EXPECT().GetKeypairByKeyUID(keypair.KeyUID).Return(keypair, nil).Times(1)
+
+	_, err := s.accManager.DeleteKeypair(keypair.KeyUID, "", 0)
+	s.Require().Error(err)
+	s.Require().True(errors.Is(err, ErrNoPasswordProvided))
+}
+
 // Regression: CreateKeypairFromMnemonicAndStore documents that accounts are
 // stored to the keystore only when the keypair is not a cold wallet / keycard,
 // but the implementation always calls storeKeystoreFilesForAccounts.

--- a/internal/accounts-management/persistence_operations.go
+++ b/internal/accounts-management/persistence_operations.go
@@ -730,11 +730,9 @@ func (m *AccountsManager) DeleteAccount(address types2.Address, password string,
 	return
 }
 
+// DeleteKeypair removes a keypair and its keystore files. The password is required unless the
+// keypair is migrated to a cold wallet (no keystore files exist for it).
 func (m *AccountsManager) DeleteKeypair(keyUID string, password string, clock uint64) (keypair *types.Keypair, err error) {
-	if password == "" {
-		return nil, ErrNoPasswordProvided
-	}
-
 	m.mu.Lock()
 	defer m.mu.Unlock()
 

--- a/internal/accounts-management/persistence_operations.go
+++ b/internal/accounts-management/persistence_operations.go
@@ -1,10 +1,16 @@
 package accountsmanagement
 
 import (
+	goerrors "errors"
+	"fmt"
 	"strings"
 
+	"go.uber.org/zap"
+
 	"github.com/status-im/status-go/internal/accounts-management/common"
+	accsmanagementerrors "github.com/status-im/status-go/internal/accounts-management/errors"
 	generator "github.com/status-im/status-go/internal/accounts-management/generator"
+	"github.com/status-im/status-go/internal/accounts-management/keystore"
 	"github.com/status-im/status-go/internal/accounts-management/types"
 	types2 "github.com/status-im/status-go/internal/crypto/types"
 	multiaccscommon "github.com/status-im/status-go/internal/db/multiaccounts/common"
@@ -413,6 +419,96 @@ func (m *AccountsManager) MakePartiallyOperableAccoutsFullyOperable(password str
 	return
 }
 
+// validateAccountAgainstKeypairXPub checks that the account's address matches the address derived from the keypair's xpub
+func validateAccountAgainstKeypairXPub(kp *types.Keypair, acc *types.Account) error {
+	prefix := common.PathWalletXPub + "/"
+	if !strings.HasPrefix(acc.Path, prefix) {
+		return ErrCannotDeriveAccountFromXPub.WithContext("path", acc.Path)
+	}
+	relativePath := strings.TrimPrefix(acc.Path, prefix)
+	if strings.Contains(relativePath, "'") {
+		return ErrCannotDeriveAccountFromXPub.WithContext("path", acc.Path)
+	}
+
+	derived, err := generator.DeriveAccountsPublicInfoFromExtendedPublicKeyForPaths(kp.XPub, []string{relativePath})
+	if err != nil {
+		return err
+	}
+	info, ok := derived[relativePath]
+	if !ok {
+		return ErrCannotDeriveAccountFromXPub.WithContext("path", acc.Path)
+	}
+	if types2.HexToAddress(info.Address) != acc.Address {
+		return ErrAccountMismatch.
+			WithContext("address", acc.Address.Hex()).
+			WithContext("derived address", info.Address)
+	}
+	return nil
+}
+
+// deriveKeypairXPubInternally derives the xpub for the passed master address using the provided password. Caller must hold m.mu.
+func (m *AccountsManager) deriveKeypairXPubInternally(deriveFrom types2.Address, password string) (string, error) {
+	childAccount, err := m.deriveChildAccountForPath(deriveFrom, common.PathWalletXPub, password)
+	if err != nil {
+		return "", err
+	}
+	xpub := childAccount.ExtendedPublicKey()
+	if xpub == "" {
+		return "", ErrCannotDeriveAccountFromXPub.WithContext("path", common.PathWalletXPub)
+	}
+	return xpub, nil
+}
+
+// backfillKeypairXPubInternally stores the keypair's xpub if it's missing, deriving it from the master keystore file
+// using the provided password. Caller must hold m.mu.
+func (m *AccountsManager) backfillKeypairXPubInternally(kp *types.Keypair, password string) error {
+	if kp.XPub != "" || kp.MigratedToColdWallet() || kp.Type == types.KeypairTypeKey || password == "" {
+		return nil
+	}
+	xpub, err := m.deriveKeypairXPubInternally(types2.HexToAddress(kp.DerivedFrom), password)
+	if err != nil {
+		var accountsErr *accsmanagementerrors.AccountsError
+		if goerrors.As(err, &accountsErr) &&
+			(accountsErr.Is(keystore.ErrKeystoreFileMissing) || accountsErr.Is(keystore.ErrIncorrectPasswordProvided)) {
+			m.logger.Info("skipping keypair xpub backfill, master keystore file not usable on this device",
+				zap.String("keyUID", kp.KeyUID), zap.Error(err))
+			return nil
+		}
+		return err
+	}
+	err = m.persistence.UpdateKeypairXPub(kp.KeyUID, xpub, kp.ColdWallet, kp.Clock)
+	if err != nil {
+		return err
+	}
+	kp.XPub = xpub
+	m.logger.Info("backfilled keypair xpub", zap.String("keyUID", kp.KeyUID))
+	return nil
+}
+
+func (m *AccountsManager) BackfillKeypairsXPub(password string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if m.persistence == nil {
+		return ErrPersistenceMissing
+	}
+
+	keypairs, err := m.persistence.GetActiveKeypairs()
+	if err != nil {
+		return err
+	}
+
+	var errs []error
+	for _, kp := range keypairs {
+		err = m.backfillKeypairXPubInternally(kp, password)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("keypair %s: %w", kp.KeyUID, err))
+		}
+	}
+
+	return goerrors.Join(errs...)
+}
+
 func (m *AccountsManager) AddAccounts(keyUID string, accounts []*types.Account, password string) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -430,29 +526,33 @@ func (m *AccountsManager) AddAccounts(keyUID string, accounts []*types.Account, 
 		return ErrCannotAddAccountsToKeypairImportedViaPrivateKey
 	}
 
-	if !kp.MigratedToColdWallet() {
+	for _, acc := range accounts {
+		if acc.KeyUID != keyUID {
+			return ErrAccountMismatch.
+				WithContext("keyuid", acc.KeyUID).
+				WithContext("expected keyuid", keyUID)
+		}
+
+		if kp.Type == types.KeypairTypeProfile {
+			if acc.Chat {
+				return ErrCannotAddDefaultChatAccount
+			}
+			if acc.Wallet {
+				return ErrCannotAddDefaultWalletAccount
+			}
+		}
+
+		for _, kpAcc := range kp.Accounts {
+			if acc.Address == kpAcc.Address {
+				return ErrAccountAlreadyAdded
+			}
+		}
+	}
+
+	deriveFromKeystore := password != "" && !kp.MigratedToColdWallet()
+
+	if deriveFromKeystore {
 		for _, acc := range accounts {
-			if acc.KeyUID != keyUID {
-				return ErrAccountMismatch.
-					WithContext("keyuid", acc.KeyUID).
-					WithContext("expected keyuid", keyUID)
-			}
-
-			if kp.Type == types.KeypairTypeProfile {
-				if acc.Chat {
-					return ErrCannotAddDefaultChatAccount
-				}
-				if acc.Wallet {
-					return ErrCannotAddDefaultWalletAccount
-				}
-			}
-
-			for _, kpAcc := range kp.Accounts {
-				if acc.Address == kpAcc.Address {
-					return ErrAccountAlreadyAdded
-				}
-			}
-
 			childAccount, err := m.deriveChildAccountForPath(types2.HexToAddress(kp.DerivedFrom), acc.Path, password)
 			if err != nil {
 				return err
@@ -464,6 +564,25 @@ func (m *AccountsManager) AddAccounts(keyUID string, accounts []*types.Account, 
 					WithContext("derived address", childAccount.Address().Hex())
 			}
 		}
+	} else {
+		if kp.XPub == "" && !kp.MigratedToColdWallet() {
+			return ErrNoPasswordProvidedAndNoXPubStored.WithContext("keyuid", keyUID)
+		}
+		// Cold-wallet keypairs migrated before the xpub was tracked have no xpub stored, in that
+		// case there is nothing the address can be validated against (matches previous behaviour).
+		if kp.XPub != "" {
+			for _, acc := range accounts {
+				err = validateAccountAgainstKeypairXPub(kp, acc)
+				if err != nil {
+					return err
+				}
+			}
+		}
+		if !kp.MigratedToColdWallet() {
+			for _, acc := range accounts {
+				acc.Operable = types.AccountPartiallyOperable
+			}
+		}
 	}
 
 	err = m.persistence.SaveOrUpdateAccounts(accounts, true)
@@ -471,12 +590,18 @@ func (m *AccountsManager) AddAccounts(keyUID string, accounts []*types.Account, 
 		return err
 	}
 
-	if !kp.MigratedToColdWallet() {
+	if deriveFromKeystore {
 		for _, acc := range accounts {
 			_, err := m.deriveChildAccountForPathAndStore(types2.HexToAddress(kp.DerivedFrom), acc.Path, password)
 			if err != nil {
 				return err
 			}
+		}
+
+		err = m.backfillKeypairXPubInternally(kp, password)
+		if err != nil {
+			m.logger.Warn("failed to backfill keypair xpub", zap.String("keyUID", kp.KeyUID), zap.Error(err))
+			return err
 		}
 	}
 
@@ -552,6 +677,11 @@ func (m *AccountsManager) MigrateKeypairToColdWallet(keyUID string, password str
 	if !kpDb.MigratedToColdWallet() {
 		if password == "" {
 			return ErrNoPasswordProvided
+		}
+
+		err = m.backfillKeypairXPubInternally(kpDb, password)
+		if err != nil {
+			return err
 		}
 
 		err = m.deleteKeystoreFilesForKeypairInternally(kpDb, password)

--- a/internal/accounts-management/xpub_test.go
+++ b/internal/accounts-management/xpub_test.go
@@ -1,0 +1,245 @@
+package accountsmanagement
+
+import (
+	"errors"
+	"os"
+
+	common "github.com/status-im/status-go/internal/accounts-management/common"
+	generator "github.com/status-im/status-go/internal/accounts-management/generator"
+	"github.com/status-im/status-go/internal/accounts-management/types"
+	types2 "github.com/status-im/status-go/internal/crypto/types"
+)
+
+func (s *ManagerTestSuite) expectedWalletXPub() string {
+	xpub, err := generator.DeriveExtendedPublicKeyAtPath(s.mnemonic, "", common.PathWalletXPub)
+	s.Require().NoError(err)
+	return xpub
+}
+
+func (s *ManagerTestSuite) deriveTestAccountAtPath(path string) *types.Account {
+	_, derived, err := generator.CreateAndDeriveAccountsFromMnemonic(s.mnemonic, []string{path}, "")
+	s.Require().NoError(err)
+	return &types.Account{
+		Address:  derived[path].Address(),
+		KeyUID:   s.masterAccount.KeyUID(),
+		Type:     types.AccountTypeGenerated,
+		Path:     path,
+		Operable: types.AccountFullyOperable,
+	}
+}
+
+func (s *ManagerTestSuite) countKeystoreFiles() int {
+	entries, err := os.ReadDir(s.getKeyDir())
+	s.Require().NoError(err)
+	return len(entries)
+}
+
+func (s *ManagerTestSuite) TestAddAccountsWithoutPasswordDerivesFromXPub() {
+	keypair := s.createAndStoreProfileKeypair()
+	s.Require().NotEmpty(keypair.XPub)
+
+	acc := s.deriveTestAccountAtPath(common.PathWalletRoot + "/1")
+
+	s.persistence.EXPECT().GetKeypairByKeyUID(keypair.KeyUID).Return(keypair, nil).Times(1)
+	s.persistence.EXPECT().SaveOrUpdateAccounts([]*types.Account{acc}, true).Return(nil).Times(1)
+
+	filesBefore := s.countKeystoreFiles()
+	err := s.accManager.AddAccounts(keypair.KeyUID, []*types.Account{acc}, "")
+	s.Require().NoError(err)
+	// no password -> the account has no keystore file and is only partially operable
+	s.Require().Equal(types.AccountPartiallyOperable, acc.Operable)
+	s.Require().Equal(filesBefore, s.countKeystoreFiles())
+}
+
+func (s *ManagerTestSuite) TestAddAccountsWithoutPasswordLedgerStylePath() {
+	keypair := s.createAndStoreProfileKeypair()
+
+	acc := s.deriveTestAccountAtPath(common.PathWalletXPub + "/5")
+
+	s.persistence.EXPECT().GetKeypairByKeyUID(keypair.KeyUID).Return(keypair, nil).Times(1)
+	s.persistence.EXPECT().SaveOrUpdateAccounts([]*types.Account{acc}, true).Return(nil).Times(1)
+
+	err := s.accManager.AddAccounts(keypair.KeyUID, []*types.Account{acc}, "")
+	s.Require().NoError(err)
+	s.Require().Equal(types.AccountPartiallyOperable, acc.Operable)
+}
+
+func (s *ManagerTestSuite) TestAddAccountsWithoutPasswordWrongAddressRejected() {
+	keypair := s.createAndStoreProfileKeypair()
+
+	acc := s.deriveTestAccountAtPath(common.PathWalletRoot + "/1")
+	// address the claimed path doesn't derive to
+	acc.Address = types2.HexToAddress("0x000000000000000000000000000000000000dead")
+
+	s.persistence.EXPECT().GetKeypairByKeyUID(keypair.KeyUID).Return(keypair, nil).Times(1)
+
+	err := s.accManager.AddAccounts(keypair.KeyUID, []*types.Account{acc}, "")
+	s.Require().Error(err)
+	s.Require().True(errors.Is(err, ErrAccountMismatch))
+}
+
+func (s *ManagerTestSuite) TestAddAccountsWithoutPasswordNonDerivablePathsRejected() {
+	keypair := s.createAndStoreProfileKeypair()
+
+	for _, path := range []string{
+		common.PathWalletXPub + "/0'/1", // hardened below the wallet xpub
+		"m/44'/61'/0'/0/1",              // out of the wallet xpub tree
+		"m",                             // master
+	} {
+		acc := &types.Account{
+			Address: types2.HexToAddress("0x000000000000000000000000000000000000dead"),
+			KeyUID:  keypair.KeyUID,
+			Type:    types.AccountTypeGenerated,
+			Path:    path,
+		}
+
+		s.persistence.EXPECT().GetKeypairByKeyUID(keypair.KeyUID).Return(keypair, nil).Times(1)
+
+		err := s.accManager.AddAccounts(keypair.KeyUID, []*types.Account{acc}, "")
+		s.Require().Error(err, "path %s", path)
+		s.Require().True(errors.Is(err, ErrCannotDeriveAccountFromXPub), "path %s", path)
+	}
+}
+
+func (s *ManagerTestSuite) TestAddAccountsWithoutPasswordAndWithoutXPubRejected() {
+	keypair := s.createAndStoreProfileKeypair()
+	keypair.XPub = "" // keypair added before the xpub was tracked
+
+	acc := s.deriveTestAccountAtPath(common.PathWalletRoot + "/1")
+
+	s.persistence.EXPECT().GetKeypairByKeyUID(keypair.KeyUID).Return(keypair, nil).Times(1)
+
+	err := s.accManager.AddAccounts(keypair.KeyUID, []*types.Account{acc}, "")
+	s.Require().Error(err)
+	s.Require().True(errors.Is(err, ErrNoPasswordProvidedAndNoXPubStored))
+}
+
+func (s *ManagerTestSuite) TestAddAccountsWithPasswordBackfillsXPub() {
+	keypair := s.createAndStoreProfileKeypair()
+	keypair.XPub = "" // keypair added before the xpub was tracked
+
+	acc := s.deriveTestAccountAtPath(common.PathWalletRoot + "/1")
+
+	s.persistence.EXPECT().GetKeypairByKeyUID(keypair.KeyUID).Return(keypair, nil).Times(1)
+	s.persistence.EXPECT().SaveOrUpdateAccounts([]*types.Account{acc}, true).Return(nil).Times(1)
+	s.persistence.EXPECT().UpdateKeypairXPub(keypair.KeyUID, s.expectedWalletXPub(), types.ColdWalletTypeNone, keypair.Clock).Return(nil).Times(1)
+
+	filesBefore := s.countKeystoreFiles()
+	err := s.accManager.AddAccounts(keypair.KeyUID, []*types.Account{acc}, s.password)
+	s.Require().NoError(err)
+	// with a password the account gets its own keystore file, stays fully operable and the
+	// keypair's missing xpub is backfilled on the way
+	s.Require().Equal(types.AccountFullyOperable, acc.Operable)
+	s.Require().Equal(filesBefore+1, s.countKeystoreFiles())
+	s.Require().Equal(s.expectedWalletXPub(), keypair.XPub)
+}
+
+func (s *ManagerTestSuite) TestAddAccountsToKeyKeypairRejected() {
+	keypair := &types.Keypair{
+		KeyUID: "key-keypair",
+		Type:   types.KeypairTypeKey,
+	}
+
+	s.persistence.EXPECT().GetKeypairByKeyUID(keypair.KeyUID).Return(keypair, nil).Times(1)
+
+	err := s.accManager.AddAccounts(keypair.KeyUID, []*types.Account{{KeyUID: keypair.KeyUID}}, "")
+	s.Require().Error(err)
+	s.Require().True(errors.Is(err, ErrCannotAddAccountsToKeypairImportedViaPrivateKey))
+}
+
+func (s *ManagerTestSuite) TestGetVerifiedWalletAccountForPartiallyOperableAccountOfNonProfileKeypair() {
+	// the profile keypair initializes the keystore
+	_ = s.createAndStoreProfileKeypair()
+
+	// a non-profile seed keypair with an account at a Ledger-style path; only the master keystore
+	// file is stored — the account itself is partially operable
+	mnemonic2, err := common.CreateRandomMnemonicWithDefaultLength()
+	s.Require().NoError(err)
+	accPath := common.PathWalletXPub + "/5"
+	master2, derived2, err := generator.CreateAndDeriveAccountsFromMnemonic(mnemonic2, []string{accPath}, "")
+	s.Require().NoError(err)
+	s.Require().NoError(s.accManager.storeToKeystore(master2, s.password))
+
+	address := derived2[accPath].Address()
+
+	s.persistence.EXPECT().AddressExists(address).Return(true, nil).Times(1)
+	s.persistence.EXPECT().GetAccountByAddress(address).Return(&types.Account{
+		Address:  address,
+		KeyUID:   master2.KeyUID(),
+		Path:     accPath,
+		Operable: types.AccountPartiallyOperable,
+	}, nil).Times(1)
+	s.persistence.EXPECT().GetKeypairByKeyUID(master2.KeyUID()).Return(&types.Keypair{
+		KeyUID:      master2.KeyUID(),
+		Type:        types.KeypairTypeSeed,
+		DerivedFrom: master2.Address().Hex(),
+	}, nil).Times(1)
+
+	account, err := s.accManager.GetVerifiedWalletAccount(address, s.password)
+	s.Require().NoError(err)
+	s.Require().Equal(address, account.Address())
+}
+
+func (s *ManagerTestSuite) TestBackfillKeypairsXPub() {
+	_ = s.createAndStoreProfileKeypair()
+	xpub := s.expectedWalletXPub()
+
+	kpRegular := &types.Keypair{
+		KeyUID:      s.masterAccount.KeyUID(),
+		Type:        types.KeypairTypeProfile,
+		DerivedFrom: s.masterAccount.Address().Hex(),
+		Clock:       42,
+	}
+	kpKey := &types.Keypair{KeyUID: "key-kp", Type: types.KeypairTypeKey}
+	kpCold := &types.Keypair{KeyUID: "cold-kp", Type: types.KeypairTypeSeed, ColdWallet: types.ColdWalletTypeStatusKeycard}
+	kpDone := &types.Keypair{KeyUID: "done-kp", Type: types.KeypairTypeSeed, XPub: "already-set"}
+	// keypair with no master keystore file — skipped with a warning
+	kpNoKeystoreFile := &types.Keypair{KeyUID: "no-file-kp", Type: types.KeypairTypeSeed,
+		DerivedFrom: "0x000000000000000000000000000000000000dead"}
+
+	s.persistence.EXPECT().GetActiveKeypairs().Return([]*types.Keypair{kpRegular, kpKey, kpCold, kpDone, kpNoKeystoreFile}, nil).Times(1)
+	// only the regular keypair with a decryptable master keystore file gets backfilled
+	s.persistence.EXPECT().UpdateKeypairXPub(kpRegular.KeyUID, xpub, types.ColdWalletTypeNone, uint64(42)).Return(nil).Times(1)
+
+	err := s.accManager.BackfillKeypairsXPub(s.password)
+	s.Require().NoError(err)
+	s.Require().Equal(xpub, kpRegular.XPub)
+	s.Require().Empty(kpNoKeystoreFile.XPub)
+}
+
+func (s *ManagerTestSuite) TestBackfillKeypairsXPubReturnsPersistenceError() {
+	_ = s.createAndStoreProfileKeypair()
+
+	kpRegular := &types.Keypair{
+		KeyUID:      s.masterAccount.KeyUID(),
+		Type:        types.KeypairTypeProfile,
+		DerivedFrom: s.masterAccount.Address().Hex(),
+		Clock:       42,
+	}
+
+	s.persistence.EXPECT().GetActiveKeypairs().Return([]*types.Keypair{kpRegular}, nil).Times(1)
+	s.persistence.EXPECT().UpdateKeypairXPub(kpRegular.KeyUID, s.expectedWalletXPub(), types.ColdWalletTypeNone, uint64(42)).
+		Return(errors.New("db failure")).Times(1)
+
+	err := s.accManager.BackfillKeypairsXPub(s.password)
+	s.Require().Error(err)
+	s.Require().ErrorContains(err, kpRegular.KeyUID)
+	s.Require().Empty(kpRegular.XPub)
+}
+
+func (s *ManagerTestSuite) TestMigrateKeypairToColdWalletBackfillsXPub() {
+	keypair := s.createAndStoreProfileKeypair()
+	keypair.XPub = "" // keypair added before the xpub was tracked
+
+	s.persistence.EXPECT().GetKeypairByKeyUID(keypair.KeyUID).Return(keypair, nil).Times(1)
+	// the xpub is captured from the master keystore file before the keystore files are deleted
+	s.persistence.EXPECT().UpdateKeypairXPub(keypair.KeyUID, s.expectedWalletXPub(), types.ColdWalletTypeNone, keypair.Clock).Return(nil).Times(1)
+	s.persistence.EXPECT().MarkKeypairFullyOperable(keypair.KeyUID, uint64(99), true).Return(nil).Times(1)
+	s.persistence.EXPECT().UpdateKeypairXPub(keypair.KeyUID, "", types.ColdWalletTypeStatusKeycard, uint64(99)).Return(nil).Times(1)
+
+	err := s.accManager.MigrateKeypairToColdWallet(keypair.KeyUID, s.password, types.ColdWalletTypeStatusKeycard, 99)
+	s.Require().NoError(err)
+	s.Require().Equal(s.expectedWalletXPub(), keypair.XPub)
+	// all keystore files of the keypair are deleted
+	s.Require().Equal(0, s.countKeystoreFiles())
+}

--- a/internal/db/multiaccounts/accounts/database.go
+++ b/internal/db/multiaccounts/accounts/database.go
@@ -1100,12 +1100,6 @@ func (db *Database) AddressExists(address types.Address) (exists bool, err error
 	return exists, err
 }
 
-// GetPath returns true if account with given address was recently key and doesn't have a key yet
-func (db *Database) GetPath(address types.Address) (path string, err error) {
-	err = db.db.QueryRow("SELECT path FROM keypairs_accounts WHERE address = ? AND removed = 0", address).Scan(&path)
-	return path, err
-}
-
 // NOTE: This should not be used to retrieve `Networks`.
 // NetworkManager should be used instead, otherwise RPCURL will be empty
 func (db *Database) GetNodeConfig() (*params.NodeConfig, error) {

--- a/pkg/backend/geth_backend.go
+++ b/pkg/backend/geth_backend.go
@@ -18,6 +18,7 @@ import (
 	"github.com/afex/hystrix-go/hystrix"
 	"github.com/imdario/mergo"
 	"github.com/pkg/errors"
+	"github.com/status-im/extkeys"
 	"go.uber.org/zap"
 
 	"github.com/ethereum/go-ethereum/common/hexutil"
@@ -730,7 +731,36 @@ func (b *StatusBackend) loginAccount(request *requests.Login) error {
 		return errors.Wrap(err, "failed to update account")
 	}
 
+	err = b.backfillKeypairsXPubOnLogin(request, accountsDB)
+	if err != nil {
+		return errors.Wrap(err, "failed to backfill keypairs xpub")
+	}
+
 	return nil
+}
+
+func (b *StatusBackend) backfillKeypairsXPubOnLogin(request *requests.Login, accountsDB *accounts.Database) error {
+	if request.WalletXPub != "" {
+		kp, err := accountsDB.GetKeypairByKeyUID(request.KeyUID)
+		if err != nil {
+			return errors.Wrap(err, "failed to get the profile keypair")
+		}
+		if kp != nil && kp.XPub == "" {
+			extKey, err := extkeys.NewKeyFromString(request.WalletXPub)
+			if err != nil {
+				return errors.Wrap(err, "invalid wallet xpub provided in the login request")
+			}
+			if extKey.IsPrivate {
+				return errors.New("private extended key provided as the wallet xpub in the login request")
+			}
+			err = accountsDB.UpdateKeypairXPub(kp.KeyUID, request.WalletXPub, kp.ColdWallet, kp.Clock)
+			if err != nil {
+				return errors.Wrap(err, "failed to store the profile keypair xpub")
+			}
+		}
+	}
+
+	return b.accountsManager.BackfillKeypairsXPub(request.Password)
 }
 
 // UpdateNodeConfigFleet loads the fleet from the settings and updates the node configuration

--- a/protocol/requests/login.go
+++ b/protocol/requests/login.go
@@ -26,6 +26,10 @@ type Login struct {
 
 	KeycardWhisperPrivateKey string `json:"keycardWhisperPrivateKey"`
 
+	// WalletXPub is the extended public key at the wallet xpub path (m/44'/60'/0') of the profile keypair.
+	// It's used to backfill the keypair's xpub if it's not stored yet (old key pairs missing it).
+	WalletXPub string `json:"walletXPub"`
+
 	// Mnemonic allows to log in to an account when password is lost.
 	// This is needed for the "Lost keycard -> Start using without keycard" flow, when a keycard account database
 	// exists locally, but now the keycard is lost. In this case client is responsible for calling


### PR DESCRIPTION
Similar to what we do for the cold wallet migrated key pairs, adding new accounts for the regular operable and partially operable key pairs is possible without providing a password. They are added as partially operable accounts and real keystore files for such accounts will be added the next time the password is provided for whatever reason.