### PR TITLE
chore(peers): remove comments saying peers is not used by status-app

### DIFF
--- a/pkg/messaging/api_transport_peers.go
+++ b/pkg/messaging/api_transport_peers.go
@@ -7,12 +7,6 @@ import (
 	types "github.com/status-im/status-go/pkg/messaging/types"
 )
 
-// The helpers below leak transport implementation details and are retained ONLY
-// for the Python functional tests (tests-functional): Peers backs the
-// wait_for_online / test_discovery checks and PeerID backs node identification.
-// They are not used by status-app — clients needing peer information should use
-// Prometheus metrics or the Waku node's RPC interface instead.
-
 func (a *API) Peers() types.PeerStats {
 	return adapters.FromWakuPeerStats(a.core.stack.Transport.Peers())
 }

--- a/pkg/messaging/layers/transport/transport.go
+++ b/pkg/messaging/layers/transport/transport.go
@@ -738,8 +738,6 @@ func (t *Transport) OnHistoryReconcileNeeded() <-chan struct{} {
 	return t.waku.OnHistoryReconcileNeeded()
 }
 
-// Peers is retained only for the Python functional tests (see tests-functional);
-// it is not used by status-app.
 func (t *Transport) Peers() types.PeerStats {
 	return t.waku.Peers()
 }

--- a/pkg/messaging/waku/gowaku.go
+++ b/pkg/messaging/waku/gowaku.go
@@ -1380,8 +1380,6 @@ func (w *Waku) processMessage(e *common.ReceivedMessage) {
 	})
 }
 
-// Peers is retained only for the Python functional tests (see tests-functional);
-// it is not used by status-app.
 func (w *Waku) Peers() types.PeerStats {
 	return FormatPeerStats(w.node)
 }

--- a/pkg/messaging/waku/types/waku.go
+++ b/pkg/messaging/waku/types/waku.go
@@ -102,8 +102,6 @@ type Waku interface {
 	// Resume re-arms goroutines suspended by Pause. Idempotent.
 	Resume() error
 
-	// Peers is retained only for the Python functional tests (see tests-functional);
-	// it is not used by status-app.
 	Peers() PeerStats
 
 	SubscribeToConnStatusChanges() (*ConnStatusSubscription, error)

--- a/protocol/messenger_peers.go
+++ b/protocol/messenger_peers.go
@@ -4,8 +4,6 @@ import (
 	messagingtypes "github.com/status-im/status-go/pkg/messaging/types"
 )
 
-// Peers is retained only for the Python functional tests (see tests-functional);
-// it is not used by status-app.
 func (m *Messenger) Peers() messagingtypes.PeerStats {
 	return m.messaging.Peers()
 }

--- a/services/ext/api.go
+++ b/services/ext/api.go
@@ -1094,10 +1094,6 @@ func (api *PublicAPI) DisableCommunityHistoryArchiveProtocol() error {
 	return api.service.messenger.DisableCommunityHistoryArchiveProtocol()
 }
 
-// Peers and PeerID are retained only for the Python functional tests
-// (tests-functional): Peers backs the wait_for_online / test_discovery checks
-// and PeerID backs node identification. They are not used by status-app.
-
 func (api *PublicAPI) Peers() types2.PeerStats {
 	return api.service.messenger.Peers()
 }


### PR DESCRIPTION
Needed for https://github.com/status-im/status-app/issues/21568