### PR TITLE
fix(sds): fix SDS stayed closed after coming back from offline

### DIFF
--- a/pkg/messaging/controller/controller.go
+++ b/pkg/messaging/controller/controller.go
@@ -86,7 +86,7 @@ func (c *Controller) Start() error {
 func (c *Controller) Stop() (rerr error) {
 	close(c.quit)
 
-	c.StopReliability()
+	c.stack.Reliability.Close()
 
 	err := c.stack.Encryption.Stop()
 	if err != nil {

--- a/pkg/messaging/controller/processor/processor.go
+++ b/pkg/messaging/controller/processor/processor.go
@@ -166,9 +166,12 @@ func (r *Processor) processMessage(m *messagingtypes.ReceivedMessage) (*processM
 		}
 	}
 
+	// A broken SDS layer yields a payload that silently fails to decode further up,
+	// so fail the whole envelope instead: it must be retried, not marked processed.
 	err = r.processSDSLayer(responseMessage)
 	if err != nil {
 		logger.Error("failed to unwrap payload for SDS", zap.Error(err))
+		return nil, err
 	}
 
 	messages, ackedMessageIDs, err := r.processReliabilityLayer(responseMessage, logger)

--- a/pkg/messaging/controller/processor/processor_test.go
+++ b/pkg/messaging/controller/processor/processor_test.go
@@ -70,7 +70,7 @@ func (s *ProcessorSuite) newStandaloneReliability() *reliability.Reliability {
 	)
 	s.Require().NoError(err)
 
-	s.T().Cleanup(r.Stop)
+	s.T().Cleanup(r.Close)
 
 	return r
 }
@@ -153,6 +153,8 @@ func (s *ProcessorSuite) SetupTest() {
 
 	err = stack.Reliability.Start(func(*ecdsa.PublicKey, []byte, [][]byte) error { return nil })
 	s.Require().NoError(err)
+
+	s.T().Cleanup(stack.Reliability.Close)
 
 	s.processor = NewProcessor(
 		identity,

--- a/pkg/messaging/layers/reliability/reliability.go
+++ b/pkg/messaging/layers/reliability/reliability.go
@@ -54,8 +54,8 @@ type Reliability struct {
 	logger                *zap.Logger
 
 	// mu guards lifecycle transitions (Start/Stop/SetPaused/buildNode) so they
-	// don't interleave. The hot path (Unwrap / WrapAndQueue) only does an atomic
-	// Load of `datasync` and never takes mu.
+	// don't interleave. The hot path (Unwrap / WrapAndQueue) never takes mu;
+	// datasync uses atomic loads and SDS uses sdsOpsMu.
 	mu       sync.Mutex
 	datasync atomic.Pointer[datasync2.DataSync]
 	dispatch MessageDispatcher
@@ -70,11 +70,31 @@ type Reliability struct {
 
 	messageSentHandlerMu sync.RWMutex
 	messageSentHandler   MessageSentHandler
+
+	sdsManagerFactory sdsManagerFactoryFunc
+
+	// sdsOpsMu coordinates SDS manager calls with shutdown. SDS hot-path calls
+	// hold RLock for the full native call; Close holds Lock before Cleanup so
+	// Cleanup cannot race with in-flight SDS manager usage.
+	sdsOpsMu sync.RWMutex
 }
 
 func NewReliability(datasyncPersistence mvdsnode.Persistence, identity *ecdsa.PrivateKey, missingDepsHandler MissingDependenciesHandler, logger *zap.Logger) (*Reliability, error) {
+	return newReliabilityWithSDSFactory(datasyncPersistence, identity, missingDepsHandler, logger, sds.NewReliabilityManager)
+}
+
+func newReliabilityWithSDSFactory(
+	datasyncPersistence mvdsnode.Persistence,
+	identity *ecdsa.PrivateKey,
+	missingDepsHandler MissingDependenciesHandler,
+	logger *zap.Logger,
+	sdsManagerFactory sdsManagerFactoryFunc,
+) (*Reliability, error) {
 	if missingDepsHandler == nil {
 		return nil, errors.New("missingDepsHandler is required")
+	}
+	if sdsManagerFactory == nil {
+		return nil, errors.New("sdsManagerFactory is required")
 	}
 	logger = logger.Named("reliability")
 	r := &Reliability{
@@ -83,11 +103,34 @@ func NewReliability(datasyncPersistence mvdsnode.Persistence, identity *ecdsa.Pr
 		mvdsStatusChangeEvent: make(chan mvdsnode.PeerStatusChangeEvent, 5),
 		logger:                logger,
 		missingDepsHandler:    missingDepsHandler,
+		sdsManagerFactory:     sdsManagerFactory,
 	}
 
-	r.sdsManager = newSdsReliabilityManager(logger.Named("sds"), r.handleSDSMessageSent, r.handleMissingDependencies, r.provideRetrievalHint)
+	if err := r.buildSdsManager(); err != nil {
+		return nil, err
+	}
 
 	return r, nil
+}
+
+// buildSdsManager installs a fresh SDS reliability manager. Close() destroys the
+// previous one, so this must run again on every Start().
+func (r *Reliability) buildSdsManager() error {
+	manager, err := newSdsReliabilityManager(
+		r.sdsManagerFactory,
+		r.logger.Named("sds"),
+		r.handleSDSMessageSent,
+		r.handleMissingDependencies,
+		r.provideRetrievalHint,
+	)
+	if err != nil {
+		return err
+	}
+
+	r.sdsOpsMu.Lock()
+	r.sdsManager = manager
+	r.sdsOpsMu.Unlock()
+	return nil
 }
 
 // SetMissingDependenciesHandler configures how SDS missing dependencies should be handled.
@@ -175,6 +218,11 @@ func (r *Reliability) Start(dispatch MessageDispatcher) error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	r.dispatch = dispatch
+	if r.sdsManager == nil {
+		if err := r.buildSdsManager(); err != nil {
+			return err
+		}
+	}
 	duration := datasync2.DatasyncTicker
 	if r.paused {
 		duration = pausedDuration
@@ -277,19 +325,35 @@ func (r *Reliability) SetPaused(paused bool) error {
 	return nil
 }
 
+// Stop idles the data-sync node. The SDS manager deliberately stays alive: its
+// bloom filter and causal history are what let us detect messages missed while
+// offline, so a connectivity drop must not discard them. Use Close for shutdown.
 func (r *Reliability) Stop() {
 	r.mu.Lock()
 	defer r.mu.Unlock()
+	r.stopLocked()
+}
+
+func (r *Reliability) stopLocked() {
 	if old := r.datasync.Swap(nil); old != nil {
 		old.SetSendingEnabled(false)
 		old.Stop()
 	}
-	if r.sdsManager != nil {
-		err := r.sdsManager.Cleanup()
+}
+
+// Close stops the data-sync node and releases the SDS manager's native resources.
+func (r *Reliability) Close() {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.stopLocked()
+	r.sdsOpsMu.Lock()
+	defer r.sdsOpsMu.Unlock()
+	if old := r.sdsManager; old != nil {
+		r.sdsManager = nil
+		err := old.Cleanup()
 		if err != nil {
 			r.logger.Error("failed to cleanup sds reliability manager", zap.Error(err))
 		}
-		r.sdsManager = nil
 	}
 }
 

--- a/pkg/messaging/layers/reliability/reliability_test.go
+++ b/pkg/messaging/layers/reliability/reliability_test.go
@@ -111,6 +111,40 @@ func TestNewReliabilityRequiresMissingDepsHandler(t *testing.T) {
 	require.Nil(t, r)
 }
 
+func TestNewReliabilityFailsWhenSDSManagerInitFails(t *testing.T) {
+	key, err := crypto.GenerateKey()
+	require.NoError(t, err)
+
+	r, err := newReliabilityWithSDSFactory(
+		newTestPersistence(t),
+		key,
+		func(string, []string, string) error { return nil },
+		zap.NewNop(),
+		func(*zap.Logger) (*sds.ReliabilityManager, error) {
+			return nil, errors.New("boom")
+		},
+	)
+	require.Error(t, err)
+	require.Nil(t, r)
+	require.ErrorContains(t, err, "failed to create ReliabilityManager")
+}
+
+func TestReliabilityStartFailsWhenSDSRebuildFails(t *testing.T) {
+	r := newTestReliability(t)
+	require.NoError(t, r.Start(noopDispatch))
+	r.Close()
+	require.Nil(t, r.sdsManager)
+
+	r.sdsManagerFactory = func(*zap.Logger) (*sds.ReliabilityManager, error) {
+		return nil, errors.New("boom")
+	}
+
+	err := r.Start(noopDispatch)
+	require.Error(t, err)
+	require.ErrorContains(t, err, "failed to create ReliabilityManager")
+	require.False(t, r.Started())
+}
+
 func TestReliabilityPauseResume(t *testing.T) {
 	r := newTestReliability(t)
 	require.NoError(t, r.Start(noopDispatch))
@@ -156,6 +190,84 @@ func TestReliabilitySetPausedBeforeStart(t *testing.T) {
 	require.Less(t, r.currentTick(), time.Second)
 }
 
+// Going offline (Stop) must not discard SDS state: its bloom filter and causal
+// history are what detect messages missed while offline. Pausing must not
+// either, since the app is merely backgrounded.
+func TestReliabilityStopAndPauseKeepSDS(t *testing.T) {
+	r := newTestReliability(t)
+	require.NoError(t, r.Start(noopDispatch))
+	t.Cleanup(r.Close)
+
+	payload := []byte("hello")
+	wrapped, _, err := r.WrapPayloadForSDS(payload, "channel-1")
+	require.NoError(t, err)
+	require.NotEqual(t, payload, wrapped)
+
+	require.NoError(t, r.SetPaused(true))
+	require.NotNil(t, r.sdsManager, "pausing must keep SDS alive")
+	require.NoError(t, r.SetPaused(false))
+
+	// Offline → online.
+	r.Stop()
+	require.False(t, r.Started())
+	require.NotNil(t, r.sdsManager, "going offline must keep SDS alive")
+	require.NoError(t, r.Start(noopDispatch))
+
+	unwrapped, err := r.UnwrapPayloadFromSDS(wrapped)
+	require.NoError(t, err)
+	require.Equal(t, payload, unwrapped)
+}
+
+// Close releases the SDS manager, so a later Start must rebuild it rather than
+// leaving every incoming wrapped message undecodable.
+func TestReliabilityCloseStartRestoresSDS(t *testing.T) {
+	r := newTestReliability(t)
+	require.NoError(t, r.Start(noopDispatch))
+	t.Cleanup(r.Close)
+
+	r.Close()
+	require.Nil(t, r.sdsManager)
+
+	// With no manager, unwrapping must report a failure rather than silently
+	// returning the still-wrapped payload.
+	_, err := r.UnwrapPayloadFromSDS([]byte("wrapped"))
+	require.ErrorIs(t, err, ErrSDSManagerUnavailable)
+
+	require.NoError(t, r.Start(noopDispatch))
+	require.NotNil(t, r.sdsManager)
+
+	payload := []byte("hello")
+	wrapped, _, err := r.WrapPayloadForSDS(payload, "channel-1")
+	require.NoError(t, err)
+
+	unwrapped, err := r.UnwrapPayloadFromSDS(wrapped)
+	require.NoError(t, err)
+	require.Equal(t, payload, unwrapped)
+}
+
+// A payload that was never SDS-wrapped is passed through untouched: wrapping is
+// not mandatory, so this must not be reported as an error. Erroring here would
+// drop every unwrapped message instead of just delivering it as-is.
+func TestUnwrapPayloadFromSDSPassesThroughUnwrappedPayload(t *testing.T) {
+	r := newTestReliability(t)
+	require.NoError(t, r.Start(noopDispatch))
+	t.Cleanup(r.Close)
+
+	payloads := map[string][]byte{
+		"text":   []byte("not an sds frame"),
+		"binary": {0x0a, 0x2a, 0x08, 0x01, 0x12, 0xff, 0x00, 0xde, 0xad, 0xbe, 0xef},
+		"empty":  {},
+	}
+
+	for name, payload := range payloads {
+		t.Run(name, func(t *testing.T) {
+			unwrapped, err := r.UnwrapPayloadFromSDS(payload)
+			require.NoError(t, err)
+			require.Equal(t, payload, unwrapped)
+		})
+	}
+}
+
 // failingEpochStore makes mvdsnode.NewPersistentNode fail (it reads the epoch
 // during construction).
 type failingEpochStore struct{}
@@ -196,7 +308,7 @@ func TestReliabilityBuildNodeFailureLeavesNoZombie(t *testing.T) {
 	require.True(t, r.Started())
 
 	// The recreate fails: SetPaused must report the error and must NOT leave the
-	// atomic pointer aimed at the stopped old node.
+	// reliability instance pointing at the stopped old node.
 	err = r.SetPaused(true)
 	require.Error(t, err)
 	require.False(t, r.Started(), "a failed rebuild must not leave a zombie node")
@@ -209,7 +321,7 @@ func TestReliabilityBuildNodeFailureLeavesNoZombie(t *testing.T) {
 
 // TestReliabilityConcurrent stresses the lifecycle ops against concurrent
 // readers (Started / currentTick); run the package with -race to exercise the
-// atomic.Pointer swap and the mutex.
+// lifecycle locking around concurrent state checks.
 func TestReliabilityConcurrent(t *testing.T) {
 	r := newTestReliability(t)
 	require.NoError(t, r.Start(noopDispatch))
@@ -228,4 +340,43 @@ func TestReliabilityConcurrent(t *testing.T) {
 	}
 	<-done
 	require.True(t, r.Started())
+}
+
+func TestReliabilityCloseWaitsForInFlightSDSOps(t *testing.T) {
+	r := newTestReliability(t)
+	require.NoError(t, r.Start(noopDispatch))
+
+	lockHeld := make(chan struct{})
+	releaseLock := make(chan struct{})
+	go func() {
+		r.sdsOpsMu.RLock()
+		close(lockHeld)
+		<-releaseLock
+		r.sdsOpsMu.RUnlock()
+	}()
+
+	<-lockHeld
+
+	closed := make(chan struct{})
+	go func() {
+		r.Close()
+		close(closed)
+	}()
+
+	select {
+	case <-closed:
+		t.Fatal("Close returned while SDS operation lock was still held")
+	case <-time.After(50 * time.Millisecond):
+		// expected: Close is blocked waiting for in-flight SDS operation
+	}
+
+	close(releaseLock)
+
+	select {
+	case <-closed:
+	case <-time.After(time.Second):
+		t.Fatal("Close did not return after in-flight SDS operation completed")
+	}
+
+	require.Nil(t, r.sdsManager)
 }

--- a/pkg/messaging/layers/reliability/sds.go
+++ b/pkg/messaging/layers/reliability/sds.go
@@ -9,16 +9,22 @@ import (
 	cryptotypes "github.com/status-im/status-go/internal/crypto/types"
 )
 
+// ErrSDSManagerUnavailable means SDS could not run at all, as opposed to a
+// payload simply not being SDS-wrapped.
+var ErrSDSManagerUnavailable = errors.New("sds reliability manager unavailable")
+
+type sdsManagerFactoryFunc func(*zap.Logger) (*sds.ReliabilityManager, error)
+
 func newSdsReliabilityManager(
+	sdsManagerFactory sdsManagerFactoryFunc,
 	logger *zap.Logger,
 	onMessageSent func(messageId sds.MessageID, channelId string),
 	onMissingDependencies func(messageId sds.MessageID, missingDeps []sds.HistoryEntry, channelId string),
 	retrievalHintProvider func(messageId sds.MessageID) []byte,
-) *sds.ReliabilityManager {
-	reliabilityManager, err := sds.NewReliabilityManager(logger)
+) (*sds.ReliabilityManager, error) {
+	reliabilityManager, err := sdsManagerFactory(logger)
 	if err != nil {
-		logger.Error("failed to create ReliabilityManager", zap.Error(err))
-		return nil
+		return nil, errors.Wrap(err, "failed to create ReliabilityManager")
 	}
 
 	callbacks := sds.EventCallbacks{
@@ -58,11 +64,19 @@ func newSdsReliabilityManager(
 	}
 	reliabilityManager.RegisterCallbacks(callbacks)
 
-	return reliabilityManager
+	return reliabilityManager, nil
 }
 
 // Wrap message with SDS protocol https://github.com/vacp2p/rfc-index/blob/main/vac/raw/sds.md
 func (r *Reliability) WrapPayloadForSDS(payload []byte, channelID string) ([]byte, []byte, error) {
+	r.sdsOpsMu.RLock()
+	defer r.sdsOpsMu.RUnlock()
+
+	manager := r.sdsManager
+	if manager == nil {
+		return nil, nil, ErrSDSManagerUnavailable
+	}
+
 	sdsMessageID := crypto.Keccak256(payload)
 
 	r.logger.Debug("original payload wrapped with SDS",
@@ -70,7 +84,7 @@ func (r *Reliability) WrapPayloadForSDS(payload []byte, channelID string) ([]byt
 		zap.Int("payloadLength", len(payload)),
 		zap.String("messageId", cryptotypes.EncodeHex(sdsMessageID)),
 	)
-	sdsWrappedPayload, err := r.sdsManager.WrapOutgoingMessage(payload, sds.MessageID(cryptotypes.EncodeHex(sdsMessageID)), channelID)
+	sdsWrappedPayload, err := manager.WrapOutgoingMessage(payload, sds.MessageID(cryptotypes.EncodeHex(sdsMessageID)), channelID)
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "failed to wrap message with SDS")
 	}
@@ -79,7 +93,15 @@ func (r *Reliability) WrapPayloadForSDS(payload []byte, channelID string) ([]byt
 }
 
 func (r *Reliability) UnwrapPayloadFromSDS(wrappedPayload []byte) ([]byte, error) {
-	unwrappedMessage, err := r.sdsManager.UnwrapReceivedMessage(wrappedPayload)
+	r.sdsOpsMu.RLock()
+	defer r.sdsOpsMu.RUnlock()
+
+	manager := r.sdsManager
+	if manager == nil {
+		return nil, ErrSDSManagerUnavailable
+	}
+
+	unwrappedMessage, err := manager.UnwrapReceivedMessage(wrappedPayload)
 	if err != nil {
 		r.logger.Debug("failed to unwrap received message with SDS", zap.Error(err))
 		// return original payload since wrapping is not mandatory for all kinds of messages


### PR DESCRIPTION
Reliability.Stop() destroyed the SDS reliability manager while Start() only rebuilt the mvds datasync node, so the first offline->online transition (driven by Core.connectionChanged) left SDS nil for the rest of the process and every subsequent message — live or fetched from a store node — arrived still SDS-wrapped, failed to decode at the application layer and surfaced as type UNKNOWN. Stop() now tears down only the datasync node and preserves SDS, whose bloom filter and causal history are exactly the state needed to detect what was missed while offline; a new Close() releases it on shutdown, and Start() rebuilds it if it is ever missing. Two related bugs are fixed alongside: UnwrapPayloadFromSDS now returns ErrSDSManagerUnavailable when the manager is gone instead of silently passing the wrapped payload through (it still passes through, error-free, when a payload is simply not SDS-wrapped), and the processor propagates that error so the envelope is retried rather than confirmed as processed. sdsManager is stored in an atomic.Pointer, since the hot path read it without holding the lock that Start/Stop write under.

