### PR TITLE
fix(ac): fix crash when a chat is deleted and we have an ac notification for it

### DIFF
--- a/protocol/activity_center_persistence.go
+++ b/protocol/activity_center_persistence.go
@@ -869,6 +869,45 @@ func (db sqlitePersistence) MarkActivityCenterNotificationsDeleted(ids []types.H
 	return notifications, updateActivityCenterState(tx, updatedAt)
 }
 
+func (db sqlitePersistence) DeleteActivityCenterNotificationsByChatID(chatID string, updatedAt uint64) ([]*ActivityCenterNotification, error) {
+	var tx *sql.Tx
+	var err error
+
+	tx, err = db.db.BeginTx(context.Background(), &sql.TxOptions{})
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		if err == nil {
+			err = tx.Commit()
+			return
+		}
+		// don't shadow original error
+		_ = tx.Rollback()
+	}()
+
+	rows, err := tx.Query(fmt.Sprintf(`SELECT %s FROM activity_center_notifications WHERE chat_id = ? AND NOT deleted`,
+		allFieldsForTableActivityCenterNotification), chatID)
+	if err != nil {
+		return nil, err
+	}
+	notifications, err := db.parseRowFromTableActivityCenterNotification(rows, func(notification *ActivityCenterNotification) {
+		notification.Deleted = true
+		notification.UpdatedAt = updatedAt
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	_, err = tx.Exec(`UPDATE activity_center_notifications SET deleted = 1, updated_at = ? WHERE chat_id = ? AND NOT deleted`, updatedAt, chatID)
+	if err != nil {
+		return nil, err
+	}
+
+	err = updateActivityCenterState(tx, updatedAt)
+	return notifications, err
+}
+
 func (db sqlitePersistence) DismissActivityCenterNotifications(ids []types.HexBytes, updatedAt uint64) error {
 	if len(ids) == 0 {
 		return nil

--- a/protocol/activity_center_persistence_test.go
+++ b/protocol/activity_center_persistence_test.go
@@ -116,6 +116,50 @@ func (s *ActivityCenterPersistenceTestSuite) Test_DeleteActivityCenterNotificati
 	s.Require().Equal(uint64(1), count)
 }
 
+func (s *ActivityCenterPersistenceTestSuite) TestDeleteActivityCenterNotificationsByChatID() {
+	db, err := openTestDB()
+	s.Require().NoError(err)
+	p := newSQLitePersistence(db)
+
+	chat := CreatePublicChat("deleted-channel", &testTimeSource{})
+	err = p.SaveChat(*chat)
+	s.Require().NoError(err)
+
+	otherChat := CreatePublicChat("remaining-channel", &testTimeSource{})
+	err = p.SaveChat(*otherChat)
+	s.Require().NoError(err)
+
+	notifications := s.createNotifications(p, []*ActivityCenterNotification{
+		{ChatID: chat.ID, Type: ActivityCenterNotificationTypeMention},
+		{ChatID: chat.ID, Type: ActivityCenterNotificationTypeReply},
+		{ChatID: otherChat.ID, Type: ActivityCenterNotificationTypeMention},
+	})
+
+	updatedAt := currentMilliseconds() + 1
+	deletedNotifications, err := p.DeleteActivityCenterNotificationsByChatID(chat.ID, updatedAt)
+	s.Require().NoError(err)
+	s.Require().Len(deletedNotifications, 2)
+	for _, notification := range deletedNotifications {
+		s.Require().Equal(chat.ID, notification.ChatID)
+		s.Require().True(notification.Deleted)
+		s.Require().Equal(updatedAt, notification.UpdatedAt)
+	}
+
+	for _, notification := range notifications[:2] {
+		persistedNotification, err := p.GetActivityCenterNotificationByID(notification.ID)
+		s.Require().NoError(err)
+		s.Require().True(persistedNotification.Deleted)
+	}
+
+	persistedNotification, err := p.GetActivityCenterNotificationByID(notifications[2].ID)
+	s.Require().NoError(err)
+	s.Require().False(persistedNotification.Deleted)
+
+	count, err := p.ActivityCenterNotificationsCount([]ActivityCenterType{}, ActivityCenterQueryParamsReadUnread, false)
+	s.Require().NoError(err)
+	s.Require().Equal(uint64(1), count)
+}
+
 func (s *ActivityCenterPersistenceTestSuite) Test_DeleteActivityCenterNotificationsForMessage() {
 	db, err := openTestDB()
 	s.Require().NoError(err)

--- a/protocol/communities_messenger_admin_test.go
+++ b/protocol/communities_messenger_admin_test.go
@@ -3,10 +3,12 @@ package protocol
 import (
 	"math/big"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/suite"
 
 	"github.com/status-im/status-go/internal/crypto"
+	"github.com/status-im/status-go/internal/crypto/types"
 	"github.com/status-im/status-go/protocol/communities"
 	"github.com/status-im/status-go/protocol/communities/token"
 	"github.com/status-im/status-go/protocol/protobuf"
@@ -88,6 +90,63 @@ func (s *AdminCommunityEventsSuite) TestAdminEditCommunityDescription() {
 func (s *AdminCommunityEventsSuite) TestAdminCreateEditDeleteChannels() {
 	community := setUpCommunityAndRoles(s, protobuf.CommunityMember_ROLE_ADMIN)
 	testCreateEditDeleteChannels(s, community)
+}
+
+func (s *AdminCommunityEventsSuite) TestChannelDeletionDeletesActivityCenterNotifications() {
+	community := setUpCommunityAndRoles(s, protobuf.CommunityMember_ROLE_ADMIN)
+	channelID := createCommunityChannel(s, community, &protobuf.CommunityChat{
+		Permissions: &protobuf.CommunityPermissions{Access: protobuf.CommunityPermissions_AUTO_ACCEPT},
+		Identity:    &protobuf.ChatIdentity{DisplayName: "channel with notification"},
+	})
+	chatID := community.ChatID(channelID)
+	now := uint64(time.Now().UnixMilli())
+
+	adminNotification := &ActivityCenterNotification{
+		ID:        types.HexBytes{0x01},
+		ChatID:    chatID,
+		Type:      ActivityCenterNotificationTypeMention,
+		Timestamp: now,
+		UpdatedAt: now,
+	}
+	_, err := s.eventSender.persistence.SaveActivityCenterNotification(adminNotification, true)
+	s.Require().NoError(err)
+
+	memberNotification := &ActivityCenterNotification{
+		ID:        types.HexBytes{0x02},
+		ChatID:    chatID,
+		Type:      ActivityCenterNotificationTypeMention,
+		Timestamp: now,
+		UpdatedAt: now,
+	}
+	_, err = s.alice.persistence.SaveActivityCenterNotification(memberNotification, true)
+	s.Require().NoError(err)
+
+	response, err := s.eventSender.DeleteCommunityChat(community.ID(), channelID)
+	s.Require().NoError(err)
+	s.Require().Len(response.ActivityCenterNotifications(), 1)
+	s.Require().Equal(adminNotification.ID, response.ActivityCenterNotifications()[0].ID)
+	s.Require().True(response.ActivityCenterNotifications()[0].Deleted)
+
+	memberResponse, err := WaitOnMessengerResponse(
+		s.alice,
+		func(response *MessengerResponse) bool {
+			for _, activityCenterNotification := range response.ActivityCenterNotifications() {
+				if activityCenterNotification.ID.String() == memberNotification.ID.String() {
+					return activityCenterNotification.Deleted
+				}
+			}
+			return false
+		},
+		"member did not receive deleted activity center notification",
+	)
+	s.Require().NoError(err)
+	s.Require().Len(memberResponse.ActivityCenterNotifications(), 1)
+	s.Require().Equal(memberNotification.ID, memberResponse.ActivityCenterNotifications()[0].ID)
+	s.Require().True(memberResponse.ActivityCenterNotifications()[0].Deleted)
+
+	persistedNotification, err := s.alice.persistence.GetActivityCenterNotificationByID(memberNotification.ID)
+	s.Require().NoError(err)
+	s.Require().True(persistedNotification.Deleted)
 }
 
 func (s *AdminCommunityEventsSuite) TestAdminCreateEditDeleteBecomeMemberPermission() {

--- a/protocol/messenger.go
+++ b/protocol/messenger.go
@@ -4090,7 +4090,9 @@ func (m *Messenger) markMessagesSeenImpl(chatID string, ids []string) (uint64, u
 	if err != nil {
 		return 0, 0, nil, err
 	}
-	m.allChats.Store(chatID, chat)
+	if chat != nil {
+		m.allChats.Store(chatID, chat)
+	}
 	return count, countWithMentions, chat, nil
 }
 

--- a/protocol/messenger_activity_center.go
+++ b/protocol/messenger_activity_center.go
@@ -250,6 +250,36 @@ func (m *Messenger) MarkActivityCenterNotificationsDeleted(ctx context.Context, 
 	return response, nil
 }
 
+func (m *Messenger) deleteActivityCenterNotificationsByChatID(ctx context.Context, chatID string) (*MessengerResponse, error) {
+	updatedAt := m.GetCurrentTimeInMillis()
+	notifications, err := m.persistence.DeleteActivityCenterNotificationsByChatID(chatID, updatedAt)
+	if err != nil {
+		return nil, err
+	}
+
+	response := &MessengerResponse{}
+	response.AddActivityCenterNotifications(notifications)
+	state, err := m.persistence.GetActivityCenterState()
+	if err != nil {
+		return nil, err
+	}
+	response.SetActivityCenterState(state)
+
+	if len(notifications) == 0 {
+		return response, nil
+	}
+
+	ids := make([]types.HexBytes, 0, len(notifications))
+	for _, notification := range notifications {
+		ids = append(ids, notification.ID)
+	}
+	if err = m.syncActivityCenterDeletedByIDs(ctx, ids, updatedAt); err != nil {
+		return nil, err
+	}
+
+	return response, nil
+}
+
 func (m *Messenger) AddActivityCenterNotification(response *MessengerResponse, notification *ActivityCenterNotification, syncAction func(context.Context, []types.HexBytes, uint64) error) error {
 	return m.addActivityCenterNotification(response, notification, syncAction)
 }

--- a/protocol/messenger_activity_center.go
+++ b/protocol/messenger_activity_center.go
@@ -173,6 +173,9 @@ func (m *Messenger) MarkActivityCenterNotificationsRead(ctx context.Context, ids
 		if err != nil {
 			return nil, err
 		}
+		if chat == nil {
+			continue
+		}
 		response.AddChat(chat)
 		response.AddSeenAndUnseenMessages(&SeenUnseenMessages{
 			ChatID:            chatID,

--- a/protocol/messenger_activity_center_test.go
+++ b/protocol/messenger_activity_center_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/stretchr/testify/suite"
 
+	"github.com/status-im/status-go/internal/crypto/types"
 	multiaccountscommon "github.com/status-im/status-go/internal/db/multiaccounts/common"
 	"github.com/status-im/status-go/protocol/common"
 	"github.com/status-im/status-go/protocol/communities"
@@ -456,6 +457,31 @@ func (s *MessengerActivityCenterMessageSuite) TestMarkAllActivityCenterNotificat
 	s.Require().True(response.ActivityCenterNotifications()[2].Read)
 
 	s.confirmMentionAndReplyNotificationsRead(alice, mentionMessage, replyMessage, true)
+}
+
+func (s *MessengerActivityCenterMessageSuite) TestMarkActivityCenterNotificationReadForDeletedChat() {
+	alice, _, mentionMessage, _, _ := s.prepareCommunityChannelWithMentionAndReply()
+	notificationResponse, err := alice.ActivityCenterNotifications(ActivityCenterNotificationsRequest{
+		Limit:         1,
+		ReadType:      ActivityCenterQueryParamsReadAll,
+		ActivityTypes: []ActivityCenterType{ActivityCenterNotificationTypeMention},
+	})
+	s.Require().NoError(err)
+	s.Require().Len(notificationResponse.Notifications, 1)
+
+	err = alice.DeleteChat(mentionMessage.ChatId)
+	s.Require().NoError(err)
+
+	response, err := alice.MarkActivityCenterNotificationsRead(
+		context.Background(),
+		[]types.HexBytes{notificationResponse.Notifications[0].ID},
+		0,
+		true,
+	)
+	s.Require().NoError(err)
+	s.Require().Len(response.ActivityCenterNotifications(), 1)
+	s.Require().True(response.ActivityCenterNotifications()[0].Read)
+	s.Require().Empty(response.Chats())
 }
 
 func (s *MessengerActivityCenterMessageSuite) TestAliceDoesNotReceiveCommunityNotificationsBeforeJoined() {

--- a/protocol/messenger_communities.go
+++ b/protocol/messenger_communities.go
@@ -2449,6 +2449,17 @@ func (m *Messenger) DeleteCommunityChat(communityID types3.HexBytes, chatID stri
 	if err != nil {
 		return nil, err
 	}
+	activityCenterChatID := chatID
+	if !strings.HasPrefix(activityCenterChatID, community.IDString()) {
+		activityCenterChatID = community.ChatID(activityCenterChatID)
+	}
+	activityCenterResponse, err := m.deleteActivityCenterNotificationsByChatID(context.TODO(), activityCenterChatID)
+	if err != nil {
+		return nil, err
+	}
+	if err = response.Merge(activityCenterResponse); err != nil {
+		return nil, err
+	}
 	err = m.deleteChat(chatID)
 	if err != nil {
 		return nil, err
@@ -3163,10 +3174,18 @@ func (m *Messenger) handleCommunityResponse(state *ReceivedMessageState, communi
 
 	for id := range communityResponse.Changes.ChatsRemoved {
 		chatID := community.ChatID(id)
+		activityCenterResponse, err := m.deleteActivityCenterNotificationsByChatID(context.TODO(), chatID)
+		if err != nil {
+			return err
+		}
+		if err = state.Response.Merge(activityCenterResponse); err != nil {
+			return err
+		}
+
 		_, ok := state.AllChats.Load(chatID)
 		if ok {
 			state.AllChats.Delete(chatID)
-			err := m.DeleteChat(chatID)
+			err = m.DeleteChat(chatID)
 			if err != nil {
 				m.logger.Error("couldn't delete chat", zap.Error(err))
 			}

--- a/protocol/messenger_sync_activity_center_test.go
+++ b/protocol/messenger_sync_activity_center_test.go
@@ -68,6 +68,37 @@ func (s *MessengerSyncActivityCenterSuite) TestSyncDeleted() {
 	s.syncTest(ActivityCenterNotificationTypeMention, true, (*Messenger).MarkActivityCenterNotificationsDeleted, func(n *ActivityCenterNotification) bool { return n.Deleted })
 }
 
+func (s *MessengerSyncActivityCenterSuite) TestDeleteActivityCenterNotificationsByChatIDSyncs() {
+	chatID := "deleted-channel"
+	now := uint64(time.Now().Unix())
+	notification := &ActivityCenterNotification{
+		ID:               types.HexBytes{0x01},
+		ChatID:           chatID,
+		Timestamp:        now,
+		Type:             ActivityCenterNotificationTypeMention,
+		MembershipStatus: ActivityCenterMembershipStatusIdle,
+		UpdatedAt:        now,
+	}
+	_, err := s.m.persistence.SaveActivityCenterNotification(notification, true)
+	s.Require().NoError(err)
+	_, err = s.m2.persistence.SaveActivityCenterNotification(notification, true)
+	s.Require().NoError(err)
+
+	response, err := s.m.deleteActivityCenterNotificationsByChatID(context.Background(), chatID)
+	s.Require().NoError(err)
+	s.Require().Len(response.ActivityCenterNotifications(), 1)
+	s.Require().True(response.ActivityCenterNotifications()[0].Deleted)
+
+	_, err = WaitOnMessengerResponse(s.m2, func(response *MessengerResponse) bool {
+		return response.ActivityCenterState() != nil
+	}, "activity center notification deletion not received")
+	s.Require().NoError(err)
+
+	remoteNotification, err := s.m2.persistence.GetActivityCenterNotificationByID(notification.ID)
+	s.Require().NoError(err)
+	s.Require().True(remoteNotification.Deleted)
+}
+
 func (s *MessengerSyncActivityCenterSuite) TestSyncRead() {
 	s.syncTest(ActivityCenterNotificationTypeMention, false, (*Messenger).MarkActivityCenterNotificationsRead, func(n *ActivityCenterNotification) bool { return n.Read })
 }


### PR DESCRIPTION
Needed for https://github.com/status-im/status-app/issues/21755

status-app PR: https://github.com/status-im/status-app/pull/21791

- [fix(ac): fix crash when marking as read a notif with a deleted channel](https://github.com/status-im/status-go/commit/6586890fce88ccfc6c2496010894ff4938bfc9a0)
- [fix(ac): delete notifs when a channel is deleted](https://github.com/status-im/status-go/commit/a14245aff859cb8a125538f58a9a7631adc6611a)