### PR TITLE
fix(node): reset running when Start fails

### DIFF
--- a/pkg/backend/node/get_status_node.go
+++ b/pkg/backend/node/get_status_node.go
@@ -82,8 +82,11 @@ type StatusNode struct {
 	config    *params.NodeConfig // Status node configuration
 	rpcClient *rpc.Client        // reference to an RPC client
 
-	services  []common.StatusService
-	rpcServer *gethrpc.Server
+	services []common.StatusService
+	// services that Start()ed successfully, in start order; only these are
+	// stopped on teardown
+	startedServices []common.StatusService
+	rpcServer       *gethrpc.Server
 
 	downloader *ipfs.Downloader
 
@@ -224,8 +227,12 @@ func (n *StatusNode) Start(config *params.NodeConfig) error {
 
 	if err := n.startWithDB(config); err != nil {
 		// startWithDB builds the node incrementally, so a failure leaves it
-		// partially constructed. Roll the flag back: callers gate teardown on
-		// IsRunning, and Stop assumes every field was assigned.
+		// partially constructed. Tear down whatever was already built, then
+		// roll the flag back: callers gate teardown on IsRunning, so a failed
+		// start would otherwise never be cleaned up.
+		if cleanupErr := n.teardown(); cleanupErr != nil {
+			n.logger.Error("cleaning up after failed start", zap.Error(cleanupErr))
+		}
 		n.running.Store(false)
 		return err
 	}
@@ -410,6 +417,7 @@ func (n *StatusNode) startWithDB(config *params.NodeConfig) error {
 			text := fmt.Sprintf("failed to start service '%s'", name)
 			return errorspkg.Wrap(err, text)
 		}
+		n.startedServices = append(n.startedServices, service)
 	}
 
 	n.populateServiceRegistry()
@@ -511,13 +519,32 @@ func (n *StatusNode) Stop() error {
 		return ErrNoRunningNode
 	}
 
-	var errs []error
-	n.timeSourceSrvc.Stop()
+	err := n.teardown()
 
-	for _, service := range n.services {
+	n.logger.Debug("status node stopped")
+	return err
+}
+
+// teardown stops and releases everything startWithDB built. It is shared by
+// Stop and the failed-start path in Start, so every field is nil-guarded: a
+// failed start leaves the node only partially constructed.
+// Callers must hold n.mu.
+func (n *StatusNode) teardown() error {
+	var errs []error
+
+	// Safe on a never-started time source: Stop is a no-op before Start.
+	if n.timeSourceSrvc != nil {
+		n.timeSourceSrvc.Stop()
+	}
+
+	// Services are not required to support Stop without a prior Start, so
+	// only the ones that started successfully are stopped.
+	for _, service := range n.startedServices {
 		err := service.Stop()
 		errs = append(errs, err)
 	}
+	n.startedServices = nil
+	n.services = nil
 
 	if n.localBackup != nil {
 		n.localBackup.Stop()
@@ -526,16 +553,27 @@ func (n *StatusNode) Stop() error {
 
 	n.accountsPublisher.Close()
 
-	n.rpcClient.Stop()
-	n.rpcClient = nil
+	if n.rpcClient != nil {
+		n.rpcClient.Stop()
+		n.rpcClient = nil
+	}
 	n.config = nil
 
 	if n.mediaServer != nil {
 		n.mediaServer.SetDataProviders(nil, nil, nil)
 	}
 
-	n.downloader.Stop()
-	n.downloader = nil
+	// Normally stopped through the wallet service; stop directly in case that
+	// service never started. Manager.Stop is idempotent.
+	if n.tokenManager != nil {
+		n.tokenManager.Stop()
+		n.tokenManager = nil
+	}
+
+	if n.downloader != nil {
+		n.downloader.Stop()
+		n.downloader = nil
+	}
 
 	n.rpcStatsSrvc = nil
 	n.accountsSrvc = nil
@@ -556,7 +594,6 @@ func (n *StatusNode) Stop() error {
 	n.newsfeedSrvc = nil
 	n.preferencesSrvc = nil
 
-	n.logger.Debug("status node stopped")
 	return errors.Join(errs...)
 }
 

--- a/pkg/backend/node/get_status_node.go
+++ b/pkg/backend/node/get_status_node.go
@@ -222,7 +222,15 @@ func (n *StatusNode) Start(config *params.NodeConfig) error {
 
 	n.logger.Debug("starting with options", zap.Stringer("ClusterConfig", &config.ClusterConfig))
 
-	return n.startWithDB(config)
+	if err := n.startWithDB(config); err != nil {
+		// startWithDB builds the node incrementally, so a failure leaves it
+		// partially constructed. Roll the flag back: callers gate teardown on
+		// IsRunning, and Stop assumes every field was assigned.
+		n.running.Store(false)
+		return err
+	}
+
+	return nil
 }
 
 func (n *StatusNode) StartLocalBackup() error {

--- a/pkg/backend/node/start_failure_test.go
+++ b/pkg/backend/node/start_failure_test.go
@@ -1,0 +1,37 @@
+package node
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"github.com/status-im/status-go/internal/testutils"
+	"github.com/status-im/status-go/params"
+	walletcommon "github.com/status-im/status-go/services/wallet/common"
+)
+
+// Regression: Start marks the node running before startup can fail. If it does
+// not roll that back, IsRunning lies and a later Stop tears down a node that
+// was never fully built, dereferencing fields that were never assigned.
+func TestStartFailureResetsRunning(t *testing.T) {
+	config, err := params.NewNodeConfig("", walletcommon.EthereumSepolia)
+	require.NoError(t, err)
+	// No active networks: TokenManager creation fails, so startWithDB returns early.
+	config.Networks = nil
+
+	n := New(nil, nil, testutils.MustCreateTestLogger())
+
+	appDB, walletDB, stop, err := setupTestDBs()
+	require.NoError(t, err)
+	defer func() {
+		if err := stop(); err != nil {
+			n.logger.Error("stopping db", zap.Error(err))
+		}
+	}()
+	n.appDB = appDB
+	n.walletDB = walletDB
+
+	require.Error(t, n.Start(config), "expected startup to fail with no active networks")
+	require.False(t, n.IsRunning(), "a failed Start must not leave the node marked running")
+}

--- a/pkg/backend/node/start_failure_test.go
+++ b/pkg/backend/node/start_failure_test.go
@@ -17,7 +17,9 @@ import (
 func TestStartFailureResetsRunning(t *testing.T) {
 	config, err := params.NewNodeConfig("", walletcommon.EthereumSepolia)
 	require.NoError(t, err)
-	// No active networks: TokenManager creation fails, so startWithDB returns early.
+	// No active networks: token.NewTokenManager fails ("chains are not
+	// provided"), so startWithDB returns after the RPC client, downloader and
+	// media server were already built.
 	config.Networks = nil
 
 	n := New(nil, nil, testutils.MustCreateTestLogger())
@@ -34,4 +36,11 @@ func TestStartFailureResetsRunning(t *testing.T) {
 
 	require.Error(t, n.Start(config), "expected startup to fail with no active networks")
 	require.False(t, n.IsRunning(), "a failed Start must not leave the node marked running")
+
+	// A failed Start must also unwind what startWithDB built before failing,
+	// not just roll the flag back.
+	require.Nil(t, n.rpcClient, "a failed Start must stop and release the RPC client")
+	require.Nil(t, n.downloader, "a failed Start must stop and release the downloader")
+	require.Nil(t, n.config, "a failed Start must not leave a config on a node that never started")
+	require.ErrorIs(t, n.Stop(), ErrNoRunningNode, "Stop after a failed Start must report no running node")
 }


### PR DESCRIPTION
Fixes #7678

`StatusNode.Start` marks the node running via `CompareAndSwap` before `startWithDB` can fail, and never rolls back (`pkg/backend/node/get_status_node.go:214`).

`startWithDB` builds the node incrementally — a `setupRPCClient` failure at :352 returns before `n.downloader` is assigned at :357 — so a failed start leaves `running == true` with `rpcClient`, `timeSourceSrvc`, `accountsPublisher` and `downloader` all nil.

`Logout` gates teardown on `IsRunning()` (`pkg/backend/geth_backend.go:2100`), so it then calls `Stop()`, which dereferences those fields without nil guards and panics.

Rolling the flag back is the fix rather than nil-guarding `Stop()`: the defect is that `running` claims a startup that did not complete.

`TestStartFailureResetsRunning` fails on the parent commit.