### PR TITLE
feat(mailserver): stop reconciling history if we were online

### DIFF
--- a/pkg/messaging/api.go
+++ b/pkg/messaging/api.go
@@ -55,8 +55,14 @@ func (a *API) ConnectionStatus() types.ConnectionStatus {
 // be reconciled with the store nodes (#7568): periodically while connectivity
 // is not reliable (relay mesh not Connected on every default shard), and once
 // more when it recovers.
-func (a *API) OnHistoryReconcileNeeded() <-chan struct{} {
+func (a *API) OnHistoryReconcileNeeded() <-chan types.HistoryReconcileWindow {
 	return a.core.stack.Transport.OnHistoryReconcileNeeded()
+}
+
+// HistoryDeliveryReliable reports whether live delivery can safely advance
+// initialized history cursors without issuing a store query.
+func (a *API) HistoryDeliveryReliable() bool {
+	return a.core.stack.Transport.HistoryDeliveryReliable()
 }
 
 // SubscribeFilterMatched returns a channel that is notified whenever an incoming

--- a/pkg/messaging/api.go
+++ b/pkg/messaging/api.go
@@ -59,12 +59,6 @@ func (a *API) OnHistoryReconcileNeeded() <-chan types.HistoryReconcileWindow {
 	return a.core.stack.Transport.OnHistoryReconcileNeeded()
 }
 
-// HistoryDeliveryReliable reports whether live delivery can safely advance
-// initialized history cursors without issuing a store query.
-func (a *API) HistoryDeliveryReliable() bool {
-	return a.core.stack.Transport.HistoryDeliveryReliable()
-}
-
 // SubscribeFilterMatched returns a channel that is notified whenever an incoming
 // envelope matches at least one installed filter. bufSize should be 1.
 // Callers must call UnsubscribeFilterMatched when done.

--- a/pkg/messaging/layers/transport/transport.go
+++ b/pkg/messaging/layers/transport/transport.go
@@ -785,10 +785,6 @@ func (t *Transport) OnHistoryReconcileNeeded() <-chan types.HistoryReconcileWind
 	return t.waku.OnHistoryReconcileNeeded()
 }
 
-func (t *Transport) HistoryDeliveryReliable() bool {
-	return t.waku != nil && t.waku.HistoryDeliveryReliable()
-}
-
 func (t *Transport) Peers() types.PeerStats {
 	return t.waku.Peers()
 }

--- a/pkg/messaging/layers/transport/transport.go
+++ b/pkg/messaging/layers/transport/transport.go
@@ -778,11 +778,15 @@ func (t *Transport) ConnectionState() types.ConnectionState {
 // (#7568): fired periodically while connectivity is not reliable and once when
 // it recovers. Without a waku node (offline transport) it returns a nil
 // channel, which blocks forever — i.e. never signals.
-func (t *Transport) OnHistoryReconcileNeeded() <-chan struct{} {
+func (t *Transport) OnHistoryReconcileNeeded() <-chan types.HistoryReconcileWindow {
 	if t.waku == nil {
 		return nil
 	}
 	return t.waku.OnHistoryReconcileNeeded()
+}
+
+func (t *Transport) HistoryDeliveryReliable() bool {
+	return t.waku != nil && t.waku.HistoryDeliveryReliable()
 }
 
 func (t *Transport) Peers() types.PeerStats {

--- a/pkg/messaging/types/connection_status.go
+++ b/pkg/messaging/types/connection_status.go
@@ -8,6 +8,7 @@ import (
 // PartiallyConnected / Connected) surfaced to the Messaging API, re-exported
 // from the waku layer that produces it.
 type ConnectionState = wakutypes.ConnectionState
+type HistoryReconcileWindow = wakutypes.HistoryReconcileWindow
 
 const (
 	ConnectionStateDisconnected       = wakutypes.ConnectionStateDisconnected

--- a/pkg/messaging/waku/gowaku.go
+++ b/pkg/messaging/waku/gowaku.go
@@ -175,12 +175,10 @@ type Waku struct {
 	// so it needs no lock of its own.
 	topicHealth   map[string]peermanager.TopicHealth
 	onlineChecker *onlinechecker.DefaultOnlineChecker
-	// historyReconcileNeeded is signalled by the history-reconcile loop (see
-	// history_reconcile.go) whenever the consumer should fetch history from the
-	// store nodes. Buffered (1) level-trigger: sends never block, a pending
-	// signal coalesces with later ones. Temporary until logos-delivery owns
+	// historyReconcileNeeded carries unreliable delivery windows detected by
+	// the history-reconcile loop. Temporary until logos-delivery owns
 	// reconciliation end to end — see OnHistoryReconcileNeeded.
-	historyReconcileNeeded chan struct{}
+	historyReconcileNeeded chan types.HistoryReconcileWindow
 	// stateMu guards state and stateInitialized. ConnectionChanged is invoked
 	// from the OS/mobile path while checkForConnectionChanges and
 	// handleNetworkChangeFromApp run on the internal poller goroutine, so all
@@ -256,7 +254,7 @@ func New(nodeKey *ecdsa.PrivateKey, cfg *Config, logger *zap.Logger, ts timesour
 		connectionNotifChan:         make(chan node.PeerConnection, 20),
 		connStatusSubscriptions:     make(map[string]*types.ConnStatusSubscription),
 		topicHealth:                 make(map[string]peermanager.TopicHealth),
-		historyReconcileNeeded:      make(chan struct{}, 1),
+		historyReconcileNeeded:      make(chan types.HistoryReconcileWindow, 16),
 		ctx:                         ctx,
 		cancel:                      cancel,
 		wg:                          sync.WaitGroup{},

--- a/pkg/messaging/waku/gowaku.go
+++ b/pkg/messaging/waku/gowaku.go
@@ -999,63 +999,14 @@ func (w *Waku) runConnectionMonitoringLoop() {
 	defer sub.Unsubscribe()
 	paused := <-sub.C()
 	tracker := newHistoryReconcileTracker(w.reliablyConnected(), time.Now())
-	var reconcileTimer *time.Timer
-	var reconcileTimerC <-chan time.Time
 	var pendingReconciliations []types.HistoryReconcileWindow
 
-	queueReconciliation := func(reliable bool) {
-		window := tracker.observe(reliable, time.Now(), historyReconcileMinInterval)
-		if window != nil {
-			w.logger.Debug("history reconciliation needed",
-				zap.Bool("reliable", reliable),
-				zap.Time("from", window.From),
-				zap.Time("to", window.To))
-			if len(pendingReconciliations) != 0 &&
-				!window.From.After(pendingReconciliations[len(pendingReconciliations)-1].To) {
-				pendingReconciliations[len(pendingReconciliations)-1].To = window.To
-			} else {
-				pendingReconciliations = append(pendingReconciliations, *window)
-			}
-		}
-
-		if tracker.reliable {
-			if reconcileTimer != nil && !reconcileTimer.Stop() {
-				select {
-				case <-reconcileTimer.C:
-				default:
-				}
-			}
-			reconcileTimerC = nil
-			return
-		}
-
-		delay := time.Until(tracker.lastReconcile.Add(historyReconcileMinInterval))
-		if delay < 0 {
-			delay = 0
-		}
-		if reconcileTimer == nil {
-			reconcileTimer = time.NewTimer(delay)
-		} else {
-			if !reconcileTimer.Stop() {
-				select {
-				case <-reconcileTimer.C:
-				default:
-				}
-			}
-			reconcileTimer.Reset(delay)
-		}
-		reconcileTimerC = reconcileTimer.C
-	}
-
 	observeConnectionState := func() {
-		queueReconciliation(w.checkForConnectionChanges() == types.ConnectionStateConnected)
+		observedAt := time.Now()
+		w.queueHistoryReconciliation(&tracker, &pendingReconciliations, w.checkForConnectionChanges() == types.ConnectionStateConnected, observedAt)
 	}
-	queueReconciliation(tracker.reliable)
-	defer func() {
-		if reconcileTimer != nil {
-			reconcileTimer.Stop()
-		}
-	}()
+	startupObservedAt := time.Now()
+	w.queueHistoryReconciliation(&tracker, &pendingReconciliations, tracker.reliable, startupObservedAt)
 	var tickerC <-chan time.Time
 	if !paused {
 		tickerC = ticker.C
@@ -1085,8 +1036,6 @@ func (w *Waku) runConnectionMonitoringLoop() {
 			}
 		case <-tickerC:
 			observeConnectionState()
-		case <-reconcileTimerC:
-			queueReconciliation(tracker.reliable)
 		case topicHealth := <-w.topicHealthStatusChan:
 			// go-waku reports per-shard mesh health (UnHealthy / MinimallyHealthy
 			// / SufficientlyHealthy); cache it so checkForConnectionChanges can

--- a/pkg/messaging/waku/gowaku.go
+++ b/pkg/messaging/waku/gowaku.go
@@ -872,53 +872,7 @@ func (w *Waku) Start() error {
 		}
 	}
 
-	w.wg.Add(1)
-	go func() {
-		defer gocommon.LogOnPanic()
-		defer w.wg.Done()
-		ticker := time.NewTicker(5 * time.Second)
-		defer ticker.Stop()
-		sub := w.PauseBroadcaster.Subscribe()
-		defer sub.Unsubscribe()
-		paused := <-sub.C()
-		var tickerC <-chan time.Time
-		if !paused {
-			tickerC = ticker.C
-		}
-		for {
-			select {
-			case <-w.ctx.Done():
-				return
-			case pausedState, ok := <-sub.C():
-				if !ok {
-					return
-				}
-				paused = pausedState
-				if paused {
-					tickerC = nil
-				} else {
-					tickerC = ticker.C
-				}
-			case <-tickerC:
-				w.checkForConnectionChanges()
-			case topicHealth := <-w.topicHealthStatusChan:
-				// go-waku reports per-shard mesh health (UnHealthy / MinimallyHealthy
-				// / SufficientlyHealthy); cache it so checkForConnectionChanges can
-				// tell PartiallyConnected from Connected. Supersedes the old no-op
-				// (status-im/status-go#4628).
-				w.topicHealth[topicHealth.Topic] = topicHealth.Health
-				if !paused {
-					w.checkForConnectionChanges()
-				}
-			case <-w.connectionNotifChan:
-				if !paused {
-					w.checkForConnectionChanges()
-				}
-			}
-		}
-	}()
-
-	w.startHistoryReconcileLoop()
+	w.startConnectionMonitoringLoop()
 
 	if w.cfg.MetricsEnabled {
 		w.wg.Add(1)
@@ -1029,6 +983,127 @@ func (w *Waku) Start() error {
 	return nil
 }
 
+// startConnectionMonitoringLoop starts the connection-state observer and its
+// associated history reconciliation scheduler.
+func (w *Waku) startConnectionMonitoringLoop() {
+	w.wg.Add(1)
+	go w.runConnectionMonitoringLoop()
+}
+
+func (w *Waku) runConnectionMonitoringLoop() {
+	defer gocommon.LogOnPanic()
+	defer w.wg.Done()
+	ticker := time.NewTicker(5 * time.Second)
+	defer ticker.Stop()
+	sub := w.PauseBroadcaster.Subscribe()
+	defer sub.Unsubscribe()
+	paused := <-sub.C()
+	tracker := newHistoryReconcileTracker(w.reliablyConnected(), time.Now())
+	var reconcileTimer *time.Timer
+	var reconcileTimerC <-chan time.Time
+	var pendingReconciliations []types.HistoryReconcileWindow
+
+	queueReconciliation := func(reliable bool) {
+		window := tracker.observe(reliable, time.Now(), historyReconcileMinInterval)
+		if window != nil {
+			w.logger.Debug("history reconciliation needed",
+				zap.Bool("reliable", reliable),
+				zap.Time("from", window.From),
+				zap.Time("to", window.To))
+			if len(pendingReconciliations) != 0 &&
+				!window.From.After(pendingReconciliations[len(pendingReconciliations)-1].To) {
+				pendingReconciliations[len(pendingReconciliations)-1].To = window.To
+			} else {
+				pendingReconciliations = append(pendingReconciliations, *window)
+			}
+		}
+
+		if tracker.reliable {
+			if reconcileTimer != nil && !reconcileTimer.Stop() {
+				select {
+				case <-reconcileTimer.C:
+				default:
+				}
+			}
+			reconcileTimerC = nil
+			return
+		}
+
+		delay := time.Until(tracker.lastReconcile.Add(historyReconcileMinInterval))
+		if delay < 0 {
+			delay = 0
+		}
+		if reconcileTimer == nil {
+			reconcileTimer = time.NewTimer(delay)
+		} else {
+			if !reconcileTimer.Stop() {
+				select {
+				case <-reconcileTimer.C:
+				default:
+				}
+			}
+			reconcileTimer.Reset(delay)
+		}
+		reconcileTimerC = reconcileTimer.C
+	}
+
+	observeConnectionState := func() {
+		queueReconciliation(w.checkForConnectionChanges() == types.ConnectionStateConnected)
+	}
+	queueReconciliation(tracker.reliable)
+	defer func() {
+		if reconcileTimer != nil {
+			reconcileTimer.Stop()
+		}
+	}()
+	var tickerC <-chan time.Time
+	if !paused {
+		tickerC = ticker.C
+	}
+	for {
+		var reconciliationOut chan<- types.HistoryReconcileWindow
+		var nextReconciliation types.HistoryReconcileWindow
+		if len(pendingReconciliations) != 0 {
+			reconciliationOut = w.historyReconcileNeeded
+			nextReconciliation = pendingReconciliations[0]
+		}
+		select {
+		case <-w.ctx.Done():
+			return
+		case reconciliationOut <- nextReconciliation:
+			pendingReconciliations = pendingReconciliations[1:]
+		case pausedState, ok := <-sub.C():
+			if !ok {
+				return
+			}
+			paused = pausedState
+			if paused {
+				tickerC = nil
+			} else {
+				tickerC = ticker.C
+				observeConnectionState()
+			}
+		case <-tickerC:
+			observeConnectionState()
+		case <-reconcileTimerC:
+			queueReconciliation(tracker.reliable)
+		case topicHealth := <-w.topicHealthStatusChan:
+			// go-waku reports per-shard mesh health (UnHealthy / MinimallyHealthy
+			// / SufficientlyHealthy); cache it so checkForConnectionChanges can
+			// tell PartiallyConnected from Connected. Supersedes the old no-op
+			// (status-im/status-go#4628).
+			w.topicHealth[topicHealth.Topic] = topicHealth.Health
+			if !paused {
+				observeConnectionState()
+			}
+		case <-w.connectionNotifChan:
+			if !paused {
+				observeConnectionState()
+			}
+		}
+	}
+}
+
 // deriveConnectionState maps the node's current connectivity onto the three-state
 // ConnectionState, mirroring logos-delivery's health monitor
 // (node_health_monitor.nim calculateConnectionState):
@@ -1063,7 +1138,7 @@ func (w *Waku) ConnectionState() types.ConnectionState {
 	return w.connState
 }
 
-func (w *Waku) checkForConnectionChanges() {
+func (w *Waku) checkForConnectionChanges() types.ConnectionState {
 
 	state := w.deriveConnectionState()
 	isOnline := state.IsOnline()
@@ -1097,6 +1172,8 @@ func (w *Waku) checkForConnectionChanges() {
 	if w.shouldFireConnectionChanged(next) {
 		w.ConnectionChanged(next)
 	}
+
+	return state
 }
 
 func (w *Waku) reportPeerMetrics() {

--- a/pkg/messaging/waku/history_reconcile.go
+++ b/pkg/messaging/waku/history_reconcile.go
@@ -83,10 +83,6 @@ func (w *Waku) reliablyConnected() bool {
 	return w.ConnectionState() == types.ConnectionStateConnected
 }
 
-func (w *Waku) HistoryDeliveryReliable() bool {
-	return w.reliablyConnected()
-}
-
 // shouldReconcileHistory decides whether a reconciliation is due at a tick:
 // when the connection just recovered (an unreliable window closed, fetch what
 // it may have missed), or while it stays unreliable and minInterval has passed

--- a/pkg/messaging/waku/history_reconcile.go
+++ b/pkg/messaging/waku/history_reconcile.go
@@ -83,11 +83,8 @@ func (w *Waku) reliablyConnected() bool {
 	return w.ConnectionState() == types.ConnectionStateConnected
 }
 
-// HistoryDeliveryReliable is stricter than reliablyConnected for light nodes:
-// their filter-subscription health is not observable, so Connected alone must
-// not advance persisted history completeness cursors.
 func (w *Waku) HistoryDeliveryReliable() bool {
-	return !w.cfg.IsLightClient() && w.reliablyConnected()
+	return w.reliablyConnected()
 }
 
 // shouldReconcileHistory decides whether a reconciliation is due at a tick:

--- a/pkg/messaging/waku/history_reconcile.go
+++ b/pkg/messaging/waku/history_reconcile.go
@@ -3,6 +3,8 @@ package wakuv2
 import (
 	"time"
 
+	"go.uber.org/zap"
+
 	"github.com/status-im/status-go/pkg/messaging/waku/types"
 )
 
@@ -49,6 +51,27 @@ func (t *historyReconcileTracker) observe(reliable bool, now time.Time, minInter
 		t.unreliableFrom = time.Time{}
 	}
 	return &window
+}
+
+// queueHistoryReconciliation records a reconciliation window, merging it with
+// the previous pending window when they overlap or touch.
+func (w *Waku) queueHistoryReconciliation(tracker *historyReconcileTracker, pending *[]types.HistoryReconcileWindow, reliable bool, now time.Time) {
+	window := tracker.observe(reliable, now, historyReconcileMinInterval)
+	if window == nil {
+		return
+	}
+
+	w.logger.Debug("history reconciliation needed",
+		zap.Bool("reliable", reliable),
+		zap.Time("from", window.From),
+		zap.Time("to", window.To))
+	if len(*pending) != 0 && !window.From.After((*pending)[len(*pending)-1].To) {
+		// Merge adjacent or overlapping windows so callers receive one
+		// continuous recovery range instead of a fragmented sequence.
+		(*pending)[len(*pending)-1].To = window.To
+	} else {
+		*pending = append(*pending, *window)
+	}
 }
 
 // OnHistoryReconcileNeeded returns unreliable delivery windows that should be

--- a/pkg/messaging/waku/history_reconcile.go
+++ b/pkg/messaging/waku/history_reconcile.go
@@ -33,7 +33,7 @@ func newHistoryReconcileTracker(reliable bool, now time.Time) historyReconcileTr
 	return tracker
 }
 
-func (t *historyReconcileTracker) observe(reliable bool, now time.Time, minInterval time.Duration) (types.HistoryReconcileWindow, bool) {
+func (t *historyReconcileTracker) observe(reliable bool, now time.Time, minInterval time.Duration) *types.HistoryReconcileWindow {
 	wasReliable := t.reliable
 	t.reliable = reliable
 	if wasReliable && !reliable {
@@ -42,7 +42,7 @@ func (t *historyReconcileTracker) observe(reliable bool, now time.Time, minInter
 	t.checkedAt = now
 
 	if !shouldReconcileHistory(reliable, wasReliable, t.lastReconcile, now, minInterval) {
-		return types.HistoryReconcileWindow{}, false
+		return nil
 	}
 	if t.unreliableFrom.IsZero() {
 		t.unreliableFrom = now
@@ -52,7 +52,7 @@ func (t *historyReconcileTracker) observe(reliable bool, now time.Time, minInter
 	if reliable {
 		t.unreliableFrom = time.Time{}
 	}
-	return window, true
+	return &window
 }
 
 // OnHistoryReconcileNeeded returns unreliable delivery windows that should be
@@ -99,8 +99,8 @@ func (w *Waku) startHistoryReconcileLoop() {
 			OnTick: func() {
 				now := time.Now()
 				reliable := w.reliablyConnected()
-				window, needed := tracker.observe(reliable, now, historyReconcileMinInterval)
-				if !needed {
+				window := tracker.observe(reliable, now, historyReconcileMinInterval)
+				if window == nil {
 					return
 				}
 				w.logger.Debug("history reconciliation needed",
@@ -108,7 +108,7 @@ func (w *Waku) startHistoryReconcileLoop() {
 					zap.Time("from", window.From),
 					zap.Time("to", window.To))
 				select {
-				case w.historyReconcileNeeded <- window:
+				case w.historyReconcileNeeded <- *window:
 				case <-w.ctx.Done():
 				}
 			},

--- a/pkg/messaging/waku/history_reconcile.go
+++ b/pkg/messaging/waku/history_reconcile.go
@@ -79,29 +79,29 @@ func (w *Waku) OnHistoryReconcileNeeded() <-chan types.HistoryReconcileWindow {
 
 // startHistoryReconcileLoop runs the timing/decision half of history
 // reconciliation. The fetch itself lives with the consumer (the protocol
-// layer), which owns the topics and per-chat watermarks; this loop only owns
-// connectivity confidence and cadence. Suspended while the node is paused
-// (app backgrounded, no ticker armed): SetPaused(false) triggers its own
-// fetch on foreground.
+// layer), which owns the topics and per-chat history cursors; this loop only owns
+// connectivity confidence and cadence. It continues observing while paused;
+// the consumer queues the resulting windows until it resumes.
 func (w *Waku) startHistoryReconcileLoop() {
 	w.wg.Add(1)
 	go func() {
 		defer gocommon.LogOnPanic()
 		defer w.wg.Done()
 
-		sub := w.PauseBroadcaster.Subscribe()
-		defer sub.Unsubscribe()
-
 		tracker := newHistoryReconcileTracker(w.reliablyConnected(), time.Now())
+		ticker := time.NewTicker(historyReconcileCheckInterval)
+		defer ticker.Stop()
 
-		pt := gocommon.NewPausableTicker(gocommon.PausableTickerConfig{
-			Interval: historyReconcileCheckInterval,
-			OnTick: func() {
+		for {
+			select {
+			case <-w.ctx.Done():
+				return
+			case <-ticker.C:
 				now := time.Now()
 				reliable := w.reliablyConnected()
 				window := tracker.observe(reliable, now, historyReconcileMinInterval)
 				if window == nil {
-					return
+					continue
 				}
 				w.logger.Debug("history reconciliation needed",
 					zap.Bool("reliable", reliable),
@@ -110,10 +110,10 @@ func (w *Waku) startHistoryReconcileLoop() {
 				select {
 				case w.historyReconcileNeeded <- *window:
 				case <-w.ctx.Done():
+					return
 				}
-			},
-		}, sub.C())
-		pt.Run(w.ctx.Done())
+			}
+		}
 	}()
 }
 

--- a/pkg/messaging/waku/history_reconcile.go
+++ b/pkg/messaging/waku/history_reconcile.go
@@ -3,9 +3,6 @@ package wakuv2
 import (
 	"time"
 
-	"go.uber.org/zap"
-
-	gocommon "github.com/status-im/status-go/common"
 	"github.com/status-im/status-go/pkg/messaging/waku/types"
 )
 
@@ -14,8 +11,7 @@ const (
 	// receiving everything live, the consumer should periodically fetch history
 	// from the store nodes so silently missed messages are recovered. The node
 	// is confident only with a Connected relay mesh on every default shard.
-	historyReconcileCheckInterval = 10 * time.Second
-	historyReconcileMinInterval   = 30 * time.Second
+	historyReconcileMinInterval = 30 * time.Second
 )
 
 type historyReconcileTracker struct {
@@ -75,46 +71,6 @@ func (t *historyReconcileTracker) observe(reliable bool, now time.Time, minInter
 // the two.
 func (w *Waku) OnHistoryReconcileNeeded() <-chan types.HistoryReconcileWindow {
 	return w.historyReconcileNeeded
-}
-
-// startHistoryReconcileLoop runs the timing/decision half of history
-// reconciliation. The fetch itself lives with the consumer (the protocol
-// layer), which owns the topics and per-chat history cursors; this loop only owns
-// connectivity confidence and cadence. It continues observing while paused;
-// the consumer queues the resulting windows until it resumes.
-func (w *Waku) startHistoryReconcileLoop() {
-	w.wg.Add(1)
-	go func() {
-		defer gocommon.LogOnPanic()
-		defer w.wg.Done()
-
-		tracker := newHistoryReconcileTracker(w.reliablyConnected(), time.Now())
-		ticker := time.NewTicker(historyReconcileCheckInterval)
-		defer ticker.Stop()
-
-		for {
-			select {
-			case <-w.ctx.Done():
-				return
-			case <-ticker.C:
-				now := time.Now()
-				reliable := w.reliablyConnected()
-				window := tracker.observe(reliable, now, historyReconcileMinInterval)
-				if window == nil {
-					continue
-				}
-				w.logger.Debug("history reconciliation needed",
-					zap.Bool("reliable", reliable),
-					zap.Time("from", window.From),
-					zap.Time("to", window.To))
-				select {
-				case w.historyReconcileNeeded <- *window:
-				case <-w.ctx.Done():
-					return
-				}
-			}
-		}
-	}()
 }
 
 // reliablyConnected reports whether connectivity is currently good enough to be

--- a/pkg/messaging/waku/history_reconcile.go
+++ b/pkg/messaging/waku/history_reconcile.go
@@ -18,26 +18,62 @@ const (
 	historyReconcileMinInterval   = 30 * time.Second
 )
 
-// OnHistoryReconcileNeeded returns a channel signalled whenever history should
-// be reconciled with the store nodes: periodically while connectivity is not
+type historyReconcileTracker struct {
+	reliable       bool
+	checkedAt      time.Time
+	unreliableFrom time.Time
+	lastReconcile  time.Time
+}
+
+func newHistoryReconcileTracker(reliable bool, now time.Time) historyReconcileTracker {
+	tracker := historyReconcileTracker{reliable: reliable, checkedAt: now}
+	if !reliable {
+		tracker.unreliableFrom = now
+	}
+	return tracker
+}
+
+func (t *historyReconcileTracker) observe(reliable bool, now time.Time, minInterval time.Duration) (types.HistoryReconcileWindow, bool) {
+	wasReliable := t.reliable
+	t.reliable = reliable
+	if wasReliable && !reliable {
+		t.unreliableFrom = t.checkedAt
+	}
+	t.checkedAt = now
+
+	if !shouldReconcileHistory(reliable, wasReliable, t.lastReconcile, now, minInterval) {
+		return types.HistoryReconcileWindow{}, false
+	}
+	if t.unreliableFrom.IsZero() {
+		t.unreliableFrom = now
+	}
+	t.lastReconcile = now
+	window := types.HistoryReconcileWindow{From: t.unreliableFrom, To: now}
+	if reliable {
+		t.unreliableFrom = time.Time{}
+	}
+	return window, true
+}
+
+// OnHistoryReconcileNeeded returns unreliable delivery windows that should be
+// reconciled with the store nodes: periodically while connectivity is not
 // reliable, and once more when it recovers (closing the unreliable window).
-// It is a buffered level-trigger; consumers that are slow or paused coalesce
-// pending signals instead of queueing them.
 //
 // Temporary: this channel exists because the Waku node cannot yet own the
 // fetch itself. It already has the subscription (filter) list, but lacks the
-// per-topic "when was it last fetched" watermark, which the Messenger persists
-// in the app DB (mailserver_topics). Eventually logos-delivery will own
-// reconciliation and history backfill entirely, including persisting
-// lastFetched per topic: its Messaging API already reconciles
+// per-topic "known complete through" cursor, which the Messenger persists in
+// the app DB (mailserver_topics). Eventually logos-delivery will own
+// reconciliation and history backfill entirely, including persisting that
+// cursor per topic: its Messaging API already reconciles
 // (https://github.com/logos-messaging/logos-delivery/issues/3941) but does not
-// yet fetch history, and neither exposes nor persists lastFetched. That gap
+// yet fetch history, and neither exposes nor persists a completeness cursor.
+// That gap
 // should be closed in logos-delivery before integration — otherwise ownership
-// is split and persistence breaks, since we cannot persist lastFetched on its
+// is split and persistence breaks, since we cannot persist the cursor on its
 // behalf. Until then the fetch stays in the Messenger (Transport would be a
 // nicer interim home, but it is a stopgap either way), and this signal bridges
 // the two.
-func (w *Waku) OnHistoryReconcileNeeded() <-chan struct{} {
+func (w *Waku) OnHistoryReconcileNeeded() <-chan types.HistoryReconcileWindow {
 	return w.historyReconcileNeeded
 }
 
@@ -56,22 +92,24 @@ func (w *Waku) startHistoryReconcileLoop() {
 		sub := w.PauseBroadcaster.Subscribe()
 		defer sub.Unsubscribe()
 
-		reliable := w.reliablyConnected()
-		var lastReconcile time.Time
+		tracker := newHistoryReconcileTracker(w.reliablyConnected(), time.Now())
 
 		pt := gocommon.NewPausableTicker(gocommon.PausableTickerConfig{
 			Interval: historyReconcileCheckInterval,
 			OnTick: func() {
-				wasReliable := reliable
-				reliable = w.reliablyConnected()
-				if !shouldReconcileHistory(reliable, wasReliable, lastReconcile, time.Now(), historyReconcileMinInterval) {
+				now := time.Now()
+				reliable := w.reliablyConnected()
+				window, needed := tracker.observe(reliable, now, historyReconcileMinInterval)
+				if !needed {
 					return
 				}
-				lastReconcile = time.Now()
-				w.logger.Debug("history reconciliation needed", zap.Bool("reliable", reliable))
+				w.logger.Debug("history reconciliation needed",
+					zap.Bool("reliable", reliable),
+					zap.Time("from", window.From),
+					zap.Time("to", window.To))
 				select {
-				case w.historyReconcileNeeded <- struct{}{}:
-				default: // a signal is already pending; coalesce
+				case w.historyReconcileNeeded <- window:
+				case <-w.ctx.Done():
 				}
 			},
 		}, sub.C())
@@ -87,6 +125,13 @@ func (w *Waku) startHistoryReconcileLoop() {
 // reconcile is a separate policy decision, deliberately not made here.
 func (w *Waku) reliablyConnected() bool {
 	return w.ConnectionState() == types.ConnectionStateConnected
+}
+
+// HistoryDeliveryReliable is stricter than reliablyConnected for light nodes:
+// their filter-subscription health is not observable, so Connected alone must
+// not advance persisted history completeness cursors.
+func (w *Waku) HistoryDeliveryReliable() bool {
+	return !w.cfg.IsLightClient() && w.reliablyConnected()
 }
 
 // shouldReconcileHistory decides whether a reconciliation is due at a tick:

--- a/pkg/messaging/waku/history_reconcile_test.go
+++ b/pkg/messaging/waku/history_reconcile_test.go
@@ -97,6 +97,23 @@ func TestHistoryReconcileTrackerBoundsUnreliableWindow(t *testing.T) {
 	require.Nil(t, window)
 }
 
+func TestHistoryReconcileTrackerCapturesRapidRecovery(t *testing.T) {
+	start := time.Unix(1_500, 0)
+	tracker := newHistoryReconcileTracker(true, start)
+
+	degradedAt := start.Add(time.Second)
+	window := tracker.observe(false, degradedAt, historyReconcileMinInterval)
+	require.NotNil(t, window)
+	require.Equal(t, start, window.From)
+	require.Equal(t, degradedAt, window.To)
+
+	recoveredAt := degradedAt.Add(time.Second)
+	window = tracker.observe(true, recoveredAt, historyReconcileMinInterval)
+	require.NotNil(t, window)
+	require.Equal(t, start, window.From)
+	require.Equal(t, recoveredAt, window.To)
+}
+
 func TestHistoryReconcileTrackerPreservesDisjointWindows(t *testing.T) {
 	start := time.Unix(2_000, 0)
 	tracker := newHistoryReconcileTracker(true, start)

--- a/pkg/messaging/waku/history_reconcile_test.go
+++ b/pkg/messaging/waku/history_reconcile_test.go
@@ -73,42 +73,43 @@ func TestHistoryReconcileTrackerBoundsUnreliableWindow(t *testing.T) {
 	start := time.Unix(1_000, 0)
 	tracker := newHistoryReconcileTracker(true, start)
 
-	_, needed := tracker.observe(true, start.Add(10*time.Second), historyReconcileMinInterval)
-	require.False(t, needed)
+	window := tracker.observe(true, start.Add(10*time.Second), historyReconcileMinInterval)
+	require.Nil(t, window)
 
 	// The transition occurred between observations, so use the previous known
 	// reliable time as the conservative lower boundary.
-	window, needed := tracker.observe(false, start.Add(20*time.Second), historyReconcileMinInterval)
-	require.True(t, needed)
+	window = tracker.observe(false, start.Add(20*time.Second), historyReconcileMinInterval)
+	require.NotNil(t, window)
 	require.Equal(t, start.Add(10*time.Second), window.From)
 	require.Equal(t, start.Add(20*time.Second), window.To)
 
-	window, needed = tracker.observe(false, start.Add(50*time.Second), historyReconcileMinInterval)
-	require.True(t, needed)
+	window = tracker.observe(false, start.Add(50*time.Second), historyReconcileMinInterval)
+	require.NotNil(t, window)
 	require.Equal(t, start.Add(10*time.Second), window.From)
 	require.Equal(t, start.Add(50*time.Second), window.To)
 
-	window, needed = tracker.observe(true, start.Add(60*time.Second), historyReconcileMinInterval)
-	require.True(t, needed)
+	window = tracker.observe(true, start.Add(60*time.Second), historyReconcileMinInterval)
+	require.NotNil(t, window)
 	require.Equal(t, start.Add(10*time.Second), window.From)
 	require.Equal(t, start.Add(60*time.Second), window.To)
 
-	_, needed = tracker.observe(true, start.Add(90*time.Second), historyReconcileMinInterval)
-	require.False(t, needed)
+	window = tracker.observe(true, start.Add(90*time.Second), historyReconcileMinInterval)
+	require.Nil(t, window)
 }
 
 func TestHistoryReconcileTrackerPreservesDisjointWindows(t *testing.T) {
 	start := time.Unix(2_000, 0)
 	tracker := newHistoryReconcileTracker(true, start)
 
-	first, needed := tracker.observe(false, start.Add(10*time.Second), historyReconcileMinInterval)
-	require.True(t, needed)
-	_, needed = tracker.observe(true, start.Add(20*time.Second), historyReconcileMinInterval)
-	require.True(t, needed)
+	first := tracker.observe(false, start.Add(10*time.Second), historyReconcileMinInterval)
+	require.NotNil(t, first)
+	window := tracker.observe(true, start.Add(20*time.Second), historyReconcileMinInterval)
+	require.NotNil(t, window)
 
-	tracker.observe(true, start.Add(50*time.Second), historyReconcileMinInterval)
-	second, needed := tracker.observe(false, start.Add(60*time.Second), historyReconcileMinInterval)
-	require.True(t, needed)
+	window = tracker.observe(true, start.Add(50*time.Second), historyReconcileMinInterval)
+	require.Nil(t, window)
+	second := tracker.observe(false, start.Add(60*time.Second), historyReconcileMinInterval)
+	require.NotNil(t, second)
 
 	require.Equal(t, start, first.From)
 	require.Equal(t, start.Add(50*time.Second), second.From)

--- a/pkg/messaging/waku/history_reconcile_test.go
+++ b/pkg/messaging/waku/history_reconcile_test.go
@@ -133,19 +133,19 @@ func TestHistoryReconcileTrackerPreservesDisjointWindows(t *testing.T) {
 	require.True(t, first.To.Before(second.From))
 }
 
-func TestHistoryDeliveryReliableExcludesLightNodes(t *testing.T) {
+func TestReliablyConnected(t *testing.T) {
 	core := &Waku{
 		cfg:       &Config{Mode: ModeCore},
 		connState: types.ConnectionStateConnected,
 	}
-	require.True(t, core.HistoryDeliveryReliable())
+	require.True(t, core.reliablyConnected())
 
 	core.connState = types.ConnectionStatePartiallyConnected
-	require.False(t, core.HistoryDeliveryReliable())
+	require.False(t, core.reliablyConnected())
 
 	edge := &Waku{
 		cfg:       &Config{Mode: ModeEdge},
 		connState: types.ConnectionStateConnected,
 	}
-	require.False(t, edge.HistoryDeliveryReliable())
+	require.True(t, edge.reliablyConnected())
 }

--- a/pkg/messaging/waku/history_reconcile_test.go
+++ b/pkg/messaging/waku/history_reconcile_test.go
@@ -4,6 +4,8 @@ import (
 	"testing"
 	"time"
 
+	"go.uber.org/zap"
+
 	"github.com/stretchr/testify/require"
 
 	"github.com/status-im/status-go/pkg/messaging/waku/types"
@@ -148,4 +150,21 @@ func TestReliablyConnected(t *testing.T) {
 		connState: types.ConnectionStateConnected,
 	}
 	require.True(t, edge.reliablyConnected())
+}
+
+func TestQueueHistoryReconciliationMergesOverlappingWindows(t *testing.T) {
+	start := time.Unix(3_000, 0)
+	tracker := newHistoryReconcileTracker(true, start)
+	w := &Waku{logger: zap.NewNop()}
+	var pending []types.HistoryReconcileWindow
+
+	w.queueHistoryReconciliation(&tracker, &pending, false, start.Add(time.Second))
+	require.Len(t, pending, 1)
+	require.Equal(t, start, pending[0].From)
+	require.Equal(t, start.Add(time.Second), pending[0].To)
+
+	w.queueHistoryReconciliation(&tracker, &pending, false, start.Add(historyReconcileMinInterval+2*time.Second))
+	require.Len(t, pending, 1)
+	require.Equal(t, start, pending[0].From)
+	require.Equal(t, start.Add(historyReconcileMinInterval+2*time.Second), pending[0].To)
 }

--- a/pkg/messaging/waku/history_reconcile_test.go
+++ b/pkg/messaging/waku/history_reconcile_test.go
@@ -5,6 +5,8 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
+
+	"github.com/status-im/status-go/pkg/messaging/waku/types"
 )
 
 func TestShouldReconcileHistory(t *testing.T) {
@@ -65,4 +67,67 @@ func TestShouldReconcileHistory(t *testing.T) {
 			require.Equal(t, tt.want, got)
 		})
 	}
+}
+
+func TestHistoryReconcileTrackerBoundsUnreliableWindow(t *testing.T) {
+	start := time.Unix(1_000, 0)
+	tracker := newHistoryReconcileTracker(true, start)
+
+	_, needed := tracker.observe(true, start.Add(10*time.Second), historyReconcileMinInterval)
+	require.False(t, needed)
+
+	// The transition occurred between observations, so use the previous known
+	// reliable time as the conservative lower boundary.
+	window, needed := tracker.observe(false, start.Add(20*time.Second), historyReconcileMinInterval)
+	require.True(t, needed)
+	require.Equal(t, start.Add(10*time.Second), window.From)
+	require.Equal(t, start.Add(20*time.Second), window.To)
+
+	window, needed = tracker.observe(false, start.Add(50*time.Second), historyReconcileMinInterval)
+	require.True(t, needed)
+	require.Equal(t, start.Add(10*time.Second), window.From)
+	require.Equal(t, start.Add(50*time.Second), window.To)
+
+	window, needed = tracker.observe(true, start.Add(60*time.Second), historyReconcileMinInterval)
+	require.True(t, needed)
+	require.Equal(t, start.Add(10*time.Second), window.From)
+	require.Equal(t, start.Add(60*time.Second), window.To)
+
+	_, needed = tracker.observe(true, start.Add(90*time.Second), historyReconcileMinInterval)
+	require.False(t, needed)
+}
+
+func TestHistoryReconcileTrackerPreservesDisjointWindows(t *testing.T) {
+	start := time.Unix(2_000, 0)
+	tracker := newHistoryReconcileTracker(true, start)
+
+	first, needed := tracker.observe(false, start.Add(10*time.Second), historyReconcileMinInterval)
+	require.True(t, needed)
+	_, needed = tracker.observe(true, start.Add(20*time.Second), historyReconcileMinInterval)
+	require.True(t, needed)
+
+	tracker.observe(true, start.Add(50*time.Second), historyReconcileMinInterval)
+	second, needed := tracker.observe(false, start.Add(60*time.Second), historyReconcileMinInterval)
+	require.True(t, needed)
+
+	require.Equal(t, start, first.From)
+	require.Equal(t, start.Add(50*time.Second), second.From)
+	require.True(t, first.To.Before(second.From))
+}
+
+func TestHistoryDeliveryReliableExcludesLightNodes(t *testing.T) {
+	core := &Waku{
+		cfg:       &Config{Mode: ModeCore},
+		connState: types.ConnectionStateConnected,
+	}
+	require.True(t, core.HistoryDeliveryReliable())
+
+	core.connState = types.ConnectionStatePartiallyConnected
+	require.False(t, core.HistoryDeliveryReliable())
+
+	edge := &Waku{
+		cfg:       &Config{Mode: ModeEdge},
+		connState: types.ConnectionStateConnected,
+	}
+	require.False(t, edge.HistoryDeliveryReliable())
 }

--- a/pkg/messaging/waku/types/connection.go
+++ b/pkg/messaging/waku/types/connection.go
@@ -1,5 +1,7 @@
 package types
 
+import "time"
+
 // ConnectionState mirrors the logos-delivery Messaging API's three-state
 // connection status (see logos-delivery waku/api/types.nim `ConnectionStatus`).
 // It lets status-go speak the same vocabulary as the Messaging API:
@@ -34,4 +36,12 @@ func (s ConnectionState) String() string {
 	default:
 		return "disconnected"
 	}
+}
+
+// HistoryReconcileWindow is a period during which live delivery could not be
+// trusted. Store reconciliation must not query beyond these bounds (apart from
+// the caller's small out-of-order tolerance).
+type HistoryReconcileWindow struct {
+	From time.Time
+	To   time.Time
 }

--- a/pkg/messaging/waku/types/waku.go
+++ b/pkg/messaging/waku/types/waku.go
@@ -115,11 +115,6 @@ type Waku interface {
 	// should be reconciled with store nodes (#7568).
 	OnHistoryReconcileNeeded() <-chan HistoryReconcileWindow
 
-	// HistoryDeliveryReliable reports whether a full-node relay mesh is healthy
-	// enough that active topics can advance their history completeness cursor
-	// without querying a store node. It is deliberately false for light nodes.
-	HistoryDeliveryReliable() bool
-
 	SubscribeEnvelopeEvents(events chan<- EnvelopeEvent) Subscription
 
 	MaxMessageSize() uint32

--- a/pkg/messaging/waku/types/waku.go
+++ b/pkg/messaging/waku/types/waku.go
@@ -111,12 +111,14 @@ type Waku interface {
 	// from it via ConnectionState.IsOnline().
 	ConnectionState() ConnectionState
 
-	// OnHistoryReconcileNeeded returns a channel signalled whenever history
-	// should be reconciled with the store nodes (#7568): periodically while
-	// connectivity is not reliable (relay mesh not Connected on every default
-	// shard), and once more when connectivity recovers. Buffered
-	// level-trigger; pending signals coalesce.
-	OnHistoryReconcileNeeded() <-chan struct{}
+	// OnHistoryReconcileNeeded returns the unreliable delivery windows that
+	// should be reconciled with store nodes (#7568).
+	OnHistoryReconcileNeeded() <-chan HistoryReconcileWindow
+
+	// HistoryDeliveryReliable reports whether a full-node relay mesh is healthy
+	// enough that active topics can advance their history completeness cursor
+	// without querying a store node. It is deliberately false for light nodes.
+	HistoryDeliveryReliable() bool
 
 	SubscribeEnvelopeEvents(events chan<- EnvelopeEvent) Subscription
 

--- a/protocol/messenger.go
+++ b/protocol/messenger.go
@@ -1336,10 +1336,10 @@ func (m *Messenger) handleENSVerificationSubscription(c chan []*ens.Verification
 // watchConnectionChange checks the connection status and call handleConnectionChange when this changes
 func (m *Messenger) watchConnectionChange() {
 	state := m.Online()
-	// lastCheck, sleepDetention and keepAlive helps us recognizing when computer was offline because of sleep, lid closed, etc.
+	// lastCheck, sleepDetention and keepAlive help recognize system sleep, a gap
+	// that Waku cannot observe while the process is suspended.
 	lastCheck := time.Now()
 	lastHistoryCheck := m.historicSyncNow()
-	var offlineSince time.Time
 	sleepDetention := 20 * time.Second
 	keepAlivePeriod := 15 * time.Second // must be lower than sleepDetention
 
@@ -1354,17 +1354,11 @@ func (m *Messenger) watchConnectionChange() {
 			return
 		}
 		wasOnline := state
-		if wasOnline && !newState {
-			offlineSince = previousCheck
-		}
 		state = newState
 		m.logger.Debug("connection changed", zap.Bool("online", state), zap.Bool("force", force))
 		m.handleConnectionChange(state)
 		if !m.isPaused() && newState {
 			switch {
-			case !wasOnline && !offlineSince.IsZero() && offlineSince.Before(historyNow):
-				m.asyncRequestHistoricMessages(types2.HistoryReconcileWindow{From: offlineSince, To: historyNow})
-				offlineSince = time.Time{}
 			case wasOnline && force && previousCheck.Before(historyNow):
 				// The process did not observe connectivity during this interval
 				// (typically system sleep), so treat it as unreliable.

--- a/protocol/messenger.go
+++ b/protocol/messenger.go
@@ -154,7 +154,6 @@ type Messenger struct {
 	historicSyncWorkerActive atomic.Bool
 	// historicSyncTrigger wakes the worker after pending work is added.
 	historicSyncTrigger  chan struct{}
-	historyPausedAt      atomic.Int64
 	ratchetNotFoundDelay time.Duration
 
 	connectionState       connection.State
@@ -562,7 +561,6 @@ func (m *Messenger) SetPaused(paused bool) {
 	wasPaused := m.paused.Swap(paused)
 	if paused && !wasPaused {
 		m.advanceHistoryCursors(now)
-		m.historyPausedAt.Store(now.Unix())
 	}
 	if m.ensVerifier != nil {
 		m.ensVerifier.SetPaused(paused)
@@ -588,12 +586,8 @@ func (m *Messenger) SetPaused(paused bool) {
 		if m.httpServer != nil {
 			m.httpServer.ToForeground()
 		}
-		if m.started && wasPaused {
-			pausedAt := m.historyPausedAt.Swap(0)
-			from := time.Unix(pausedAt, 0)
-			if pausedAt > 0 && from.Before(now) {
-				m.asyncRequestHistoricMessages(types2.HistoryReconcileWindow{From: from, To: now})
-			}
+		if wasPaused {
+			m.notifyHistoricSyncWorker()
 		}
 	} else if m.httpServer != nil {
 		m.httpServer.ToBackground()

--- a/protocol/messenger.go
+++ b/protocol/messenger.go
@@ -150,7 +150,7 @@ type Messenger struct {
 	historicSyncMu           sync.Mutex
 	historicSyncInFlight     bool
 	historicSyncQueueMu      sync.Mutex
-	historicSyncPending      []historicSyncRequest
+	historicSyncQueue        []historicSyncRequest
 	historicSyncWorkerActive atomic.Bool
 	// historicSyncTrigger wakes the worker after pending work is added.
 	historicSyncTrigger  chan struct{}
@@ -561,7 +561,7 @@ func (m *Messenger) SetPaused(paused bool) {
 	now := m.historicSyncNow()
 	wasPaused := m.paused.Swap(paused)
 	if paused && !wasPaused {
-		m.checkpointHistoryWatermarks(now)
+		m.advanceHistoryCursors(now)
 		m.historyPausedAt.Store(now.Unix())
 	}
 	if m.ensVerifier != nil {
@@ -661,7 +661,7 @@ func (m *Messenger) Start() (*MessengerResponse, error) {
 	m.watchConnectionChange()
 	m.startHistoricSyncWorker()
 	m.startHistoryReconciliationLoop()
-	m.startHistoryWatermarkCheckpointLoop()
+	m.startHistoryCursorMonitor()
 	m.watchChatsToUnmute()
 	m.watchCommunitiesToUnmute()
 	m.watchExpiredMessages()
@@ -1636,7 +1636,7 @@ func (m *Messenger) Shutdown() (err error) {
 	}
 
 	if !m.isPaused() {
-		m.checkpointHistoryWatermarks(m.historicSyncNow())
+		m.advanceHistoryCursors(m.historicSyncNow())
 	}
 	close(m.quit)
 	m.cancel()

--- a/protocol/messenger.go
+++ b/protocol/messenger.go
@@ -147,11 +147,14 @@ type Messenger struct {
 		wait chan struct{}
 		once sync.Once
 	}
-	historicSyncMu       sync.Mutex
-	historicSyncInFlight bool
-	// historicSyncTrigger feeds the historic-sync worker; buffered (1) so
-	// triggers coalesce (see asyncRequestAllHistoricMessages).
+	historicSyncMu           sync.Mutex
+	historicSyncInFlight     bool
+	historicSyncQueueMu      sync.Mutex
+	historicSyncPending      []historicSyncRequest
+	historicSyncWorkerActive atomic.Bool
+	// historicSyncTrigger wakes the worker after pending work is added.
 	historicSyncTrigger  chan struct{}
+	historyPausedAt      atomic.Int64
 	ratchetNotFoundDelay time.Duration
 
 	connectionState       connection.State
@@ -555,7 +558,12 @@ func (m *Messenger) processSentMessage(id string) error {
 }
 
 func (m *Messenger) SetPaused(paused bool) {
-	m.paused.Store(paused)
+	now := m.historicSyncNow()
+	wasPaused := m.paused.Swap(paused)
+	if paused && !wasPaused {
+		m.checkpointHistoryWatermarks(now)
+		m.historyPausedAt.Store(now.Unix())
+	}
 	if m.ensVerifier != nil {
 		m.ensVerifier.SetPaused(paused)
 	}
@@ -580,8 +588,12 @@ func (m *Messenger) SetPaused(paused bool) {
 		if m.httpServer != nil {
 			m.httpServer.ToForeground()
 		}
-		if m.started {
-			m.asyncRequestAllHistoricMessages()
+		if m.started && wasPaused {
+			pausedAt := m.historyPausedAt.Swap(0)
+			from := time.Unix(pausedAt, 0)
+			if pausedAt > 0 && from.Before(now) {
+				m.asyncRequestHistoricMessages(types2.HistoryReconcileWindow{From: from, To: now})
+			}
 		}
 	} else if m.httpServer != nil {
 		m.httpServer.ToBackground()
@@ -649,6 +661,7 @@ func (m *Messenger) Start() (*MessengerResponse, error) {
 	m.watchConnectionChange()
 	m.startHistoricSyncWorker()
 	m.startHistoryReconciliationLoop()
+	m.startHistoryWatermarkCheckpointLoop()
 	m.watchChatsToUnmute()
 	m.watchCommunitiesToUnmute()
 	m.watchExpiredMessages()
@@ -820,12 +833,6 @@ func (m *Messenger) handleConnectionChange(online bool) {
 			m.logger.Error("could not publish on contact code", zap.Error(err))
 		}
 		m.shouldPublishContactCode = false
-	}
-
-	// Start fetching messages from store nodes.
-	// Skip when backgrounded: the sync will run when the app returns to foreground.
-	if online && !m.isPaused() {
-		m.asyncRequestAllHistoricMessages()
 	}
 
 	// Update ENS verifier
@@ -1336,20 +1343,41 @@ func (m *Messenger) handleENSVerificationSubscription(c chan []*ens.Verification
 func (m *Messenger) watchConnectionChange() {
 	state := m.Online()
 	// lastCheck, sleepDetention and keepAlive helps us recognizing when computer was offline because of sleep, lid closed, etc.
-	lastCheck := time.Now().Unix()
-	sleepDetentionInSecs := int64(20)
-	keepAlivePeriod := 15 * time.Second // must be lower than sleepDetentionInSecs
+	lastCheck := time.Now()
+	lastHistoryCheck := m.historicSyncNow()
+	var offlineSince time.Time
+	sleepDetention := 20 * time.Second
+	keepAlivePeriod := 15 * time.Second // must be lower than sleepDetention
 
 	processNewState := func(newState bool) {
-		now := time.Now().Unix()
-		force := now-lastCheck > sleepDetentionInSecs
+		now := time.Now()
+		historyNow := m.historicSyncNow()
+		previousCheck := lastHistoryCheck
+		force := now.Sub(lastCheck) > sleepDetention
 		lastCheck = now
+		lastHistoryCheck = historyNow
 		if !force && state == newState {
 			return
+		}
+		wasOnline := state
+		if wasOnline && !newState {
+			offlineSince = previousCheck
 		}
 		state = newState
 		m.logger.Debug("connection changed", zap.Bool("online", state), zap.Bool("force", force))
 		m.handleConnectionChange(state)
+		if !m.isPaused() && newState {
+			switch {
+			case !wasOnline && !offlineSince.IsZero() && offlineSince.Before(historyNow):
+				m.asyncRequestHistoricMessages(types2.HistoryReconcileWindow{From: offlineSince, To: historyNow})
+				offlineSince = time.Time{}
+			case wasOnline && force && previousCheck.Before(historyNow):
+				// The process did not observe connectivity during this interval
+				// (typically system sleep), so treat it as unreliable.
+				m.asyncRequestHistoricMessages(types2.HistoryReconcileWindow{From: previousCheck, To: historyNow})
+			}
+			m.notifyHistoricSyncWorker()
+		}
 	}
 
 	subscribedConnectionStatus := func(subscription types2.ConnectionStatusSubscription) {
@@ -1607,6 +1635,9 @@ func (m *Messenger) Shutdown() (err error) {
 	default:
 	}
 
+	if !m.isPaused() {
+		m.checkpointHistoryWatermarks(m.historicSyncNow())
+	}
 	close(m.quit)
 	m.cancel()
 

--- a/protocol/messenger_mailserver.go
+++ b/protocol/messenger_mailserver.go
@@ -268,22 +268,7 @@ func (m *Messenger) requestAllHistoricMessagesWithOptions(aggregateResponses boo
 		return nil, false, nil
 	}
 
-	m.historicSyncMu.Lock()
-	if m.historicSyncInFlight {
-		m.historicSyncMu.Unlock()
-		m.logger.Debug("defer historic sync request (already in progress)")
-		return nil, false, nil
-	}
-	m.historicSyncInFlight = true
-	m.historicSyncMu.Unlock()
-	defer func() {
-		m.historicSyncMu.Lock()
-		m.historicSyncInFlight = false
-		m.historicSyncMu.Unlock()
-		m.notifyHistoricSyncWorker()
-	}()
-
-	response, err := func() (*MessengerResponse, error) {
+	return m.withHistoricSyncInFlight(func() (*MessengerResponse, error) {
 		var allResponses *MessengerResponse
 		if aggregateResponses {
 			allResponses = &MessengerResponse{}
@@ -312,20 +297,19 @@ func (m *Messenger) requestAllHistoricMessagesWithOptions(aggregateResponses boo
 			allResponses.AddMessages(response.Messages())
 		}
 		return allResponses, nil
-	}()
-	return response, true, err
+	})
 }
 
 // withHistoricSyncInFlight runs fn unless another historic sync is already in
 // progress. Automatic syncs are serialized and spaced by the historic-sync
 // worker (startHistoricSyncWorker); this gate protects against a manual
 // RequestAllHistoricMessages (RPC) racing the worker.
-func (m *Messenger) withHistoricSyncInFlight(fn func() (*MessengerResponse, error)) (*MessengerResponse, error) {
+func (m *Messenger) withHistoricSyncInFlight(fn func() (*MessengerResponse, error)) (*MessengerResponse, bool, error) {
 	m.historicSyncMu.Lock()
 	if m.historicSyncInFlight {
 		m.historicSyncMu.Unlock()
 		m.logger.Debug("skip historic sync request (already in progress)")
-		return nil, nil
+		return nil, false, nil
 	}
 	m.historicSyncInFlight = true
 	m.historicSyncMu.Unlock()
@@ -333,9 +317,11 @@ func (m *Messenger) withHistoricSyncInFlight(fn func() (*MessengerResponse, erro
 		m.historicSyncMu.Lock()
 		m.historicSyncInFlight = false
 		m.historicSyncMu.Unlock()
+		m.notifyHistoricSyncWorker()
 	}()
 
-	return fn()
+	response, err := fn()
+	return response, true, err
 }
 
 type syncFiltersOptions struct {

--- a/protocol/messenger_mailserver.go
+++ b/protocol/messenger_mailserver.go
@@ -599,7 +599,7 @@ func (m *Messenger) syncFiltersWithOptions(filters types2.ChatFilters, options s
 		}
 	}
 
-	m.fetchLatestCommunityDescriptions(communityDescriptionFilters, options.Window)
+	m.fetchLatestCommunityDescriptions(communityDescriptionFilters)
 
 	return response, nil
 }
@@ -625,27 +625,12 @@ func (m *Messenger) communityDescriptionChatIDs() (map[string]struct{}, error) {
 // fetchLatestCommunityDescriptions gets the latest description for each
 // community filter and stops after the first page of results.
 // This avoids downloading many older copies.
-func (m *Messenger) fetchLatestCommunityDescriptions(filters []*types2.ChatFilter, windows ...*types2.HistoryReconcileWindow) {
+func (m *Messenger) fetchLatestCommunityDescriptions(filters []*types2.ChatFilter) {
 	if len(filters) == 0 {
 		return
 	}
 
 	from, to := m.calculateMailserverTimeBounds(oneMonthDuration)
-	var window *types2.HistoryReconcileWindow
-	if len(windows) > 0 {
-		window = windows[0]
-	}
-	if window != nil {
-		if !window.To.IsZero() {
-			to = window.To
-		}
-		if !window.From.IsZero() {
-			windowFrom := window.From.Add(-time.Duration(tolerance) * time.Second)
-			if windowFrom.After(from) {
-				from = windowFrom
-			}
-		}
-	}
 	if !from.Before(to) {
 		return
 	}

--- a/protocol/messenger_mailserver.go
+++ b/protocol/messenger_mailserver.go
@@ -240,6 +240,9 @@ func (m *Messenger) requestAllHistoricMessages(aggregateResponses bool) (*Messen
 }
 
 func (m *Messenger) runAutomaticHistoricSync(request historicSyncRequest) (bool, error) {
+	if m.isPaused() {
+		return false, nil
+	}
 	_, executed, err := m.requestAllHistoricMessagesWithOptions(false, syncFiltersOptions{
 		Window: &types2.HistoryReconcileWindow{From: request.From, To: request.To},
 	})

--- a/protocol/messenger_mailserver.go
+++ b/protocol/messenger_mailserver.go
@@ -235,28 +235,55 @@ func (m *Messenger) RequestAllHistoricMessages() (*MessengerResponse, error) {
 }
 
 func (m *Messenger) requestAllHistoricMessages(aggregateResponses bool) (*MessengerResponse, error) {
+	response, _, err := m.requestAllHistoricMessagesWithOptions(aggregateResponses, syncFiltersOptions{})
+	return response, err
+}
+
+func (m *Messenger) runAutomaticHistoricSync(request historicSyncRequest) (bool, error) {
+	_, executed, err := m.requestAllHistoricMessagesWithOptions(false, syncFiltersOptions{
+		Window: &types2.HistoryReconcileWindow{From: request.From, To: request.To},
+	})
+	return executed, err
+}
+
+func (m *Messenger) requestAllHistoricMessagesWithOptions(aggregateResponses bool, options syncFiltersOptions) (*MessengerResponse, bool, error) {
 	shouldSync, err := m.shouldSync()
 	if err != nil {
-		return nil, err
+		return nil, false, err
 	}
 
 	if !shouldSync {
-		return nil, nil
+		return nil, false, nil
 	}
 
 	if m.mailserversDatabase == nil {
-		return nil, nil
+		return nil, true, nil
 	}
 
 	canSync, err := m.canSyncWithStoreNodes()
 	if err != nil {
-		return nil, err
+		return nil, false, err
 	}
 	if !canSync {
-		return nil, nil
+		return nil, false, nil
 	}
 
-	return m.withHistoricSyncInFlight(func() (*MessengerResponse, error) {
+	m.historicSyncMu.Lock()
+	if m.historicSyncInFlight {
+		m.historicSyncMu.Unlock()
+		m.logger.Debug("defer historic sync request (already in progress)")
+		return nil, false, nil
+	}
+	m.historicSyncInFlight = true
+	m.historicSyncMu.Unlock()
+	defer func() {
+		m.historicSyncMu.Lock()
+		m.historicSyncInFlight = false
+		m.historicSyncMu.Unlock()
+		m.notifyHistoricSyncWorker()
+	}()
+
+	response, err := func() (*MessengerResponse, error) {
 		var allResponses *MessengerResponse
 		if aggregateResponses {
 			allResponses = &MessengerResponse{}
@@ -276,7 +303,7 @@ func (m *Messenger) requestAllHistoricMessages(aggregateResponses bool) (*Messen
 
 		// Retry and failover are handled per query by the StoreClient (it pins a
 		// store node for the whole query and fails over only at query boundaries).
-		response, err := m.syncFilters(filters)
+		response, err := m.syncFiltersWithOptions(filters, options)
 		if err != nil {
 			return nil, err
 		}
@@ -285,7 +312,8 @@ func (m *Messenger) requestAllHistoricMessages(aggregateResponses bool) (*Messen
 			allResponses.AddMessages(response.Messages())
 		}
 		return allResponses, nil
-	})
+	}()
+	return response, true, err
 }
 
 // withHistoricSyncInFlight runs fn unless another historic sync is already in
@@ -310,11 +338,38 @@ func (m *Messenger) withHistoricSyncInFlight(fn func() (*MessengerResponse, erro
 	return fn()
 }
 
+type syncFiltersOptions struct {
+	// ExactFrom preserves the archive-builder behavior: existing topics are
+	// queried from this timestamp regardless of their completeness cursor.
+	ExactFrom uint32
+	// Window bounds automatic reconciliation. A zero From means cursor-based
+	// catch-up with only a fixed upper bound (used at startup).
+	Window *types2.HistoryReconcileWindow
+}
+
+func applyHistoryWindowFloor(from uint32, initialized bool, window *types2.HistoryReconcileWindow) uint32 {
+	if !initialized || window == nil || window.From.IsZero() {
+		return from
+	}
+	windowFrom := window.From.Unix() - int64(tolerance)
+	if windowFrom < 0 {
+		windowFrom = 0
+	}
+	if uint32(windowFrom) > from {
+		return uint32(windowFrom)
+	}
+	return from
+}
+
 func getPrioritizedBatches() []int {
 	return []int{1, 5, 10}
 }
 
 func (m *Messenger) syncFiltersFrom(filters types2.ChatFilters, lastRequest uint32) (*MessengerResponse, error) {
+	return m.syncFiltersWithOptions(filters, syncFiltersOptions{ExactFrom: lastRequest})
+}
+
+func (m *Messenger) syncFiltersWithOptions(filters types2.ChatFilters, options syncFiltersOptions) (*MessengerResponse, error) {
 	canSync, err := m.canSyncWithStoreNodes()
 	if err != nil {
 		return nil, err
@@ -337,6 +392,9 @@ func (m *Messenger) syncFiltersFrom(filters types2.ChatFilters, lastRequest uint
 	batches := make(map[string]map[int]types2.StoreNodeBatch)
 
 	to := m.calculateMailserverTo()
+	if options.Window != nil && !options.Window.To.IsZero() {
+		to = options.Window.To
+	}
 	syncedTopics := make([]mailservers.MailserverTopic, 0, len(filters))
 
 	sort.Slice(filters[:], func(i, j int) bool {
@@ -348,6 +406,12 @@ func (m *Messenger) syncFiltersFrom(filters types2.ChatFilters, lastRequest uint
 	currentBatch := 0
 
 	if len(filters) == 0 || filters[0].Priority() == 0 {
+		currentBatch = len(prioritizedBatches)
+	}
+	if options.Window != nil && !options.Window.From.IsZero() {
+		// Windowed reconciliation must evaluate every topic's lower and upper
+		// bounds independently; priority batches may intentionally combine
+		// topics with different cursors.
 		currentBatch = len(prioritizedBatches)
 	}
 
@@ -402,18 +466,16 @@ func (m *Messenger) syncFiltersFrom(filters types2.ChatFilters, lastRequest uint
 			}
 
 			topicData, ok := topicsData[fmt.Sprintf("%s-%s", filter.PubsubTopic(), filter.ContentTopic())]
+			topicExists := ok
 			var capToDefaultSyncPeriod = true
 			if !ok {
-				if lastRequest == 0 {
-					lastRequest = defaultPeriodFromNow
-				}
 				topicData = mailservers.MailserverTopic{
 					PubsubTopic:  filter.PubsubTopic(),
 					ContentTopic: filter.ContentTopic().String(),
 					LastRequest:  int(defaultPeriodFromNow),
 				}
-			} else if lastRequest != 0 {
-				topicData.LastRequest = int(lastRequest)
+			} else if options.ExactFrom != 0 {
+				topicData.LastRequest = int(options.ExactFrom)
 				capToDefaultSyncPeriod = false
 			}
 
@@ -448,6 +510,17 @@ func (m *Messenger) syncFiltersFrom(filters types2.ChatFilters, lastRequest uint
 						return nil, err
 					}
 				}
+				// Only initialized, existing topics may be narrowed to an
+				// unreliable window. New/reset topics still need their default
+				// initial history regardless of the current window.
+				from = applyHistoryWindowFloor(
+					from,
+					topicExists && topicData.LastRequest > 0,
+					options.Window,
+				)
+				if int64(from) >= to.Unix() {
+					continue
+				}
 				batch = types2.StoreNodeBatch{From: time.Unix(int64(from), 0), To: to}
 			}
 
@@ -457,13 +530,21 @@ func (m *Messenger) syncFiltersFrom(filters types2.ChatFilters, lastRequest uint
 			batches[pubsubTopic][batchID] = batch
 
 			// Set last request to the new `to`
-			topicData.LastRequest = int(to.Unix())
+			if topicData.LastRequest < int(to.Unix()) {
+				topicData.LastRequest = int(to.Unix())
+			}
 			syncedTopics = append(syncedTopics, topicData)
 		}
 	}
 
-	if m.config.messengerSignalsHandler != nil {
-		m.config.messengerSignalsHandler.HistoryRequestStarted(len(batches))
+	batchedPubsubTopics := 0
+	for _, topicBatches := range batches {
+		if len(topicBatches) > 0 {
+			batchedPubsubTopics++
+		}
+	}
+	if batchedPubsubTopics > 0 && m.config.messengerSignalsHandler != nil {
+		m.config.messengerSignalsHandler.HistoryRequestStarted(batchedPubsubTopics)
 	}
 
 	for pubsubTopic := range batches {
@@ -479,13 +560,15 @@ func (m *Messenger) syncFiltersFrom(filters types2.ChatFilters, lastRequest uint
 	}
 
 	m.logger.Debug("topics synced")
-	if m.config.messengerSignalsHandler != nil {
+	if batchedPubsubTopics > 0 && m.config.messengerSignalsHandler != nil {
 		m.config.messengerSignalsHandler.HistoryRequestCompleted()
 	}
 
-	err = m.mailserversDatabase.AddTopics(syncedTopics)
-	if err != nil {
-		return nil, err
+	if len(syncedTopics) > 0 {
+		err = m.mailserversDatabase.AddTopics(syncedTopics)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	messagesToBeSaved := make([]*common.Message, 0, len(syncedTopics))
@@ -527,13 +610,13 @@ func (m *Messenger) syncFiltersFrom(filters types2.ChatFilters, lastRequest uint
 		}
 	}
 
-	m.fetchLatestCommunityDescriptions(communityDescriptionFilters)
+	m.fetchLatestCommunityDescriptions(communityDescriptionFilters, options.Window)
 
 	return response, nil
 }
 
 func (m *Messenger) syncFilters(filters types2.ChatFilters) (*MessengerResponse, error) {
-	return m.syncFiltersFrom(filters, 0)
+	return m.syncFiltersWithOptions(filters, syncFiltersOptions{})
 }
 
 // communityDescriptionChatIDs returns chat IDs for joined and spectated communities.
@@ -553,12 +636,30 @@ func (m *Messenger) communityDescriptionChatIDs() (map[string]struct{}, error) {
 // fetchLatestCommunityDescriptions gets the latest description for each
 // community filter and stops after the first page of results.
 // This avoids downloading many older copies.
-func (m *Messenger) fetchLatestCommunityDescriptions(filters []*types2.ChatFilter) {
+func (m *Messenger) fetchLatestCommunityDescriptions(filters []*types2.ChatFilter, windows ...*types2.HistoryReconcileWindow) {
 	if len(filters) == 0 {
 		return
 	}
 
 	from, to := m.calculateMailserverTimeBounds(oneMonthDuration)
+	var window *types2.HistoryReconcileWindow
+	if len(windows) > 0 {
+		window = windows[0]
+	}
+	if window != nil {
+		if !window.To.IsZero() {
+			to = window.To
+		}
+		if !window.From.IsZero() {
+			windowFrom := window.From.Add(-time.Duration(tolerance) * time.Second)
+			if windowFrom.After(from) {
+				from = windowFrom
+			}
+		}
+	}
+	if !from.Before(to) {
+		return
+	}
 	stopAfterFirstPage := func(int) (bool, uint64) {
 		return false, 0
 	}

--- a/protocol/messenger_mailserver_cycle.go
+++ b/protocol/messenger_mailserver_cycle.go
@@ -12,6 +12,8 @@ import (
 
 const historyCursorMonitorInterval = time.Minute
 
+// historicSyncNow returns the upper-bound timestamp for history sync requests,
+// using the Messenger clock when available and wall time during initialization.
 func (m *Messenger) historicSyncNow() time.Time {
 	if m.messaging == nil {
 		return time.Now()
@@ -306,12 +308,16 @@ func (m *Messenger) startHistoricSyncWorker() {
 						deferred = true
 						break
 					}
+					previousAttempt := lastAttempt
 					lastAttempt = time.Now()
 					executed, err := m.runAutomaticHistoricSync(request)
 					if err == nil && executed {
 						break
 					}
 					if err == nil {
+						// A skipped run never touched a store node, so it must not
+						// consume the rate-limit budget of the next real attempt.
+						lastAttempt = previousAttempt
 						// Offline and policy-blocked requests stay pending. Their
 						// corresponding online/resume/setting transition wakes us.
 						m.requeueHistoricSync(request)

--- a/protocol/messenger_mailserver_cycle.go
+++ b/protocol/messenger_mailserver_cycle.go
@@ -141,8 +141,8 @@ func (m *Messenger) startHistoryReconciliationLoop() {
 }
 
 // startHistoryCursorMonitor advances initialized topic cursors while
-// a foreground full node has a healthy relay mesh. This records reliable live
-// delivery without issuing store queries and bounds catch-up after a crash.
+// a full node has a healthy relay mesh. This records reliable live delivery
+// without issuing store queries and bounds catch-up after a crash.
 func (m *Messenger) startHistoryCursorMonitor() {
 	if !m.config.codeControlFlags.AutoRequestHistoricMessages {
 		return
@@ -160,14 +160,12 @@ func (m *Messenger) startHistoryCursorMonitor() {
 			case <-m.quit:
 				return
 			case <-ticker.C:
-				if !m.isPaused() {
-					// Stay one tolerance window behind the observation so a
-					// concurrent reliability transition cannot advance a cursor
-					// into the newly unreliable interval.
-					m.advanceHistoryCursors(
-						m.historicSyncNow().Add(-time.Duration(tolerance) * time.Second),
-					)
-				}
+				// Stay one tolerance window behind the observation so a
+				// concurrent reliability transition cannot advance a cursor
+				// into the newly unreliable interval.
+				m.advanceHistoryCursors(
+					m.historicSyncNow().Add(-time.Duration(tolerance) * time.Second),
+				)
 			}
 		}
 	}()
@@ -303,6 +301,11 @@ func (m *Messenger) startHistoricSyncWorker() {
 				deadline := time.Now().Add(historicSyncRetryTimeout)
 				deferred := false
 				for {
+					if m.isPaused() {
+						m.requeueHistoricSync(request)
+						deferred = true
+						break
+					}
 					lastAttempt = time.Now()
 					executed, err := m.runAutomaticHistoricSync(request)
 					if err == nil && executed {

--- a/protocol/messenger_mailserver_cycle.go
+++ b/protocol/messenger_mailserver_cycle.go
@@ -175,7 +175,7 @@ func (m *Messenger) startHistoryCursorMonitor() {
 
 func (m *Messenger) advanceHistoryCursors(through time.Time) {
 	if through.IsZero() || m.mailserversDatabase == nil || m.messaging == nil ||
-		!m.messaging.HistoryDeliveryReliable() {
+		m.messaging.ConnectionStatus().State != messagingtypes.ConnectionStateConnected {
 		return
 	}
 	m.historicSyncQueueMu.Lock()

--- a/protocol/messenger_mailserver_cycle.go
+++ b/protocol/messenger_mailserver_cycle.go
@@ -10,7 +10,7 @@ import (
 	messagingtypes "github.com/status-im/status-go/pkg/messaging/types"
 )
 
-const historyWatermarkCheckpointInterval = time.Minute
+const historyCursorMonitorInterval = time.Minute
 
 func (m *Messenger) historicSyncNow() time.Time {
 	if m.messaging == nil {
@@ -133,17 +133,17 @@ func (m *Messenger) startHistoryReconciliationLoop() {
 				if window.From.IsZero() {
 					continue
 				}
-				m.checkpointHistoryWatermarks(window.From)
+				m.advanceHistoryCursors(window.From)
 				m.asyncRequestHistoricMessages(window)
 			}
 		}
 	}()
 }
 
-// startHistoryWatermarkCheckpointLoop advances initialized topic cursors while
+// startHistoryCursorMonitor advances initialized topic cursors while
 // a foreground full node has a healthy relay mesh. This records reliable live
 // delivery without issuing store queries and bounds catch-up after a crash.
-func (m *Messenger) startHistoryWatermarkCheckpointLoop() {
+func (m *Messenger) startHistoryCursorMonitor() {
 	if !m.config.codeControlFlags.AutoRequestHistoricMessages {
 		return
 	}
@@ -153,7 +153,7 @@ func (m *Messenger) startHistoryWatermarkCheckpointLoop() {
 		defer gocommon.LogOnPanic()
 		defer m.shutdownWaitGroup.Done()
 
-		ticker := time.NewTicker(historyWatermarkCheckpointInterval)
+		ticker := time.NewTicker(historyCursorMonitorInterval)
 		defer ticker.Stop()
 		for {
 			select {
@@ -164,7 +164,7 @@ func (m *Messenger) startHistoryWatermarkCheckpointLoop() {
 					// Stay one tolerance window behind the observation so a
 					// concurrent reliability transition cannot advance a cursor
 					// into the newly unreliable interval.
-					m.checkpointHistoryWatermarks(
+					m.advanceHistoryCursors(
 						m.historicSyncNow().Add(-time.Duration(tolerance) * time.Second),
 					)
 				}
@@ -173,13 +173,13 @@ func (m *Messenger) startHistoryWatermarkCheckpointLoop() {
 	}()
 }
 
-func (m *Messenger) checkpointHistoryWatermarks(through time.Time) {
+func (m *Messenger) advanceHistoryCursors(through time.Time) {
 	if through.IsZero() || m.mailserversDatabase == nil || m.messaging == nil ||
 		!m.messaging.HistoryDeliveryReliable() {
 		return
 	}
 	m.historicSyncQueueMu.Lock()
-	hasPending := len(m.historicSyncPending) > 0
+	hasPending := len(m.historicSyncQueue) > 0
 	m.historicSyncQueueMu.Unlock()
 	if hasPending || m.historicSyncWorkerActive.Load() {
 		return
@@ -189,8 +189,8 @@ func (m *Messenger) checkpointHistoryWatermarks(through time.Time) {
 	if m.historicSyncInFlight {
 		return
 	}
-	if err := m.mailserversDatabase.AdvanceLastRequest(int(through.Unix())); err != nil {
-		m.logger.Warn("failed to checkpoint history completeness", zap.Error(err))
+	if err := m.mailserversDatabase.AdvanceHistoryCursors(int(through.Unix())); err != nil {
+		m.logger.Warn("failed to advance history cursors", zap.Error(err))
 	}
 }
 
@@ -215,8 +215,8 @@ func (m *Messenger) enqueueHistoricSync(request historicSyncRequest) {
 		zap.Time("to", request.To))
 
 	m.historicSyncQueueMu.Lock()
-	m.historicSyncPending = append(m.historicSyncPending, request)
-	m.historicSyncPending = coalesceHistoricSyncRequests(m.historicSyncPending)
+	m.historicSyncQueue = append(m.historicSyncQueue, request)
+	m.historicSyncQueue = coalesceHistoricSyncRequests(m.historicSyncQueue)
 	m.historicSyncQueueMu.Unlock()
 
 	m.notifyHistoricSyncWorker()
@@ -232,18 +232,18 @@ func (m *Messenger) notifyHistoricSyncWorker() {
 func (m *Messenger) takeHistoricSync() (historicSyncRequest, bool) {
 	m.historicSyncQueueMu.Lock()
 	defer m.historicSyncQueueMu.Unlock()
-	if len(m.historicSyncPending) == 0 {
+	if len(m.historicSyncQueue) == 0 {
 		return historicSyncRequest{}, false
 	}
-	request := m.historicSyncPending[0]
-	m.historicSyncPending = m.historicSyncPending[1:]
+	request := m.historicSyncQueue[0]
+	m.historicSyncQueue = m.historicSyncQueue[1:]
 	return request, true
 }
 
 func (m *Messenger) requeueHistoricSync(request historicSyncRequest) {
 	m.historicSyncQueueMu.Lock()
-	m.historicSyncPending = append(m.historicSyncPending, request)
-	m.historicSyncPending = coalesceHistoricSyncRequests(m.historicSyncPending)
+	m.historicSyncQueue = append(m.historicSyncQueue, request)
+	m.historicSyncQueue = coalesceHistoricSyncRequests(m.historicSyncQueue)
 	m.historicSyncQueueMu.Unlock()
 }
 

--- a/protocol/messenger_mailserver_cycle.go
+++ b/protocol/messenger_mailserver_cycle.go
@@ -1,12 +1,101 @@
 package protocol
 
 import (
+	"sort"
 	"time"
 
 	"go.uber.org/zap"
 
 	gocommon "github.com/status-im/status-go/common"
+	messagingtypes "github.com/status-im/status-go/pkg/messaging/types"
 )
+
+const historyWatermarkCheckpointInterval = time.Minute
+
+func (m *Messenger) historicSyncNow() time.Time {
+	if m.messaging == nil {
+		return time.Now()
+	}
+	return m.calculateMailserverTo()
+}
+
+// historicSyncRequest has a fixed upper bound so queueing and retries never
+// expand a request into time during which delivery has become reliable.
+// A zero From means "start from each topic's completeness cursor".
+type historicSyncRequest struct {
+	From time.Time
+	To   time.Time
+}
+
+func (r historicSyncRequest) bounded() bool {
+	return !r.From.IsZero()
+}
+
+func (r historicSyncRequest) valid() bool {
+	return !r.To.IsZero() && (!r.bounded() || r.From.Before(r.To))
+}
+
+func historicSyncRequestsOverlap(a, b historicSyncRequest) bool {
+	return a.bounded() && b.bounded() &&
+		!a.To.Before(b.From) && !b.To.Before(a.From)
+}
+
+func translateHistoryReconcileWindow(window messagingtypes.HistoryReconcileWindow, observedNow, syncNow time.Time) messagingtypes.HistoryReconcileWindow {
+	if window.From.IsZero() || window.To.IsZero() || !window.From.Before(window.To) {
+		return messagingtypes.HistoryReconcileWindow{}
+	}
+	age := observedNow.Sub(window.To)
+	if age < 0 {
+		age = 0
+	}
+	to := syncNow.Add(-age)
+	return messagingtypes.HistoryReconcileWindow{
+		From: to.Add(-window.To.Sub(window.From)),
+		To:   to,
+	}
+}
+
+func coalesceHistoricSyncRequests(requests []historicSyncRequest) []historicSyncRequest {
+	bounded := make([]historicSyncRequest, 0, len(requests))
+	var cursorRequest historicSyncRequest
+	for _, request := range requests {
+		if request.bounded() {
+			bounded = append(bounded, request)
+			continue
+		}
+		if cursorRequest.To.IsZero() || request.To.After(cursorRequest.To) {
+			cursorRequest = request
+		}
+	}
+
+	sort.SliceStable(bounded, func(i, j int) bool {
+		return bounded[i].From.Before(bounded[j].From)
+	})
+	merged := make([]historicSyncRequest, 0, len(bounded)+1)
+	for _, request := range bounded {
+		if len(merged) == 0 || !historicSyncRequestsOverlap(merged[len(merged)-1], request) {
+			merged = append(merged, request)
+			continue
+		}
+		if request.To.After(merged[len(merged)-1].To) {
+			merged[len(merged)-1].To = request.To
+		}
+	}
+	if !cursorRequest.To.IsZero() {
+		kept := merged[:0]
+		for _, request := range merged {
+			if request.To.After(cursorRequest.To) {
+				kept = append(kept, request)
+			}
+		}
+		merged = kept
+		merged = append(merged, cursorRequest)
+	}
+	sort.SliceStable(merged, func(i, j int) bool {
+		return merged[i].To.Before(merged[j].To)
+	})
+	return merged
+}
 
 // startHistoryReconciliationLoop schedules a historic sync whenever the
 // transport signals that reconciliation is needed — periodically while
@@ -16,8 +105,8 @@ import (
 // message that silently misses live delivery (degraded relay mesh) while the
 // client stays online is never recovered (see status-app#21405). The
 // transport owns the timing and the connectivity confidence; the fetch lives
-// here, for now, because the per-topic lastFetched watermark is persisted by
-// the Messenger in the app DB. This split is temporary until logos-delivery
+// here, for now, because the per-topic completeness cursor is persisted by the
+// Messenger in the app DB. This split is temporary until logos-delivery
 // owns reconciliation and backfill end to end — see the note on
 // Waku.OnHistoryReconcileNeeded.
 func (m *Messenger) startHistoryReconciliationLoop() {
@@ -35,23 +124,127 @@ func (m *Messenger) startHistoryReconciliationLoop() {
 			select {
 			case <-m.quit:
 				return
-			case <-needed:
-				m.asyncRequestAllHistoricMessages()
+			case transportWindow := <-needed:
+				window := translateHistoryReconcileWindow(
+					transportWindow,
+					time.Now(),
+					m.historicSyncNow(),
+				)
+				if window.From.IsZero() {
+					continue
+				}
+				m.checkpointHistoryWatermarks(window.From)
+				m.asyncRequestHistoricMessages(window)
 			}
 		}
 	}()
 }
 
-// asyncRequestAllHistoricMessages schedules a historic-message sync on the
-// historic-sync worker (startHistoricSyncWorker). Non-blocking; concurrent
-// triggers coalesce into a single pending sync and are never silently
-// dropped — the worker spaces, serializes and retries them.
+// startHistoryWatermarkCheckpointLoop advances initialized topic cursors while
+// a foreground full node has a healthy relay mesh. This records reliable live
+// delivery without issuing store queries and bounds catch-up after a crash.
+func (m *Messenger) startHistoryWatermarkCheckpointLoop() {
+	if !m.config.codeControlFlags.AutoRequestHistoricMessages {
+		return
+	}
+
+	m.shutdownWaitGroup.Add(1)
+	go func() {
+		defer gocommon.LogOnPanic()
+		defer m.shutdownWaitGroup.Done()
+
+		ticker := time.NewTicker(historyWatermarkCheckpointInterval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-m.quit:
+				return
+			case <-ticker.C:
+				if !m.isPaused() {
+					// Stay one tolerance window behind the observation so a
+					// concurrent reliability transition cannot advance a cursor
+					// into the newly unreliable interval.
+					m.checkpointHistoryWatermarks(
+						m.historicSyncNow().Add(-time.Duration(tolerance) * time.Second),
+					)
+				}
+			}
+		}
+	}()
+}
+
+func (m *Messenger) checkpointHistoryWatermarks(through time.Time) {
+	if through.IsZero() || m.mailserversDatabase == nil || m.messaging == nil ||
+		!m.messaging.HistoryDeliveryReliable() {
+		return
+	}
+	m.historicSyncQueueMu.Lock()
+	hasPending := len(m.historicSyncPending) > 0
+	m.historicSyncQueueMu.Unlock()
+	if hasPending || m.historicSyncWorkerActive.Load() {
+		return
+	}
+	m.historicSyncMu.Lock()
+	defer m.historicSyncMu.Unlock()
+	if m.historicSyncInFlight {
+		return
+	}
+	if err := m.mailserversDatabase.AdvanceLastRequest(int(through.Unix())); err != nil {
+		m.logger.Warn("failed to checkpoint history completeness", zap.Error(err))
+	}
+}
+
+// asyncRequestAllHistoricMessages schedules a cursor-based catch-up with a
+// fixed upper bound. It is used at startup, where the preceding app-off period
+// is a genuine delivery gap.
 func (m *Messenger) asyncRequestAllHistoricMessages() {
-	m.logger.Debug("asyncRequestAllHistoricMessages")
+	m.enqueueHistoricSync(historicSyncRequest{To: m.historicSyncNow()})
+}
+
+func (m *Messenger) asyncRequestHistoricMessages(window messagingtypes.HistoryReconcileWindow) {
+	m.enqueueHistoricSync(historicSyncRequest{From: window.From, To: window.To})
+}
+
+func (m *Messenger) enqueueHistoricSync(request historicSyncRequest) {
+	if !request.valid() {
+		return
+	}
+
+	m.logger.Debug("enqueue historic sync",
+		zap.Time("from", request.From),
+		zap.Time("to", request.To))
+
+	m.historicSyncQueueMu.Lock()
+	m.historicSyncPending = append(m.historicSyncPending, request)
+	m.historicSyncPending = coalesceHistoricSyncRequests(m.historicSyncPending)
+	m.historicSyncQueueMu.Unlock()
+
+	m.notifyHistoricSyncWorker()
+}
+
+func (m *Messenger) notifyHistoricSyncWorker() {
 	select {
 	case m.historicSyncTrigger <- struct{}{}:
-	default: // a sync is already pending; it will cover this trigger too
+	default:
 	}
+}
+
+func (m *Messenger) takeHistoricSync() (historicSyncRequest, bool) {
+	m.historicSyncQueueMu.Lock()
+	defer m.historicSyncQueueMu.Unlock()
+	if len(m.historicSyncPending) == 0 {
+		return historicSyncRequest{}, false
+	}
+	request := m.historicSyncPending[0]
+	m.historicSyncPending = m.historicSyncPending[1:]
+	return request, true
+}
+
+func (m *Messenger) requeueHistoricSync(request historicSyncRequest) {
+	m.historicSyncQueueMu.Lock()
+	m.historicSyncPending = append(m.historicSyncPending, request)
+	m.historicSyncPending = coalesceHistoricSyncRequests(m.historicSyncPending)
+	m.historicSyncQueueMu.Unlock()
 }
 
 // startHistoricSyncWorker owns the execution of automatic historic-message
@@ -72,6 +265,7 @@ func (m *Messenger) startHistoricSyncWorker() {
 	go func() {
 		defer gocommon.LogOnPanic()
 		defer m.shutdownWaitGroup.Done()
+		defer m.historicSyncWorkerActive.Store(false)
 
 		var lastAttempt time.Time
 		for {
@@ -81,37 +275,65 @@ func (m *Messenger) startHistoricSyncWorker() {
 			case <-m.historicSyncTrigger:
 			}
 
-			if m.isPaused() {
-				// Dropped, not deferred: returning to foreground schedules its own
-				// sync (SetPaused(false) → asyncRequestAllHistoricMessages).
-				continue
-			}
-
-			if wait := historicSyncMinInterval - time.Since(lastAttempt); wait > 0 {
-				select {
-				case <-m.quit:
-					return
-				case <-time.After(wait):
-				}
-			}
-
-			deadline := time.Now().Add(historicSyncRetryTimeout)
 			for {
-				lastAttempt = time.Now()
-				_, err := m.requestAllHistoricMessages(false)
-				if err == nil {
+				if m.isPaused() {
 					break
 				}
-				if time.Now().After(deadline) {
-					m.logger.Error("historic sync failed after retries", zap.Error(err))
+
+				m.historicSyncWorkerActive.Store(true)
+				request, ok := m.takeHistoricSync()
+				if !ok {
+					m.historicSyncWorkerActive.Store(false)
 					break
 				}
-				m.logger.Warn("historic sync failed, retrying", zap.Error(err))
-				select {
-				case <-m.quit:
-					return
-				case <-time.After(historicSyncRetryInterval):
+
+				if wait := historicSyncMinInterval - time.Since(lastAttempt); wait > 0 {
+					select {
+					case <-m.quit:
+						return
+					case <-time.After(wait):
+					}
 				}
+				if m.isPaused() {
+					m.requeueHistoricSync(request)
+					m.historicSyncWorkerActive.Store(false)
+					break
+				}
+
+				deadline := time.Now().Add(historicSyncRetryTimeout)
+				deferred := false
+				for {
+					lastAttempt = time.Now()
+					executed, err := m.runAutomaticHistoricSync(request)
+					if err == nil && executed {
+						break
+					}
+					if err == nil {
+						// Offline and policy-blocked requests stay pending. Their
+						// corresponding online/resume/setting transition wakes us.
+						m.requeueHistoricSync(request)
+						deferred = true
+						break
+					}
+					if time.Now().After(deadline) {
+						m.logger.Error("historic sync failed after retries", zap.Error(err))
+						m.requeueHistoricSync(request)
+						deferred = true
+						break
+					}
+					m.logger.Warn("historic sync failed, retrying", zap.Error(err))
+					select {
+					case <-m.quit:
+						return
+					case <-time.After(historicSyncRetryInterval):
+					}
+				}
+
+				if deferred {
+					m.historicSyncWorkerActive.Store(false)
+					break
+				}
+				m.historicSyncWorkerActive.Store(false)
 			}
 		}
 	}()

--- a/protocol/messenger_mailserver_sync_gate_test.go
+++ b/protocol/messenger_mailserver_sync_gate_test.go
@@ -11,10 +11,11 @@ import (
 func TestWithHistoricSyncInFlightResetsFlagOnError(t *testing.T) {
 	m := &Messenger{logger: zap.NewNop()}
 
-	_, err := m.withHistoricSyncInFlight(func() (*MessengerResponse, error) {
+	_, executed, err := m.withHistoricSyncInFlight(func() (*MessengerResponse, error) {
 		return nil, errors.New("boom")
 	})
 	require.Error(t, err)
+	require.True(t, executed)
 
 	m.historicSyncMu.Lock()
 	require.False(t, m.historicSyncInFlight)
@@ -25,12 +26,13 @@ func TestWithHistoricSyncInFlightSkipsWhenAlreadyInFlight(t *testing.T) {
 	m := &Messenger{logger: zap.NewNop(), historicSyncInFlight: true}
 
 	called := false
-	resp, err := m.withHistoricSyncInFlight(func() (*MessengerResponse, error) {
+	resp, executed, err := m.withHistoricSyncInFlight(func() (*MessengerResponse, error) {
 		called = true
 		return &MessengerResponse{}, nil
 	})
 	require.NoError(t, err)
 	require.Nil(t, resp)
+	require.False(t, executed)
 	require.False(t, called)
 
 	m.historicSyncMu.Lock()
@@ -42,12 +44,13 @@ func TestWithHistoricSyncInFlightRuns(t *testing.T) {
 	m := &Messenger{logger: zap.NewNop()}
 
 	called := false
-	resp, err := m.withHistoricSyncInFlight(func() (*MessengerResponse, error) {
+	resp, executed, err := m.withHistoricSyncInFlight(func() (*MessengerResponse, error) {
 		called = true
 		return &MessengerResponse{}, nil
 	})
 	require.NoError(t, err)
 	require.NotNil(t, resp)
+	require.True(t, executed)
 	require.True(t, called)
 
 	m.historicSyncMu.Lock()

--- a/protocol/messenger_mailserver_test.go
+++ b/protocol/messenger_mailserver_test.go
@@ -3,6 +3,7 @@ package protocol
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/suite"
 
@@ -124,6 +125,22 @@ func (s *MessengerFetchLatestCommunityDescriptionsSuite) TestNoFiltersIsNoop() {
 	s.m.fetchLatestCommunityDescriptions(nil)
 
 	s.Require().Empty(*recorded, "no store request should be made when there are no filters")
+}
+
+func (s *MessengerFetchLatestCommunityDescriptionsSuite) TestReconciliationWindowBoundsDescriptionFetch() {
+	recorded := s.recordMailserverBatches()
+	filter := descriptionFilter("0xcommunity1", "/waku/2/pubsub-a", "0xcontenttopic1")
+	to := s.m.calculateMailserverTo()
+	window := &types2.HistoryReconcileWindow{
+		From: to.Add(-100 * time.Second),
+		To:   to,
+	}
+
+	s.m.fetchLatestCommunityDescriptions([]*types2.ChatFilter{filter}, window)
+
+	s.Require().Len(*recorded, 1)
+	s.Require().Equal(window.From.Add(-time.Duration(tolerance)*time.Second), (*recorded)[0].batch.From)
+	s.Require().Equal(window.To, (*recorded)[0].batch.To)
 }
 
 // TestReusedFilterForgottenForNonMember verifies that a description filter

--- a/protocol/messenger_mailserver_test.go
+++ b/protocol/messenger_mailserver_test.go
@@ -3,7 +3,6 @@ package protocol
 import (
 	"context"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/suite"
 
@@ -127,20 +126,16 @@ func (s *MessengerFetchLatestCommunityDescriptionsSuite) TestNoFiltersIsNoop() {
 	s.Require().Empty(*recorded, "no store request should be made when there are no filters")
 }
 
-func (s *MessengerFetchLatestCommunityDescriptionsSuite) TestReconciliationWindowBoundsDescriptionFetch() {
+func (s *MessengerFetchLatestCommunityDescriptionsSuite) TestLatestDescriptionUsesRollingMonth() {
 	recorded := s.recordMailserverBatches()
 	filter := descriptionFilter("0xcommunity1", "/waku/2/pubsub-a", "0xcontenttopic1")
-	to := s.m.calculateMailserverTo()
-	window := &types2.HistoryReconcileWindow{
-		From: to.Add(-100 * time.Second),
-		To:   to,
-	}
+	from, to := s.m.calculateMailserverTimeBounds(oneMonthDuration)
 
-	s.m.fetchLatestCommunityDescriptions([]*types2.ChatFilter{filter}, window)
+	s.m.fetchLatestCommunityDescriptions([]*types2.ChatFilter{filter})
 
 	s.Require().Len(*recorded, 1)
-	s.Require().Equal(window.From.Add(-time.Duration(tolerance)*time.Second), (*recorded)[0].batch.From)
-	s.Require().Equal(window.To, (*recorded)[0].batch.To)
+	s.Require().Equal(from, (*recorded)[0].batch.From)
+	s.Require().Equal(to, (*recorded)[0].batch.To)
 }
 
 // TestReusedFilterForgottenForNonMember verifies that a description filter

--- a/protocol/messenger_mailserver_window_test.go
+++ b/protocol/messenger_mailserver_window_test.go
@@ -91,5 +91,5 @@ func TestEnqueueHistoricSyncConcurrent(t *testing.T) {
 	require.Equal(t, []historicSyncRequest{{
 		From: from,
 		To:   from.Add(100 * time.Second),
-	}}, m.historicSyncPending)
+	}}, m.historicSyncQueue)
 }

--- a/protocol/messenger_mailserver_window_test.go
+++ b/protocol/messenger_mailserver_window_test.go
@@ -1,0 +1,95 @@
+package protocol
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	messagingtypes "github.com/status-im/status-go/pkg/messaging/types"
+)
+
+func TestApplyHistoryWindowFloor(t *testing.T) {
+	window := &messagingtypes.HistoryReconcileWindow{
+		From: time.Unix(1_000, 0),
+		To:   time.Unix(1_100, 0),
+	}
+
+	require.Equal(t, uint32(940), applyHistoryWindowFloor(100, true, window),
+		"an old cursor should be bounded to the unreliable window with tolerance")
+	require.Equal(t, uint32(980), applyHistoryWindowFloor(980, true, window),
+		"a newer completeness cursor should remain authoritative")
+	require.Equal(t, uint32(100), applyHistoryWindowFloor(100, false, window),
+		"an uninitialized topic must retain its initial-history range")
+	require.Equal(t, uint32(100), applyHistoryWindowFloor(100, true, nil))
+}
+
+func TestTranslateHistoryReconcileWindowUsesMessengerClock(t *testing.T) {
+	window := messagingtypes.HistoryReconcileWindow{
+		From: time.Unix(100, 0),
+		To:   time.Unix(200, 0),
+	}
+
+	got := translateHistoryReconcileWindow(
+		window,
+		time.Unix(250, 0),
+		time.Unix(1_000, 0),
+	)
+	require.Equal(t, time.Unix(850, 0), got.From)
+	require.Equal(t, time.Unix(950, 0), got.To)
+}
+
+func TestCoalesceHistoricSyncRequests(t *testing.T) {
+	at := func(seconds int64) time.Time { return time.Unix(seconds, 0) }
+	requests := []historicSyncRequest{
+		{From: at(100), To: at(200)},
+		{From: at(150), To: at(250)},
+		{From: at(400), To: at(450)},
+		{To: at(300)},
+		{To: at(350)},
+	}
+
+	got := coalesceHistoricSyncRequests(requests)
+	require.Equal(t, []historicSyncRequest{
+		{To: at(350)},
+		{From: at(400), To: at(450)},
+	}, got)
+}
+
+func TestCoalesceHistoricSyncRequestsKeepsAdjacentReliableGap(t *testing.T) {
+	first := historicSyncRequest{From: time.Unix(100, 0), To: time.Unix(200, 0)}
+	second := historicSyncRequest{From: time.Unix(201, 0), To: time.Unix(300, 0)}
+
+	require.Equal(t, []historicSyncRequest{first, second},
+		coalesceHistoricSyncRequests([]historicSyncRequest{first, second}))
+}
+
+func TestEnqueueHistoricSyncConcurrent(t *testing.T) {
+	m := &Messenger{
+		logger:              zap.NewNop(),
+		historicSyncTrigger: make(chan struct{}, 1),
+	}
+	from := time.Unix(100, 0)
+
+	var wg sync.WaitGroup
+	for i := 1; i <= 100; i++ {
+		wg.Add(1)
+		go func(offset int) {
+			defer wg.Done()
+			m.enqueueHistoricSync(historicSyncRequest{
+				From: from,
+				To:   from.Add(time.Duration(offset) * time.Second),
+			})
+		}(i)
+	}
+	wg.Wait()
+
+	m.historicSyncQueueMu.Lock()
+	defer m.historicSyncQueueMu.Unlock()
+	require.Equal(t, []historicSyncRequest{{
+		From: from,
+		To:   from.Add(100 * time.Second),
+	}}, m.historicSyncPending)
+}

--- a/protocol/messenger_pause_play_test.go
+++ b/protocol/messenger_pause_play_test.go
@@ -2,6 +2,7 @@ package protocol
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
@@ -17,7 +18,7 @@ func TestSetPausedUpdatesMessengerFlag(t *testing.T) {
 	require.False(t, m.isPaused())
 }
 
-func TestSetPausedEnqueuesBoundedForegroundCatchup(t *testing.T) {
+func TestSetPausedDoesNotEnqueueForegroundCatchup(t *testing.T) {
 	m := &Messenger{
 		started:             true,
 		logger:              zap.NewNop(),
@@ -28,14 +29,24 @@ func TestSetPausedEnqueuesBoundedForegroundCatchup(t *testing.T) {
 	m.SetPaused(false)
 
 	m.historicSyncQueueMu.Lock()
-	require.Len(t, m.historicSyncQueue, 1)
-	request := m.historicSyncQueue[0]
+	require.Empty(t, m.historicSyncQueue)
 	m.historicSyncQueueMu.Unlock()
-	require.True(t, request.bounded())
-	require.True(t, request.From.Before(request.To))
 
 	m.SetPaused(false)
 	m.historicSyncQueueMu.Lock()
-	require.Len(t, m.historicSyncQueue, 1, "idempotent resume must not enqueue another catch-up")
+	require.Empty(t, m.historicSyncQueue, "idempotent resume must not enqueue a catch-up")
 	m.historicSyncQueueMu.Unlock()
+}
+
+func TestAutomaticHistoricSyncIsDeferredWhilePaused(t *testing.T) {
+	m := &Messenger{}
+	m.SetPaused(true)
+
+	executed, err := m.runAutomaticHistoricSync(historicSyncRequest{
+		From: time.Unix(100, 0),
+		To:   time.Unix(200, 0),
+	})
+
+	require.NoError(t, err)
+	require.False(t, executed)
 }

--- a/protocol/messenger_pause_play_test.go
+++ b/protocol/messenger_pause_play_test.go
@@ -28,14 +28,14 @@ func TestSetPausedEnqueuesBoundedForegroundCatchup(t *testing.T) {
 	m.SetPaused(false)
 
 	m.historicSyncQueueMu.Lock()
-	require.Len(t, m.historicSyncPending, 1)
-	request := m.historicSyncPending[0]
+	require.Len(t, m.historicSyncQueue, 1)
+	request := m.historicSyncQueue[0]
 	m.historicSyncQueueMu.Unlock()
 	require.True(t, request.bounded())
 	require.True(t, request.From.Before(request.To))
 
 	m.SetPaused(false)
 	m.historicSyncQueueMu.Lock()
-	require.Len(t, m.historicSyncPending, 1, "idempotent resume must not enqueue another catch-up")
+	require.Len(t, m.historicSyncQueue, 1, "idempotent resume must not enqueue another catch-up")
 	m.historicSyncQueueMu.Unlock()
 }

--- a/protocol/messenger_pause_play_test.go
+++ b/protocol/messenger_pause_play_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
 )
 
 func TestSetPausedUpdatesMessengerFlag(t *testing.T) {
@@ -14,4 +15,27 @@ func TestSetPausedUpdatesMessengerFlag(t *testing.T) {
 
 	m.SetPaused(false)
 	require.False(t, m.isPaused())
+}
+
+func TestSetPausedEnqueuesBoundedForegroundCatchup(t *testing.T) {
+	m := &Messenger{
+		started:             true,
+		logger:              zap.NewNop(),
+		historicSyncTrigger: make(chan struct{}, 1),
+	}
+
+	m.SetPaused(true)
+	m.SetPaused(false)
+
+	m.historicSyncQueueMu.Lock()
+	require.Len(t, m.historicSyncPending, 1)
+	request := m.historicSyncPending[0]
+	m.historicSyncQueueMu.Unlock()
+	require.True(t, request.bounded())
+	require.True(t, request.From.Before(request.To))
+
+	m.SetPaused(false)
+	m.historicSyncQueueMu.Lock()
+	require.Len(t, m.historicSyncPending, 1, "idempotent resume must not enqueue another catch-up")
+	m.historicSyncQueueMu.Unlock()
 }

--- a/protocol/messenger_settings.go
+++ b/protocol/messenger_settings.go
@@ -21,7 +21,7 @@ func (m *Messenger) SetSyncingOnMobileNetwork(request *requests.SetSyncingOnMobi
 		return err
 	}
 	if request.Enabled {
-		m.asyncRequestAllHistoricMessages()
+		m.notifyHistoricSyncWorker()
 	}
 	return nil
 }

--- a/services/mailservers/api_test.go
+++ b/services/mailservers/api_test.go
@@ -68,7 +68,22 @@ func TestTopic(t *testing.T) {
 	require.Equal(t, topics[0].LastRequest, 1)
 
 	require.Equal(t, topics[1].ContentTopic, topicD)
-	require.NotEmpty(t, topics[1].LastRequest)
+	require.Zero(t, topics[1].LastRequest)
 	require.True(t, topics[1].Negotiated)
 	require.True(t, topics[1].Discovery)
+
+	require.NoError(t, db.AdvanceLastRequest(10))
+	topics, err = db.Topics()
+	require.NoError(t, err)
+	require.Equal(t, 10, topics[0].LastRequest)
+	require.Zero(t, topics[1].LastRequest, "uninitialized topics must not be advanced")
+
+	require.NoError(t, db.AddTopics([]MailserverTopic{{
+		PubsubTopic:  types.DefaultShardPubsubTopic(),
+		ContentTopic: topicA,
+		LastRequest:  5,
+	}}))
+	topics, err = db.Topics()
+	require.NoError(t, err)
+	require.Equal(t, 10, topics[0].LastRequest, "completed cursors must never regress")
 }

--- a/services/mailservers/api_test.go
+++ b/services/mailservers/api_test.go
@@ -72,7 +72,7 @@ func TestTopic(t *testing.T) {
 	require.True(t, topics[1].Negotiated)
 	require.True(t, topics[1].Discovery)
 
-	require.NoError(t, db.AdvanceLastRequest(10))
+	require.NoError(t, db.AdvanceHistoryCursors(10))
 	topics, err = db.Topics()
 	require.NoError(t, err)
 	require.Equal(t, 10, topics[0].LastRequest)

--- a/services/mailservers/database.go
+++ b/services/mailservers/database.go
@@ -130,15 +130,15 @@ func (d *Database) ResetLastRequest(pubsubTopic, contentTopic string) error {
 	return err
 }
 
-// AdvanceLastRequest marks every initialized topic complete through the given
-// timestamp. Topics with a zero cursor are deliberately left untouched so a
-// reliable live connection cannot suppress their initial history fetch.
-func (d *Database) AdvanceLastRequest(lastRequest int) error {
+// AdvanceHistoryCursors marks every initialized topic complete through the
+// given timestamp. Topics with a zero cursor are deliberately left untouched
+// so a reliable live connection cannot suppress their initial history fetch.
+func (d *Database) AdvanceHistoryCursors(through int) error {
 	_, err := d.db.Exec(`
 		UPDATE mailserver_topics
 		SET last_request = ?
 		WHERE last_request > 0 AND last_request < ?
-	`, lastRequest, lastRequest)
+	`, through, through)
 	return err
 }
 

--- a/services/mailservers/database.go
+++ b/services/mailservers/database.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"errors"
 	"strings"
-	"time"
 
 	messagingtypes "github.com/status-im/status-go/pkg/messaging/types"
 )
@@ -17,7 +16,9 @@ type MailserverTopic struct {
 	Discovery    bool     `json:"discovery?"`
 	Negotiated   bool     `json:"negotiated?"`
 	ChatIDs      []string `json:"chat-ids"`
-	LastRequest  int      `json:"last-request"` // default is 1
+	// LastRequest is the timestamp through which this topic is known complete.
+	// Zero means the topic has not completed its initial history fetch yet.
+	LastRequest int `json:"last-request"`
 }
 
 // sqlStringSlice helps to serialize a slice of strings into a single column using JSON serialization.
@@ -66,14 +67,19 @@ func (d *Database) AddTopics(topics []MailserverTopic) (err error) {
 
 	for _, topic := range topics {
 		chatIDs := sqlStringSlice(topic.ChatIDs)
-		_, err = tx.Exec(`INSERT OR REPLACE INTO mailserver_topics(
+		_, err = tx.Exec(`INSERT INTO mailserver_topics(
 			  pubsub_topic,
 			  topic,
 			  chat_ids,
 			  last_request,
 			  discovery,
 			  negotiated
-		  ) VALUES (?, ?, ?, ?, ?, ?)`,
+		  ) VALUES (?, ?, ?, ?, ?, ?)
+		  ON CONFLICT(topic, pubsub_topic) DO UPDATE SET
+			  chat_ids = excluded.chat_ids,
+			  last_request = MAX(mailserver_topics.last_request, excluded.last_request),
+			  discovery = excluded.discovery,
+			  negotiated = excluded.negotiated`,
 			topic.PubsubTopic,
 			topic.ContentTopic,
 			chatIDs,
@@ -124,6 +130,18 @@ func (d *Database) ResetLastRequest(pubsubTopic, contentTopic string) error {
 	return err
 }
 
+// AdvanceLastRequest marks every initialized topic complete through the given
+// timestamp. Topics with a zero cursor are deliberately left untouched so a
+// reliable live connection cannot suppress their initial history fetch.
+func (d *Database) AdvanceLastRequest(lastRequest int) error {
+	_, err := d.db.Exec(`
+		UPDATE mailserver_topics
+		SET last_request = ?
+		WHERE last_request > 0 AND last_request < ?
+	`, lastRequest, lastRequest)
+	return err
+}
+
 // SetTopics deletes all topics excepts the one set, or upsert those if
 // missing
 func (d *Database) SetTopics(filters messagingtypes.ChatFilters) (err error) {
@@ -168,8 +186,6 @@ func (d *Database) SetTopics(filters messagingtypes.ChatFilters) (err error) {
 		_, err = tx.Exec(query, topicsArgs...)
 	}
 
-	// Default to now - 1.day
-	lastRequest := (time.Now().Add(-24 * time.Hour)).Unix()
 	// Insert if not existing
 	for _, filter := range filters {
 		// fetch
@@ -179,7 +195,7 @@ func (d *Database) SetTopics(filters messagingtypes.ChatFilters) (err error) {
 			return
 		} else if err == sql.ErrNoRows {
 			// we insert the topic
-			_, err = tx.Exec(`INSERT INTO mailserver_topics(topic,pubsub_topic,last_request,discovery,negotiated) VALUES (?,?,?,?,?)`, filter.ContentTopic().String(), filter.PubsubTopic(), lastRequest, filter.IsDiscovery(), filter.IsNegotiated())
+			_, err = tx.Exec(`INSERT INTO mailserver_topics(topic,pubsub_topic,last_request,discovery,negotiated) VALUES (?,?,?,?,?)`, filter.ContentTopic().String(), filter.PubsubTopic(), 0, filter.IsDiscovery(), filter.IsNegotiated())
 		}
 		if err != nil {
 			return


### PR DESCRIPTION
Fixes https://github.com/status-im/status-go/issues/7568
Status-app PR: https://github.com/status-im/status-app/pull/21714

## Summary

- bound automatic history reconciliation to observed unreliable-delivery windows
- introduce typed reconciliation events carrying fixed `From` and `To` bounds
- retain, retry, and coalesce pending windows while preserving disjoint outages
- prevent stable online periods from being queried during later reconciliation
- use `mailserver_topics.last_request` as a monotonic “known complete through” cursor
- checkpoint initialized topic cursors during reliable full-node connectivity
- schedule bounded reconciliation for offline recovery, sleep/wake, and pause/resume
- remove duplicate startup fetching and retain one cursor-based startup catch-up
- wake retained work when mobile-network syncing is enabled
- bound newest-community-description queries to the reconciliation window
- preserve existing behavior for initial topic history, manual requests, and archive backfills

## Testing

- added coverage for reliable and unreliable connectivity transitions
- added overlapping/disjoint window coalescing and concurrent queue tests
- added fixed retry-bound and blocked-work retention coverage
- added cursor initialization, checkpointing, and monotonic update tests
- added pause/resume and community-description window tests
- ran focused Waku and protocol tests, including race coverage
- ran messaging package compilation and `go vet`
- ran protocol tests with `-tags lint` because `libsds.h` is unavailable in this checkout
