### PR TITLE
fix(stickers): fix crash when estimating gas price for sticker purchases

### DIFF
--- a/services/wallet/router/pathprocessor/processor_stickers_buy.go
+++ b/services/wallet/router/pathprocessor/processor_stickers_buy.go
@@ -31,8 +31,9 @@ type StickersBuyProcessor struct {
 
 func NewStickersBuyProcessor(ethClientGetter rpc.EthClientGetter, transactor transactions.TransactorIface) *StickersBuyProcessor {
 	return &StickersBuyProcessor{
-		contractMaker: contracts.NewContractMaker(ethClientGetter),
-		transactor:    transactor,
+		contractMaker:   contracts.NewContractMaker(ethClientGetter),
+		ethClientGetter: ethClientGetter,
+		transactor:      transactor,
 	}
 }
 

--- a/services/wallet/router/pathprocessor/processor_stickers_buy_test.go
+++ b/services/wallet/router/pathprocessor/processor_stickers_buy_test.go
@@ -1,0 +1,30 @@
+package pathprocessor
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+
+	mock_client "github.com/status-im/status-go/internal/rpc/chain/mock/client"
+	mock_rpcclient "github.com/status-im/status-go/internal/rpc/mock/client"
+	"github.com/status-im/status-go/params"
+	walletCommon "github.com/status-im/status-go/services/wallet/common"
+)
+
+func TestStickersBuyProcessorEstimateGas(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	ethClientGetter := mock_rpcclient.NewMockEthClientGetter(ctrl)
+	ethClient := mock_client.NewMockClientInterface(ctrl)
+
+	ethClientGetter.EXPECT().EthClient(walletCommon.EthereumMainnet).Return(ethClient, nil)
+	ethClient.EXPECT().EstimateGas(gomock.Any(), gomock.Any()).Return(uint64(1000), nil)
+
+	processor := NewStickersBuyProcessor(ethClientGetter, nil)
+	gas, err := processor.EstimateGas(ProcessorInputParams{
+		FromChain: &params.Network{ChainID: walletCommon.EthereumMainnet},
+	}, nil)
+
+	require.NoError(t, err)
+	require.Equal(t, uint64(1050), gas)
+}


### PR DESCRIPTION
Fixes https://github.com/status-im/status-app/issues/21580
status-app PR: https://github.com/status-im/status-app/pull/21739

The crash was caused by `NewStickersBuyProcessor` failing to assign the provided Ethereum client getter to the processor, leaving it nil when gas estimation called `EthClient`. The constructor now stores that dependency correctly, and a regression test verifies that sticker-pack gas estimation retrieves and uses the Ethereum client without crashing.

