### PR TITLE
fix(ci): set nim sds source directory

### DIFF
--- a/_assets/ci/Jenkinsfile.desktop
+++ b/_assets/ci/Jenkinsfile.desktop
@@ -59,6 +59,8 @@ pipeline {
     GO_GENERATE_FAST_DIR = "${env.WORKSPACE_TMP}/go-generate-fast"
     /* fixes nim cache collision */
     XDG_CACHE_HOME = "${env.WORKSPACE_TMP}/.cache"
+    /* nim-sds source directory */
+    NIM_SDS_SOURCE_DIR = "${env.WORKSPACE_TMP}/nim-sds"
   }
 
   stages {


### PR DESCRIPTION
Otherwise it gets created in root workspace and is never cleaned up.

Also can cause issues like this : 

```
[2026-08-04T06:25:55.779Z] [vcvarsall.bat] Environment initialized for: 'x64'
[2026-08-04T06:25:56.162Z] mkdir -p build/bin/statusgo-lib
[2026-08-04T06:25:56.162Z] GOOS=windows GOARCH=amd64 go run ./tools/generate-cbindings > build/bin/statusgo-lib/main.go
[2026-08-04T06:25:56.989Z] Cloning or updating nim-sds ...
[2026-08-04T06:25:56.989Z] if [ ! -d "J:/Users/jenkins/workspace/_prs_windows_x86_64_main_PR-7480//../nim-sds" ]; then \
[2026-08-04T06:25:56.989Z]     git clone --recurse-submodules https://github.com/waku-org/nim-sds.git "J:/Users/jenkins/workspace/_prs_windows_x86_64_main_PR-7480//../nim-sds"; \
[2026-08-04T06:25:56.989Z] else \
[2026-08-04T06:25:56.989Z]     cd "J:/Users/jenkins/worspace/_prs_windows_x86_64_main_PR-7480//../nim-sds" && git fetch --tags; \
[2026-08-04T06:25:56.989Z] fi
[2026-08-04T06:25:56.989Z] fatal: detected dubious ownership in repository at 'J:/Users/jenkins/workspace/nim-sds'
[2026-08-04T06:25:56.989Z] 'J:/Users/jenkins/workspace/nim-sds' is owned by:
[2026-08-04T06:25:56.989Z]     (inconvertible) (S-1-5-21-386285418-2648410042-1024235771-1009)
[2026-08-04T06:25:56.989Z] but the current user is:
[2026-08-04T06:25:56.989Z]     WINDOWS-03/jenkins (S-1-5-21-2054692709-198351212-1038358559-1009)
[2026-08-04T06:25:56.989Z] To add an exception for this directory, call:
[2026-08-04T06:25:56.989Z] 
[2026-08-04T06:25:56.989Z]     git config --global --add safe.directory J:/Users/jenkins/workspace/nim-sds
[2026-08-04T06:25:56.989Z] make: *** [makefile:335: clone-nim-sds] Error 128
script returned exit code 2
```