### PR TITLE
fix(ipfs): don't deadlock logout on downloader shutdown

### DIFF
--- a/internal/ipfs/ipfs.go
+++ b/internal/ipfs/ipfs.go
@@ -22,6 +22,10 @@ import (
 
 const maxRequestsPerSecond = 3
 
+// ErrDownloaderStopped is returned by Get for requests that cannot be served
+// because the downloader is shutting down.
+var ErrDownloaderStopped = errors.New("ipfs downloader stopped")
+
 type taskResponse struct {
 	err      error
 	response []byte
@@ -81,18 +85,27 @@ func (d *Downloader) Stop() {
 	d.cancel()
 
 	d.wg.Wait()
-
-	close(d.inputTaskChan)
-	close(d.rateLimiterChan)
+	// The task channels are deliberately left open: callers racing with Stop
+	// select on quit instead, and a closed channel would turn that race into a
+	// send-on-closed-channel panic.
 }
 
 func (d *Downloader) worker() {
 	defer common.LogOnPanic()
-	for request := range d.rateLimiterChan {
-		resp, err := d.download(request.cid, request.download)
-		request.doneChan <- taskResponse{
-			err:      err,
-			response: resp,
+	for {
+		select {
+		case <-d.quit:
+			return
+		case request, ok := <-d.rateLimiterChan:
+			if !ok {
+				return
+			}
+			resp, err := d.download(request.cid, request.download)
+			// doneChan is buffered, so an abandoned request never blocks here.
+			request.doneChan <- taskResponse{
+				err:      err,
+				response: resp,
+			}
 		}
 	}
 }
@@ -178,19 +191,26 @@ func (d *Downloader) Get(hash string, download bool) ([]byte, error) {
 	doneChan := make(chan taskResponse, 1)
 
 	d.wg.Add(1)
+	defer d.wg.Done()
 
-	d.inputTaskChan <- taskRequest{
+	// Both hand-offs must give up on quit: Stop waits on wg, so a request left
+	// queued here would deadlock shutdown.
+	select {
+	case d.inputTaskChan <- taskRequest{
 		cid:      cid,
 		download: download,
 		doneChan: doneChan,
+	}:
+	case <-d.quit:
+		return nil, ErrDownloaderStopped
 	}
 
-	done := <-doneChan
-	close(doneChan)
-
-	d.wg.Done()
-
-	return done.response, done.err
+	select {
+	case done := <-doneChan:
+		return done.response, done.err
+	case <-d.quit:
+		return nil, ErrDownloaderStopped
+	}
 }
 
 func (d *Downloader) exists(cid string) (bool, []byte, error) {

--- a/internal/ipfs/ipfs.go
+++ b/internal/ipfs/ipfs.go
@@ -78,8 +78,17 @@ func NewDownloader(rootDir string) *Downloader {
 		quit: make(chan struct{}),
 	}
 
-	go d.taskDispatcher()
-	go d.worker()
+	// Tracked on the same WaitGroup as Get callers so Stop cannot return while
+	// either goroutine is still touching the ipfs dir.
+	d.wg.Add(2)
+	go func() {
+		defer d.wg.Done()
+		d.taskDispatcher()
+	}()
+	go func() {
+		defer d.wg.Done()
+		d.worker()
+	}()
 
 	return d
 }
@@ -105,10 +114,7 @@ func (d *Downloader) worker() {
 		select {
 		case <-d.quit:
 			return
-		case request, ok := <-d.rateLimiterChan:
-			if !ok {
-				return
-			}
+		case request := <-d.rateLimiterChan:
 			resp, err := d.download(request.cid, request.download)
 			// doneChan is buffered, so an abandoned request never blocks here.
 			request.doneChan <- taskResponse{
@@ -127,10 +133,7 @@ func (d *Downloader) taskDispatcher() {
 		Interval: time.Second / maxRequestsPerSecond,
 		OnTick: func() {
 			select {
-			case request, ok := <-d.inputTaskChan:
-				if !ok {
-					return
-				}
+			case request := <-d.inputTaskChan:
 				// Quit-aware: rateLimiterChan may be full with no worker left to
 				// drain it, which would park this goroutine for good.
 				select {
@@ -229,11 +232,22 @@ func (d *Downloader) Get(hash string, download bool) ([]byte, error) {
 		return nil, ErrDownloaderStopped
 	}
 
+	return d.awaitResult(doneChan)
+}
+
+func (d *Downloader) awaitResult(doneChan chan taskResponse) ([]byte, error) {
 	select {
 	case done := <-doneChan:
 		return done.response, done.err
 	case <-d.quit:
-		return nil, ErrDownloaderStopped
+		// select picks uniformly among ready cases, so re-check: a result the
+		// worker already delivered beats the shutdown error.
+		select {
+		case done := <-doneChan:
+			return done.response, done.err
+		default:
+			return nil, ErrDownloaderStopped
+		}
 	}
 }
 

--- a/internal/ipfs/ipfs.go
+++ b/internal/ipfs/ipfs.go
@@ -79,13 +79,16 @@ func NewDownloader(rootDir string) *Downloader {
 	}
 
 	// Tracked on the same WaitGroup as Get callers so Stop cannot return while
-	// either goroutine is still touching the ipfs dir.
+	// either goroutine is still touching the ipfs dir. wg.Done is deferred after
+	// the panic guard so it still runs before LogOnPanic re-raises.
 	d.wg.Add(2)
 	go func() {
+		defer common.LogOnPanic()
 		defer d.wg.Done()
 		d.taskDispatcher()
 	}()
 	go func() {
+		defer common.LogOnPanic()
 		defer d.wg.Done()
 		d.worker()
 	}()
@@ -109,7 +112,6 @@ func (d *Downloader) Stop() {
 }
 
 func (d *Downloader) worker() {
-	defer common.LogOnPanic()
 	for {
 		select {
 		case <-d.quit:
@@ -126,7 +128,6 @@ func (d *Downloader) worker() {
 }
 
 func (d *Downloader) taskDispatcher() {
-	defer common.LogOnPanic()
 	sub := d.Subscribe()
 	defer sub.Unsubscribe()
 	pt := common.NewPausableTicker(common.PausableTickerConfig{

--- a/internal/ipfs/ipfs.go
+++ b/internal/ipfs/ipfs.go
@@ -48,7 +48,12 @@ type Downloader struct {
 	inputTaskChan   chan taskRequest
 	client          *http.Client
 
-	quit chan struct{}
+	// stopMu orders wg.Add against wg.Wait: Get takes it for reading before
+	// adding, Stop takes it for writing to close quit, so no Add can slip in
+	// once Stop has begun waiting.
+	stopMu   sync.RWMutex
+	stopOnce sync.Once
+	quit     chan struct{}
 }
 
 func NewDownloader(rootDir string) *Downloader {
@@ -70,7 +75,7 @@ func NewDownloader(rootDir string) *Downloader {
 			Timeout: time.Second * 5,
 		},
 
-		quit: make(chan struct{}, 1),
+		quit: make(chan struct{}),
 	}
 
 	go d.taskDispatcher()
@@ -80,7 +85,11 @@ func NewDownloader(rootDir string) *Downloader {
 }
 
 func (d *Downloader) Stop() {
-	close(d.quit)
+	d.stopOnce.Do(func() {
+		d.stopMu.Lock()
+		close(d.quit)
+		d.stopMu.Unlock()
+	})
 
 	d.cancel()
 
@@ -122,7 +131,12 @@ func (d *Downloader) taskDispatcher() {
 				if !ok {
 					return
 				}
-				d.rateLimiterChan <- request
+				// Quit-aware: rateLimiterChan may be full with no worker left to
+				// drain it, which would park this goroutine for good.
+				select {
+				case d.rateLimiterChan <- request:
+				case <-d.quit:
+				}
 			default:
 			}
 		},
@@ -190,7 +204,17 @@ func (d *Downloader) Get(hash string, download bool) ([]byte, error) {
 
 	doneChan := make(chan taskResponse, 1)
 
+	// Register under the read lock so Stop cannot begin waiting between the
+	// quit check and the Add.
+	d.stopMu.RLock()
+	select {
+	case <-d.quit:
+		d.stopMu.RUnlock()
+		return nil, ErrDownloaderStopped
+	default:
+	}
 	d.wg.Add(1)
+	d.stopMu.RUnlock()
 	defer d.wg.Done()
 
 	// Both hand-offs must give up on quit: Stop waits on wg, so a request left

--- a/internal/ipfs/stop_test.go
+++ b/internal/ipfs/stop_test.go
@@ -1,6 +1,7 @@
 package ipfs
 
 import (
+	"sync"
 	"testing"
 	"time"
 
@@ -66,4 +67,56 @@ func TestGetAfterStopFailsWithoutPanic(t *testing.T) {
 		_, err := d.Get(testContentHash, false)
 		require.ErrorIs(t, err, ErrDownloaderStopped)
 	}
+}
+
+// Regression: with rateLimiterChan full and no worker left to drain it, the
+// dispatcher must still observe quit rather than park on its send forever.
+func TestDispatcherUnblocksOnQuitWithFullRateLimiter(t *testing.T) {
+	d := &Downloader{
+		inputTaskChan:   make(chan taskRequest, 10),
+		rateLimiterChan: make(chan taskRequest, 1),
+		quit:            make(chan struct{}),
+	}
+
+	exited := make(chan struct{})
+	go func() { d.taskDispatcher(); close(exited) }()
+
+	// First fills rateLimiterChan, second parks the dispatcher on the send.
+	d.inputTaskChan <- taskRequest{cid: "a", doneChan: make(chan taskResponse, 1)}
+	d.inputTaskChan <- taskRequest{cid: "b", doneChan: make(chan taskResponse, 1)}
+	time.Sleep(3 * time.Second / maxRequestsPerSecond)
+
+	close(d.quit)
+
+	select {
+	case <-exited:
+	case <-time.After(3 * time.Second):
+		t.Fatal("dispatcher stayed blocked on a full rateLimiterChan after quit")
+	}
+}
+
+// Regression: Get registering on the WaitGroup must not race Stop's Wait,
+// which panics with "WaitGroup misuse". Run this package with -race.
+func TestConcurrentGetAndStop(t *testing.T) {
+	for round := 0; round < 50; round++ {
+		d := NewDownloader(t.TempDir())
+
+		var callers sync.WaitGroup
+		for i := 0; i < 8; i++ {
+			callers.Add(1)
+			go func() {
+				defer callers.Done()
+				_, _ = d.Get(testContentHash, false)
+			}()
+		}
+		go d.Stop()
+		callers.Wait()
+	}
+}
+
+// Stop is exported; calling it twice must not panic on close of a closed channel.
+func TestDoubleStopDoesNotPanic(t *testing.T) {
+	d := NewDownloader(t.TempDir())
+	d.Stop()
+	d.Stop()
 }

--- a/internal/ipfs/stop_test.go
+++ b/internal/ipfs/stop_test.go
@@ -1,0 +1,69 @@
+package ipfs
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// A well-formed ipfs-ns contenthash; the content is never actually fetched in
+// these tests, the request only has to get past decoding.
+const testContentHash = "e3010170122029f2d17be6139079dc48696d1f582a8530eb9805b561eda517e22a892c7e3f1f"
+
+// waitForQueuedRequest blocks until Get has put its request on inputTaskChan,
+// so the test controls the moment Stop is called rather than racing it.
+func waitForQueuedRequest(t *testing.T, d *Downloader) {
+	t.Helper()
+	require.Eventually(t, func() bool {
+		return len(d.inputTaskChan) > 0
+	}, 2*time.Second, 5*time.Millisecond, "Get never queued its request")
+}
+
+// Regression: a request that is queued but not yet dispatched used to leave
+// Stop blocked forever on wg.Wait(), wedging the whole logout path.
+func TestStopReturnsWithUndispatchedRequest(t *testing.T) {
+	d := NewDownloader(t.TempDir())
+
+	// Pausing keeps the dispatcher from draining inputTaskChan, which makes the
+	// otherwise sub-tick-length race window deterministic.
+	require.NoError(t, d.Pause())
+
+	getErr := make(chan error, 1)
+	go func() {
+		_, err := d.Get(testContentHash, false)
+		getErr <- err
+	}()
+	waitForQueuedRequest(t, d)
+
+	stopped := make(chan struct{})
+	go func() {
+		d.Stop()
+		close(stopped)
+	}()
+
+	select {
+	case <-stopped:
+	case <-time.After(5 * time.Second):
+		t.Fatal("Stop did not return while a request was queued")
+	}
+
+	select {
+	case err := <-getErr:
+		require.Error(t, err, "Get should fail once the downloader is stopped")
+	case <-time.After(2 * time.Second):
+		t.Fatal("Get did not return after Stop")
+	}
+}
+
+// The media server keeps serving requests while the node tears down, so Get is
+// still called after Stop; it must fail rather than send on a closed channel.
+func TestGetAfterStopFailsWithoutPanic(t *testing.T) {
+	d := NewDownloader(t.TempDir())
+	d.Stop()
+
+	for i := 0; i < 50; i++ {
+		_, err := d.Get(testContentHash, false)
+		require.ErrorIs(t, err, ErrDownloaderStopped)
+	}
+}

--- a/internal/ipfs/stop_test.go
+++ b/internal/ipfs/stop_test.go
@@ -1,6 +1,8 @@
 package ipfs
 
 import (
+	"errors"
+	"net/http"
 	"sync"
 	"testing"
 	"time"
@@ -92,6 +94,82 @@ func TestDispatcherUnblocksOnQuitWithFullRateLimiter(t *testing.T) {
 	case <-exited:
 	case <-time.After(3 * time.Second):
 		t.Fatal("dispatcher stayed blocked on a full rateLimiterChan after quit")
+	}
+}
+
+// blockingRoundTripper parks the worker inside download() until the test
+// releases it, so the test owns the moment Stop is called.
+type blockingRoundTripper struct {
+	inFlight chan struct{}
+	release  chan struct{}
+	entered  sync.Once
+}
+
+func newBlockingRoundTripper() *blockingRoundTripper {
+	return &blockingRoundTripper{
+		inFlight: make(chan struct{}),
+		release:  make(chan struct{}),
+	}
+}
+
+func (b *blockingRoundTripper) RoundTrip(*http.Request) (*http.Response, error) {
+	b.entered.Do(func() { close(b.inFlight) })
+	<-b.release
+	return nil, errors.New("transport released")
+}
+
+// The node tears down its data directory right after Stop returns, so Stop must
+// not hand back control while the worker is still inside download() writing into
+// it. d.wg tracked only Get callers, never the worker or the dispatcher.
+func TestStopWaitsForInFlightDownload(t *testing.T) {
+	d := NewDownloader(t.TempDir())
+
+	transport := newBlockingRoundTripper()
+	d.client = &http.Client{Transport: transport}
+
+	go func() { _, _ = d.Get(testContentHash, false) }()
+
+	select {
+	case <-transport.inFlight:
+	case <-time.After(5 * time.Second):
+		t.Fatal("worker never entered download")
+	}
+
+	stopped := make(chan struct{})
+	go func() {
+		d.Stop()
+		close(stopped)
+	}()
+
+	select {
+	case <-stopped:
+		t.Fatal("Stop returned while the worker was still downloading")
+	case <-time.After(300 * time.Millisecond):
+	}
+
+	close(transport.release)
+
+	select {
+	case <-stopped:
+	case <-time.After(5 * time.Second):
+		t.Fatal("Stop did not return after the download finished")
+	}
+}
+
+// A select over a ready doneChan and a closed quit picks uniformly, so a result
+// the worker already delivered used to be thrown away in favour of the shutdown
+// error about half the time. Looped so a uniform pick cannot pass by luck.
+func TestAwaitResultPrefersDeliveredResponse(t *testing.T) {
+	d := &Downloader{quit: make(chan struct{})}
+	close(d.quit)
+
+	for i := 0; i < 100; i++ {
+		doneChan := make(chan taskResponse, 1)
+		doneChan <- taskResponse{response: []byte("payload")}
+
+		resp, err := d.awaitResult(doneChan)
+		require.NoError(t, err)
+		require.Equal(t, []byte("payload"), resp)
 	}
 }
 

--- a/server/lifecycle_test.go
+++ b/server/lifecycle_test.go
@@ -159,3 +159,57 @@ func TestStartRebindsWhenListenerDiesSilently(t *testing.T) {
 	require.Equal(t, firstPort, s.GetPort())
 	require.NoError(t, s.Stop())
 }
+
+// Regression: a handler that never returns (e.g. the media server blocked on a
+// stuck IPFS download) used to wedge Stop forever, and with it the whole logout
+// path that owns the backend mutex.
+func TestServerStopReturnsDespiteStuckHandler(t *testing.T) {
+	s := NewServer(zap.NewNop(), &Config{
+		AddrPort: netip.MustParseAddrPort("127.0.0.1:0"),
+	})
+
+	started := make(chan struct{})
+	release := make(chan struct{})
+	var startedOnce sync.Once
+	var releaseOnce sync.Once
+	s.SetHandlers(HandlerPatternMap{
+		// Deliberately ignores r.Context(): Shutdown does not cancel in-flight
+		// requests, so only a bounded Stop can break this.
+		"/stuck": func(w http.ResponseWriter, r *http.Request) {
+			startedOnce.Do(func() { close(started) })
+			<-release
+		},
+	})
+
+	require.NoError(t, s.Start())
+	t.Cleanup(func() { releaseOnce.Do(func() { close(release) }) })
+
+	require.Eventually(t, func() bool {
+		return s.GetListeningAddrPort() != ""
+	}, time.Second, 10*time.Millisecond)
+
+	go func() {
+		resp, err := http.Get("http://" + s.GetListeningAddrPort() + "/stuck")
+		if err == nil {
+			_, _ = io.Copy(io.Discard, resp.Body)
+			_ = resp.Body.Close()
+		}
+	}()
+
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for stuck request to start")
+	}
+
+	stopped := make(chan error, 1)
+	go func() { stopped <- s.Stop() }()
+
+	select {
+	case <-stopped:
+	case <-time.After(teardownShutdownTimeout + 2*time.Second):
+		t.Fatal("Stop did not return while a handler was stuck")
+	}
+
+	require.False(t, s.IsRunning())
+}

--- a/server/server.go
+++ b/server/server.go
@@ -23,6 +23,12 @@ import (
 // active HTTP handlers to drain before force-closing remaining connections.
 const backgroundShutdownTimeout = 300 * time.Millisecond
 
+// teardownShutdownTimeout bounds the same drain at teardown. It is generous
+// enough for normal in-flight requests to finish, but a handler that never
+// returns must not be able to wedge Stop — and with it the logout path that
+// holds the backend mutex.
+const teardownShutdownTimeout = 3 * time.Second
+
 // tcpListenConfig sets SO_REUSEADDR so that after the previous listener is fully
 // closed, the kernel can allow binding the same cached ephemeral port again (e.g.
 // TIME_WAIT) without a long delay. It does not help if Stop returns before that
@@ -328,15 +334,23 @@ func (s *Server) Start() error {
 }
 
 func (s *Server) Stop() error {
-	return s.stopWith(context.Background())
+	ctx, cancel := context.WithTimeout(context.Background(), teardownShutdownTimeout)
+	defer cancel()
+
+	err := s.stopWith(ctx)
+	if shouldForceCloseOnShutdownError(err) {
+		s.logger.Warn("server graceful shutdown did not complete in time; forced close",
+			zap.Error(err), zap.Duration("timeout", teardownShutdownTimeout))
+		return nil
+	}
+	return err
 }
 
 // stopWith performs the graceful shutdown sequence bounded by ctx. If ctx
 // expires or is canceled before active connections drain, the server is
 // force-closed via Close so the caller isn't blocked by a slow or stuck
-// handler. Pass context.Background() for the unbounded behaviour expected at
-// teardown/shutdown; use a short deadline for lifecycle events like
-// pause/ToBackground.
+// handler. Callers always pass a deadline: a generous one at teardown, a short
+// one for lifecycle events like pause/ToBackground.
 func (s *Server) stopWith(ctx context.Context) error {
 	s.mu.Lock()
 	s.StopTimeout()


### PR DESCRIPTION
Fixes status-im/status-app#21733
Companion PR: https://github.com/status-im/status-app/pull/21737


`Downloader.Stop()` closes `d.quit` first, which makes `taskDispatcher` return immediately. Any request already queued in `inputTaskChan` is then never handed to the worker, so `Get()` stays blocked on `doneChan` and `Stop()` blocks forever on `wg.Wait()`.

That wedges the logout path — `StatusNode.Stop()` → `downloader.Stop()`, under both `n.mu` and the backend's `b.mu`. Change-password logs out while the UI is still pulling media, so it hangs on "Re-encrypting your data..." and never completes.

Regression from #7391, which replaced the dispatcher's unbounded drain loop with a `PausableTicker` that returns on quit. Before that, the dispatcher kept draining until `Stop()` closed `inputTaskChan` after `wg.Wait()`.

- `Get()` abandons both hand-offs on quit and returns `ErrDownloaderStopped`
- `worker()` exits on quit
- `Stop()` no longer closes the task channels — a `Get()` racing with `Stop()` would otherwise panic with send on closed channel
- `Server.Stop()` bounds its graceful shutdown (was `context.Background()`), so one stuck handler can't hold the media server, and therefore logout, indefinitely

Tests: `TestStopReturnsWithUndispatchedRequest`, `TestGetAfterStopFailsWithoutPanic`, `TestServerStopReturnsDespiteStuckHandler` — each fails on the parent commit.