### PR TITLE
fix(messenger): prevent self CRs in messenger protocol

### DIFF
--- a/protocol/messenger_contact_requests_test.go
+++ b/protocol/messenger_contact_requests_test.go
@@ -1756,6 +1756,21 @@ func (s *MessengerContactRequestSuite) TestAcceptContactWithoutRequest() { //nol
 	s.Require().Equal(mutualStateUpdate.Text, fmt.Sprintf(outgoingMutualStateEventAcceptedDefaultText, contactRequestMsg.From))
 }
 
+func (s *MessengerContactRequestSuite) TestCannotSendContactRequestToSelf() {
+	request := &requests.SendContactRequest{
+		ID:      s.m.IdentityPublicKeyString(),
+		Message: "hello me",
+	}
+
+	resp, err := s.m.SendContactRequest(context.Background(), request)
+	s.Require().ErrorIs(err, ErrSendContactRequestToSelf)
+	s.Require().Nil(resp)
+
+	pendingRequests, _, err := s.m.PendingContactRequests("", 10)
+	s.Require().NoError(err)
+	s.Require().Len(pendingRequests, 0)
+}
+
 func (s *MessengerContactRequestSuite) TestSyncInstallationContactV2_IgnoresNonCanonicalSelfID() {
 	state := s.m.buildMessageState()
 

--- a/protocol/messenger_contacts.go
+++ b/protocol/messenger_contacts.go
@@ -5,6 +5,7 @@ import (
 	"crypto/ecdsa"
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/golang/protobuf/proto"
 	"go.uber.org/zap"
@@ -29,6 +30,7 @@ const incomingMutualStateEventAcceptedDefaultText = "@%s accepted your contact r
 const incomingMutualStateEventRemovedDefaultText = "@%s removed you as a contact"
 
 var ErrGetLatestContactRequestForContactInvalidID = errors.New("get-latest-contact-request-for-contact: invalid id")
+var ErrSendContactRequestToSelf = errors.New("send-contact-request: cannot send contact request to self")
 
 type SelfContactChangeEvent struct {
 	DisplayNameChanged   bool
@@ -274,6 +276,9 @@ func (m *Messenger) SendContactRequest(ctx context.Context, request *requests.Se
 	chatID, err := request.HexID()
 	if err != nil {
 		return nil, err
+	}
+	if strings.EqualFold(chatID, m.myHexIdentity()) {
+		return nil, ErrSendContactRequestToSelf
 	}
 
 	var ensName, nickname, displayName string


### PR DESCRIPTION
This pull request implements a guard to prevent users from sending contact requests to themselves

### Changes made

- **Test Addition**: 
  - Introduced a new test case `TestCannotSendContactRequestToSelf` in `messenger_contact_requests_test.go` to ensure that the `SendContactRequest` function returns an error when the target ID is the same as the sender's ID.
  
- **Runtime Guard**: 
  - Added a new error `ErrSendContactRequestToSelf` in `messenger_contacts.go`.
  - Updated the `SendContactRequest` function to check if the target ID matches the sender's ID (case-insensitive) after normalization, returning the new error if they match.

Companion Status PR: https://github.com/status-im/status-app/pull/21723
