### PR TITLE
Feat/fast password change

### DIFF
--- a/cmd/unwrap-kek/main.go
+++ b/cmd/unwrap-kek/main.go
@@ -1,0 +1,95 @@
+// Command unwrap-kek is a developer utility to unwrap a profile's wrapped-DEK file.
+//
+// Usage:
+//
+//	go run ./cmd/unwrap-kek <path/to/<keyUID>-profile.kek> <password>
+//
+// The password may be given as:
+// - the raw profile password
+// - in its hashed form, as the already-hashed 0x… value
+// - the keycard encryption public key (both raw and hashed forms are tried)
+
+package main
+
+import (
+	"encoding/hex"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	ethcrypto "github.com/ethereum/go-ethereum/crypto"
+
+	"github.com/status-im/status-go/internal/accounts-management/keystore/envelope"
+)
+
+const (
+	mainSuffix    = "-profile.kek"
+	pendingSuffix = "-profile.kek.pending"
+)
+
+func fatalf(format string, args ...any) {
+	fmt.Fprintf(os.Stderr, "error: "+format+"\n", args...)
+	os.Exit(1)
+}
+
+func main() {
+	if len(os.Args) != 3 {
+		fmt.Fprintf(os.Stderr, "usage: %s <path/to/<keyUID>-profile.kek[.pending]> <password>\n", filepath.Base(os.Args[0]))
+		os.Exit(2)
+	}
+	filePath, password := os.Args[1], os.Args[2]
+
+	rootDataDir := filepath.Dir(filePath)
+	base := filepath.Base(filePath)
+
+	var keyUID string
+	pending := false
+	switch {
+	case strings.HasSuffix(base, pendingSuffix):
+		keyUID = strings.TrimSuffix(base, pendingSuffix)
+		pending = true
+	case strings.HasSuffix(base, mainSuffix):
+		keyUID = strings.TrimSuffix(base, mainSuffix)
+	default:
+		fatalf("%s is not a %s file", base, mainSuffix)
+	}
+
+	if _, err := os.Stat(filePath); err != nil {
+		fatalf("%v", err)
+	}
+
+	unwrap := envelope.Unwrap
+	if pending {
+		unwrap = envelope.UnwrapPending
+	}
+
+	// Whatever is sent as the password, we try to unwrap the envelope with it.
+	hashed := "0x" + strings.ToLower(hex.EncodeToString(ethcrypto.Keccak256([]byte(password))))
+	candidates := []struct{ label, kek string }{
+		{"provided value used as-is", password},
+		{"keccak256-hashed password (client convention)", hashed},
+	}
+
+	for _, candidate := range candidates {
+		dekHex, dbKdfIterations, err := unwrap(rootDataDir, keyUID, candidate.kek)
+		if err != nil {
+			continue
+		}
+		fmt.Printf("KEK accepted:   %s\n", candidate.label)
+		fmt.Printf("keyUID:         %s\n", keyUID)
+		fmt.Printf("DEK (secret):   %s\n", dekHex)
+		fmt.Printf("db kdf_iter:    %d\n", dbKdfIterations)
+		fmt.Println()
+		fmt.Println("The DEK is the passphrase for the profile databases and keystore files.")
+		fmt.Println("To open a database with the sqlcipher CLI:")
+		fmt.Printf("  PRAGMA key = '%s';\n", dekHex)
+		fmt.Printf("  PRAGMA kdf_iter = %d;\n", dbKdfIterations)
+		fmt.Println("  PRAGMA cipher_page_size = 8192;")
+		fmt.Println("  PRAGMA cipher_hmac_algorithm = HMAC_SHA1;")
+		fmt.Println("  PRAGMA cipher_kdf_algorithm = PBKDF2_HMAC_SHA1;")
+		return
+	}
+
+	fatalf("the provided password does not unwrap this envelope (tried as-is and keccak256-hashed)")
+}

--- a/internal/accounts-management/keystore/adapter.go
+++ b/internal/accounts-management/keystore/adapter.go
@@ -208,6 +208,12 @@ func VerifyKeyStoreDirAtPath(keystoreDir, password string) error {
 	return mapToKeystoreError(geth.VerifyKeyStoreDir(keystoreDir, password))
 }
 
+// ReEncryptRawKey decrypts a raw keystore file with oldPass and re-encrypts it with newPass
+func ReEncryptRawKey(rawKey []byte, oldPass, newPass string) ([]byte, error) {
+	reEncrypted, err := geth.ReEncryptKey(rawKey, oldPass, newPass)
+	return reEncrypted, mapToKeystoreError(err)
+}
+
 func (a *Adapter) MigrateKeyStoreDir(newDir string) (err error) {
 	defer func() {
 		err = mapToKeystoreError(err)

--- a/internal/accounts-management/keystore/adapter.go
+++ b/internal/accounts-management/keystore/adapter.go
@@ -198,6 +198,16 @@ func (a *Adapter) ReEncryptKeyStoreDir(oldPass, newPass string) (err error) {
 	return
 }
 
+// ReEncryptKeyStoreDirAtPath re-encrypts all keystore files in the given directory
+func ReEncryptKeyStoreDirAtPath(keystoreDir, oldPass, newPass string) error {
+	return mapToKeystoreError(geth.ReEncryptKeyStoreDir(keystoreDir, oldPass, newPass))
+}
+
+// VerifyKeyStoreDirAtPath checks that every key file in the directory decrypts with password
+func VerifyKeyStoreDirAtPath(keystoreDir, password string) error {
+	return mapToKeystoreError(geth.VerifyKeyStoreDir(keystoreDir, password))
+}
+
 func (a *Adapter) MigrateKeyStoreDir(newDir string) (err error) {
 	defer func() {
 		err = mapToKeystoreError(err)

--- a/internal/accounts-management/keystore/envelope/envelope.go
+++ b/internal/accounts-management/keystore/envelope/envelope.go
@@ -1,0 +1,210 @@
+// Package envelope implements the per-profile wrapped database-encryption-key (DEK).
+//
+// Goal: Changing the password only re-wraps the DEK in <keyUID>-profile.kek file, the databases and keystore files are untouched.
+package envelope
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	geth "github.com/status-im/status-go/internal/accounts-management/keystore/internal/geth"
+)
+
+const (
+	fileSuffix  = "-profile.kek"
+	fileVersion = 1
+
+	pendingSuffix = ".pending" // used for deep rekey (when a new DEK is generated)
+
+	dekLength = 32 // DEK size in bytes
+
+	scryptN = 1 << 18
+	scryptP = 1
+)
+
+var ErrInvalidKEK = errors.New("envelope: invalid key-encryption key")
+
+type wrappedKeyFile struct {
+	Version         int             `json:"version"`
+	KeyUID          string          `json:"keyUid"`
+	DBKdfIterations int             `json:"dbKdfIterations"`
+	Crypto          geth.CryptoJSON `json:"crypto"`
+}
+
+// Path returns the wrapped-DEK file path for the given profile.
+func Path(rootDataDir, keyUID string) string {
+	return filepath.Join(rootDataDir, keyUID+fileSuffix)
+}
+
+// PendingPath returns the path of the pending (rekey-in-progress) envelope.
+func PendingPath(rootDataDir, keyUID string) string {
+	return Path(rootDataDir, keyUID) + pendingSuffix
+}
+
+// Exists reports whether the profile has a wrapped-DEK file.
+func Exists(rootDataDir, keyUID string) bool {
+	_, err := os.Stat(Path(rootDataDir, keyUID))
+	return err == nil
+}
+
+// PendingExists reports whether an interrupted rekey left a pending envelope.
+func PendingExists(rootDataDir, keyUID string) bool {
+	_, err := os.Stat(PendingPath(rootDataDir, keyUID))
+	return err == nil
+}
+
+// Generate creates a new random DEK and returns it as a lowercase hex string.
+func Generate() (string, error) {
+	dek := make([]byte, dekLength)
+	if _, err := rand.Read(dek); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(dek), nil
+}
+
+// Write wraps dekHex with kek and atomically writes the wrapped-DEK file, replacing any existing one.
+func Write(rootDataDir, keyUID, dekHex, kek string, dbKdfIterations int) error {
+	return writeToPath(Path(rootDataDir, keyUID), keyUID, dekHex, kek, dbKdfIterations)
+}
+
+// WritePending writes the pending (rekey-in-progress) envelope.
+func WritePending(rootDataDir, keyUID, dekHex, kek string, dbKdfIterations int) error {
+	return writeToPath(PendingPath(rootDataDir, keyUID), keyUID, dekHex, kek, dbKdfIterations)
+}
+
+func writeToPath(path, keyUID, dekHex, kek string, dbKdfIterations int) error {
+	dek, err := hex.DecodeString(dekHex)
+	if err != nil || len(dek) != dekLength {
+		return fmt.Errorf("envelope: DEK must be %d hex-encoded bytes", dekLength)
+	}
+
+	cryptoJSON, err := geth.EncryptDataV3(dek, []byte(kek), scryptN, scryptP)
+	if err != nil {
+		return err
+	}
+
+	content, err := json.Marshal(wrappedKeyFile{
+		Version:         fileVersion,
+		KeyUID:          keyUID,
+		DBKdfIterations: dbKdfIterations,
+		Crypto:          cryptoJSON,
+	})
+	if err != nil {
+		return err
+	}
+
+	return atomicWrite(path, content)
+}
+
+// Unwrap reads the profile's wrapped-DEK file and decrypts the DEK with kek.
+func Unwrap(rootDataDir, keyUID, kek string) (dekHex string, dbKdfIterations int, err error) {
+	return unwrapFromPath(Path(rootDataDir, keyUID), kek)
+}
+
+// UnwrapPending reads and decrypts the pending (rekey-in-progress) envelope.
+func UnwrapPending(rootDataDir, keyUID, kek string) (dekHex string, dbKdfIterations int, err error) {
+	return unwrapFromPath(PendingPath(rootDataDir, keyUID), kek)
+}
+
+func unwrapFromPath(path, kek string) (dekHex string, dbKdfIterations int, err error) {
+	content, err := os.ReadFile(path)
+	if err != nil {
+		return "", 0, err
+	}
+
+	var file wrappedKeyFile
+	if err := json.Unmarshal(content, &file); err != nil {
+		return "", 0, fmt.Errorf("envelope: malformed wrapped-DEK file: %w", err)
+	}
+	if file.Version != fileVersion {
+		return "", 0, fmt.Errorf("envelope: unsupported wrapped-DEK file version %d", file.Version)
+	}
+
+	dek, err := geth.DecryptDataV3(file.Crypto, kek)
+	if err != nil {
+		// MAC mismatch (or any decrypt failure) means the KEK is wrong.
+		return "", 0, ErrInvalidKEK
+	}
+	if len(dek) != dekLength {
+		return "", 0, fmt.Errorf("envelope: unexpected DEK length %d", len(dek))
+	}
+
+	return hex.EncodeToString(dek), file.DBKdfIterations, nil
+}
+
+// Rewrap re-encrypts the profile's DEK with a new KEK, atomically replacing the wrapped-DEK file.
+func Rewrap(rootDataDir, keyUID, oldKEK, newKEK string) error {
+	dekHex, dbKdfIterations, err := Unwrap(rootDataDir, keyUID, oldKEK)
+	if err != nil {
+		return err
+	}
+	return Write(rootDataDir, keyUID, dekHex, newKEK, dbKdfIterations)
+}
+
+// Remove deletes the profile's wrapped-DEK file, its pending sidecar and any leftover temp files from interrupted writes.
+func Remove(rootDataDir, keyUID string) error {
+	if err := RemovePending(rootDataDir, keyUID); err != nil {
+		return err
+	}
+	return removePath(Path(rootDataDir, keyUID))
+}
+
+// RemovePending deletes the pending (rekey-in-progress) envelope, if any.
+func RemovePending(rootDataDir, keyUID string) error {
+	return removePath(PendingPath(rootDataDir, keyUID))
+}
+
+func removePath(path string) error {
+	if matches, globErr := filepath.Glob(path + ".*.tmp"); globErr == nil {
+		for _, match := range matches {
+			_ = os.Remove(match)
+		}
+	}
+	err := os.Remove(path)
+	if err != nil && !errors.Is(err, os.ErrNotExist) {
+		return err
+	}
+	return nil
+}
+
+// atomicWrite writes content to path via a unique same-directory temp file + fsync + rename, so a crash never leaves
+// a partially-written (unrecoverable) key file behind and concurrent writers cannot corrupt each other's temp content.
+// The last completed rename wins with a self-consistent file.
+func atomicWrite(path string, content []byte) error {
+	f, err := os.CreateTemp(filepath.Dir(path), filepath.Base(path)+".*.tmp")
+	if err != nil {
+		return err
+	}
+	tmpPath := f.Name()
+
+	if err = f.Chmod(0600); err != nil {
+		_ = f.Close()
+		_ = os.Remove(tmpPath)
+		return err
+	}
+	if _, err = f.Write(content); err != nil {
+		_ = f.Close()
+		_ = os.Remove(tmpPath)
+		return err
+	}
+	if err = f.Sync(); err != nil {
+		_ = f.Close()
+		_ = os.Remove(tmpPath)
+		return err
+	}
+	if err = f.Close(); err != nil {
+		_ = os.Remove(tmpPath)
+		return err
+	}
+
+	if err = os.Rename(tmpPath, path); err != nil {
+		_ = os.Remove(tmpPath)
+		return err
+	}
+	return nil
+}

--- a/internal/accounts-management/keystore/envelope/envelope_test.go
+++ b/internal/accounts-management/keystore/envelope/envelope_test.go
@@ -1,0 +1,154 @@
+package envelope
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	testKeyUID = "0x1122334455667788990011223344556677889900112233445566778899001122"
+	testKEK    = "0x20756e6465727374616e64207468652063757272656e74206265686176696f72"
+	otherKEK   = "0x6f74686572206b656b206f74686572206b656b206f74686572206b656b202121"
+)
+
+func TestGenerate(t *testing.T) {
+	dek1, err := Generate()
+	require.NoError(t, err)
+	require.Len(t, dek1, 2*dekLength)
+
+	dek2, err := Generate()
+	require.NoError(t, err)
+	require.NotEqual(t, dek1, dek2)
+}
+
+func TestWriteUnwrapRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+
+	dek, err := Generate()
+	require.NoError(t, err)
+
+	require.False(t, Exists(dir, testKeyUID))
+	require.NoError(t, Write(dir, testKeyUID, dek, testKEK, 3200))
+	require.True(t, Exists(dir, testKeyUID))
+
+	unwrapped, kdfIterations, err := Unwrap(dir, testKeyUID, testKEK)
+	require.NoError(t, err)
+	require.Equal(t, dek, unwrapped)
+	require.Equal(t, 3200, kdfIterations)
+}
+
+func TestUnwrapWrongKEK(t *testing.T) {
+	dir := t.TempDir()
+
+	dek, err := Generate()
+	require.NoError(t, err)
+	require.NoError(t, Write(dir, testKeyUID, dek, testKEK, 3200))
+
+	_, _, err = Unwrap(dir, testKeyUID, otherKEK)
+	require.ErrorIs(t, err, ErrInvalidKEK)
+}
+
+func TestUnwrapMissingFile(t *testing.T) {
+	_, _, err := Unwrap(t.TempDir(), testKeyUID, testKEK)
+	require.ErrorIs(t, err, os.ErrNotExist)
+}
+
+func TestRewrap(t *testing.T) {
+	dir := t.TempDir()
+
+	dek, err := Generate()
+	require.NoError(t, err)
+	require.NoError(t, Write(dir, testKeyUID, dek, testKEK, 3200))
+
+	// Wrong old KEK must not touch the file.
+	require.ErrorIs(t, Rewrap(dir, testKeyUID, otherKEK, "irrelevant"), ErrInvalidKEK)
+	unwrapped, _, err := Unwrap(dir, testKeyUID, testKEK)
+	require.NoError(t, err)
+	require.Equal(t, dek, unwrapped)
+
+	require.NoError(t, Rewrap(dir, testKeyUID, testKEK, otherKEK))
+
+	_, _, err = Unwrap(dir, testKeyUID, testKEK)
+	require.ErrorIs(t, err, ErrInvalidKEK)
+
+	unwrapped, kdfIterations, err := Unwrap(dir, testKeyUID, otherKEK)
+	require.NoError(t, err)
+	require.Equal(t, dek, unwrapped)
+	require.Equal(t, 3200, kdfIterations)
+}
+
+func TestWriteReplacesAtomically(t *testing.T) {
+	dir := t.TempDir()
+
+	dek1, err := Generate()
+	require.NoError(t, err)
+	require.NoError(t, Write(dir, testKeyUID, dek1, testKEK, 3200))
+
+	dek2, err := Generate()
+	require.NoError(t, err)
+	require.NoError(t, Write(dir, testKeyUID, dek2, otherKEK, 3200))
+
+	unwrapped, _, err := Unwrap(dir, testKeyUID, otherKEK)
+	require.NoError(t, err)
+	require.Equal(t, dek2, unwrapped)
+
+	// No temp file left behind.
+	matches, err := filepath.Glob(Path(dir, testKeyUID) + ".*.tmp")
+	require.NoError(t, err)
+	require.Empty(t, matches)
+}
+
+func TestUnwrapMalformedFile(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(Path(dir, testKeyUID), []byte("not json"), 0600))
+
+	_, _, err := Unwrap(dir, testKeyUID, testKEK)
+	require.Error(t, err)
+	require.NotErrorIs(t, err, ErrInvalidKEK)
+}
+
+func TestUnwrapUnsupportedVersion(t *testing.T) {
+	dir := t.TempDir()
+
+	dek, err := Generate()
+	require.NoError(t, err)
+	require.NoError(t, Write(dir, testKeyUID, dek, testKEK, 3200))
+
+	content, err := os.ReadFile(Path(dir, testKeyUID))
+	require.NoError(t, err)
+	var file map[string]interface{}
+	require.NoError(t, json.Unmarshal(content, &file))
+	file["version"] = 999
+	content, err = json.Marshal(file)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(Path(dir, testKeyUID), content, 0600))
+
+	_, _, err = Unwrap(dir, testKeyUID, testKEK)
+	require.ErrorContains(t, err, "unsupported wrapped-DEK file version")
+}
+
+func TestRemove(t *testing.T) {
+	dir := t.TempDir()
+
+	// Removing a non-existent file is not an error.
+	require.NoError(t, Remove(dir, testKeyUID))
+
+	dek, err := Generate()
+	require.NoError(t, err)
+	require.NoError(t, Write(dir, testKeyUID, dek, testKEK, 3200))
+	require.NoError(t, os.WriteFile(Path(dir, testKeyUID)+".123456.tmp", []byte("leftover"), 0600))
+
+	require.NoError(t, Remove(dir, testKeyUID))
+	require.False(t, Exists(dir, testKeyUID))
+	matches, err := filepath.Glob(Path(dir, testKeyUID) + ".*.tmp")
+	require.NoError(t, err)
+	require.Empty(t, matches)
+}
+
+func TestPathNaming(t *testing.T) {
+	require.Equal(t, filepath.Join("/data", testKeyUID+"-profile.kek"), Path("/data", testKeyUID))
+}

--- a/internal/accounts-management/keystore/internal/geth/reencryption.go
+++ b/internal/accounts-management/keystore/internal/geth/reencryption.go
@@ -13,7 +13,8 @@ import (
 	"github.com/status-im/status-go/internal/accounts-management/types"
 )
 
-func reEncryptKey(rawKey []byte, pass string, newPass string) (reEncryptedKey []byte, e error) {
+// ReEncryptKey decrypts a raw keystore file with pass and re-encrypts it with newPass
+func ReEncryptKey(rawKey []byte, pass string, newPass string) (reEncryptedKey []byte, e error) {
 	cryptoJSON, e := RawKeyToCryptoJSON(rawKey)
 	if e != nil {
 		return reEncryptedKey, fmt.Errorf("convert to crypto json error: %v", e)
@@ -57,7 +58,7 @@ func ReEncryptKeyStoreDir(keyDirPath, oldPass, newPass string) error {
 			return fmt.Errorf("invalid account key file: %v", e)
 		}
 
-		reEncryptedKey, e := reEncryptKey(rawKeyFile, oldPass, newPass)
+		reEncryptedKey, e := ReEncryptKey(rawKeyFile, oldPass, newPass)
 		if e != nil {
 			return fmt.Errorf("unable to re-encrypt key file: %v, path: %s, name: %s", e, path, fileInfo.Name())
 		}

--- a/internal/accounts-management/keystore/internal/geth/reencryption.go
+++ b/internal/accounts-management/keystore/internal/geth/reencryption.go
@@ -130,3 +130,29 @@ func ReEncryptKeyStoreDir(keyDirPath, oldPass, newPass string) error {
 
 	return nil
 }
+
+// VerifyKeyStoreDir checks that every key file in the directory decrypts with password
+func VerifyKeyStoreDir(keyDirPath, password string) error {
+	if _, err := os.Stat(keyDirPath); os.IsNotExist(err) {
+		return nil
+	}
+
+	return filepath.Walk(keyDirPath, func(path string, fileInfo os.FileInfo, err error) error {
+		if err != nil {
+			return fmt.Errorf("walk callback error: %v", err)
+		}
+		if fileInfo.IsDir() || strings.HasPrefix(fileInfo.Name(), ".") {
+			return nil
+		}
+
+		rawKeyFile, e := ioutil.ReadFile(path)
+		if e != nil {
+			return fmt.Errorf("invalid account key file: %v", e)
+		}
+
+		if _, e = DecryptKey(rawKeyFile, password); e != nil {
+			return fmt.Errorf("key file does not decrypt: %v, name: %s", e, fileInfo.Name())
+		}
+		return nil
+	})
+}

--- a/internal/accounts-management/keystore_operations.go
+++ b/internal/accounts-management/keystore_operations.go
@@ -103,7 +103,7 @@ func (m *AccountsManager) storeToKeystore(acc *generator.Account, password strin
 		return ErrAccountIsNil
 	}
 
-	secret, err := m.resolveSecret(password)
+	secret, err := m.resolveSecretForWrite(password)
 	if err != nil {
 		return err
 	}
@@ -140,6 +140,8 @@ func (m *AccountsManager) deleteAccountFromKeystoreIfExists(address cryptotypes.
 		m.logger.Error("cannot delete account, keystore is missing", zap.String("address", address.Hex()))
 		return ErrKeystoreMissing
 	}
+	// Deletion is authorized by the password: use the strict resolver, so a password that does not resolve
+	// (and thus could not decrypt the key) cannot delete it either.
 	secret, err := m.resolveSecret(password)
 	if err != nil {
 		return err

--- a/internal/accounts-management/keystore_operations.go
+++ b/internal/accounts-management/keystore_operations.go
@@ -103,14 +103,19 @@ func (m *AccountsManager) storeToKeystore(acc *generator.Account, password strin
 		return ErrAccountIsNil
 	}
 
+	secret, err := m.resolveSecret(password)
+	if err != nil {
+		return err
+	}
+
 	m.logger.Info("storing account to keystore", zap.String("address", acc.Address().Hex()))
 
 	if acc.HasExtendedKey() {
-		_, err = m.keystore.ImportSingleExtendedKey(acc.ExtendedKey(), password)
+		_, err = m.keystore.ImportSingleExtendedKey(acc.ExtendedKey(), secret)
 		return
 	}
 
-	_, err = m.keystore.ImportECDSA(acc.PrivateKey(), password)
+	_, err = m.keystore.ImportECDSA(acc.PrivateKey(), secret)
 	return
 }
 
@@ -135,8 +140,20 @@ func (m *AccountsManager) deleteAccountFromKeystoreIfExists(address cryptotypes.
 		m.logger.Error("cannot delete account, keystore is missing", zap.String("address", address.Hex()))
 		return ErrKeystoreMissing
 	}
+	secret, err := m.resolveSecret(password)
+	if err != nil {
+		return err
+	}
 	m.logger.Info("deleting account", zap.String("address", address.Hex()))
-	err := m.keystore.Delete(address, password)
+	err = m.keystore.Delete(address, secret)
+	if err != nil && !errors.Is(err, keystore.ErrKeystoreFileMissing) && secret != password {
+		// Fallback for interrupted migrations.
+		if fbErr := m.keystore.Delete(address, password); fbErr == nil {
+			m.logger.Warn("keystore file deleted with legacy credentials after failed DEK attempt; encryption-scheme migration was likely interrupted",
+				zap.String("address", address.Hex()))
+			err = nil
+		}
+	}
 	if errors.Is(err, keystore.ErrKeystoreFileMissing) {
 		return nil
 	}

--- a/internal/accounts-management/manager.go
+++ b/internal/accounts-management/manager.go
@@ -15,6 +15,9 @@ import (
 	"github.com/status-im/status-go/internal/logutils"
 )
 
+// SecretResolver translates the password provided by the client into the secret
+type SecretResolver func(password string) (string, error)
+
 // AccountsManager represents the default account manager implementation
 type AccountsManager struct {
 	mu          sync.RWMutex
@@ -24,6 +27,7 @@ type AccountsManager struct {
 	rootDataDir         string
 	profileKeyUID       string
 	selectedChatAccount *generator.Account
+	secretResolver      SecretResolver
 
 	logger *zap.Logger
 }
@@ -53,6 +57,23 @@ func (m *AccountsManager) SetRootDataDir(rootDataDir string) {
 	defer m.mu.Unlock()
 
 	m.rootDataDir = rootDataDir
+}
+
+// SetSecretResolver sets (or clears, with nil) the resolver
+func (m *AccountsManager) SetSecretResolver(resolver SecretResolver) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	m.secretResolver = resolver
+}
+
+// resolveSecret applies the configured secret resolver to a client-provided password
+// Callers must hold m.mu (read or write).
+func (m *AccountsManager) resolveSecret(password string) (string, error) {
+	if m.secretResolver == nil {
+		return password, nil
+	}
+	return m.secretResolver(password)
 }
 
 func (m *AccountsManager) setKeystore(keystore KeyStore) {
@@ -98,7 +119,20 @@ func (m *AccountsManager) loadAccountInternally(address cryptotypes.Address, pas
 		return nil, ErrKeystoreMissing
 	}
 
-	_, privateKey, extendedKey, err := m.keystore.AccountDecryptedKey(address, password)
+	secret, err := m.resolveSecret(password)
+	if err != nil {
+		return nil, err
+	}
+
+	_, privateKey, extendedKey, err := m.keystore.AccountDecryptedKey(address, secret)
+	if err != nil && secret != password {
+		// Fallback for interrupted migrations.
+		if _, fbPrivateKey, fbExtendedKey, fbErr := m.keystore.AccountDecryptedKey(address, password); fbErr == nil {
+			m.logger.Warn("keystore file decrypted with legacy credentials after failed DEK decrypt; encryption-scheme migration was likely interrupted",
+				zap.String("address", address.Hex()))
+			privateKey, extendedKey, err = fbPrivateKey, fbExtendedKey, nil
+		}
+	}
 	if err != nil {
 		m.logger.Error("error loading account", zap.String("address", address.Hex()), zap.Error(err))
 		if errors.Is(err, keystore.ErrKeystoreFileMissing) {
@@ -123,7 +157,20 @@ func (m *AccountsManager) loadPrivateKeyInternally(address cryptotypes.Address, 
 		return nil, ErrKeystoreMissing
 	}
 
-	_, privateKey, err := m.keystore.AccountDecryptedPrivateKey(address, password)
+	secret, err := m.resolveSecret(password)
+	if err != nil {
+		return nil, err
+	}
+
+	_, privateKey, err := m.keystore.AccountDecryptedPrivateKey(address, secret)
+	if err != nil && secret != password {
+		// Fallback for interrupted migrations.
+		if _, fbPrivateKey, fbErr := m.keystore.AccountDecryptedPrivateKey(address, password); fbErr == nil {
+			m.logger.Warn("keystore file decrypted with legacy credentials after failed DEK decrypt; encryption-scheme migration was likely interrupted",
+				zap.String("address", address.Hex()))
+			privateKey, err = fbPrivateKey, nil
+		}
+	}
 	if err != nil {
 		m.logger.Error("error loading account", zap.String("address", address.Hex()), zap.Error(err))
 		if errors.Is(err, keystore.ErrKeystoreFileMissing) {
@@ -208,6 +255,7 @@ func (m *AccountsManager) Logout() {
 	m.rootDataDir = ""
 	m.selectedChatAccount = nil
 	m.profileKeyUID = ""
+	m.secretResolver = nil
 	m.logger.Info("logout")
 }
 

--- a/internal/accounts-management/manager.go
+++ b/internal/accounts-management/manager.go
@@ -28,6 +28,7 @@ type AccountsManager struct {
 	profileKeyUID       string
 	selectedChatAccount *generator.Account
 	secretResolver      SecretResolver
+	writeSecretResolver SecretResolver
 
 	logger *zap.Logger
 }
@@ -74,6 +75,23 @@ func (m *AccountsManager) resolveSecret(password string) (string, error) {
 		return password, nil
 	}
 	return m.secretResolver(password)
+}
+
+// SetWriteSecretResolver sets (or clears, with nil) the resolver used for keystore store/import operations.
+// Deletion intentionally stays on the strict resolver: it is authorized by the password.
+func (m *AccountsManager) SetWriteSecretResolver(resolver SecretResolver) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	m.writeSecretResolver = resolver
+}
+
+// resolveSecretForWrite resolves the secret for keystore store/import operations.
+func (m *AccountsManager) resolveSecretForWrite(password string) (string, error) {
+	if m.writeSecretResolver != nil {
+		return m.writeSecretResolver(password)
+	}
+	return m.resolveSecret(password)
 }
 
 func (m *AccountsManager) setKeystore(keystore KeyStore) {

--- a/internal/accounts-management/manager_test.go
+++ b/internal/accounts-management/manager_test.go
@@ -151,6 +151,85 @@ func TestVerifyAccountPassword(t *testing.T) {
 	}
 }
 
+// TestSecretResolver verifies that keystore operations translate the
+// client-provided password through the configured secret resolver, and fall
+// back to the raw password when the keystore files are still encrypted with
+// it (interrupted encryption-scheme migration).
+func TestSecretResolver(t *testing.T) {
+	// testdata/test-account1-status-chain.pk is encrypted with "password".
+	const (
+		filename     = "testdata/test-account1-status-chain.pk"
+		keyUID       = "0x0000000000000000000000000000000000000000000000000000000000000001"
+		address      = "0xbF164ca341326a03b547c05B343b2E21eFAe24b9"
+		filePassword = "password"
+		clientKEK    = "client-kek"
+	)
+
+	newManagerWithTestKey := func(t *testing.T) *AccountsManager {
+		accManager, err := NewAccountsManager(testutils.MustCreateTestLogger())
+		require.NoError(t, err)
+		accManager.SetRootDataDir(t.TempDir())
+		ks, err := accManager.createKeystore(keyUID)
+		require.NoError(t, err)
+		require.NoError(t, os.Link(filename, filepath.Join(ks.KeystorePath(), filepath.Base(filename))))
+		ks, err = accManager.createKeystore(keyUID)
+		require.NoError(t, err)
+		accManager.setKeystore(ks)
+		return accManager
+	}
+
+	t.Run("resolved secret decrypts the keystore", func(t *testing.T) {
+		accManager := newManagerWithTestKey(t)
+		// Migrated profile in steady state: the resolver maps the client KEK
+		// to the secret the keystore files are encrypted with.
+		accManager.SetSecretResolver(func(password string) (string, error) {
+			require.Equal(t, clientKEK, password)
+			return filePassword, nil
+		})
+
+		ok, err := accManager.VerifyAccountPassword(cryptotypes.HexToAddress(address), clientKEK)
+		require.NoError(t, err)
+		require.True(t, ok)
+	})
+
+	t.Run("fallback to raw password after interrupted migration", func(t *testing.T) {
+		accManager := newManagerWithTestKey(t)
+		// Interrupted migration: the resolver yields a DEK, but the keystore
+		// files are still encrypted with the raw password.
+		accManager.SetSecretResolver(func(password string) (string, error) {
+			require.Equal(t, filePassword, password)
+			return "dek-the-keystore-does-not-use-yet", nil
+		})
+
+		ok, err := accManager.VerifyAccountPassword(cryptotypes.HexToAddress(address), filePassword)
+		require.NoError(t, err)
+		require.True(t, ok)
+	})
+
+	t.Run("resolver rejection fails before touching the keystore", func(t *testing.T) {
+		accManager := newManagerWithTestKey(t)
+		resolverErr := errors.New("invalid key-encryption key")
+		accManager.SetSecretResolver(func(string) (string, error) {
+			return "", resolverErr
+		})
+
+		ok, err := accManager.VerifyAccountPassword(cryptotypes.HexToAddress(address), filePassword)
+		require.ErrorIs(t, err, resolverErr)
+		require.False(t, ok)
+	})
+
+	t.Run("wrong secret with wrong fallback still fails", func(t *testing.T) {
+		accManager := newManagerWithTestKey(t)
+		accManager.SetSecretResolver(func(string) (string, error) {
+			return "some-dek", nil
+		})
+
+		ok, err := accManager.VerifyAccountPassword(cryptotypes.HexToAddress(address), "wrong-password")
+		require.Error(t, err)
+		require.False(t, ok)
+	})
+}
+
 // TestVerifyAccountPasswordWithAccountBeforeEIP55 verifies if VerifyAccountPassword
 // can handle accounts before introduction of EIP55.
 func TestVerifyAccountPasswordWithAccountBeforeEIP55(t *testing.T) {

--- a/internal/db/multiaccounts/database.go
+++ b/internal/db/multiaccounts/database.go
@@ -371,6 +371,14 @@ func (db *Database) UpdateAccountKeycardPairing(keyUID string, keycardPairing st
 	return err
 }
 
+func (db *Database) UpdateAccountKDFIterations(keyUID string, kdfIterations int) error {
+	if kdfIterations <= 0 {
+		kdfIterations = dbsetup.ReducedKDFIterationsNumber
+	}
+	_, err := db.db.Exec("UPDATE accounts SET kdfIterations = ? WHERE keyUid = ?", kdfIterations, keyUID)
+	return err
+}
+
 func (db *Database) UpdateAccountTimestamp(keyUID string, loginTimestamp int64) error {
 	_, err := db.db.Exec("UPDATE accounts SET loginTimestamp = ? WHERE keyUid = ?", loginTimestamp, keyUID)
 	return err

--- a/internal/db/sqlite/export_test.go
+++ b/internal/db/sqlite/export_test.go
@@ -1,0 +1,71 @@
+package sqlite
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func createTestDB(t *testing.T, path, key string, kdfIter int) {
+	t.Helper()
+	db, err := OpenDB(path, key, kdfIter)
+	require.NoError(t, err)
+	_, err = db.Exec("CREATE TABLE test (value TEXT); INSERT INTO test (value) VALUES ('hello')")
+	require.NoError(t, err)
+	require.NoError(t, db.Close())
+}
+
+func requireDBValue(t *testing.T, path, key string, kdfIter int) {
+	t.Helper()
+	db, err := OpenDB(path, key, kdfIter)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, db.Close()) }()
+	var value string
+	require.NoError(t, db.QueryRow("SELECT value FROM test").Scan(&value))
+	require.Equal(t, "hello", value)
+}
+
+func TestExportDBWithKDFChange(t *testing.T) {
+	dir := t.TempDir()
+	srcPath := filepath.Join(dir, "src.db")
+	dstPath := filepath.Join(dir, "dst.db")
+
+	const (
+		srcKey  = "old-password"
+		dstKey  = "new-high-entropy-key"
+		srcIter = 25600
+		dstIter = ReducedKDFIterationsNumber
+	)
+
+	createTestDB(t, srcPath, srcKey, srcIter)
+
+	started, finished := false, false
+	require.NoError(t, ExportDBWithKDFChange(srcPath, srcKey, srcIter, dstPath, dstKey, dstIter,
+		func() { started = true }, func() { finished = true }))
+	require.True(t, started)
+	require.True(t, finished)
+
+	// The exported DB opens with the new key and the new iteration count...
+	requireDBValue(t, dstPath, dstKey, dstIter)
+
+	// ...and not with the old iteration count or the old key.
+	_, err := OpenDB(dstPath, dstKey, srcIter)
+	require.Error(t, err)
+	_, err = OpenDB(dstPath, srcKey, dstIter)
+	require.Error(t, err)
+
+	// The source is untouched.
+	requireDBValue(t, srcPath, srcKey, srcIter)
+}
+
+func TestExportDBKeepsKDFIterations(t *testing.T) {
+	dir := t.TempDir()
+	srcPath := filepath.Join(dir, "src.db")
+	dstPath := filepath.Join(dir, "dst.db")
+
+	createTestDB(t, srcPath, "old-password", ReducedKDFIterationsNumber)
+
+	require.NoError(t, ExportDB(srcPath, "old-password", ReducedKDFIterationsNumber, dstPath, "new-password", nil, nil))
+	requireDBValue(t, dstPath, "new-password", ReducedKDFIterationsNumber)
+}

--- a/internal/db/sqlite/sqlite.go
+++ b/internal/db/sqlite/sqlite.go
@@ -134,12 +134,17 @@ func EncryptDB(unencryptedPath string, encryptedPath string, key string, kdfIter
 
 // Export takes an encrypted database and re-encrypts it in a new file, with a new key
 func ExportDB(encryptedPath string, key string, kdfIterationsNumber int, newPath string, newKey string, onStart func(), onEnd func()) error {
+	return ExportDBWithKDFChange(encryptedPath, key, kdfIterationsNumber, newPath, newKey, kdfIterationsNumber, onStart, onEnd)
+}
+
+// ExportDBWithKDFChange is like ExportDB but allows the exported database to use a different number of kdf iterations than the source database.
+func ExportDBWithKDFChange(encryptedPath string, key string, kdfIterationsNumber int, newPath string, newKey string, newKdfIterationsNumber int, onStart func(), onEnd func()) error {
 	db, err := openDB(encryptedPath, key, kdfIterationsNumber, V4CipherPageSize)
 	if err != nil {
 		return err
 	}
 	defer db.Close()
-	return encryptDB(db, newPath, newKey, kdfIterationsNumber, onStart, onEnd)
+	return encryptDB(db, newPath, newKey, newKdfIterationsNumber, onStart, onEnd)
 }
 
 func buildSqlcipherDSN(path string) (string, error) {

--- a/internal/protocol/requests/change_database_password.go
+++ b/internal/protocol/requests/change_database_password.go
@@ -4,4 +4,5 @@ type ChangeDatabasePassword struct {
 	KeyUID      string `json:"keyUID"`
 	OldPassword string `json:"oldPassword"`
 	NewPassword string `json:"newPassword"`
+	Rekey       bool   `json:"rekey"` // if true, a new DEK is generated and the databases and keystore files are re-encrypted with it.
 }

--- a/internal/protocol/requests/get_profile_encryption_info.go
+++ b/internal/protocol/requests/get_profile_encryption_info.go
@@ -1,0 +1,16 @@
+package requests
+
+import "errors"
+
+var ErrGetProfileEncryptionInfoInvalidKeyUID = errors.New("get-profile-encryption-info: no keyUID provided")
+
+type GetProfileEncryptionInfo struct {
+	KeyUID string `json:"keyUID"`
+}
+
+func (r *GetProfileEncryptionInfo) Validate() error {
+	if len(r.KeyUID) == 0 {
+		return ErrGetProfileEncryptionInfoInvalidKeyUID
+	}
+	return nil
+}

--- a/mobile/status.go
+++ b/mobile/status.go
@@ -1211,8 +1211,34 @@ func changeDatabasePasswordV2(requestJSON string) string {
 		return makeJSONResponse(errors.New("incorrect current password"))
 	}
 
-	err = statusBackend.ChangeDatabasePassword(request.KeyUID, request.OldPassword, request.NewPassword)
+	err = statusBackend.ChangeDatabasePassword(request.KeyUID, request.OldPassword, request.NewPassword, request.Rekey)
 	return makeJSONResponse(err)
+}
+
+// GetProfileEncryptionInfo reports whether the profile uses the DEK encryption
+func GetProfileEncryptionInfo(requestJSON string) string {
+	return callWithResponse(getProfileEncryptionInfo, requestJSON)
+}
+
+func getProfileEncryptionInfo(requestJSON string) string {
+	var request requests.GetProfileEncryptionInfo
+	err := json.Unmarshal([]byte(requestJSON), &request)
+	if err != nil {
+		return makeJSONResponse(err)
+	}
+
+	if err := request.Validate(); err != nil {
+		return makeJSONResponse(err)
+	}
+
+	respJSON, err := json.Marshal(struct {
+		Migrated bool `json:"migrated"`
+	}{Migrated: statusBackend.ProfileEncryptionInfo(request.KeyUID)})
+	if err != nil {
+		return makeJSONResponse(err)
+	}
+
+	return string(respJSON)
 }
 
 // Deprecated: Use ConvertToKeycardAccountV2 instead.

--- a/pkg/backend/backend_test.go
+++ b/pkg/backend/backend_test.go
@@ -848,6 +848,11 @@ func TestConvertAccount(t *testing.T) {
 	err = testContext.backend.ConvertToKeycardAccount(keycardAccount, keycardSettings, testContext.profileKeypair.KeyUID, testPassword, keycardPassword)
 	require.NoError(t, err)
 
+	require.NotNil(t, testContext.backend.appDB)
+	activeAccount, err := testContext.backend.GetActiveAccount()
+	require.NoError(t, err)
+	require.Equal(t, keycardAccount.KeycardPairing, activeAccount.KeycardPairing)
+
 	// Validating results of converting to a keycard account.
 	// All keystore files for the account which is migrated need to be removed.
 	ok, err = testContext.backend.AccountsManager().VerifyAccountPassword(masterAddress, testPassword)
@@ -872,7 +877,7 @@ func TestConvertAccount(t *testing.T) {
 	}()
 
 	// Ensure we're able to open the DB
-	err = testContext.backend.ensureAppDBOpened(keycardAccount, dbCredentials{secret: keycardPassword, kdfIter: keycardAccount.KDFIterations})
+	err = testContext.backend.ensureDBsOpened(keycardAccount, keycardPassword)
 	require.NoError(t, err)
 
 	// db creation after re-encryption
@@ -888,6 +893,10 @@ func TestConvertAccount(t *testing.T) {
 	err = testContext.backend.ConvertToRegularAccount(testContext.mnemonic, keycardPassword, testPassword)
 	require.NoError(t, err)
 
+	activeAccount, err = testContext.backend.GetActiveAccount()
+	require.NoError(t, err)
+	require.Empty(t, activeAccount.KeycardPairing)
+
 	// Validating results of converting to a regular account.
 	// All keystore files for need to be created.
 	ok, err = testContext.backend.AccountsManager().VerifyAccountPassword(masterAddress, testPassword)
@@ -901,7 +910,7 @@ func TestConvertAccount(t *testing.T) {
 	}
 
 	// Ensure we're able to open the DB
-	err = testContext.backend.ensureAppDBOpened(keycardAccount, dbCredentials{secret: testPassword, kdfIter: keycardAccount.KDFIterations})
+	err = testContext.backend.ensureDBsOpened(keycardAccount, testPassword)
 	require.NoError(t, err)
 
 	// db creation after re-encryption
@@ -1036,7 +1045,7 @@ func TestChangeDatabasePassword(t *testing.T) {
 
 	// Change password
 	const newPassword = "newPassword"
-	err = testContext.backend.ChangeDatabasePassword(testContext.profileKeypair.KeyUID, testPassword, newPassword)
+	err = testContext.backend.ChangeDatabasePassword(testContext.profileKeypair.KeyUID, testPassword, newPassword, false)
 	require.NoError(t, err)
 
 	testContext.backend.UpdateRootDataDir(testContext.config.RootDataDir)

--- a/pkg/backend/backend_test.go
+++ b/pkg/backend/backend_test.go
@@ -826,7 +826,7 @@ func TestConvertAccount(t *testing.T) {
 	}
 
 	// Ensure we're able to open the DB
-	err = testContext.backend.ensureAppDBOpened(*testContext.multiAcc, testPassword)
+	err = testContext.backend.ensureAppDBOpened(*testContext.multiAcc, dbCredentials{secret: testPassword, kdfIter: testContext.multiAcc.KDFIterations})
 	require.NoError(t, err)
 
 	// db creation
@@ -872,7 +872,7 @@ func TestConvertAccount(t *testing.T) {
 	}()
 
 	// Ensure we're able to open the DB
-	err = testContext.backend.ensureAppDBOpened(keycardAccount, keycardPassword)
+	err = testContext.backend.ensureAppDBOpened(keycardAccount, dbCredentials{secret: keycardPassword, kdfIter: keycardAccount.KDFIterations})
 	require.NoError(t, err)
 
 	// db creation after re-encryption
@@ -901,7 +901,7 @@ func TestConvertAccount(t *testing.T) {
 	}
 
 	// Ensure we're able to open the DB
-	err = testContext.backend.ensureAppDBOpened(keycardAccount, testPassword)
+	err = testContext.backend.ensureAppDBOpened(keycardAccount, dbCredentials{secret: testPassword, kdfIter: keycardAccount.KDFIterations})
 	require.NoError(t, err)
 
 	// db creation after re-encryption

--- a/pkg/backend/fast_password_change_test.go
+++ b/pkg/backend/fast_password_change_test.go
@@ -8,8 +8,10 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	accsmanagementcommon "github.com/status-im/status-go/internal/accounts-management/common"
 	keystorepkg "github.com/status-im/status-go/internal/accounts-management/keystore"
 	"github.com/status-im/status-go/internal/accounts-management/keystore/envelope"
+	accsmanagementtypes "github.com/status-im/status-go/internal/accounts-management/types"
 	types "github.com/status-im/status-go/internal/crypto/types"
 	settings "github.com/status-im/status-go/internal/db/multiaccounts/settings"
 	"github.com/status-im/status-go/internal/db/sqlite"
@@ -150,6 +152,49 @@ func TestMigrationRejectsWrongOldPassword(t *testing.T) {
 	require.NoError(t, err)
 }
 
+// TestAddKeypairWithEmptyPasswordOnDEKProfile verifies that adding a keypair with an empty password (allowed
+// by the API and used by clients) still works on a DEK profile: the write resolver falls back to the session
+// secret, so the new keystore files stay uniformly encrypted with the profile DEK.
+func TestAddKeypairWithEmptyPasswordOnDEKProfile(t *testing.T) {
+	testContext := setupTestContext(t, testPassword, true, true, false)
+	b := testContext.backend
+	keyUID := testContext.profileKeypair.KeyUID
+
+	require.NoError(t, b.StartNode(testContext.config))
+	defer func() {
+		require.NoError(t, b.StopNode())
+	}()
+
+	const password1 = "new-password-1"
+	require.NoError(t, b.ChangeDatabasePassword(keyUID, testPassword, password1, false))
+	b.UpdateRootDataDir(testContext.config.RootDataDir)
+	require.True(t, envelope.Exists(b.rootDataDir, keyUID))
+
+	const mnemonic = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about"
+	kp, err := b.AccountsManager().CreateKeypairFromMnemonicAndStore(mnemonic, "", "empty password keypair",
+		accsmanagementtypes.ColdWalletTypeNone,
+		&accsmanagementtypes.AccountCreationDetails{Path: accsmanagementcommon.PathDefaultWalletAccount}, false, 0)
+	require.NoError(t, err)
+	require.NotNil(t, kp)
+
+	// The new keystore files are encrypted with the profile DEK: they open with the login password (resolved
+	// through the envelope), while reads keep verifying the provided password strictly.
+	masterAddress := types.HexToAddress(kp.DerivedFrom)
+	ok, err := b.AccountsManager().VerifyAccountPassword(masterAddress, password1)
+	require.NoError(t, err)
+	require.True(t, ok)
+	// A password that cannot unwrap the envelope keeps the pre-DEK error contract.
+	_, err = b.AccountsManager().VerifyAccountPassword(masterAddress, "")
+	require.ErrorIs(t, err, keystorepkg.ErrIncorrectPasswordProvided)
+
+	// Deletion stays password-gated: a password that does not resolve must not delete the keys,
+	// while the login password does.
+	_, err = b.AccountsManager().DeleteKeypair(kp.KeyUID, "wrong-password", 0)
+	require.ErrorIs(t, err, keystorepkg.ErrIncorrectPasswordProvided)
+	_, err = b.AccountsManager().DeleteKeypair(kp.KeyUID, password1, 0)
+	require.NoError(t, err)
+}
+
 // TestChangeDatabasePasswordRekey verifies that a deep rekey rotates the DEK and
 // re-encrypts the databases and keystore with it.
 func TestChangeDatabasePasswordRekey(t *testing.T) {
@@ -208,12 +253,12 @@ func TestCreateAccountUsesDEKFromDayOne(t *testing.T) {
 	}
 
 	c := make(chan interface{}, 10)
-	signal.SetMobileSignalHandler(func(data []byte) {
+	signal.SetHandler(func(data []byte) {
 		if strings.Contains(string(data), "node.login") {
 			c <- struct{}{}
 		}
 	})
-	t.Cleanup(signal.ResetMobileSignalHandler)
+	t.Cleanup(signal.ResetHandler)
 
 	account, err := testContext.backend.CreateAccountAndLogin(createAccountRequest)
 	require.NoError(t, err)

--- a/pkg/backend/fast_password_change_test.go
+++ b/pkg/backend/fast_password_change_test.go
@@ -113,6 +113,43 @@ func TestChangeDatabasePasswordMigratesToDEK(t *testing.T) {
 	require.True(t, ok)
 }
 
+// TestMigrationRejectsWrongOldPassword verifies that a migration attempt with a wrong old
+// password fails before anything is persisted: no envelope may be left behind (it would be
+// wrapped with an unknown KEK and make the profile unopenable with the real password).
+func TestMigrationRejectsWrongOldPassword(t *testing.T) {
+	testContext := setupTestContext(t, testPassword, true, true, false)
+	b := testContext.backend
+	keyUID := testContext.profileKeypair.KeyUID
+	masterAddress := types.HexToAddress(testContext.profileKeypair.DerivedFrom)
+
+	require.NoError(t, b.StartNode(testContext.config))
+	defer func() {
+		require.NoError(t, b.StopNode())
+	}()
+
+	require.False(t, envelope.Exists(b.rootDataDir, keyUID))
+
+	require.Error(t, b.ChangeDatabasePassword(keyUID, "wrong-password", "new-password", false))
+	b.UpdateRootDataDir(testContext.config.RootDataDir)
+
+	// Nothing was persisted: no envelope, databases and keystore still on the old password.
+	require.False(t, envelope.Exists(b.rootDataDir, keyUID))
+	kdfIter, err := b.multiaccountsDB.GetAccountKDFIterationsNumber(keyUID)
+	require.NoError(t, err)
+	appDBPath, err := b.getAppDBPath(keyUID)
+	require.NoError(t, err)
+	requireDBOpensWith(t, appDBPath, testPassword, kdfIter)
+	ok, err := b.AccountsManager().VerifyAccountPassword(masterAddress, testPassword)
+	require.NoError(t, err)
+	require.True(t, ok)
+
+	// The profile is intact: migration with the correct password still works.
+	require.NoError(t, b.ChangeDatabasePassword(keyUID, testPassword, "new-password", false))
+	require.True(t, envelope.Exists(b.rootDataDir, keyUID))
+	_, _, err = envelope.Unwrap(b.rootDataDir, keyUID, "new-password")
+	require.NoError(t, err)
+}
+
 // TestChangeDatabasePasswordRekey verifies that a deep rekey rotates the DEK and
 // re-encrypts the databases and keystore with it.
 func TestChangeDatabasePasswordRekey(t *testing.T) {

--- a/pkg/backend/fast_password_change_test.go
+++ b/pkg/backend/fast_password_change_test.go
@@ -1,0 +1,678 @@
+package backend
+
+import (
+	"errors"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	keystorepkg "github.com/status-im/status-go/internal/accounts-management/keystore"
+	"github.com/status-im/status-go/internal/accounts-management/keystore/envelope"
+	types "github.com/status-im/status-go/internal/crypto/types"
+	settings "github.com/status-im/status-go/internal/db/multiaccounts/settings"
+	"github.com/status-im/status-go/internal/db/sqlite"
+	"github.com/status-im/status-go/internal/protocol/requests"
+	"github.com/status-im/status-go/internal/signal"
+)
+
+// requireDBOpensWith asserts that the sqlcipher database at path opens with the given key.
+func requireDBOpensWith(t *testing.T, path, key string, kdfIter int) {
+	t.Helper()
+	db, err := sqlite.OpenDB(path, key, kdfIter)
+	require.NoError(t, err)
+	require.NoError(t, db.Close())
+}
+
+func requireDBDoesNotOpenWith(t *testing.T, path, key string, kdfIter int) {
+	t.Helper()
+	db, err := sqlite.OpenDB(path, key, kdfIter)
+	if err == nil {
+		_ = db.Close()
+	}
+	require.Error(t, err)
+}
+
+// TestChangeDatabasePasswordMigratesToDEK verifies that the first password change of a
+// legacy profile performs the one-time migration to the DEK scheme, and that subsequent
+// changes take the fast (re-wrap only) path without touching the databases.
+func TestChangeDatabasePasswordMigratesToDEK(t *testing.T) {
+	testContext := setupTestContext(t, testPassword, true, true, false)
+	b := testContext.backend
+	keyUID := testContext.profileKeypair.KeyUID
+	masterAddress := types.HexToAddress(testContext.profileKeypair.DerivedFrom)
+
+	require.NoError(t, b.StartNode(testContext.config))
+	defer func() {
+		require.NoError(t, b.StopNode())
+	}()
+
+	require.False(t, envelope.Exists(b.rootDataDir, keyUID))
+
+	const password1 = "new-password-1"
+	require.NoError(t, b.ChangeDatabasePassword(keyUID, testPassword, password1, false))
+	b.UpdateRootDataDir(testContext.config.RootDataDir)
+
+	// The envelope exists, unwraps with the new password only, and prescribes reduced kdf iterations.
+	require.True(t, envelope.Exists(b.rootDataDir, keyUID))
+	dek, dekIter, err := envelope.Unwrap(b.rootDataDir, keyUID, password1)
+	require.NoError(t, err)
+	require.Equal(t, sqlite.ReducedKDFIterationsNumber, dekIter)
+	_, _, err = envelope.Unwrap(b.rootDataDir, keyUID, testPassword)
+	require.ErrorIs(t, err, envelope.ErrInvalidKEK)
+
+	// The kdfIterations column follows.
+	columnIter, err := b.multiaccountsDB.GetAccountKDFIterationsNumber(keyUID)
+	require.NoError(t, err)
+	require.Equal(t, sqlite.ReducedKDFIterationsNumber, columnIter)
+
+	// Both databases are now encrypted with the DEK.
+	appDBPath, err := b.getAppDBPath(keyUID)
+	require.NoError(t, err)
+	walletDBPath, err := b.getWalletDBPath(keyUID)
+	require.NoError(t, err)
+	requireDBOpensWith(t, appDBPath, dek, sqlite.ReducedKDFIterationsNumber)
+	requireDBOpensWith(t, walletDBPath, dek, sqlite.ReducedKDFIterationsNumber)
+	requireDBDoesNotOpenWith(t, appDBPath, testPassword, 1)
+
+	// The keystore resolves through the DEK with the new password.
+	ok, err := b.AccountsManager().VerifyAccountPassword(masterAddress, password1)
+	require.NoError(t, err)
+	require.True(t, ok)
+
+	// Second change: fast path — the database files must not be rewritten.
+	appStatBefore, err := os.Stat(appDBPath)
+	require.NoError(t, err)
+	walletStatBefore, err := os.Stat(walletDBPath)
+	require.NoError(t, err)
+
+	const password2 = "new-password-2"
+	require.NoError(t, b.ChangeDatabasePassword(keyUID, password1, password2, false))
+
+	appStatAfter, err := os.Stat(appDBPath)
+	require.NoError(t, err)
+	walletStatAfter, err := os.Stat(walletDBPath)
+	require.NoError(t, err)
+	require.Equal(t, appStatBefore.ModTime(), appStatAfter.ModTime())
+	require.Equal(t, walletStatBefore.ModTime(), walletStatAfter.ModTime())
+
+	// Same DEK, new wrapper.
+	dekAfter, _, err := envelope.Unwrap(b.rootDataDir, keyUID, password2)
+	require.NoError(t, err)
+	require.Equal(t, dek, dekAfter)
+	_, _, err = envelope.Unwrap(b.rootDataDir, keyUID, password1)
+	require.ErrorIs(t, err, envelope.ErrInvalidKEK)
+
+	// Wrong old password is rejected by the fast path.
+	require.ErrorIs(t, b.ChangeDatabasePassword(keyUID, "wrong-password", "whatever", false), envelope.ErrInvalidKEK)
+
+	// Keystore operations follow the new password.
+	ok, err = b.AccountsManager().VerifyAccountPassword(masterAddress, password2)
+	require.NoError(t, err)
+	require.True(t, ok)
+}
+
+// TestChangeDatabasePasswordRekey verifies that a deep rekey rotates the DEK and
+// re-encrypts the databases and keystore with it.
+func TestChangeDatabasePasswordRekey(t *testing.T) {
+	testContext := setupTestContext(t, testPassword, true, true, false)
+	b := testContext.backend
+	keyUID := testContext.profileKeypair.KeyUID
+	masterAddress := types.HexToAddress(testContext.profileKeypair.DerivedFrom)
+
+	require.NoError(t, b.StartNode(testContext.config))
+	defer func() {
+		require.NoError(t, b.StopNode())
+	}()
+
+	const password1 = "new-password-1"
+	require.NoError(t, b.ChangeDatabasePassword(keyUID, testPassword, password1, false))
+	b.UpdateRootDataDir(testContext.config.RootDataDir)
+	dek1, _, err := envelope.Unwrap(b.rootDataDir, keyUID, password1)
+	require.NoError(t, err)
+
+	const password2 = "new-password-2"
+	require.NoError(t, b.ChangeDatabasePassword(keyUID, password1, password2, true))
+	b.UpdateRootDataDir(testContext.config.RootDataDir)
+
+	// Fresh DEK, committed envelope, no pending leftover.
+	dek2, _, err := envelope.Unwrap(b.rootDataDir, keyUID, password2)
+	require.NoError(t, err)
+	require.NotEqual(t, dek1, dek2)
+	require.False(t, envelope.PendingExists(b.rootDataDir, keyUID))
+
+	// Databases are on the new DEK; the old one no longer opens them.
+	appDBPath, err := b.getAppDBPath(keyUID)
+	require.NoError(t, err)
+	walletDBPath, err := b.getWalletDBPath(keyUID)
+	require.NoError(t, err)
+	requireDBOpensWith(t, appDBPath, dek2, sqlite.ReducedKDFIterationsNumber)
+	requireDBOpensWith(t, walletDBPath, dek2, sqlite.ReducedKDFIterationsNumber)
+	requireDBDoesNotOpenWith(t, appDBPath, dek1, sqlite.ReducedKDFIterationsNumber)
+
+	// Keystore follows.
+	ok, err := b.AccountsManager().VerifyAccountPassword(masterAddress, password2)
+	require.NoError(t, err)
+	require.True(t, ok)
+}
+
+// TestCreateAccountUsesDEKFromDayOne verifies that newly created profiles are on the DEK
+// scheme immediately, with reduced kdf iterations.
+func TestCreateAccountUsesDEKFromDayOne(t *testing.T) {
+	testContext := setupTestContext(t, testPassword, false, false, true)
+
+	createAccountRequest := &requests.CreateAccount{
+		DisplayName:        "some-display-name",
+		CustomizationColor: "#ffffff",
+		Password:           testPassword,
+		RootDataDir:        testContext.config.RootDataDir,
+		LogFilePath:        testContext.config.RootDataDir + "/log",
+	}
+
+	c := make(chan interface{}, 10)
+	signal.SetMobileSignalHandler(func(data []byte) {
+		if strings.Contains(string(data), "node.login") {
+			c <- struct{}{}
+		}
+	})
+	t.Cleanup(signal.ResetMobileSignalHandler)
+
+	account, err := testContext.backend.CreateAccountAndLogin(createAccountRequest)
+	require.NoError(t, err)
+	<-c
+
+	b := testContext.backend
+	require.True(t, envelope.Exists(b.rootDataDir, account.KeyUID))
+	require.True(t, b.ProfileEncryptionInfo(account.KeyUID))
+	require.Equal(t, sqlite.ReducedKDFIterationsNumber, account.KDFIterations)
+
+	columnIter, err := b.multiaccountsDB.GetAccountKDFIterationsNumber(account.KeyUID)
+	require.NoError(t, err)
+	require.Equal(t, sqlite.ReducedKDFIterationsNumber, columnIter)
+
+	dek, _, err := envelope.Unwrap(b.rootDataDir, account.KeyUID, testPassword)
+	require.NoError(t, err)
+
+	appDBPath, err := b.getAppDBPath(account.KeyUID)
+	require.NoError(t, err)
+	requireDBOpensWith(t, appDBPath, dek, sqlite.ReducedKDFIterationsNumber)
+
+	require.NoError(t, b.Logout())
+	require.NoError(t, b.StopNode())
+}
+
+// reEncryptDBFileForTest re-encrypts a closed sqlcipher database file in place.
+func reEncryptDBFileForTest(t *testing.T, path, oldKey string, oldIter int, newKey string, newIter int) {
+	t.Helper()
+	tmpPath := path + ".reencrypted"
+	require.NoError(t, sqlite.ExportDBWithKDFChange(path, oldKey, oldIter, tmpPath, newKey, newIter, nil, nil))
+	require.NoError(t, os.Rename(tmpPath, path))
+	_ = os.Remove(path + "-wal")
+	_ = os.Remove(path + "-shm")
+}
+
+// migratedFixture returns a profile already migrated to the DEK scheme (logged out), with
+// the password it is wrapped with and its DEK.
+func migratedFixture(t *testing.T) (testContext *setupContext, password, dek string) {
+	t.Helper()
+	testContext = setupTestContext(t, testPassword, true, true, false)
+	b := testContext.backend
+	keyUID := testContext.profileKeypair.KeyUID
+
+	password = "migrated-password"
+	require.NoError(t, b.ChangeDatabasePassword(keyUID, testPassword, password, false))
+	b.UpdateRootDataDir(testContext.config.RootDataDir)
+	var err error
+	dek, _, err = envelope.Unwrap(b.rootDataDir, keyUID, password)
+	require.NoError(t, err)
+
+	require.NoError(t, b.Logout())
+	return testContext, password, dek
+}
+
+func profilePaths(t *testing.T, b *StatusBackend, keyUID string) (appDBPath, walletDBPath, keystoreDir string) {
+	t.Helper()
+	var err error
+	appDBPath, err = b.getAppDBPath(keyUID)
+	require.NoError(t, err)
+	walletDBPath, err = b.getWalletDBPath(keyUID)
+	require.NoError(t, err)
+	_, keystoreDir = DefaultKeystorePath(b.rootDataDir, keyUID)
+	return
+}
+
+// TestRepairMigrationInterruptedAfterKeystore simulates a crash after the migration
+// re-encrypted the keystore (databases still on the raw password). This is also the state
+// left behind when keystore re-encryption returns an ambiguous error after installing the
+// files. Repair must roll the profile back to a clean legacy state.
+func TestRepairMigrationInterruptedAfterKeystore(t *testing.T) {
+	testContext := setupTestContext(t, testPassword, true, true, false)
+	b := testContext.backend
+	keyUID := testContext.profileKeypair.KeyUID
+	_, _, keystoreDir := profilePaths(t, b, keyUID)
+
+	dek, err := envelope.Generate()
+	require.NoError(t, err)
+	require.NoError(t, envelope.Write(b.rootDataDir, keyUID, dek, testPassword, sqlite.ReducedKDFIterationsNumber))
+	require.NoError(t, keystorepkg.ReEncryptKeyStoreDirAtPath(keystoreDir, testPassword, dek))
+
+	require.NoError(t, b.Logout())
+	require.NoError(t, b.ensureDBsOpened(*testContext.multiAcc, testPassword))
+	appSecret, _ := b.dbOpenSecrets()
+	require.Equal(t, testPassword, appSecret)
+
+	require.NoError(t, b.repairProfileEncryption(keyUID, testPassword, testContext.multiAcc.KDFIterations))
+
+	require.False(t, envelope.Exists(b.rootDataDir, keyUID))
+	require.NoError(t, keystorepkg.VerifyKeyStoreDirAtPath(keystoreDir, testPassword))
+	require.NoError(t, b.Logout())
+}
+
+// TestRepairMigrationInterruptedBetweenSwaps simulates a crash between the two database
+// swaps: app DB on the DEK, wallet DB still on the raw password. Repair must realign the
+// wallet DB forward to the DEK.
+func TestRepairMigrationInterruptedBetweenSwaps(t *testing.T) {
+	testContext := setupTestContext(t, testPassword, true, true, false)
+	b := testContext.backend
+	keyUID := testContext.profileKeypair.KeyUID
+	appDBPath, walletDBPath, keystoreDir := profilePaths(t, b, keyUID)
+
+	require.NoError(t, b.Logout())
+
+	dek, err := envelope.Generate()
+	require.NoError(t, err)
+	require.NoError(t, envelope.Write(b.rootDataDir, keyUID, dek, testPassword, sqlite.ReducedKDFIterationsNumber))
+	require.NoError(t, keystorepkg.ReEncryptKeyStoreDirAtPath(keystoreDir, testPassword, dek))
+	reEncryptDBFileForTest(t, appDBPath, testPassword, testContext.multiAcc.KDFIterations, dek, sqlite.ReducedKDFIterationsNumber)
+
+	require.NoError(t, b.ensureDBsOpened(*testContext.multiAcc, testPassword))
+	appSecret, walletSecret := b.dbOpenSecrets()
+	require.Equal(t, dek, appSecret)
+	require.Equal(t, testPassword, walletSecret)
+
+	require.NoError(t, b.repairProfileEncryption(keyUID, testPassword, testContext.multiAcc.KDFIterations))
+
+	// Fully on the DEK now; envelope kept (still wrapped with the login password).
+	require.True(t, envelope.Exists(b.rootDataDir, keyUID))
+	require.NoError(t, keystorepkg.VerifyKeyStoreDirAtPath(keystoreDir, dek))
+	require.NoError(t, b.Logout())
+	requireDBOpensWith(t, walletDBPath, dek, sqlite.ReducedKDFIterationsNumber)
+}
+
+// TestRepairMigrationInterruptedBeforeCommit simulates a crash after both swaps but before
+// the envelope was re-wrapped to the new password: a fully consistent DEK profile still
+// wrapped with the old password. Login with the old password must work without repair.
+func TestRepairMigrationInterruptedBeforeCommit(t *testing.T) {
+	testContext := setupTestContext(t, testPassword, true, true, false)
+	b := testContext.backend
+	keyUID := testContext.profileKeypair.KeyUID
+	appDBPath, walletDBPath, keystoreDir := profilePaths(t, b, keyUID)
+
+	require.NoError(t, b.Logout())
+
+	dek, err := envelope.Generate()
+	require.NoError(t, err)
+	require.NoError(t, envelope.Write(b.rootDataDir, keyUID, dek, testPassword, sqlite.ReducedKDFIterationsNumber))
+	require.NoError(t, keystorepkg.ReEncryptKeyStoreDirAtPath(keystoreDir, testPassword, dek))
+	reEncryptDBFileForTest(t, appDBPath, testPassword, testContext.multiAcc.KDFIterations, dek, sqlite.ReducedKDFIterationsNumber)
+	reEncryptDBFileForTest(t, walletDBPath, testPassword, testContext.multiAcc.KDFIterations, dek, sqlite.ReducedKDFIterationsNumber)
+
+	require.NoError(t, b.ensureDBsOpened(*testContext.multiAcc, testPassword))
+	appSecret, walletSecret := b.dbOpenSecrets()
+	require.Equal(t, dek, appSecret)
+	require.Equal(t, dek, walletSecret)
+
+	require.NoError(t, b.repairProfileEncryption(keyUID, testPassword, testContext.multiAcc.KDFIterations))
+
+	// Nothing to repair: consistent DEK profile, old password stays valid.
+	require.True(t, envelope.Exists(b.rootDataDir, keyUID))
+	unwrapped, _, err := envelope.Unwrap(b.rootDataDir, keyUID, testPassword)
+	require.NoError(t, err)
+	require.Equal(t, dek, unwrapped)
+	require.NoError(t, b.Logout())
+}
+
+// TestRepairRekeyInterruptedAfterPendingWrite simulates a crash right after the rekey wrote
+// the pending envelope (nothing else changed). Repair must drop the pending envelope.
+func TestRepairRekeyInterruptedAfterPendingWrite(t *testing.T) {
+	testContext, password, dek1 := migratedFixture(t)
+	b := testContext.backend
+	keyUID := testContext.profileKeypair.KeyUID
+	_, _, keystoreDir := profilePaths(t, b, keyUID)
+
+	dek2, err := envelope.Generate()
+	require.NoError(t, err)
+	require.NoError(t, envelope.WritePending(b.rootDataDir, keyUID, dek2, password, sqlite.ReducedKDFIterationsNumber))
+
+	require.NoError(t, b.ensureDBsOpened(*testContext.multiAcc, password))
+	require.NoError(t, b.repairProfileEncryption(keyUID, password, testContext.multiAcc.KDFIterations))
+
+	require.False(t, envelope.PendingExists(b.rootDataDir, keyUID))
+	unwrapped, _, err := envelope.Unwrap(b.rootDataDir, keyUID, password)
+	require.NoError(t, err)
+	require.Equal(t, dek1, unwrapped)
+	require.NoError(t, keystorepkg.VerifyKeyStoreDirAtPath(keystoreDir, dek1))
+	require.NoError(t, b.Logout())
+}
+
+// TestRepairRekeyInterruptedBetweenSwaps simulates a crash after the rekey swapped the app
+// DB and re-encrypted the keystore, with the wallet DB still on the old DEK. Repair must
+// roll everything forward to the new DEK and commit it.
+func TestRepairRekeyInterruptedBetweenSwaps(t *testing.T) {
+	testContext, password, dek1 := migratedFixture(t)
+	b := testContext.backend
+	keyUID := testContext.profileKeypair.KeyUID
+	appDBPath, walletDBPath, keystoreDir := profilePaths(t, b, keyUID)
+
+	dek2, err := envelope.Generate()
+	require.NoError(t, err)
+	require.NoError(t, envelope.WritePending(b.rootDataDir, keyUID, dek2, password, sqlite.ReducedKDFIterationsNumber))
+	reEncryptDBFileForTest(t, appDBPath, dek1, sqlite.ReducedKDFIterationsNumber, dek2, sqlite.ReducedKDFIterationsNumber)
+	require.NoError(t, keystorepkg.ReEncryptKeyStoreDirAtPath(keystoreDir, dek1, dek2))
+
+	require.NoError(t, b.ensureDBsOpened(*testContext.multiAcc, password))
+	appSecret, walletSecret := b.dbOpenSecrets()
+	require.Equal(t, dek2, appSecret)
+	require.Equal(t, dek1, walletSecret)
+
+	require.NoError(t, b.repairProfileEncryption(keyUID, password, testContext.multiAcc.KDFIterations))
+
+	require.False(t, envelope.PendingExists(b.rootDataDir, keyUID))
+	unwrapped, _, err := envelope.Unwrap(b.rootDataDir, keyUID, password)
+	require.NoError(t, err)
+	require.Equal(t, dek2, unwrapped)
+	require.NoError(t, keystorepkg.VerifyKeyStoreDirAtPath(keystoreDir, dek2))
+	require.NoError(t, b.Logout())
+	requireDBOpensWith(t, walletDBPath, dek2, sqlite.ReducedKDFIterationsNumber)
+}
+
+// TestRepairRekeyInterruptedAfterCommit simulates a crash after the rekey committed the
+// main envelope under the NEW password but before removing the pending envelope. A login
+// with the OLD password must still succeed (via the pending envelope) and repair must
+// re-commit the main envelope under that password.
+func TestRepairRekeyInterruptedAfterCommit(t *testing.T) {
+	testContext, password, dek1 := migratedFixture(t)
+	b := testContext.backend
+	keyUID := testContext.profileKeypair.KeyUID
+	appDBPath, walletDBPath, keystoreDir := profilePaths(t, b, keyUID)
+
+	const newPassword = "committed-new-password"
+	dek2, err := envelope.Generate()
+	require.NoError(t, err)
+	reEncryptDBFileForTest(t, appDBPath, dek1, sqlite.ReducedKDFIterationsNumber, dek2, sqlite.ReducedKDFIterationsNumber)
+	reEncryptDBFileForTest(t, walletDBPath, dek1, sqlite.ReducedKDFIterationsNumber, dek2, sqlite.ReducedKDFIterationsNumber)
+	require.NoError(t, keystorepkg.ReEncryptKeyStoreDirAtPath(keystoreDir, dek1, dek2))
+	require.NoError(t, envelope.Write(b.rootDataDir, keyUID, dek2, newPassword, sqlite.ReducedKDFIterationsNumber))
+	require.NoError(t, envelope.WritePending(b.rootDataDir, keyUID, dek2, password, sqlite.ReducedKDFIterationsNumber))
+
+	// Login with the OLD password: resolution succeeds via the pending envelope.
+	require.NoError(t, b.ensureDBsOpened(*testContext.multiAcc, password))
+	appSecret, _ := b.dbOpenSecrets()
+	require.Equal(t, dek2, appSecret)
+
+	require.NoError(t, b.repairProfileEncryption(keyUID, password, testContext.multiAcc.KDFIterations))
+
+	// The old password is committed as the KEK again; pending is gone.
+	require.False(t, envelope.PendingExists(b.rootDataDir, keyUID))
+	unwrapped, _, err := envelope.Unwrap(b.rootDataDir, keyUID, password)
+	require.NoError(t, err)
+	require.Equal(t, dek2, unwrapped)
+	require.NoError(t, b.Logout())
+}
+
+// demigrateProfileForTest converts a DEK-native profile (logged out) back to the legacy
+// scheme, as if it had been created by an older app version.
+func demigrateProfileForTest(t *testing.T, b *StatusBackend, keyUID, password string) {
+	t.Helper()
+	dek, dekIter, err := envelope.Unwrap(b.rootDataDir, keyUID, password)
+	require.NoError(t, err)
+	appDBPath, walletDBPath, keystoreDir := profilePaths(t, b, keyUID)
+	reEncryptDBFileForTest(t, appDBPath, dek, dekIter, password, sqlite.ReducedKDFIterationsNumber)
+	reEncryptDBFileForTest(t, walletDBPath, dek, dekIter, password, sqlite.ReducedKDFIterationsNumber)
+	require.NoError(t, keystorepkg.ReEncryptKeyStoreDirAtPath(keystoreDir, dek, password))
+	require.NoError(t, envelope.Remove(b.rootDataDir, keyUID))
+	b.clearProfileSecretCache()
+}
+
+// TestConvertAccountLegacyProfile verifies the keycard conversion of a LEGACY profile: the
+// conversion performs the one-time migration to the DEK scheme, wrapped with the keycard
+// encryption key. (TestConvertAccount covers the DEK-native profile: both of its
+// conversions take the fast re-wrap path.)
+func TestConvertAccountLegacyProfile(t *testing.T) {
+	testContext := setupTestContext(t, testPassword, false, false, true)
+	b := testContext.backend
+
+	request := &requests.CreateAccount{
+		RootDataDir:   testContext.config.RootDataDir,
+		Password:      testPassword,
+		KdfIterations: 1,
+	}
+	_, err := b.StartNodeWithChatKeyOrMnemonic(request, testContext.mnemonic, nil, false)
+	require.NoError(t, err)
+
+	accountsList, err := b.GetAccounts()
+	require.NoError(t, err)
+	require.Len(t, accountsList, 1)
+	multiAcc := accountsList[0]
+	keyUID := multiAcc.KeyUID
+
+	// Bring the profile back to the legacy scheme, as if created by an older version.
+	require.NoError(t, b.Logout())
+	require.NoError(t, b.StopNode())
+	demigrateProfileForTest(t, b, keyUID, testPassword)
+	require.False(t, b.ProfileEncryptionInfo(keyUID))
+
+	chatPrivKey := strings.TrimPrefix(testContext.chatPrivateKey, "0x")
+	require.NoError(t, b.StartNodeWithKey(multiAcc, testPassword, chatPrivKey, testContext.config))
+	defer func() {
+		_ = b.Logout()
+		_ = b.StopNode()
+	}()
+
+	keycardAccount := multiAcc
+	keycardAccount.KeycardPairing = "pairing"
+	const keycardPassword = "222222"
+	require.NoError(t, b.ConvertToKeycardAccount(keycardAccount, settings.Settings{}, keyUID, testPassword, keycardPassword))
+
+	// The conversion migrated the profile to the DEK scheme, wrapped with the keycard key.
+	require.True(t, b.ProfileEncryptionInfo(keyUID))
+	dek, dekIter, err := envelope.Unwrap(b.rootDataDir, keyUID, keycardPassword)
+	require.NoError(t, err)
+	require.Equal(t, sqlite.ReducedKDFIterationsNumber, dekIter)
+	_, _, err = envelope.Unwrap(b.rootDataDir, keyUID, testPassword)
+	require.ErrorIs(t, err, envelope.ErrInvalidKEK)
+
+	appDBPath, walletDBPath, _ := profilePaths(t, b, keyUID)
+	requireDBOpensWith(t, appDBPath, dek, sqlite.ReducedKDFIterationsNumber)
+	requireDBOpensWith(t, walletDBPath, dek, sqlite.ReducedKDFIterationsNumber)
+}
+
+// TestChangeDatabasePasswordCrashInjection drives the REAL migration/rekey flows and
+// simulates a process crash at every mutation boundary via reEncryptionCrashHook, then
+// verifies that the recovery a fresh app start performs (open databases with fallbacks +
+// login-time repair) always converges to a consistent state that the OLD password opens.
+func TestChangeDatabasePasswordCrashInjection(t *testing.T) {
+	cases := []struct {
+		stage string
+		rekey bool
+		// wantLegacy: recovery rolls the profile back to a clean legacy state
+		wantLegacy bool
+		// wantNewDek: recovery converges forward onto a rotated DEK (rekey post-swap stages)
+		wantNewDek bool
+	}{
+		{stage: "migrate:envelope-written", wantLegacy: true},
+		{stage: "migrate:keystore-reencrypted", wantLegacy: true},
+		{stage: "migrate:dbs-exported", wantLegacy: true},
+		{stage: "migrate:app-swapped"},
+		{stage: "migrate:dbs-swapped"},
+		{stage: "rekey:pending-written", rekey: true},
+		{stage: "rekey:dbs-exported", rekey: true},
+		{stage: "rekey:keystore-reencrypted", rekey: true},
+		{stage: "rekey:app-swapped", rekey: true, wantNewDek: true},
+		{stage: "rekey:dbs-swapped", rekey: true, wantNewDek: true},
+		{stage: "rekey:committed", rekey: true, wantNewDek: true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.stage, func(t *testing.T) {
+			testContext := setupTestContext(t, testPassword, true, true, false)
+			b := testContext.backend
+			keyUID := testContext.profileKeypair.KeyUID
+			appDBPath, walletDBPath, keystoreDir := profilePaths(t, b, keyUID)
+
+			require.NoError(t, b.StartNode(testContext.config))
+			defer func() {
+				_ = b.StopNode()
+			}()
+
+			oldPassword := testPassword
+			dekBefore := ""
+			if tc.rekey {
+				// bring the profile onto the DEK scheme first
+				oldPassword = "rekey-old-password"
+				require.NoError(t, b.ChangeDatabasePassword(keyUID, testPassword, oldPassword, false))
+				b.UpdateRootDataDir(testContext.config.RootDataDir)
+				var err error
+				dekBefore, _, err = envelope.Unwrap(b.rootDataDir, keyUID, oldPassword)
+				require.NoError(t, err)
+			}
+
+			reEncryptionCrashHook = func(stage string) error {
+				if stage == tc.stage {
+					return errors.New("injected crash at " + stage)
+				}
+				return nil
+			}
+			t.Cleanup(func() { reEncryptionCrashHook = nil })
+
+			err := b.ChangeDatabasePassword(keyUID, oldPassword, "crash-new-password", tc.rekey)
+			require.ErrorContains(t, err, "injected crash")
+			reEncryptionCrashHook = nil
+
+			// Recovery, as a fresh app start would do it: open + repair with the OLD password.
+			_ = b.Logout()
+			require.NoError(t, b.ensureDBsOpened(*testContext.multiAcc, oldPassword))
+			require.NoError(t, b.repairProfileEncryption(keyUID, oldPassword, testContext.multiAcc.KDFIterations))
+			require.NoError(t, b.Logout())
+
+			if tc.wantLegacy {
+				require.False(t, envelope.Exists(b.rootDataDir, keyUID))
+				require.NoError(t, keystorepkg.VerifyKeyStoreDirAtPath(keystoreDir, oldPassword))
+				requireDBOpensWith(t, appDBPath, oldPassword, testContext.multiAcc.KDFIterations)
+				requireDBOpensWith(t, walletDBPath, oldPassword, testContext.multiAcc.KDFIterations)
+				return
+			}
+
+			require.False(t, envelope.PendingExists(b.rootDataDir, keyUID))
+			dekNow, dekIter, err := envelope.Unwrap(b.rootDataDir, keyUID, oldPassword)
+			require.NoError(t, err)
+			require.Equal(t, sqlite.ReducedKDFIterationsNumber, dekIter)
+			if tc.rekey {
+				if tc.wantNewDek {
+					require.NotEqual(t, dekBefore, dekNow)
+				} else {
+					require.Equal(t, dekBefore, dekNow)
+				}
+			}
+			require.NoError(t, keystorepkg.VerifyKeyStoreDirAtPath(keystoreDir, dekNow))
+			requireDBOpensWith(t, appDBPath, dekNow, sqlite.ReducedKDFIterationsNumber)
+			requireDBOpensWith(t, walletDBPath, dekNow, sqlite.ReducedKDFIterationsNumber)
+		})
+	}
+}
+
+// TestRepairInterruptedMigration simulates a crash right after the migration wrote the
+// envelope (databases and keystore still on the raw password) and verifies that login
+// falls back and repair rolls the profile back to a clean legacy state.
+func TestRepairInterruptedMigration(t *testing.T) {
+	testContext := setupTestContext(t, testPassword, true, true, false)
+	b := testContext.backend
+	keyUID := testContext.profileKeypair.KeyUID
+
+	// Simulate the crash state: envelope present, everything else untouched.
+	dek, err := envelope.Generate()
+	require.NoError(t, err)
+	require.NoError(t, envelope.Write(b.rootDataDir, keyUID, dek, testPassword, sqlite.ReducedKDFIterationsNumber))
+
+	require.NoError(t, b.Logout())
+
+	// Login path: databases open via the raw-password fallback.
+	require.NoError(t, b.ensureDBsOpened(*testContext.multiAcc, testPassword))
+	appSecret, walletSecret := b.dbOpenSecrets()
+	require.Equal(t, testPassword, appSecret)
+	require.Equal(t, testPassword, walletSecret)
+
+	require.NoError(t, b.repairProfileEncryption(keyUID, testPassword, testContext.multiAcc.KDFIterations))
+
+	// Rolled back to a clean legacy profile.
+	require.False(t, envelope.Exists(b.rootDataDir, keyUID))
+
+	// Keystore still decrypts with the raw password.
+	_, keystoreDir := DefaultKeystorePath(b.rootDataDir, keyUID)
+	require.NoError(t, keystorepkg.ReEncryptKeyStoreDirAtPath(keystoreDir, testPassword, testPassword))
+
+	require.NoError(t, b.Logout())
+}
+
+// TestRepairInterruptedRekey simulates a crash after a rekey swapped the databases and
+// re-encrypted the keystore to the new DEK, but before the new envelope was committed.
+// Login must succeed via the pending envelope and repair must commit it.
+func TestRepairInterruptedRekey(t *testing.T) {
+	testContext := setupTestContext(t, testPassword, true, true, false)
+	b := testContext.backend
+	keyUID := testContext.profileKeypair.KeyUID
+
+	// Migrate to the DEK scheme first.
+	const password1 = "new-password-1"
+	require.NoError(t, b.ChangeDatabasePassword(keyUID, testPassword, password1, false))
+	b.UpdateRootDataDir(testContext.config.RootDataDir)
+	dek1, _, err := envelope.Unwrap(b.rootDataDir, keyUID, password1)
+	require.NoError(t, err)
+
+	require.NoError(t, b.Logout())
+
+	// Simulate the rekey crash state: pending envelope + databases + keystore on a new
+	// DEK, while the main envelope still holds the old one.
+	dek2, err := envelope.Generate()
+	require.NoError(t, err)
+	require.NoError(t, envelope.WritePending(b.rootDataDir, keyUID, dek2, password1, sqlite.ReducedKDFIterationsNumber))
+
+	reEncryptInPlace := func(path string) {
+		tmpPath := path + ".rekeyed"
+		require.NoError(t, sqlite.ExportDBWithKDFChange(path, dek1, sqlite.ReducedKDFIterationsNumber,
+			tmpPath, dek2, sqlite.ReducedKDFIterationsNumber, nil, nil))
+		require.NoError(t, os.Rename(tmpPath, path))
+		_ = os.Remove(path + "-wal")
+		_ = os.Remove(path + "-shm")
+	}
+	appDBPath, err := b.getAppDBPath(keyUID)
+	require.NoError(t, err)
+	walletDBPath, err := b.getWalletDBPath(keyUID)
+	require.NoError(t, err)
+	reEncryptInPlace(appDBPath)
+	reEncryptInPlace(walletDBPath)
+
+	_, keystoreDir := DefaultKeystorePath(b.rootDataDir, keyUID)
+	require.NoError(t, keystorepkg.ReEncryptKeyStoreDirAtPath(keystoreDir, dek1, dek2))
+
+	// Login with the (old) password: primary resolve yields dek1, databases open via the
+	// pending-DEK fallback.
+	require.NoError(t, b.ensureDBsOpened(*testContext.multiAcc, password1))
+	appSecret, walletSecret := b.dbOpenSecrets()
+	require.Equal(t, dek2, appSecret)
+	require.Equal(t, dek2, walletSecret)
+
+	require.NoError(t, b.repairProfileEncryption(keyUID, password1, testContext.multiAcc.KDFIterations))
+
+	// The pending envelope was committed: dek2 is now the main DEK, wrapped with the password.
+	require.False(t, envelope.PendingExists(b.rootDataDir, keyUID))
+	dekNow, _, err := envelope.Unwrap(b.rootDataDir, keyUID, password1)
+	require.NoError(t, err)
+	require.Equal(t, dek2, dekNow)
+
+	// Keystore is on dek2 (probe: re-encrypt dek2 → dek2 succeeds).
+	require.NoError(t, keystorepkg.ReEncryptKeyStoreDirAtPath(keystoreDir, dek2, dek2))
+
+	require.NoError(t, b.Logout())
+}

--- a/pkg/backend/geth_backend.go
+++ b/pkg/backend/geth_backend.go
@@ -1265,6 +1265,14 @@ func reEncryptionCrash(stage string) error {
 	return reEncryptionCrashHook(stage)
 }
 
+func verifyDBKey(path, key string, kdfIter int) error {
+	db, err := sqlite.OpenDB(path, key, kdfIter)
+	if err != nil {
+		return err
+	}
+	return db.Close()
+}
+
 // migrateProfileToDEK performs the one-time migration of a legacy profile to the DEK scheme, both databases and
 // the keystore are re-encrypted with a fresh random DEK, wrapped with newKEK.
 func (b *StatusBackend) migrateProfileToDEK(keyUID, oldKEK, newKEK string) (restart func(), err error) {
@@ -1282,6 +1290,20 @@ func (b *StatusBackend) migrateProfileToDEK(keyUID, oldKEK, newKEK string) (rest
 			return nil
 		}
 		return func() { b.restartNodeAfterReEncryption(acc, password) }
+	}
+
+	appDBPath, err := b.getAppDBPath(keyUID)
+	if err != nil {
+		return nil, err
+	}
+	walletDBPath, err := b.getWalletDBPath(keyUID)
+	if err != nil {
+		return nil, err
+	}
+
+	// Verify oldKEK before starting the migration
+	if err := verifyDBKey(appDBPath, oldKEK, acc.KDFIterations); err != nil {
+		return nil, fmt.Errorf("old password verification failed: %w", err)
 	}
 
 	dek, err := envelope.Generate()
@@ -1317,17 +1339,6 @@ func (b *StatusBackend) migrateProfileToDEK(keyUID, oldKEK, newKEK string) (rest
 	}
 
 	// Export both databases before swapping either, so no revert-re-encryption is needed
-	appDBPath, err := b.getAppDBPath(keyUID)
-	if err != nil {
-		revertKeystoreAndEnvelope()
-		return nil, err
-	}
-	walletDBPath, err := b.getWalletDBPath(keyUID)
-	if err != nil {
-		revertKeystoreAndEnvelope()
-		return nil, err
-	}
-
 	appTmpPath, appCleanup, err := b.createTempDBFile("v4.db")
 	if err != nil {
 		revertKeystoreAndEnvelope()

--- a/pkg/backend/geth_backend.go
+++ b/pkg/backend/geth_backend.go
@@ -111,32 +111,42 @@ type StatusBackend struct {
 
 	secretCache profileSecretCache
 
+	reEncryptionMu sync.Mutex
+
 	shutdownTasks []func() error
 }
 
 // dbCredentials carries the resolved sqlcipher credentials for opening the profile databases.
 type dbCredentials struct {
-	secret          string
-	kdfIter         int
-	fallbackSecret  string
-	fallbackKdfIter int
+	secret    string
+	kdfIter   int
+	fallbacks []dbFallbackCredential
 }
 
 // openDBWithCredsFallback opens a database with the resolved secret, retrying with the fallback credentials (when present)
-// so a crash mid-migration never locks the user out. The primary error is reported if both fail.
+// so a crash mid-migration/rekey never locks the user out. The secret that succeeded is recorded for login-time repair.
+// The primary error is reported if all attempts fail.
 func (b *StatusBackend) openDBWithCredsFallback(dbName string, creds dbCredentials, open func(secret string, kdfIter int) (*sql.DB, error)) (*sql.DB, error) {
 	db, err := open(creds.secret, creds.kdfIter)
-	if err == nil || creds.fallbackSecret == "" || creds.fallbackSecret == creds.secret {
-		return db, err
+	if err == nil {
+		b.recordDBOpenSecret(dbName, creds.secret)
+		return db, nil
 	}
 
-	fallbackDB, fallbackErr := open(creds.fallbackSecret, creds.fallbackKdfIter)
-	if fallbackErr != nil {
-		return nil, err
+	for _, fallback := range creds.fallbacks {
+		if fallback.secret == "" || fallback.secret == creds.secret {
+			continue
+		}
+		fallbackDB, fallbackErr := open(fallback.secret, fallback.kdfIter)
+		if fallbackErr == nil {
+			b.logger.Warn("database opened with fallback credentials after failed primary open; encryption-scheme migration/rekey was likely interrupted",
+				zap.String("db", dbName))
+			b.recordDBOpenSecret(dbName, fallback.secret)
+			return fallbackDB, nil
+		}
 	}
-	b.logger.Warn("database opened with legacy credentials after failed DEK open; encryption-scheme migration was likely interrupted",
-		zap.String("db", dbName))
-	return fallbackDB, nil
+
+	return nil, err
 }
 
 // NewStatusBackend create a new StatusBackend instance
@@ -460,11 +470,7 @@ func (b *StatusBackend) ensureDBsOpened(account multiaccounts.Account, password 
 	if err != nil {
 		return err
 	}
-	creds := dbCredentials{secret: resolved.secret, kdfIter: resolved.dbKdfIter}
-	if resolved.migrated {
-		creds.fallbackSecret = resolved.legacySecret
-		creds.fallbackKdfIter = resolved.legacyKdfIter
-	}
+	creds := dbCredentials{secret: resolved.secret, kdfIter: resolved.dbKdfIter, fallbacks: resolved.fallbacks}
 
 	b.mu.Lock()
 	dbsUnset := b.walletDB == nil && b.appDB == nil
@@ -805,6 +811,11 @@ func (b *StatusBackend) loginAccount(request *requests.Login) error {
 		return errors.Wrap(err, "failed to open database")
 	}
 
+	// Fix any interrupted encryption-scheme migration/rekey before the keystore is used.
+	if err := b.repairProfileEncryption(acc.KeyUID, request.Password, acc.KDFIterations); err != nil {
+		return errors.Wrap(err, "failed to repair profile encryption")
+	}
+
 	defaultCfg := &params.NodeConfig{
 		// why we need this? relate PR: https://github.com/status-im/status-go/pull/4014
 		KeycardPairingDataFile: filepath.Join(b.rootDataDir, DefaultKeycardPairingDataFileRelativePath),
@@ -974,6 +985,11 @@ func (b *StatusBackend) startNodeWithAccount(acc multiaccounts.Account, password
 	err := b.ensureDBsOpened(acc, password)
 	if err != nil {
 		return err
+	}
+
+	// Fix any interrupted encryption-scheme migration/rekey before the keystore is used.
+	if err := b.repairProfileEncryption(acc.KeyUID, password, acc.KDFIterations); err != nil {
+		return errors.Wrap(err, "failed to repair profile encryption")
 	}
 
 	err = b.loadNodeConfig(inputNodeCfg)
@@ -1173,154 +1189,361 @@ func (b *StatusBackend) reEncryptKeyStoreDir(currentPassword string, newPassword
 	return nil
 }
 
-func (b *StatusBackend) ChangeDatabasePassword(keyUID string, password string, newPassword string) error {
-	acc, err := b.multiaccountsDB.GetAccount(keyUID)
-	if err != nil {
-		return err
+// ChangeDatabasePassword re-encrypts the profile's secrets from password to newPassword.
+//   - profile on the DEK scheme, rekey=false → fast path: only the wrapped-DEK file is re-wrapped (no new DEK is generated)
+//   - profile on the DEK scheme, rekey=true → deep rekey: fresh DEK, databases and keystore re-encrypted (new DEK is generated)
+//   - legacy profile → one-time migration to the DEK scheme (full re-encryption, new DEK is generated)
+func (b *StatusBackend) ChangeDatabasePassword(keyUID string, password string, newPassword string, rekey bool) error {
+	restart, err := b.changeDatabasePasswordSerialized(keyUID, password, newPassword, rekey)
+	if restart != nil {
+		restart()
 	}
+	return err
+}
 
+// changeDatabasePasswordSerialized holds the re-encryption lock for the whole mutation, returns the node-restart step
+// (when one is needed) to run after unlocking the lock.
+func (b *StatusBackend) changeDatabasePasswordSerialized(keyUID, password, newPassword string, rekey bool) (restart func(), err error) {
+	b.reEncryptionMu.Lock()
+	defer b.reEncryptionMu.Unlock()
+
+	if envelope.Exists(b.rootDataDir, keyUID) {
+		if !rekey {
+			// Fast path: nothing that is open (databases, keystore, node) changes.
+			if err := envelope.Rewrap(b.rootDataDir, keyUID, password, newPassword); err != nil {
+				return nil, err
+			}
+			b.refreshSecretCacheKEK(keyUID, newPassword)
+			return nil, nil
+		}
+		return b.rekeyProfile(keyUID, password, newPassword)
+	}
+	return b.migrateProfileToDEK(keyUID, password, newPassword)
+}
+
+// isCurrentAccountOpen reports whether the currently opened app DB belongs to the given profile.
+func (b *StatusBackend) isCurrentAccountOpen(keyUID string) (bool, error) {
 	internalDbPath, err := dbsetup.GetDBFilename(b.appDB)
 	if err != nil {
-		return fmt.Errorf("failed to get database file name, %w", err)
+		return false, fmt.Errorf("failed to get database file name, %w", err)
 	}
 
 	appDBPath, err := b.getAppDBPath(keyUID)
 	if err != nil {
-		return err
+		return false, err
 	}
 
 	// In order to overcome Mac OS symlink issue, we check if the internalDbPath contains the appDBPath.
 	// Cause on macOS, `/var` is actually a symlink to `/private/var`.
-	isCurrentAccount := strings.Contains(internalDbPath, appDBPath)
-
-	restartNode := func() {
-		if isCurrentAccount {
-			pass := password
-			if err == nil {
-				pass = newPassword
-			}
-
-			err := b.StopNode()
-			if err != nil {
-				b.logger.Error("failed to stop node", zap.Error(err))
-				return
-			}
-
-			// TODO https://github.com/status-im/status-go/issues/3906
-			// Fix restarting node, as it always fails but the error is ignored
-			// because UI calls Logout and Quit afterwards. It should not be UI-dependent
-			// and should be handled gracefully here if it makes sense to run dummy node after
-			// logout
-			err = b.startNodeWithAccount(*acc, pass, b.config, nil)
-			if err != nil {
-				b.logger.Error("failed to start node", zap.Error(err))
-				return
-			}
-			b.statusNode.StartTokenManager()
-		}
-	}
-	defer restartNode()
-
-	logout := func() {
-		if isCurrentAccount {
-			_ = b.Logout()
-		}
-	}
-	noLogout := func() {}
-
-	// First change app DB password, because it also reencrypts the keystore,
-	// otherwise if we call changeWalletDbPassword first and logout, we will fail
-	// to reencrypt	the keystore
-	err = b.changeAppDBPassword(acc, logout, password, newPassword)
-	if err != nil {
-		return err
-	}
-
-	// Already logged out but pass a param to decouple the logic for testing
-	err = b.changeWalletDBPassword(acc, noLogout, password, newPassword)
-	if err != nil {
-		// Revert the password to original
-		err2 := b.changeAppDBPassword(acc, noLogout, newPassword, password)
-		if err2 != nil {
-			b.logger.Error("failed to revert app db password", zap.Error(err2))
-		}
-
-		return err
-	}
-
-	return nil
+	return internalDbPath != "" && strings.Contains(internalDbPath, appDBPath), nil
 }
 
-func (b *StatusBackend) changeAppDBPassword(account *multiaccounts.Account, logout func(), password string, newPassword string) error {
-	tmpDbPath, cleanup, err := b.createTempDBFile("v4.db")
+// restartNodeAfterReEncryption preserves the historical restart-after-password-change behavior.
+func (b *StatusBackend) restartNodeAfterReEncryption(acc *multiaccounts.Account, password string) {
+	err := b.StopNode()
 	if err != nil {
-		return err
+		b.logger.Error("failed to stop node", zap.Error(err))
+		return
 	}
-	defer cleanup()
 
-	dbPath, err := b.getAppDBPath(account.KeyUID)
+	err = b.startNodeWithAccount(*acc, password, b.config, nil)
 	if err != nil {
-		return err
+		b.logger.Error("failed to start node", zap.Error(err))
+		return
 	}
-
-	// Exporting database to a temporary file with a new password
-	err = sqlite.ExportDB(dbPath, password, account.KDFIterations, tmpDbPath, newPassword, signal.SendReEncryptionStarted, signal.SendReEncryptionFinished)
-	if err != nil {
-		return err
-	}
-
-	err = b.reEncryptKeyStoreDir(password, newPassword)
-	if err != nil {
-		return err
-	}
-
-	// Replacing the old database with the new one requires closing all connections to the database
-	// This is done by stopping the node and restarting it with the new DB
-	logout()
-
-	// Replacing the old database files with the new ones, ignoring the wal and shm errors
-	replaceCleanup, err := replaceDBFile(dbPath, tmpDbPath)
-	if replaceCleanup != nil {
-		defer replaceCleanup()
-	}
-
-	if err != nil {
-		// Restore the old account
-		_ = b.reEncryptKeyStoreDir(newPassword, password)
-		return err
-	}
-
-	return nil
+	b.statusNode.StartTokenManager()
 }
 
-func (b *StatusBackend) changeWalletDBPassword(account *multiaccounts.Account, logout func(), password string, newPassword string) error {
-	tmpDbPath, cleanup, err := b.createTempDBFile("wallet.db")
-	if err != nil {
-		return err
+// reEncryptionCrashHook, when set (tests only), simulates a process crash at named boundaries of the migration/rekey flows.
+// A returned error aborts the flow at that exact point with no further cleanup, leaving the on-disk state for login-time repair.
+var reEncryptionCrashHook func(stage string) error
+
+func reEncryptionCrash(stage string) error {
+	if reEncryptionCrashHook == nil {
+		return nil
 	}
-	defer cleanup()
+	return reEncryptionCrashHook(stage)
+}
 
-	dbPath, err := b.getWalletDBPath(account.KeyUID)
+// migrateProfileToDEK performs the one-time migration of a legacy profile to the DEK scheme, both databases and
+// the keystore are re-encrypted with a fresh random DEK, wrapped with newKEK.
+func (b *StatusBackend) migrateProfileToDEK(keyUID, oldKEK, newKEK string) (restart func(), err error) {
+	acc, err := b.multiaccountsDB.GetAccount(keyUID)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
-	// Exporting database to a temporary file with a new password
-	err = sqlite.ExportDB(dbPath, password, account.KDFIterations, tmpDbPath, newPassword, signal.SendReEncryptionStarted, signal.SendReEncryptionFinished)
+	isCurrentAccount, err := b.isCurrentAccountOpen(keyUID)
 	if err != nil {
-		return err
+		return nil, err
+	}
+	restartWith := func(password string) func() {
+		if !isCurrentAccount {
+			return nil
+		}
+		return func() { b.restartNodeAfterReEncryption(acc, password) }
 	}
 
-	// Replacing the old database with the new one requires closing all connections to the database
-	// This is done by stopping the node and restarting it with the new DB
-	logout()
+	dek, err := envelope.Generate()
+	if err != nil {
+		return nil, err
+	}
 
-	// Replacing the old database files with the new ones, ignoring the wal and shm errors
-	replaceCleanup, err := replaceDBFile(dbPath, tmpDbPath)
+	signal.SendReEncryptionStarted()
+	defer signal.SendReEncryptionFinished()
+
+	// Envelope first, wrapped with the OLD KEK: if crash happens login keeps working via the raw-password fallbacks and repair
+	if err := envelope.Write(b.rootDataDir, keyUID, dek, oldKEK, sqlite.ReducedKDFIterationsNumber); err != nil {
+		return nil, err
+	}
+	if err := reEncryptionCrash("migrate:envelope-written"); err != nil {
+		return nil, err
+	}
+
+	// Keystore to the DEK. On error don't remove the envelope, so next login-time repair can determine the actual state
+	if err := b.reEncryptKeyStoreDir(oldKEK, dek); err != nil {
+		return nil, fmt.Errorf("failed to re-encrypt keystore: %w", err)
+	}
+	if err := reEncryptionCrash("migrate:keystore-reencrypted"); err != nil {
+		return nil, err
+	}
+
+	revertKeystoreAndEnvelope := func() {
+		if err := b.reEncryptKeyStoreDir(dek, oldKEK); err != nil {
+			b.logger.Error("failed to revert keystore re-encryption; repair will run at next login", zap.Error(err))
+			return // keep the envelope: the keystore may be on the DEK and need it
+		}
+		_ = envelope.Remove(b.rootDataDir, keyUID)
+	}
+
+	// Export both databases before swapping either, so no revert-re-encryption is needed
+	appDBPath, err := b.getAppDBPath(keyUID)
+	if err != nil {
+		revertKeystoreAndEnvelope()
+		return nil, err
+	}
+	walletDBPath, err := b.getWalletDBPath(keyUID)
+	if err != nil {
+		revertKeystoreAndEnvelope()
+		return nil, err
+	}
+
+	appTmpPath, appCleanup, err := b.createTempDBFile("v4.db")
+	if err != nil {
+		revertKeystoreAndEnvelope()
+		return nil, err
+	}
+	defer appCleanup()
+	err = sqlite.ExportDBWithKDFChange(appDBPath, oldKEK, acc.KDFIterations, appTmpPath, dek, sqlite.ReducedKDFIterationsNumber, nil, nil)
+	if err != nil {
+		revertKeystoreAndEnvelope()
+		return nil, fmt.Errorf("failed to export app database: %w", err)
+	}
+
+	walletTmpPath, walletCleanup, err := b.createTempDBFile("wallet.db")
+	if err != nil {
+		revertKeystoreAndEnvelope()
+		return nil, err
+	}
+	defer walletCleanup()
+	err = sqlite.ExportDBWithKDFChange(walletDBPath, oldKEK, acc.KDFIterations, walletTmpPath, dek, sqlite.ReducedKDFIterationsNumber, nil, nil)
+	if err != nil {
+		revertKeystoreAndEnvelope()
+		return nil, fmt.Errorf("failed to export wallet database: %w", err)
+	}
+	if err := reEncryptionCrash("migrate:dbs-exported"); err != nil {
+		return nil, err
+	}
+
+	// Replacing the database files requires closing all connections to them first
+	if isCurrentAccount {
+		_ = b.Logout()
+	}
+
+	// Swap both databases
+	replaceCleanup, err := replaceDBFile(appDBPath, appTmpPath)
 	if replaceCleanup != nil {
-		defer replaceCleanup()
+		replaceCleanup()
 	}
-	return err
+	if err != nil {
+		revertKeystoreAndEnvelope()
+		return restartWith(oldKEK), err
+	}
+	if err := reEncryptionCrash("migrate:app-swapped"); err != nil {
+		return nil, err
+	}
+
+	replaceCleanup, err = replaceDBFile(walletDBPath, walletTmpPath)
+	if replaceCleanup != nil {
+		replaceCleanup()
+	}
+	if err != nil {
+		// The app DB is already on the DEK, no rollback from here, the wallet DB stays on the old password, the next login will repair it
+		b.logger.Error("wallet database swap failed mid-migration; will be repaired at login", zap.Error(err))
+		return restartWith(oldKEK), err
+	}
+	if err := reEncryptionCrash("migrate:dbs-swapped"); err != nil {
+		return nil, err
+	}
+
+	// The kdf value lives inside the envelope, keep the column in sync for observability
+	if err := b.multiaccountsDB.UpdateAccountKDFIterations(keyUID, sqlite.ReducedKDFIterationsNumber); err != nil {
+		b.logger.Error("failed to update kdfIterations after migration", zap.Error(err))
+	}
+
+	// Commit the new KEK
+	if err := envelope.Rewrap(b.rootDataDir, keyUID, oldKEK, newKEK); err != nil {
+		// Fully migrated but still wrapped with the old password, report failure so the client keeps using the old password
+		return restartWith(oldKEK), err
+	}
+
+	b.clearProfileSecretCache()
+
+	return restartWith(newKEK), nil
+}
+
+// rekeyProfile performs a deep rekey of a profile already on the DEK scheme - a new DEK is generated and the databases
+// and keystore are re-encrypted with it.
+func (b *StatusBackend) rekeyProfile(keyUID, oldKEK, newKEK string) (restart func(), err error) {
+	// Verify oldKEK before anything is touched
+	oldDEK, dbKdfIter, err := envelope.Unwrap(b.rootDataDir, keyUID, oldKEK)
+	if err != nil {
+		return nil, err
+	}
+
+	acc, err := b.multiaccountsDB.GetAccount(keyUID)
+	if err != nil {
+		return nil, err
+	}
+
+	isCurrentAccount, err := b.isCurrentAccountOpen(keyUID)
+	if err != nil {
+		return nil, err
+	}
+	restartWith := func(password string) func() {
+		if !isCurrentAccount {
+			return nil
+		}
+		return func() { b.restartNodeAfterReEncryption(acc, password) }
+	}
+
+	newDEK, err := envelope.Generate()
+	if err != nil {
+		return nil, err
+	}
+
+	signal.SendReEncryptionStarted()
+	defer signal.SendReEncryptionFinished()
+
+	// Pending envelope first (new DEK wrapped with the OLD KEK): every crash state below stays openable with the old password
+	if err := envelope.WritePending(b.rootDataDir, keyUID, newDEK, oldKEK, sqlite.ReducedKDFIterationsNumber); err != nil {
+		return nil, err
+	}
+	if err := reEncryptionCrash("rekey:pending-written"); err != nil {
+		return nil, err
+	}
+
+	abort := func() {
+		_ = envelope.RemovePending(b.rootDataDir, keyUID)
+	}
+
+	// Export both databases from old DEK to new DEK
+	appDBPath, err := b.getAppDBPath(keyUID)
+	if err != nil {
+		abort()
+		return nil, err
+	}
+	walletDBPath, err := b.getWalletDBPath(keyUID)
+	if err != nil {
+		abort()
+		return nil, err
+	}
+
+	appTmpPath, appCleanup, err := b.createTempDBFile("v4.db")
+	if err != nil {
+		abort()
+		return nil, err
+	}
+	defer appCleanup()
+	err = sqlite.ExportDBWithKDFChange(appDBPath, oldDEK, dbKdfIter, appTmpPath, newDEK, sqlite.ReducedKDFIterationsNumber, nil, nil)
+	if err != nil {
+		abort()
+		return nil, fmt.Errorf("failed to export app database: %w", err)
+	}
+
+	walletTmpPath, walletCleanup, err := b.createTempDBFile("wallet.db")
+	if err != nil {
+		abort()
+		return nil, err
+	}
+	defer walletCleanup()
+	err = sqlite.ExportDBWithKDFChange(walletDBPath, oldDEK, dbKdfIter, walletTmpPath, newDEK, sqlite.ReducedKDFIterationsNumber, nil, nil)
+	if err != nil {
+		abort()
+		return nil, fmt.Errorf("failed to export wallet database: %w", err)
+	}
+	if err := reEncryptionCrash("rekey:dbs-exported"); err != nil {
+		return nil, err
+	}
+
+	// Keystore from old DEK to new DEK. On error don't remove the pending envelope, so next login-time repair can determine the actual state
+	if err := b.reEncryptKeyStoreDir(oldDEK, newDEK); err != nil {
+		return nil, fmt.Errorf("failed to re-encrypt keystore: %w", err)
+	}
+	if err := reEncryptionCrash("rekey:keystore-reencrypted"); err != nil {
+		return nil, err
+	}
+
+	// Replacing the database files requires closing all connections to them first
+	if isCurrentAccount {
+		_ = b.Logout()
+	}
+
+	// Swap both databases
+	replaceCleanup, err := replaceDBFile(appDBPath, appTmpPath)
+	if replaceCleanup != nil {
+		replaceCleanup()
+	}
+	if err != nil {
+		// Nothing swapped yet, roll the keystore back and abort cleanly
+		if revertErr := b.reEncryptKeyStoreDir(newDEK, oldDEK); revertErr != nil {
+			b.logger.Error("failed to revert keystore re-encryption; repair will run at login", zap.Error(revertErr))
+			return restartWith(oldKEK), err
+		}
+		abort()
+		return restartWith(oldKEK), err
+	}
+	if err := reEncryptionCrash("rekey:app-swapped"); err != nil {
+		return nil, err
+	}
+
+	replaceCleanup, err = replaceDBFile(walletDBPath, walletTmpPath)
+	if replaceCleanup != nil {
+		replaceCleanup()
+	}
+	if err != nil {
+		// The app DB is already on the new DEK, no rollback from here, the pending envelope keeps the profile openable, the next login will repair it
+		b.logger.Error("wallet database swap failed mid-rekey; will be repaired at login", zap.Error(err))
+		return restartWith(oldKEK), err
+	}
+	if err := reEncryptionCrash("rekey:dbs-swapped"); err != nil {
+		return nil, err
+	}
+
+	// Commit the new DEK wrapped with the new KEK
+	if err := envelope.Write(b.rootDataDir, keyUID, newDEK, newKEK, sqlite.ReducedKDFIterationsNumber); err != nil {
+		// Databases and keystore are on the new DEK, the pending envelope (old password) still opens them, the next login will repair it
+		return restartWith(oldKEK), err
+	}
+	if err := reEncryptionCrash("rekey:committed"); err != nil {
+		return nil, err
+	}
+
+	_ = envelope.RemovePending(b.rootDataDir, keyUID)
+
+	b.clearProfileSecretCache()
+
+	return restartWith(newKEK), nil
 }
 
 func (b *StatusBackend) createTempDBFile(pattern string) (tmpDbPath string, cleanup func(), err error) {
@@ -1409,12 +1632,28 @@ func (b *StatusBackend) ConvertToKeycardAccount(account multiaccounts.Account, s
 		return err
 	}
 
+	if envelope.Exists(b.rootDataDir, account.KeyUID) {
+		if err := b.ChangeDatabasePassword(account.KeyUID, oldPassword, newPassword, false); err != nil {
+			return err
+		}
+		b.updateSessionAccountKeycardPairing(account.KeyUID, account.KeycardPairing)
+		return nil
+	}
+
 	err = b.closeDBs()
 	if err != nil {
 		return err
 	}
 
-	return b.ChangeDatabasePassword(account.KeyUID, oldPassword, newPassword)
+	return b.ChangeDatabasePassword(account.KeyUID, oldPassword, newPassword, false)
+}
+
+func (b *StatusBackend) updateSessionAccountKeycardPairing(keyUID, keycardPairing string) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.account != nil && b.account.KeyUID == keyUID {
+		b.account.KeycardPairing = keycardPairing
+	}
 }
 
 // CreateAccountAndLogin creates a new account and logs in with it.
@@ -1721,16 +1960,29 @@ func (b *StatusBackend) ConvertToRegularAccount(mnemonic string, currPassword st
 		return err
 	}
 
+	if envelope.Exists(b.rootDataDir, generatedAccountInfo.KeyUID) {
+		if err := b.ChangeDatabasePassword(generatedAccountInfo.KeyUID, currPassword, newPassword, false); err != nil {
+			return err
+		}
+		b.updateSessionAccountKeycardPairing(generatedAccountInfo.KeyUID, "")
+		return nil
+	}
+
 	err = b.closeDBs()
 	if err != nil {
 		return err
 	}
 
-	return b.ChangeDatabasePassword(generatedAccountInfo.KeyUID, currPassword, newPassword)
+	return b.ChangeDatabasePassword(generatedAccountInfo.KeyUID, currPassword, newPassword, false)
 }
 
 func (b *StatusBackend) VerifyProfilePassword(password string) (bool, error) {
 	return b.statusNode.AccountService().VerifyPassword(password)
+}
+
+// ProfileEncryptionInfo reports whether the profile uses the DEK encryption scheme
+func (b *StatusBackend) ProfileEncryptionInfo(keyUID string) (migrated bool) {
+	return envelope.Exists(b.rootDataDir, keyUID)
 }
 
 func (b *StatusBackend) VerifyDatabasePassword(keyUID string, password string) error {
@@ -1903,6 +2155,19 @@ func (b *StatusBackend) StartNodeWithChatKeyOrMnemonic(
 	nodeConfig, err := b.prepareConfig(request, keyUID, settings.InstallationID)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to prepare node config")
+	}
+
+	// Brand-new profiles use the DEK encryption scheme from the start
+	if !envelope.Exists(b.rootDataDir, keyUID) && !b.appDBExists(keyUID) && !b.walletDBExists(keyUID) {
+		dek, err := envelope.Generate()
+		if err != nil {
+			return nil, err
+		}
+		if err := envelope.Write(b.rootDataDir, keyUID, dek, request.Password, sqlite.ReducedKDFIterationsNumber); err != nil {
+			return nil, err
+		}
+		// High-entropy DEK needs no key stretching
+		multiAccount.KDFIterations = sqlite.ReducedKDFIterationsNumber
 	}
 
 	err = b.ensureDBsOpened(*multiAccount, request.Password)

--- a/pkg/backend/geth_backend.go
+++ b/pkg/backend/geth_backend.go
@@ -28,6 +28,7 @@ import (
 	accsmanagement "github.com/status-im/status-go/internal/accounts-management"
 	"github.com/status-im/status-go/internal/accounts-management/common"
 	generator "github.com/status-im/status-go/internal/accounts-management/generator"
+	"github.com/status-im/status-go/internal/accounts-management/keystore/envelope"
 	accsmanagementtypes "github.com/status-im/status-go/internal/accounts-management/types"
 	"github.com/status-im/status-go/internal/connection"
 	"github.com/status-im/status-go/internal/crypto"
@@ -108,7 +109,34 @@ type StatusBackend struct {
 	logger            *zap.Logger
 	preLoginLogConfig *logutils.PreLoginLogConfig
 
+	secretCache profileSecretCache
+
 	shutdownTasks []func() error
+}
+
+// dbCredentials carries the resolved sqlcipher credentials for opening the profile databases.
+type dbCredentials struct {
+	secret          string
+	kdfIter         int
+	fallbackSecret  string
+	fallbackKdfIter int
+}
+
+// openDBWithCredsFallback opens a database with the resolved secret, retrying with the fallback credentials (when present)
+// so a crash mid-migration never locks the user out. The primary error is reported if both fail.
+func (b *StatusBackend) openDBWithCredsFallback(dbName string, creds dbCredentials, open func(secret string, kdfIter int) (*sql.DB, error)) (*sql.DB, error) {
+	db, err := open(creds.secret, creds.kdfIter)
+	if err == nil || creds.fallbackSecret == "" || creds.fallbackSecret == creds.secret {
+		return db, err
+	}
+
+	fallbackDB, fallbackErr := open(creds.fallbackSecret, creds.fallbackKdfIter)
+	if fallbackErr != nil {
+		return nil, err
+	}
+	b.logger.Warn("database opened with legacy credentials after failed DEK open; encryption-scheme migration was likely interrupted",
+		zap.String("db", dbName))
+	return fallbackDB, nil
 }
 
 // NewStatusBackend create a new StatusBackend instance
@@ -378,9 +406,14 @@ func (b *StatusBackend) DeleteMultiaccount(keyUID string, keyStoreDir string) er
 		}
 	}
 
+	if err := envelope.Remove(b.rootDataDir, keyUID); err != nil {
+		return err
+	}
+
 	if b.account != nil && b.account.KeyUID == keyUID {
 		// reset active account
 		b.account = nil
+		b.clearProfileSecretCache()
 	}
 
 	return os.RemoveAll(keyStoreDir)
@@ -423,10 +456,22 @@ func (b *StatusBackend) runDBFileMigrations(account multiaccounts.Account, passw
 }
 
 func (b *StatusBackend) ensureDBsOpened(account multiaccounts.Account, password string) (err error) {
+	resolved, err := b.resolveProfileSecret(account.KeyUID, password, account.KDFIterations)
+	if err != nil {
+		return err
+	}
+	creds := dbCredentials{secret: resolved.secret, kdfIter: resolved.dbKdfIter}
+	if resolved.migrated {
+		creds.fallbackSecret = resolved.legacySecret
+		creds.fallbackKdfIter = resolved.legacyKdfIter
+	}
+
 	b.mu.Lock()
 	dbsUnset := b.walletDB == nil && b.appDB == nil
 	b.mu.Unlock()
 	if dbsUnset {
+		b.setSecretResolverForProfile(account.KeyUID, account.KDFIterations)
+
 		appDBPath, pathErr := b.getAppDBPath(account.KeyUID)
 		if pathErr == nil {
 			walletDBPath, walletPathErr := b.getWalletDBPath(account.KeyUID)
@@ -434,19 +479,19 @@ func (b *StatusBackend) ensureDBsOpened(account multiaccounts.Account, password 
 			unsupportedAppDBPath := filepath.Join(b.rootDataDir, fmt.Sprintf("app-%x.sql", account.KeyUID))
 			if walletPathErr == nil && fileExists(walletDBPath) && fileExists(appDBPath) &&
 				!fileExists(legacyAppDBPath) && !fileExists(unsupportedAppDBPath) {
-				return b.ensureEstablishedDBsOpened(account, password, appDBPath, walletDBPath)
+				return b.ensureEstablishedDBsOpened(account, creds, appDBPath, walletDBPath)
 			}
 		}
 	}
 
-	return b.ensureDBsOpenedSequential(account, password)
+	return b.ensureDBsOpenedSequential(account, creds)
 }
 
-func (b *StatusBackend) ensureEstablishedDBsOpened(account multiaccounts.Account, password, appDBPath, walletDBPath string) (err error) {
+func (b *StatusBackend) ensureEstablishedDBsOpened(account multiaccounts.Account, creds dbCredentials, appDBPath, walletDBPath string) (err error) {
 	b.mu.Lock()
 	if b.walletDB != nil || b.appDB != nil {
 		b.mu.Unlock()
-		return b.ensureDBsOpenedSequential(account, password)
+		return b.ensureDBsOpenedSequential(account, creds)
 	}
 	defer b.mu.Unlock()
 
@@ -460,7 +505,9 @@ func (b *StatusBackend) ensureEstablishedDBsOpened(account multiaccounts.Account
 	}, 1)
 	go func() {
 		defer panics.LogOnPanic()
-		db, openErr := walletdb.OpenDB(walletDBPath, password, account.KDFIterations)
+		db, openErr := b.openDBWithCredsFallback("wallet", creds, func(secret string, kdfIter int) (*sql.DB, error) {
+			return walletdb.OpenDB(walletDBPath, secret, kdfIter)
+		})
 		walletResultCh <- struct {
 			db  *sql.DB
 			err error
@@ -468,7 +515,9 @@ func (b *StatusBackend) ensureEstablishedDBsOpened(account multiaccounts.Account
 	}()
 	go func() {
 		defer panics.LogOnPanic()
-		db, openErr := appdatabase.OpenDB(appDBPath, password, account.KDFIterations)
+		db, openErr := b.openDBWithCredsFallback("app", creds, func(secret string, kdfIter int) (*sql.DB, error) {
+			return appdatabase.OpenDB(appDBPath, secret, kdfIter)
+		})
 		appResultCh <- struct {
 			db  *sql.DB
 			err error
@@ -514,21 +563,21 @@ func (b *StatusBackend) ensureEstablishedDBsOpened(account multiaccounts.Account
 	return nil
 }
 
-func (b *StatusBackend) ensureDBsOpenedSequential(account multiaccounts.Account, password string) (err error) {
+func (b *StatusBackend) ensureDBsOpenedSequential(account multiaccounts.Account, creds dbCredentials) (err error) {
 	// After wallet DB initial migration, the tables moved to wallet DB are removed from appDB
 	// so better migrate wallet DB first to avoid removal if wallet DB migration fails
-	if err = b.ensureWalletDBOpened(account, password); err != nil {
+	if err = b.ensureWalletDBOpened(account, creds); err != nil {
 		return err
 	}
 
-	if err = b.ensureAppDBOpened(account, password); err != nil {
+	if err = b.ensureAppDBOpened(account, creds); err != nil {
 		return err
 	}
 
 	return nil
 }
 
-func (b *StatusBackend) ensureAppDBOpened(account multiaccounts.Account, password string) (err error) {
+func (b *StatusBackend) ensureAppDBOpened(account multiaccounts.Account, creds dbCredentials) (err error) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	if b.appDB != nil {
@@ -538,13 +587,16 @@ func (b *StatusBackend) ensureAppDBOpened(account multiaccounts.Account, passwor
 		return errors.New("root datadir wasn't provided")
 	}
 
-	dbFilePath, err := b.runDBFileMigrations(account, password)
+	account.KDFIterations = creds.kdfIter
+	dbFilePath, err := b.runDBFileMigrations(account, creds.secret)
 	if err != nil {
 		return errors.New("Failed to migrate db file: " + err.Error())
 	}
 
 	appdatabase.CurrentAppDBKeyUID = account.KeyUID
-	b.appDB, err = appdatabase.InitializeDB(dbFilePath, password, account.KDFIterations)
+	b.appDB, err = b.openDBWithCredsFallback("app", creds, func(secret string, kdfIter int) (*sql.DB, error) {
+		return appdatabase.InitializeDB(dbFilePath, secret, kdfIter)
+	})
 	if err != nil {
 		b.logger.Error("failed to initialize db", zap.Error(err))
 		return err
@@ -588,7 +640,7 @@ func (b *StatusBackend) appDBExists(keyUID string) bool {
 	return fileExists(path)
 }
 
-func (b *StatusBackend) ensureWalletDBOpened(account multiaccounts.Account, password string) (err error) {
+func (b *StatusBackend) ensureWalletDBOpened(account multiaccounts.Account, creds dbCredentials) (err error) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	if b.walletDB != nil {
@@ -600,7 +652,9 @@ func (b *StatusBackend) ensureWalletDBOpened(account multiaccounts.Account, pass
 		return err
 	}
 
-	b.walletDB, err = walletdb.InitializeDB(dbWalletPath, password, account.KDFIterations)
+	b.walletDB, err = b.openDBWithCredsFallback("wallet", creds, func(secret string, kdfIter int) (*sql.DB, error) {
+		return walletdb.InitializeDB(dbWalletPath, secret, kdfIter)
+	})
 	if err != nil {
 		b.logger.Error("failed to initialize wallet db", zap.Error(err))
 		return err
@@ -1058,6 +1112,11 @@ func (b *StatusBackend) LoggedIn(keyUID string, err error) error {
 }
 
 func (b *StatusBackend) ExportUnencryptedDatabase(acc multiaccounts.Account, password, directory string) error {
+	resolved, err := b.resolveProfileSecret(acc.KeyUID, password, acc.KDFIterations)
+	if err != nil {
+		return err
+	}
+
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	if b.appDB != nil {
@@ -1067,12 +1126,13 @@ func (b *StatusBackend) ExportUnencryptedDatabase(acc multiaccounts.Account, pas
 		return errors.New("root datadir wasn't provided")
 	}
 
-	dbPath, err := b.runDBFileMigrations(acc, password)
+	acc.KDFIterations = resolved.dbKdfIter
+	dbPath, err := b.runDBFileMigrations(acc, resolved.secret)
 	if err != nil {
 		return err
 	}
 
-	err = sqlite.DecryptDB(dbPath, directory, password, acc.KDFIterations)
+	err = sqlite.DecryptDB(dbPath, directory, resolved.secret, resolved.dbKdfIter)
 	if err != nil {
 		b.logger.Error("failed to initialize db", zap.Error(err))
 		return err
@@ -1081,6 +1141,11 @@ func (b *StatusBackend) ExportUnencryptedDatabase(acc multiaccounts.Account, pas
 }
 
 func (b *StatusBackend) ImportUnencryptedDatabase(acc multiaccounts.Account, password, databasePath string) error {
+	resolved, err := b.resolveProfileSecret(acc.KeyUID, password, acc.KDFIterations)
+	if err != nil {
+		return err
+	}
+
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	if b.appDB != nil {
@@ -1092,7 +1157,7 @@ func (b *StatusBackend) ImportUnencryptedDatabase(acc multiaccounts.Account, pas
 		return err
 	}
 
-	err = sqlite.EncryptDB(databasePath, path, password, acc.KDFIterations, signal.SendReEncryptionStarted, signal.SendReEncryptionFinished)
+	err = sqlite.EncryptDB(databasePath, path, resolved.secret, resolved.dbKdfIter, signal.SendReEncryptionStarted, signal.SendReEncryptionFinished)
 	if err != nil {
 		b.logger.Error("failed to initialize db", zap.Error(err))
 		return err
@@ -2252,6 +2317,7 @@ func (b *StatusBackend) Logout() error {
 
 	b.AccountsManager().Logout()
 	b.account = nil
+	b.clearProfileSecretCache()
 
 	if b.statusNode != nil {
 		if b.statusNode.IsRunning() {

--- a/pkg/backend/profile_encryption_repair.go
+++ b/pkg/backend/profile_encryption_repair.go
@@ -1,0 +1,151 @@
+package backend
+
+import (
+	"fmt"
+
+	"go.uber.org/zap"
+
+	keystorepkg "github.com/status-im/status-go/internal/accounts-management/keystore"
+	"github.com/status-im/status-go/internal/accounts-management/keystore/envelope"
+	"github.com/status-im/status-go/internal/db/sqlite"
+	"github.com/status-im/status-go/internal/db/walletdb"
+)
+
+// repairProfileEncryption reconciles a profile whose encryption-scheme migration or rekey was interrupted by a crash.
+// It must run after the databases were opened (possibly via fallback credentials) and before the keystore is used.
+func (b *StatusBackend) repairProfileEncryption(keyUID, password string, kdfIterations int) error {
+	b.reEncryptionMu.Lock()
+	defer b.reEncryptionMu.Unlock()
+
+	if !envelope.Exists(b.rootDataDir, keyUID) {
+		return nil
+	}
+
+	appSecret, walletSecret := b.dbOpenSecrets()
+	if appSecret == "" {
+		// databases were not opened by this session, so nothing to align against
+		return nil
+	}
+
+	resolved, err := b.resolveProfileSecret(keyUID, password, kdfIterations)
+	if err != nil {
+		return err
+	}
+
+	pendingExists := envelope.PendingExists(b.rootDataDir, keyUID)
+	misaligned := pendingExists || appSecret != resolved.secret || (walletSecret != "" && walletSecret != appSecret)
+	if !misaligned {
+		return nil
+	}
+
+	b.logger.Warn("repairing interrupted encryption-scheme migration/rekey", zap.String("keyUID", keyUID))
+
+	// kdf_iter per known candidate secret
+	iterOf := map[string]int{resolved.secret: resolved.dbKdfIter}
+	candidates := []string{resolved.secret}
+	for _, fallback := range resolved.fallbacks {
+		if _, known := iterOf[fallback.secret]; !known {
+			iterOf[fallback.secret] = fallback.kdfIter
+			candidates = append(candidates, fallback.secret)
+		}
+	}
+
+	target := appSecret
+	targetIter, known := iterOf[target]
+	if !known {
+		return fmt.Errorf("app database opened with an unknown secret; cannot repair profile encryption")
+	}
+
+	_, keystoreDir := DefaultKeystorePath(b.rootDataDir, keyUID)
+	if err := ensureKeystoreEncryptedWith(keystoreDir, target, candidates); err != nil {
+		return fmt.Errorf("failed to reconcile keystore encryption: %w", err)
+	}
+
+	if walletSecret != "" && walletSecret != target {
+		if err := b.reEncryptWalletDBInPlace(keyUID, walletSecret, iterOf[walletSecret], target, targetIter); err != nil {
+			return err
+		}
+	}
+
+	if target == password {
+		// The app DB is still on the raw password, so an interrupted migration is rolled back to a clean legacy state.
+		if err := envelope.Remove(b.rootDataDir, keyUID); err != nil {
+			return err
+		}
+		b.clearProfileSecretCache()
+		return nil
+	}
+
+	// Commit the envelope to the DEK that actually encrypts the data.
+	if resolved.secret != target || resolved.primaryFromPending {
+		if err := envelope.Write(b.rootDataDir, keyUID, target, password, targetIter); err != nil {
+			return err
+		}
+	}
+	if err := envelope.RemovePending(b.rootDataDir, keyUID); err != nil {
+		return err
+	}
+	b.clearProfileSecretCache()
+	return nil
+}
+
+// ensureKeystoreEncryptedWith re-encrypts the keystore directory to target if not already encrypted with it.
+func ensureKeystoreEncryptedWith(keystoreDir, target string, candidates []string) error {
+	if err := keystorepkg.VerifyKeyStoreDirAtPath(keystoreDir, target); err == nil {
+		return nil
+	}
+
+	for _, candidate := range candidates {
+		if candidate == "" || candidate == target {
+			continue
+		}
+		if err := keystorepkg.ReEncryptKeyStoreDirAtPath(keystoreDir, candidate, target); err == nil {
+			return nil
+		}
+	}
+
+	// A previous re-encryption may have failed after installing the files, so re-verify.
+	return keystorepkg.VerifyKeyStoreDirAtPath(keystoreDir, target)
+}
+
+// reEncryptWalletDBInPlace re-encrypts the (currently open) wallet database from oldSecret to newSecret.
+func (b *StatusBackend) reEncryptWalletDBInPlace(keyUID, oldSecret string, oldIter int, newSecret string, newIter int) error {
+	walletDBPath, err := b.getWalletDBPath(keyUID)
+	if err != nil {
+		return err
+	}
+
+	tmpPath, cleanup, err := b.createTempDBFile("wallet.db")
+	if err != nil {
+		return err
+	}
+	defer cleanup()
+
+	if err := sqlite.ExportDBWithKDFChange(walletDBPath, oldSecret, oldIter, tmpPath, newSecret, newIter, nil, nil); err != nil {
+		return err
+	}
+
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	if err := b.closeWalletDB(); err != nil {
+		return err
+	}
+
+	// Run the wal/shm cleanup before reopening, so it cannot delete the fresh WAL files.
+	replaceCleanup, err := replaceDBFile(walletDBPath, tmpPath)
+	if replaceCleanup != nil {
+		replaceCleanup()
+	}
+	if err != nil {
+		return err
+	}
+
+	b.walletDB, err = walletdb.InitializeDB(walletDBPath, newSecret, newIter)
+	if err != nil {
+		return err
+	}
+	b.statusNode.SetWalletDB(b.walletDB)
+	b.recordDBOpenSecret("wallet", newSecret)
+	return nil
+}

--- a/pkg/backend/profile_secret.go
+++ b/pkg/backend/profile_secret.go
@@ -16,28 +16,34 @@ type profileSecretCache struct {
 	kekFingerprint []byte
 	dekHex         string
 	dbKdfIter      int
+
+	primaryFromPending bool // true when dekHex came from the pending envelope
+
+	pendingDekHex    string
+	pendingDbKdfIter int
+
+	dbAppOpenedWith    string
+	dbWalletOpenedWith string
+}
+
+// dbFallbackCredential is an alternative credential for opening a database (when the primary one fails).
+type dbFallbackCredential struct {
+	secret  string
+	kdfIter int
 }
 
 // resolvedProfileSecret is the outcome of translating a client-provided password into the secret.
 type resolvedProfileSecret struct {
-	secret    string
-	dbKdfIter int
-	migrated  bool // true when the profile uses the DEK encryption scheme.
-	// legacySecret/legacyKdfIter are here for the crash-recovery fallback
-	legacySecret  string
-	legacyKdfIter int
+	secret             string
+	dbKdfIter          int
+	migrated           bool                   // true when the profile uses the DEK encryption scheme.
+	primaryFromPending bool                   // true when the main envelope rejected the password and the secret came from the pending envelope instead.
+	fallbacks          []dbFallbackCredential // tried in order when a database fails to open with secret
 }
 
 // resolveProfileSecret translates (keyUID, password) into the secret used for the databases and keystore files.
 // It returns either the secret or password if the profile is not migrated and an error if the password is wrong.
 func (b *StatusBackend) resolveProfileSecret(keyUID, password string, kdfIterationsFallback int) (resolvedProfileSecret, error) {
-	legacy := resolvedProfileSecret{
-		secret:        password,
-		dbKdfIter:     kdfIterationsFallback,
-		legacySecret:  password,
-		legacyKdfIter: kdfIterationsFallback,
-	}
-
 	c := &b.secretCache
 	c.mu.Lock()
 	if c.keyUID == keyUID && c.dekHex != "" {
@@ -45,11 +51,15 @@ func (b *StatusBackend) resolveProfileSecret(keyUID, password string, kdfIterati
 		if subtle.ConstantTimeCompare(fingerprint[:], c.kekFingerprint) == 1 ||
 			subtle.ConstantTimeCompare([]byte(password), []byte(c.dekHex)) == 1 {
 			resolved := resolvedProfileSecret{
-				secret:        c.dekHex,
-				dbKdfIter:     c.dbKdfIter,
-				migrated:      true,
-				legacySecret:  password,
-				legacyKdfIter: kdfIterationsFallback,
+				secret:             c.dekHex,
+				dbKdfIter:          c.dbKdfIter,
+				migrated:           true,
+				primaryFromPending: c.primaryFromPending,
+				fallbacks:          []dbFallbackCredential{{secret: password, kdfIter: kdfIterationsFallback}},
+			}
+			if c.pendingDekHex != "" && c.pendingDekHex != c.dekHex {
+				resolved.fallbacks = append(resolved.fallbacks,
+					dbFallbackCredential{secret: c.pendingDekHex, kdfIter: c.pendingDbKdfIter})
 			}
 			c.mu.Unlock()
 			return resolved, nil
@@ -58,11 +68,29 @@ func (b *StatusBackend) resolveProfileSecret(keyUID, password string, kdfIterati
 	c.mu.Unlock()
 
 	if !envelope.Exists(b.rootDataDir, keyUID) {
-		return legacy, nil
+		return resolvedProfileSecret{
+			secret:    password,
+			dbKdfIter: kdfIterationsFallback,
+		}, nil
 	}
 
+	pendingDek, pendingIter := "", 0
+	if envelope.PendingExists(b.rootDataDir, keyUID) {
+		pendingDek, pendingIter, _ = envelope.UnwrapPending(b.rootDataDir, keyUID, password)
+	}
+
+	primary, primaryIter := "", 0
+	primaryFromPending := false
 	dekHex, dbKdfIter, err := envelope.Unwrap(b.rootDataDir, keyUID, password)
-	if err != nil {
+	if err == nil {
+		primary, primaryIter = dekHex, dbKdfIter
+	} else if pendingDek != "" {
+		// The main envelope rejects this password but the pending one accepts it, so the pending DEK is what the databases
+		// are encrypted with (mostly).
+		primary, primaryIter = pendingDek, pendingIter
+		primaryFromPending = true
+		pendingDek, pendingIter = "", 0
+	} else {
 		return resolvedProfileSecret{}, err
 	}
 
@@ -70,17 +98,25 @@ func (b *StatusBackend) resolveProfileSecret(keyUID, password string, kdfIterati
 	c.mu.Lock()
 	c.keyUID = keyUID
 	c.kekFingerprint = fingerprint[:]
-	c.dekHex = dekHex
-	c.dbKdfIter = dbKdfIter
+	c.dekHex = primary
+	c.dbKdfIter = primaryIter
+	c.primaryFromPending = primaryFromPending
+	c.pendingDekHex = pendingDek
+	c.pendingDbKdfIter = pendingIter
 	c.mu.Unlock()
 
-	return resolvedProfileSecret{
-		secret:        dekHex,
-		dbKdfIter:     dbKdfIter,
-		migrated:      true,
-		legacySecret:  password,
-		legacyKdfIter: kdfIterationsFallback,
-	}, nil
+	resolved := resolvedProfileSecret{
+		secret:             primary,
+		dbKdfIter:          primaryIter,
+		migrated:           true,
+		primaryFromPending: primaryFromPending,
+		fallbacks:          []dbFallbackCredential{{secret: password, kdfIter: kdfIterationsFallback}},
+	}
+	if pendingDek != "" && pendingDek != primary {
+		resolved.fallbacks = append(resolved.fallbacks,
+			dbFallbackCredential{secret: pendingDek, kdfIter: pendingIter})
+	}
+	return resolved, nil
 }
 
 // clearProfileSecretCache clears the cached secret.
@@ -91,7 +127,45 @@ func (b *StatusBackend) clearProfileSecretCache() {
 	c.kekFingerprint = nil
 	c.dekHex = ""
 	c.dbKdfIter = 0
+	c.primaryFromPending = false
+	c.pendingDekHex = ""
+	c.pendingDbKdfIter = 0
+	c.dbAppOpenedWith = ""
+	c.dbWalletOpenedWith = ""
 	c.mu.Unlock()
+}
+
+// refreshSecretCacheKEK updates the cached KEK fingerprint after the envelope was re-wrapped with
+// a new KEK (fast password change).
+func (b *StatusBackend) refreshSecretCacheKEK(keyUID, newKEK string) {
+	c := &b.secretCache
+	c.mu.Lock()
+	if c.keyUID == keyUID && c.dekHex != "" {
+		fingerprint := sha256.Sum256([]byte(newKEK))
+		c.kekFingerprint = fingerprint[:]
+	}
+	c.mu.Unlock()
+}
+
+// recordDBOpenSecret notes which secret successfully opened a database.
+func (b *StatusBackend) recordDBOpenSecret(dbName, secret string) {
+	c := &b.secretCache
+	c.mu.Lock()
+	switch dbName {
+	case "app":
+		c.dbAppOpenedWith = secret
+	case "wallet":
+		c.dbWalletOpenedWith = secret
+	}
+	c.mu.Unlock()
+}
+
+// dbOpenSecrets returns which secrets opened the app and wallet databases.
+func (b *StatusBackend) dbOpenSecrets() (app, wallet string) {
+	c := &b.secretCache
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.dbAppOpenedWith, c.dbWalletOpenedWith
 }
 
 // setSecretResolverForProfile points the accounts manager's keystore operations at this profile's secret resolution.

--- a/pkg/backend/profile_secret.go
+++ b/pkg/backend/profile_secret.go
@@ -168,6 +168,15 @@ func (b *StatusBackend) dbOpenSecrets() (app, wallet string) {
 	return c.dbAppOpenedWith, c.dbWalletOpenedWith
 }
 
+// ResolveKeystoreSecret translates a client-provided password into the secret the profile's keystore files are encrypted with
+func (b *StatusBackend) ResolveKeystoreSecret(keyUID, password string) (string, error) {
+	resolved, err := b.resolveProfileSecret(keyUID, password, 0)
+	if err != nil {
+		return "", err
+	}
+	return resolved.secret, nil
+}
+
 // setSecretResolverForProfile points the accounts manager's keystore operations at this profile's secret resolution.
 func (b *StatusBackend) setSecretResolverForProfile(keyUID string, kdfIterations int) {
 	b.accountsManager.SetSecretResolver(func(password string) (string, error) {

--- a/pkg/backend/profile_secret.go
+++ b/pkg/backend/profile_secret.go
@@ -1,0 +1,106 @@
+package backend
+
+import (
+	"crypto/sha256"
+	"crypto/subtle"
+	"sync"
+
+	"github.com/status-im/status-go/internal/accounts-management/keystore/envelope"
+)
+
+// profileSecretCache remembers the unwrapped DEK of the profile bound to the current session.
+// The KEK itself is not stored — only its sha256 fingerprint, enough to re-verify an incoming password.
+type profileSecretCache struct {
+	mu             sync.Mutex
+	keyUID         string
+	kekFingerprint []byte
+	dekHex         string
+	dbKdfIter      int
+}
+
+// resolvedProfileSecret is the outcome of translating a client-provided password into the secret.
+type resolvedProfileSecret struct {
+	secret    string
+	dbKdfIter int
+	migrated  bool // true when the profile uses the DEK encryption scheme.
+	// legacySecret/legacyKdfIter are here for the crash-recovery fallback
+	legacySecret  string
+	legacyKdfIter int
+}
+
+// resolveProfileSecret translates (keyUID, password) into the secret used for the databases and keystore files.
+// It returns either the secret or password if the profile is not migrated and an error if the password is wrong.
+func (b *StatusBackend) resolveProfileSecret(keyUID, password string, kdfIterationsFallback int) (resolvedProfileSecret, error) {
+	legacy := resolvedProfileSecret{
+		secret:        password,
+		dbKdfIter:     kdfIterationsFallback,
+		legacySecret:  password,
+		legacyKdfIter: kdfIterationsFallback,
+	}
+
+	c := &b.secretCache
+	c.mu.Lock()
+	if c.keyUID == keyUID && c.dekHex != "" {
+		fingerprint := sha256.Sum256([]byte(password))
+		if subtle.ConstantTimeCompare(fingerprint[:], c.kekFingerprint) == 1 ||
+			subtle.ConstantTimeCompare([]byte(password), []byte(c.dekHex)) == 1 {
+			resolved := resolvedProfileSecret{
+				secret:        c.dekHex,
+				dbKdfIter:     c.dbKdfIter,
+				migrated:      true,
+				legacySecret:  password,
+				legacyKdfIter: kdfIterationsFallback,
+			}
+			c.mu.Unlock()
+			return resolved, nil
+		}
+	}
+	c.mu.Unlock()
+
+	if !envelope.Exists(b.rootDataDir, keyUID) {
+		return legacy, nil
+	}
+
+	dekHex, dbKdfIter, err := envelope.Unwrap(b.rootDataDir, keyUID, password)
+	if err != nil {
+		return resolvedProfileSecret{}, err
+	}
+
+	fingerprint := sha256.Sum256([]byte(password))
+	c.mu.Lock()
+	c.keyUID = keyUID
+	c.kekFingerprint = fingerprint[:]
+	c.dekHex = dekHex
+	c.dbKdfIter = dbKdfIter
+	c.mu.Unlock()
+
+	return resolvedProfileSecret{
+		secret:        dekHex,
+		dbKdfIter:     dbKdfIter,
+		migrated:      true,
+		legacySecret:  password,
+		legacyKdfIter: kdfIterationsFallback,
+	}, nil
+}
+
+// clearProfileSecretCache clears the cached secret.
+func (b *StatusBackend) clearProfileSecretCache() {
+	c := &b.secretCache
+	c.mu.Lock()
+	c.keyUID = ""
+	c.kekFingerprint = nil
+	c.dekHex = ""
+	c.dbKdfIter = 0
+	c.mu.Unlock()
+}
+
+// setSecretResolverForProfile points the accounts manager's keystore operations at this profile's secret resolution.
+func (b *StatusBackend) setSecretResolverForProfile(keyUID string, kdfIterations int) {
+	b.accountsManager.SetSecretResolver(func(password string) (string, error) {
+		resolved, err := b.resolveProfileSecret(keyUID, password, kdfIterations)
+		if err != nil {
+			return "", err
+		}
+		return resolved.secret, nil
+	})
+}

--- a/pkg/backend/profile_secret.go
+++ b/pkg/backend/profile_secret.go
@@ -3,8 +3,10 @@ package backend
 import (
 	"crypto/sha256"
 	"crypto/subtle"
+	"errors"
 	"sync"
 
+	"github.com/status-im/status-go/internal/accounts-management/keystore"
 	"github.com/status-im/status-go/internal/accounts-management/keystore/envelope"
 )
 
@@ -177,13 +179,46 @@ func (b *StatusBackend) ResolveKeystoreSecret(keyUID, password string) (string, 
 	return resolved.secret, nil
 }
 
+// sessionSecret returns the cached profile secret (DEK) for keyUID, available while the profile is unlocked
+// in this session.
+func (b *StatusBackend) sessionSecret(keyUID string) (string, bool) {
+	c := &b.secretCache
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.keyUID == keyUID && c.dekHex != "" {
+		return c.dekHex, true
+	}
+	return "", false
+}
+
+// asKeystoreResolutionError keeps the pre-DEK error contract of the keystore operations: a password that
+// cannot unwrap the profile envelope is simply an incorrect password.
+func asKeystoreResolutionError(err error) error {
+	if errors.Is(err, envelope.ErrInvalidKEK) {
+		return keystore.ErrIncorrectPasswordProvided
+	}
+	return err
+}
+
 // setSecretResolverForProfile points the accounts manager's keystore operations at this profile's secret resolution.
 func (b *StatusBackend) setSecretResolverForProfile(keyUID string, kdfIterations int) {
 	b.accountsManager.SetSecretResolver(func(password string) (string, error) {
 		resolved, err := b.resolveProfileSecret(keyUID, password, kdfIterations)
 		if err != nil {
-			return "", err
+			return "", asKeystoreResolutionError(err)
 		}
 		return resolved.secret, nil
+	})
+	// Keystore writes must keep the directory uniformly encrypted with the profile secret. Clients may pass a
+	// password that is not the login password, so fall back to the session secret instead of failing.
+	b.accountsManager.SetWriteSecretResolver(func(password string) (string, error) {
+		resolved, err := b.resolveProfileSecret(keyUID, password, kdfIterations)
+		if err == nil {
+			return resolved.secret, nil
+		}
+		if secret, ok := b.sessionSecret(keyUID); ok {
+			return secret, nil
+		}
+		return "", asKeystoreResolutionError(err)
 	})
 }

--- a/pkg/backend/profile_secret_test.go
+++ b/pkg/backend/profile_secret_test.go
@@ -1,0 +1,173 @@
+package backend
+
+import (
+	"database/sql"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"github.com/status-im/status-go/internal/accounts-management/keystore/envelope"
+)
+
+const (
+	secretTestKeyUID   = "0xaabbccddeeff00112233445566778899aabbccddeeff001122334455667788aa"
+	secretTestPassword = "0x8a9f7d2b6c1e4f3a5d8b9c0e2f4a6b8d0c2e4f6a8b0d2c4e6f8a0b2d4c6e8f0a"
+)
+
+func newSecretTestBackend(t *testing.T) *StatusBackend {
+	t.Helper()
+	return &StatusBackend{
+		rootDataDir: t.TempDir(),
+		logger:      zap.NewNop(),
+	}
+}
+
+func TestResolveProfileSecretLegacyProfile(t *testing.T) {
+	b := newSecretTestBackend(t)
+
+	// No wrapped-DEK file: the password is the secret, untouched.
+	resolved, err := b.resolveProfileSecret(secretTestKeyUID, secretTestPassword, 256000)
+	require.NoError(t, err)
+	require.False(t, resolved.migrated)
+	require.Equal(t, secretTestPassword, resolved.secret)
+	require.Equal(t, 256000, resolved.dbKdfIter)
+}
+
+func TestResolveProfileSecretMigratedProfile(t *testing.T) {
+	b := newSecretTestBackend(t)
+
+	dek, err := envelope.Generate()
+	require.NoError(t, err)
+	require.NoError(t, envelope.Write(b.rootDataDir, secretTestKeyUID, dek, secretTestPassword, 3200))
+
+	resolved, err := b.resolveProfileSecret(secretTestKeyUID, secretTestPassword, 256000)
+	require.NoError(t, err)
+	require.True(t, resolved.migrated)
+	require.Equal(t, dek, resolved.secret)
+	require.Equal(t, 3200, resolved.dbKdfIter)
+	require.Equal(t, secretTestPassword, resolved.legacySecret)
+	require.Equal(t, 256000, resolved.legacyKdfIter)
+}
+
+func TestResolveProfileSecretWrongPassword(t *testing.T) {
+	b := newSecretTestBackend(t)
+
+	dek, err := envelope.Generate()
+	require.NoError(t, err)
+	require.NoError(t, envelope.Write(b.rootDataDir, secretTestKeyUID, dek, secretTestPassword, 3200))
+
+	_, err = b.resolveProfileSecret(secretTestKeyUID, "0xwrong", 256000)
+	require.ErrorIs(t, err, envelope.ErrInvalidKEK)
+
+	// A wrong password after a successful (cached) resolution must still fail.
+	_, err = b.resolveProfileSecret(secretTestKeyUID, secretTestPassword, 256000)
+	require.NoError(t, err)
+	_, err = b.resolveProfileSecret(secretTestKeyUID, "0xwrong", 256000)
+	require.ErrorIs(t, err, envelope.ErrInvalidKEK)
+}
+
+func TestResolveProfileSecretCache(t *testing.T) {
+	b := newSecretTestBackend(t)
+
+	dek, err := envelope.Generate()
+	require.NoError(t, err)
+	require.NoError(t, envelope.Write(b.rootDataDir, secretTestKeyUID, dek, secretTestPassword, 3200))
+
+	resolved, err := b.resolveProfileSecret(secretTestKeyUID, secretTestPassword, 256000)
+	require.NoError(t, err)
+	require.Equal(t, dek, resolved.secret)
+
+	// Remove the file: a cached resolution must still succeed (no disk access).
+	require.NoError(t, envelope.Remove(b.rootDataDir, secretTestKeyUID))
+	resolved, err = b.resolveProfileSecret(secretTestKeyUID, secretTestPassword, 256000)
+	require.NoError(t, err)
+	require.True(t, resolved.migrated)
+	require.Equal(t, dek, resolved.secret)
+
+	// Resolution is idempotent: passing the resolved secret back in returns it.
+	resolved, err = b.resolveProfileSecret(secretTestKeyUID, dek, 256000)
+	require.NoError(t, err)
+	require.Equal(t, dek, resolved.secret)
+
+	// After clearing the cache the profile is treated as legacy again
+	// (file was removed above).
+	b.clearProfileSecretCache()
+	resolved, err = b.resolveProfileSecret(secretTestKeyUID, secretTestPassword, 256000)
+	require.NoError(t, err)
+	require.False(t, resolved.migrated)
+	require.Equal(t, secretTestPassword, resolved.secret)
+}
+
+func TestResolveProfileSecretCacheIsPerProfile(t *testing.T) {
+	b := newSecretTestBackend(t)
+
+	dek, err := envelope.Generate()
+	require.NoError(t, err)
+	require.NoError(t, envelope.Write(b.rootDataDir, secretTestKeyUID, dek, secretTestPassword, 3200))
+
+	_, err = b.resolveProfileSecret(secretTestKeyUID, secretTestPassword, 256000)
+	require.NoError(t, err)
+
+	// Same password, different profile: must not hit the cache.
+	otherKeyUID := "0x99" + secretTestKeyUID[4:]
+	resolved, err := b.resolveProfileSecret(otherKeyUID, secretTestPassword, 256000)
+	require.NoError(t, err)
+	require.False(t, resolved.migrated)
+	require.Equal(t, secretTestPassword, resolved.secret)
+}
+
+func TestOpenDBWithCredsFallback(t *testing.T) {
+	b := newSecretTestBackend(t)
+
+	openErr := errors.New("file is not a database")
+
+	// Primary succeeds: fallback never attempted.
+	attempts := []string{}
+	db, err := b.openDBWithCredsFallback("app", dbCredentials{secret: "dek", kdfIter: 3200, fallbackSecret: "pw", fallbackKdfIter: 256000},
+		func(secret string, kdfIter int) (*sql.DB, error) {
+			attempts = append(attempts, secret)
+			return nil, nil
+		})
+	require.NoError(t, err)
+	require.Nil(t, db)
+	require.Equal(t, []string{"dek"}, attempts)
+
+	// Primary fails, fallback succeeds.
+	attempts = nil
+	_, err = b.openDBWithCredsFallback("app", dbCredentials{secret: "dek", kdfIter: 3200, fallbackSecret: "pw", fallbackKdfIter: 256000},
+		func(secret string, kdfIter int) (*sql.DB, error) {
+			attempts = append(attempts, secret)
+			if secret == "dek" {
+				return nil, openErr
+			}
+			return nil, nil
+		})
+	require.NoError(t, err)
+	require.Equal(t, []string{"dek", "pw"}, attempts)
+
+	// Both fail: the primary error is reported.
+	attempts = nil
+	fallbackErr := errors.New("also wrong")
+	_, err = b.openDBWithCredsFallback("app", dbCredentials{secret: "dek", kdfIter: 3200, fallbackSecret: "pw", fallbackKdfIter: 256000},
+		func(secret string, kdfIter int) (*sql.DB, error) {
+			attempts = append(attempts, secret)
+			if secret == "dek" {
+				return nil, openErr
+			}
+			return nil, fallbackErr
+		})
+	require.ErrorIs(t, err, openErr)
+	require.Equal(t, []string{"dek", "pw"}, attempts)
+
+	// No fallback credentials (legacy profile): single attempt.
+	attempts = nil
+	_, err = b.openDBWithCredsFallback("app", dbCredentials{secret: "pw", kdfIter: 256000},
+		func(secret string, kdfIter int) (*sql.DB, error) {
+			attempts = append(attempts, secret)
+			return nil, openErr
+		})
+	require.ErrorIs(t, err, openErr)
+	require.Equal(t, []string{"pw"}, attempts)
+}

--- a/pkg/backend/profile_secret_test.go
+++ b/pkg/backend/profile_secret_test.go
@@ -47,8 +47,7 @@ func TestResolveProfileSecretMigratedProfile(t *testing.T) {
 	require.True(t, resolved.migrated)
 	require.Equal(t, dek, resolved.secret)
 	require.Equal(t, 3200, resolved.dbKdfIter)
-	require.Equal(t, secretTestPassword, resolved.legacySecret)
-	require.Equal(t, 256000, resolved.legacyKdfIter)
+	require.Equal(t, []dbFallbackCredential{{secret: secretTestPassword, kdfIter: 256000}}, resolved.fallbacks)
 }
 
 func TestResolveProfileSecretWrongPassword(t *testing.T) {
@@ -122,10 +121,14 @@ func TestOpenDBWithCredsFallback(t *testing.T) {
 	b := newSecretTestBackend(t)
 
 	openErr := errors.New("file is not a database")
+	credsWithFallbacks := dbCredentials{secret: "dek", kdfIter: 3200, fallbacks: []dbFallbackCredential{
+		{secret: "pw", kdfIter: 256000},
+		{secret: "pendingdek", kdfIter: 3200},
+	}}
 
-	// Primary succeeds: fallback never attempted.
+	// Primary succeeds: fallbacks never attempted.
 	attempts := []string{}
-	db, err := b.openDBWithCredsFallback("app", dbCredentials{secret: "dek", kdfIter: 3200, fallbackSecret: "pw", fallbackKdfIter: 256000},
+	db, err := b.openDBWithCredsFallback("app", credsWithFallbacks,
 		func(secret string, kdfIter int) (*sql.DB, error) {
 			attempts = append(attempts, secret)
 			return nil, nil
@@ -133,33 +136,33 @@ func TestOpenDBWithCredsFallback(t *testing.T) {
 	require.NoError(t, err)
 	require.Nil(t, db)
 	require.Equal(t, []string{"dek"}, attempts)
+	usedApp, _ := b.dbOpenSecrets()
+	require.Equal(t, "dek", usedApp)
 
-	// Primary fails, fallback succeeds.
+	// Primary fails, second fallback succeeds; the winning secret is recorded.
 	attempts = nil
-	_, err = b.openDBWithCredsFallback("app", dbCredentials{secret: "dek", kdfIter: 3200, fallbackSecret: "pw", fallbackKdfIter: 256000},
+	_, err = b.openDBWithCredsFallback("app", credsWithFallbacks,
 		func(secret string, kdfIter int) (*sql.DB, error) {
 			attempts = append(attempts, secret)
-			if secret == "dek" {
-				return nil, openErr
+			if secret == "pendingdek" {
+				return nil, nil
 			}
-			return nil, nil
+			return nil, openErr
 		})
 	require.NoError(t, err)
-	require.Equal(t, []string{"dek", "pw"}, attempts)
+	require.Equal(t, []string{"dek", "pw", "pendingdek"}, attempts)
+	usedApp, _ = b.dbOpenSecrets()
+	require.Equal(t, "pendingdek", usedApp)
 
-	// Both fail: the primary error is reported.
+	// All fail: the primary error is reported.
 	attempts = nil
-	fallbackErr := errors.New("also wrong")
-	_, err = b.openDBWithCredsFallback("app", dbCredentials{secret: "dek", kdfIter: 3200, fallbackSecret: "pw", fallbackKdfIter: 256000},
+	_, err = b.openDBWithCredsFallback("app", credsWithFallbacks,
 		func(secret string, kdfIter int) (*sql.DB, error) {
 			attempts = append(attempts, secret)
-			if secret == "dek" {
-				return nil, openErr
-			}
-			return nil, fallbackErr
+			return nil, errors.New("wrong key: " + secret)
 		})
-	require.ErrorIs(t, err, openErr)
-	require.Equal(t, []string{"dek", "pw"}, attempts)
+	require.ErrorContains(t, err, "wrong key: dek")
+	require.Equal(t, []string{"dek", "pw", "pendingdek"}, attempts)
 
 	// No fallback credentials (legacy profile): single attempt.
 	attempts = nil

--- a/pkg/services/pairing/common.go
+++ b/pkg/services/pairing/common.go
@@ -12,6 +12,8 @@ import (
 
 	"github.com/status-im/status-go/internal/accounts-management/common"
 	"github.com/status-im/status-go/internal/accounts-management/generator"
+	"github.com/status-im/status-go/internal/accounts-management/keystore"
+	"github.com/status-im/status-go/internal/accounts-management/keystore/envelope"
 	"github.com/status-im/status-go/internal/protocol/requests"
 	"github.com/status-im/status-go/pkg/backend"
 
@@ -55,6 +57,40 @@ func validateKeys(keys map[string][]byte, password string) error {
 		}
 	}
 
+	return nil
+}
+
+// rootDataDirFromKeystorePath derives the root data dir from a profile keystore path
+// which is either `<root>/keystore/<keyUID>` or `<root>/keystore`
+func rootDataDirFromKeystorePath(keystorePath, keyUID string) string {
+	keystorePath = strings.TrimRight(keystorePath, "/\\")
+	if filepath.Base(keystorePath) == keyUID {
+		return filepath.Dir(filepath.Dir(keystorePath))
+	}
+	return filepath.Dir(keystorePath)
+}
+
+// prepareKeysForTransfer re-encrypts loaded keystore files in memory from the profile's DEK to the transfer password
+// when the profile uses the DEK encryption scheme. The local-pairing wire format therefore stays password-encrypted,
+// compatible with receivers of any version. No-op for legacy profiles.
+func prepareKeysForTransfer(keys map[string][]byte, keystorePath, keyUID, password string) error {
+	rootDataDir := rootDataDirFromKeystorePath(keystorePath, keyUID)
+	if !envelope.Exists(rootDataDir, keyUID) {
+		return nil
+	}
+
+	dek, _, err := envelope.Unwrap(rootDataDir, keyUID, password)
+	if err != nil {
+		return err
+	}
+
+	for name, rawKey := range keys {
+		reEncrypted, err := keystore.ReEncryptRawKey(rawKey, dek, password)
+		if err != nil {
+			return fmt.Errorf("failed to re-encrypt keystore file %s for transfer: %w", name, err)
+		}
+		keys[name] = reEncrypted
+	}
 	return nil
 }
 
@@ -112,7 +148,16 @@ func validateAndVerifyPassword(s interface{}, senderConfig *SenderConfig) error 
 		return err
 	}
 
-	return validateKeys(keys, senderConfig.Password)
+	secret := senderConfig.Password
+	rootDataDir := rootDataDirFromKeystorePath(senderConfig.KeystorePath, senderConfig.KeyUID)
+	if envelope.Exists(rootDataDir, senderConfig.KeyUID) {
+		secret, _, err = envelope.Unwrap(rootDataDir, senderConfig.KeyUID, senderConfig.Password)
+		if err != nil {
+			return err
+		}
+	}
+
+	return validateKeys(keys, secret)
 }
 
 func validateReceiverConfig(s interface{}, receiverConfig *ReceiverConfig) error {

--- a/pkg/services/pairing/dek_transfer_test.go
+++ b/pkg/services/pairing/dek_transfer_test.go
@@ -1,0 +1,261 @@
+package pairing
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	ethcrypto "github.com/ethereum/go-ethereum/crypto"
+
+	accsmanagementcommon "github.com/status-im/status-go/internal/accounts-management/common"
+	keystorepkg "github.com/status-im/status-go/internal/accounts-management/keystore"
+	"github.com/status-im/status-go/internal/accounts-management/keystore/envelope"
+	"github.com/status-im/status-go/internal/db/multiaccounts"
+	"github.com/status-im/status-go/internal/db/sqlite"
+	"github.com/status-im/status-go/internal/protocol/requests"
+	"github.com/status-im/status-go/pkg/backend"
+)
+
+const (
+	dekTransferKeyUID   = "0x1122334455667788990011223344556677889900112233445566778899001122"
+	dekTransferPassword = "0xtransfer-password"
+)
+
+// prepareSenderProfileOnDisk creates a sender profile on disk: a keystore dir with one key
+// file encrypted with keystoreSecret, and (when migrated) an envelope wrapping keystoreSecret
+// as the DEK. Returns the sender config for an AccountPayloadLoader.
+func prepareSenderProfileOnDisk(t *testing.T, rootDataDir, keystoreSecret string, migrated bool) *SenderConfig {
+	t.Helper()
+
+	keystorePath := filepath.Join(rootDataDir, backend.DefaultKeystoreRelativePath, dekTransferKeyUID)
+	adapter, err := keystorepkg.NewGethKeystoreAdapter(keystorePath)
+	require.NoError(t, err)
+
+	privateKey, err := ethcrypto.GenerateKey()
+	require.NoError(t, err)
+	_, err = adapter.ImportECDSA(privateKey, keystoreSecret)
+	require.NoError(t, err)
+
+	if migrated {
+		require.NoError(t, envelope.Write(rootDataDir, dekTransferKeyUID, keystoreSecret, dekTransferPassword, sqlite.ReducedKDFIterationsNumber))
+	}
+
+	db, err := multiaccounts.InitializeDB(filepath.Join(rootDataDir, "accounts.sql"))
+	require.NoError(t, err)
+	require.NoError(t, db.SaveAccount(multiaccounts.Account{
+		Name:          "sender",
+		KeyUID:        dekTransferKeyUID,
+		KDFIterations: sqlite.ReducedKDFIterationsNumber,
+	}))
+
+	return &SenderConfig{
+		KeystorePath: keystorePath,
+		KeyUID:       dekTransferKeyUID,
+		Password:     dekTransferPassword,
+		DeviceType:   "desktop",
+		DB:           db,
+	}
+}
+
+// storePayloadOnReceiver runs the receiver side (AccountPayloadStorer) on the payload and
+// returns the receiver's profile keystore path and multiaccounts DB.
+func storePayloadOnReceiver(t *testing.T, p *AccountPayload, rootDataDir string) (string, *multiaccounts.Database) {
+	t.Helper()
+
+	db, err := multiaccounts.InitializeDB(filepath.Join(rootDataDir, "accounts.sql"))
+	require.NoError(t, err)
+
+	storer, err := NewAccountPayloadStorer(p, &ReceiverConfig{
+		CreateAccount: &requests.CreateAccount{
+			RootDataDir:   rootDataDir,
+			KdfIterations: 256000, // legacy default coming from an (old) client
+		},
+		DB: db,
+	})
+	require.NoError(t, err)
+	require.NoError(t, storer.Store())
+
+	return filepath.Join(rootDataDir, backend.DefaultKeystoreRelativePath, dekTransferKeyUID), db
+}
+
+func requireReceiverAdoptedDEK(t *testing.T, rootDataDir, receiverKeystorePath string, db *multiaccounts.Database, senderSecret string) {
+	t.Helper()
+
+	// The receiver generated its own DEK, wrapped with the transfer password.
+	require.True(t, envelope.Exists(rootDataDir, dekTransferKeyUID))
+	receiverDek, dekIter, err := envelope.Unwrap(rootDataDir, dekTransferKeyUID, dekTransferPassword)
+	require.NoError(t, err)
+	require.Equal(t, sqlite.ReducedKDFIterationsNumber, dekIter)
+	require.NotEqual(t, senderSecret, receiverDek)
+
+	// The stored keystore files are encrypted with the receiver's DEK — not the password.
+	require.NoError(t, keystorepkg.VerifyKeyStoreDirAtPath(receiverKeystorePath, receiverDek))
+	require.Error(t, keystorepkg.VerifyKeyStoreDirAtPath(receiverKeystorePath, dekTransferPassword))
+
+	// The saved account uses reduced kdf iterations (high-entropy DEK).
+	kdfIterations, err := db.GetAccountKDFIterationsNumber(dekTransferKeyUID)
+	require.NoError(t, err)
+	require.Equal(t, sqlite.ReducedKDFIterationsNumber, kdfIterations)
+}
+
+// TestAccountPayloadTransferFromMigratedSender covers the migrated-sender → new-receiver
+// account transfer: the sender re-encrypts its DEK-encrypted keystore files to the transfer
+// password (the wire format, understood by receivers of ANY version — this is the
+// new-sender → old-receiver compatibility guarantee), and the receiver adopts a fresh
+// device-local DEK.
+func TestAccountPayloadTransferFromMigratedSender(t *testing.T) {
+	senderRoot := t.TempDir()
+	senderDek, err := envelope.Generate()
+	require.NoError(t, err)
+	senderConfig := prepareSenderProfileOnDisk(t, senderRoot, senderDek, true)
+
+	p := new(AccountPayload)
+	loader, err := NewAccountPayloadLoader(p, senderConfig)
+	require.NoError(t, err)
+	require.NoError(t, loader.Load())
+
+	// Wire format: every transferred key decrypts with the plain transfer password.
+	require.NotEmpty(t, p.keys)
+	for _, rawKey := range p.keys {
+		_, err := accsmanagementcommon.DecryptKey(rawKey, dekTransferPassword)
+		require.NoError(t, err)
+	}
+
+	// Sender's on-disk keystore is untouched (still DEK-encrypted).
+	require.NoError(t, keystorepkg.VerifyKeyStoreDirAtPath(senderConfig.KeystorePath, senderDek))
+
+	receiverRoot := t.TempDir()
+	receiverKeystorePath, receiverDB := storePayloadOnReceiver(t, p, receiverRoot)
+	requireReceiverAdoptedDEK(t, receiverRoot, receiverKeystorePath, receiverDB, senderDek)
+}
+
+// TestAccountPayloadTransferFromLegacySender covers the legacy-sender → new-receiver
+// account transfer (an old app pairing to a new one): the wire format is unchanged and the
+// receiver still adopts the DEK scheme.
+func TestAccountPayloadTransferFromLegacySender(t *testing.T) {
+	senderRoot := t.TempDir()
+	// legacy: keystore files are encrypted directly with the password, no envelope
+	senderConfig := prepareSenderProfileOnDisk(t, senderRoot, dekTransferPassword, false)
+
+	p := new(AccountPayload)
+	loader, err := NewAccountPayloadLoader(p, senderConfig)
+	require.NoError(t, err)
+	require.NoError(t, loader.Load())
+
+	require.NotEmpty(t, p.keys)
+	for _, rawKey := range p.keys {
+		_, err := accsmanagementcommon.DecryptKey(rawKey, dekTransferPassword)
+		require.NoError(t, err)
+	}
+
+	receiverRoot := t.TempDir()
+	receiverKeystorePath, receiverDB := storePayloadOnReceiver(t, p, receiverRoot)
+	requireReceiverAdoptedDEK(t, receiverRoot, receiverKeystorePath, receiverDB, dekTransferPassword)
+}
+
+// TestAccountPayloadStoreRetryAfterFailure verifies that a failure after the keystore
+// directory was created (here: saving the account row into a closed multiaccounts DB)
+// cleans up the new-profile state, so the pairing can be retried from scratch.
+func TestAccountPayloadStoreRetryAfterFailure(t *testing.T) {
+	senderRoot := t.TempDir()
+	senderConfig := prepareSenderProfileOnDisk(t, senderRoot, dekTransferPassword, false)
+
+	p := new(AccountPayload)
+	loader, err := NewAccountPayloadLoader(p, senderConfig)
+	require.NoError(t, err)
+	require.NoError(t, loader.Load())
+
+	receiverRoot := t.TempDir()
+	brokenDB, err := multiaccounts.InitializeDB(filepath.Join(receiverRoot, "accounts.sql"))
+	require.NoError(t, err)
+	require.NoError(t, brokenDB.Close())
+
+	storer, err := NewAccountPayloadStorer(p, &ReceiverConfig{
+		CreateAccount: &requests.CreateAccount{
+			RootDataDir:   receiverRoot,
+			KdfIterations: 256000,
+		},
+		DB: brokenDB,
+	})
+	require.NoError(t, err)
+	require.Error(t, storer.Store(), "storing the account row must fail on the closed DB")
+
+	// The new-profile state was cleaned up: no keystore dir, no envelope.
+	profileKeystorePath := filepath.Join(receiverRoot, backend.DefaultKeystoreRelativePath, dekTransferKeyUID)
+	_, statErr := os.Stat(profileKeystorePath)
+	require.True(t, os.IsNotExist(statErr))
+	require.False(t, envelope.Exists(receiverRoot, dekTransferKeyUID))
+
+	// A retry with a working DB succeeds end to end.
+	receiverKeystorePath, receiverDB := storePayloadOnReceiver(t, p, receiverRoot)
+	requireReceiverAdoptedDEK(t, receiverRoot, receiverKeystorePath, receiverDB, dekTransferPassword)
+}
+
+// TestAccountPayloadStoreRetryAfterKeyWriteFailure verifies that a key-file write failure
+// inside storeKeys removes the profile directory this attempt created (storeKeys itself only
+// empties it), keeping the pairing retryable.
+func TestAccountPayloadStoreRetryAfterKeyWriteFailure(t *testing.T) {
+	senderRoot := t.TempDir()
+	senderConfig := prepareSenderProfileOnDisk(t, senderRoot, dekTransferPassword, false)
+
+	p := new(AccountPayload)
+	loader, err := NewAccountPayloadLoader(p, senderConfig)
+	require.NoError(t, err)
+	require.NoError(t, loader.Load())
+
+	// Inject a valid key under an unwritable name (nested path) to make its write fail.
+	for name, data := range p.keys {
+		p.keys["unwritable/"+name] = data
+		break
+	}
+
+	receiverRoot := t.TempDir()
+	db, err := multiaccounts.InitializeDB(filepath.Join(receiverRoot, "accounts.sql"))
+	require.NoError(t, err)
+
+	storer, err := NewAccountPayloadStorer(p, &ReceiverConfig{
+		CreateAccount: &requests.CreateAccount{
+			RootDataDir:   receiverRoot,
+			KdfIterations: 256000,
+		},
+		DB: db,
+	})
+	require.NoError(t, err)
+	require.Error(t, storer.Store(), "writing the injected key file must fail")
+
+	// The directory created by this attempt is gone, so the retry starts from scratch.
+	profileKeystorePath := filepath.Join(receiverRoot, backend.DefaultKeystoreRelativePath, dekTransferKeyUID)
+	_, statErr := os.Stat(profileKeystorePath)
+	require.True(t, os.IsNotExist(statErr))
+	require.False(t, envelope.Exists(receiverRoot, dekTransferKeyUID))
+
+	// A retry without the bad entry succeeds end to end.
+	for name := range p.keys {
+		if strings.HasPrefix(name, "unwritable/") {
+			delete(p.keys, name)
+		}
+	}
+	receiverKeystorePath, receiverDB := storePayloadOnReceiver(t, p, receiverRoot)
+	requireReceiverAdoptedDEK(t, receiverRoot, receiverKeystorePath, receiverDB, dekTransferPassword)
+}
+
+// TestValidateAndVerifyPasswordMigratedSender ensures the sender-side config validation
+// accepts a migrated profile (whose keystore no longer decrypts with the raw password).
+func TestValidateAndVerifyPasswordMigratedSender(t *testing.T) {
+	senderRoot := t.TempDir()
+	senderDek, err := envelope.Generate()
+	require.NoError(t, err)
+	senderConfig := prepareSenderProfileOnDisk(t, senderRoot, senderDek, true)
+
+	err = validateAndVerifyPassword(&SenderServerConfig{SenderConfig: senderConfig, ServerConfig: new(ServerConfig)}, senderConfig)
+	require.NoError(t, err)
+
+	// A wrong password must still be rejected.
+	wrongConfig := *senderConfig
+	wrongConfig.Password = "0xwrong-password"
+	err = validateAndVerifyPassword(&SenderServerConfig{SenderConfig: &wrongConfig, ServerConfig: new(ServerConfig)}, &wrongConfig)
+	require.Error(t, err)
+}

--- a/pkg/services/pairing/payload_management_test.go
+++ b/pkg/services/pairing/payload_management_test.go
@@ -14,6 +14,8 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
+	"github.com/status-im/status-go/internal/accounts-management/keystore"
+	"github.com/status-im/status-go/internal/accounts-management/keystore/envelope"
 	"github.com/status-im/status-go/internal/db/dbsetup"
 	"github.com/status-im/status-go/internal/db/multiaccounts"
 	"github.com/status-im/status-go/internal/httpserver/servertest"
@@ -330,19 +332,30 @@ func (pms *PayloadMarshallerSuite) TestPayloadMarshaller_StorePayloads() {
 	pms.Require().NoError(err)
 
 	// TEST PairingPayloadRepository 2 Store()
-	keys := getFiles(pms.T(), filepath.Join(pms.config2.AbsoluteKeystorePath(), keyUID))
-
-	pms.Require().Len(keys, 2)
-	pms.Require().Len(keys[pk1fileName], 489)
-	pms.Require().Len(keys[pk2fileName], 489)
+	// The wire payload preserves the sender's password-encrypted file bytes...
+	pms.Require().Len(pp2.keys, 2)
+	pms.Require().Len(pp2.keys[pk1fileName], 489)
+	pms.Require().Len(pp2.keys[pk2fileName], 489)
 
 	h1 := sha256.New()
-	h1.Write(keys[pk1fileName])
+	h1.Write(pp2.keys[pk1fileName])
 	pms.Require().Exactly(account1Hash, h1.Sum(nil))
 
 	h2 := sha256.New()
-	h2.Write(keys[pk2fileName])
+	h2.Write(pp2.keys[pk2fileName])
 	pms.Require().Exactly(account2Hash, h2.Sum(nil))
+
+	// ...while the receiver stores them re-encrypted with its freshly adopted DEK.
+	profileKeystorePath := filepath.Join(pms.config2.AbsoluteKeystorePath(), keyUID)
+	keys := getFiles(pms.T(), profileKeystorePath)
+	pms.Require().Len(keys, 2)
+
+	receiverRootDataDir := pms.config2.CreateAccount.RootDataDir
+	pms.Require().True(envelope.Exists(receiverRootDataDir, keyUID))
+	receiverDek, _, err := envelope.Unwrap(receiverRootDataDir, keyUID, password)
+	pms.Require().NoError(err)
+	pms.Require().NoError(keystore.VerifyKeyStoreDirAtPath(profileKeystorePath, receiverDek))
+	pms.Require().Error(keystore.VerifyKeyStoreDirAtPath(profileKeystorePath, password))
 
 	acc, err := pms.config2.DB.GetAccount(keyUID)
 	pms.Require().NoError(err)

--- a/pkg/services/pairing/payload_mounter.go
+++ b/pkg/services/pairing/payload_mounter.go
@@ -123,6 +123,12 @@ func (apl *AccountPayloadLoader) Load() error {
 		return err
 	}
 
+	// migrated profiles transfer their keystore files password-encrypted (wire format)
+	err = prepareKeysForTransfer(apl.keys, apl.keystorePath, apl.keyUID, apl.password)
+	if err != nil {
+		return err
+	}
+
 	err = validateKeys(apl.keys, apl.password)
 	if err != nil {
 		return err
@@ -333,6 +339,12 @@ func (kfpl *KeystoreFilesPayloadLoader) Load() error {
 	}
 
 	kfpl.keys = filteredMap
+
+	// migrated profiles transfer their keystore files password-encrypted (wire format)
+	err = prepareKeysForTransfer(kfpl.keys, kfpl.keystorePath, kfpl.loggedInKeyUID, kfpl.password)
+	if err != nil {
+		return err
+	}
 
 	return validateKeys(kfpl.keys, kfpl.password)
 }

--- a/pkg/services/pairing/payload_receiver.go
+++ b/pkg/services/pairing/payload_receiver.go
@@ -10,8 +10,11 @@ import (
 	"go.uber.org/multierr"
 	"go.uber.org/zap"
 
+	keystorepkg "github.com/status-im/status-go/internal/accounts-management/keystore"
+	"github.com/status-im/status-go/internal/accounts-management/keystore/envelope"
 	accsmanagementtypes "github.com/status-im/status-go/internal/accounts-management/types"
 	"github.com/status-im/status-go/internal/db/multiaccounts"
+	"github.com/status-im/status-go/internal/db/sqlite"
 	"github.com/status-im/status-go/internal/protocol/requests"
 	"github.com/status-im/status-go/internal/signal"
 	"github.com/status-im/status-go/pkg/backend"
@@ -151,7 +154,13 @@ func (aps *AccountPayloadStorer) Store() error {
 		return err
 	}
 
+	_, profileDirStatErr := os.Stat(aps.profileKeystorePathFor(keyUID))
+	profileDirExistedBefore := profileDirStatErr == nil
+
 	if err = aps.storeKeys(aps.keystorePath); err != nil && err != ErrKeyFileAlreadyExists {
+		if !profileDirExistedBefore {
+			aps.cleanupProfileState(keyUID)
+		}
 		return err
 	}
 
@@ -164,7 +173,68 @@ func (aps *AccountPayloadStorer) Store() error {
 		}
 		return nil
 	}
-	return aps.storeMultiAccount()
+
+	// A brand-new profile on this device adopts the DEK encryption scheme right away, so the first login creates the databases
+	// under a device-local DEK. The transferred keystore files (password-encrypted wire format) are re-encrypted to the DEK.
+	if err := aps.adoptDEKScheme(keyUID); err != nil {
+		aps.cleanupProfileState(keyUID)
+		return err
+	}
+
+	if err := aps.storeMultiAccount(); err != nil {
+		aps.cleanupProfileState(keyUID)
+		return err
+	}
+	return nil
+}
+
+// profileKeystorePathFor returns the profile keystore directory for the given keyUID.
+func (aps *AccountPayloadStorer) profileKeystorePathFor(keyUID string) string {
+	path := aps.keystorePath
+	if filepath.Base(strings.TrimRight(path, "/\\")) == backend.DefaultKeystoreRelativePath {
+		path = filepath.Join(path, keyUID)
+	}
+	return path
+}
+
+// cleanupProfileState removes the state created for a profile with passed keyUID
+func (aps *AccountPayloadStorer) cleanupProfileState(keyUID string) {
+	profileKeystorePath := aps.profileKeystorePathFor(keyUID)
+	rootDataDir := rootDataDirFromKeystorePath(profileKeystorePath, keyUID)
+	_ = envelope.Remove(rootDataDir, keyUID)
+	_ = os.RemoveAll(profileKeystorePath)
+	_ = os.RemoveAll(profileKeystorePath + "-backup")
+	_ = os.RemoveAll(profileKeystorePath + "-re-encrypted")
+}
+
+func (aps *AccountPayloadStorer) adoptDEKScheme(keyUID string) error {
+	profileKeystorePath := aps.profileKeystorePathFor(keyUID)
+	rootDataDir := rootDataDirFromKeystorePath(profileKeystorePath, keyUID)
+
+	dek, err := envelope.Generate()
+	if err != nil {
+		return err
+	}
+	if err := envelope.Write(rootDataDir, keyUID, dek, aps.password, sqlite.ReducedKDFIterationsNumber); err != nil {
+		return err
+	}
+
+	if err := keystorepkg.ReEncryptKeyStoreDirAtPath(profileKeystorePath, aps.password, dek); err != nil {
+		if verifyErr := keystorepkg.VerifyKeyStoreDirAtPath(profileKeystorePath, dek); verifyErr == nil {
+			// fully on the DEK - the adoption effectively succeeded
+			aps.kdfIterations = sqlite.ReducedKDFIterationsNumber
+			return nil
+		}
+		if verifyErr := keystorepkg.VerifyKeyStoreDirAtPath(profileKeystorePath, aps.password); verifyErr == nil {
+			// untouched - drop the envelope and leave the profile legacy
+			_ = envelope.Remove(rootDataDir, keyUID)
+			return nil
+		}
+		return err
+	}
+
+	aps.kdfIterations = sqlite.ReducedKDFIterationsNumber
+	return nil
 }
 
 func (aps *AccountPayloadStorer) storeKeys(keyStorePath string) error {
@@ -455,6 +525,13 @@ func (kfps *KeystoreFilesPayloadStorer) storeKeys(keyStorePath string) error {
 		}
 	}
 
+	// When the logged-in profile uses the DEK encryption scheme, the received files (password-encrypted wire format)
+	// must be stored under the profile's keystore secret
+	storeSecret, err := kfps.backend.ResolveKeystoreSecret(kfps.loggedInKeyUID, kfps.password)
+	if err != nil {
+		return err
+	}
+
 	for name, data := range kfps.keys {
 		address := ""
 		for _, key := range kfps.expectedKeystoreFilesToReceive {
@@ -474,6 +551,13 @@ func (kfps *KeystoreFilesPayloadStorer) storeKeys(keyStorePath string) error {
 		}
 		if exists {
 			continue
+		}
+
+		if storeSecret != kfps.password {
+			data, err = keystorepkg.ReEncryptRawKey(data, kfps.password, storeSecret)
+			if err != nil {
+				return fmt.Errorf("failed to re-encrypt received keystore file %s: %w", name, err)
+			}
 		}
 
 		err = ioutil.WriteFile(filepath.Join(keyStorePath, name), data, 0600)

--- a/pkg/services/pairing/sync_device_test.go
+++ b/pkg/services/pairing/sync_device_test.go
@@ -15,9 +15,12 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	accsmanagementcommon "github.com/status-im/status-go/internal/accounts-management/common"
+	keystorepkg "github.com/status-im/status-go/internal/accounts-management/keystore"
+	"github.com/status-im/status-go/internal/accounts-management/keystore/envelope"
 	accsmanagementtypes "github.com/status-im/status-go/internal/accounts-management/types"
 	"github.com/status-im/status-go/internal/crypto/types"
 	"github.com/status-im/status-go/internal/db/dbsetup"
+	"github.com/status-im/status-go/internal/db/sqlite"
 	"github.com/status-im/status-go/internal/protocol"
 	"github.com/status-im/status-go/internal/protocol/common"
 	"github.com/status-im/status-go/internal/protocol/requests"
@@ -105,6 +108,30 @@ func (s *SyncDeviceSuite) prepareBackendWithoutAccount(tmpdir string) *backend.S
 	backend := backend.NewStatusBackend(s.logger)
 	backend.UpdateRootDataDir(tmpdir)
 	return backend
+}
+
+func (s *SyncDeviceSuite) reEncryptDBInPlace(path, oldKey string, oldIter int, newKey string, newIter int) {
+	tmpPath := path + ".reencrypted"
+	require.NoError(s.T(), sqlite.ExportDBWithKDFChange(path, oldKey, oldIter, tmpPath, newKey, newIter, nil, nil))
+	require.NoError(s.T(), os.Rename(tmpPath, path))
+	_ = os.Remove(path + "-wal")
+	_ = os.Remove(path + "-shm")
+}
+
+// demigrateBackend converts a logged-in DEK-native backend to the legacy encryption scheme
+// (as if the profile had been created by an older app version) and logs it back in.
+func (s *SyncDeviceSuite) demigrateBackend(b *backend.StatusBackend, tmpdir, keyUID string) {
+	require.NoError(s.T(), b.Logout())
+
+	dek, dekIter, err := envelope.Unwrap(tmpdir, keyUID, s.password)
+	require.NoError(s.T(), err)
+
+	s.reEncryptDBInPlace(filepath.Join(tmpdir, keyUID+"-v4.db"), dek, dekIter, s.password, dbsetup.ReducedKDFIterationsNumber)
+	s.reEncryptDBInPlace(filepath.Join(tmpdir, keyUID+"-wallet.db"), dek, dekIter, s.password, dbsetup.ReducedKDFIterationsNumber)
+	require.NoError(s.T(), keystorepkg.ReEncryptKeyStoreDirAtPath(filepath.Join(tmpdir, backend.DefaultKeystoreRelativePath, keyUID), dek, s.password))
+	require.NoError(s.T(), envelope.Remove(tmpdir, keyUID))
+
+	require.NoError(s.T(), b.LoginAccount(&requests.Login{KeyUID: keyUID, Password: s.password}))
 }
 
 func containsKeystoreFile(directory, key string) bool {
@@ -249,6 +276,13 @@ func (s *SyncDeviceSuite) TestTransferringKeystoreFiles() {
 	err = accountsManager.ReloadKeystore()
 	require.NoError(s.T(), err)
 
+	// both backends are DEK-native (created by this version): the received files must be
+	// stored under the client's DEK, not the raw password (the manager's raw-password
+	// fallback would mask that, so check the files directly)
+	clientDek, _, err := envelope.Unwrap(clientTmpDir, clientActiveAccount.KeyUID, s.password)
+	require.NoError(s.T(), err)
+	require.NoError(s.T(), keystorepkg.VerifyKeyStoreDirAtPath(clientKeystorePath, clientDek))
+
 	// check keystore on client
 	genAcc, err := accountsManager.LoadAccount(types.HexToAddress(clientSeedPhraseKp.DerivedFrom), s.password)
 	require.NoError(s.T(), err)
@@ -262,6 +296,124 @@ func (s *SyncDeviceSuite) TestTransferringKeystoreFiles() {
 		accInfo := genAcc.ToIdentifiedAccountInfo()
 		require.Equal(s.T(), acc.Address.String(), accInfo.Address)
 	}
+}
+
+// TestTransferringKeystoreFilesFromLegacySender covers the KeystoreFilesPayload flow with a
+// LEGACY sender (an old app version) and a DEK-native receiver: the wire format is unchanged
+// and the receiver stores the files under its own DEK.
+func (s *SyncDeviceSuite) TestTransferringKeystoreFilesFromLegacySender() {
+	ctx := context.TODO()
+
+	serverTmpDir := filepath.Join(s.tmpdir, "server")
+	serverBackend := s.prepareBackendWithAccount(profileKeypairMnemonic, serverTmpDir)
+
+	clientTmpDir := filepath.Join(s.tmpdir, "client")
+	clientBackend := s.prepareBackendWithAccount(profileKeypairMnemonic, clientTmpDir)
+	defer func() {
+		require.NoError(s.T(), clientBackend.Logout())
+		require.NoError(s.T(), serverBackend.Logout())
+	}()
+
+	serverActiveAccount, err := serverBackend.GetActiveAccount()
+	require.NoError(s.T(), err)
+	clientActiveAccount, err := clientBackend.GetActiveAccount()
+	require.NoError(s.T(), err)
+	require.True(s.T(), serverActiveAccount.KeyUID == clientActiveAccount.KeyUID)
+
+	// Bring the server profile back to the legacy scheme, as an older app version would have it.
+	s.demigrateBackend(serverBackend, serverTmpDir, serverActiveAccount.KeyUID)
+
+	serverBackend.Messenger().SetLocalPairing(true)
+	clientBackend.Messenger().SetLocalPairing(true)
+
+	serverAccountsAPI := serverBackend.StatusNode().AccountService().APIs()[1].Service.(*accservice.API)
+	walletAccounts := &accsmanagementtypes.AccountCreationDetails{
+		Path:    accsmanagementcommon.PathDefaultWalletAccount,
+		Name:    "Default Wallet Account",
+		Emoji:   "💰",
+		ColorID: "primary",
+	}
+	serverSeedPhraseKp, err := serverAccountsAPI.AddKeypairViaSeedPhrase(ctx, seedKeypairMnemonic, s.password, "Seed Phrase Keypair", accsmanagementtypes.ColdWalletTypeNone, walletAccounts)
+	require.NoError(s.T(), err, "saving seed phrase keypair on legacy server with keystore files created")
+
+	clientAccountsAPI := clientBackend.StatusNode().AccountService().APIs()[1].Service.(*accservice.API)
+	clientSeedPhraseKp, err := clientAccountsAPI.AddKeypairViaSeedPhrase(ctx, seedKeypairMnemonic, s.password, "Seed Phrase Keypair", accsmanagementtypes.ColdWalletTypeNone, walletAccounts)
+	require.NoError(s.T(), err, "saving seed phrase keypair on client without keystore files")
+
+	// the legacy server keystore stays password-encrypted
+	serverKeystorePath := filepath.Join(serverTmpDir, backend.DefaultKeystoreRelativePath, serverActiveAccount.KeyUID)
+	require.False(s.T(), envelope.Exists(serverTmpDir, serverActiveAccount.KeyUID))
+	require.NoError(s.T(), keystorepkg.VerifyKeyStoreDirAtPath(serverKeystorePath, s.password))
+	require.True(s.T(), containsKeystoreFile(serverKeystorePath, serverSeedPhraseKp.DerivedFrom[2:]))
+
+	// remove the client's keystore files for the seed keypair, simulating a restored keypair
+	clientKeystorePath := filepath.Join(clientTmpDir, backend.DefaultKeystoreRelativePath, clientActiveAccount.KeyUID)
+	files, err := os.ReadDir(clientKeystorePath)
+	require.NoError(s.T(), err)
+	for _, file := range files {
+		if strings.Contains(strings.ToLower(file.Name()), strings.ToLower(clientSeedPhraseKp.DerivedFrom[2:])) {
+			require.NoError(s.T(), os.RemoveAll(filepath.Join(clientKeystorePath, file.Name())))
+			continue
+		}
+		for _, acc := range clientSeedPhraseKp.Accounts {
+			if strings.Contains(strings.ToLower(file.Name()), strings.ToLower(acc.Address.String()[2:])) {
+				require.NoError(s.T(), os.RemoveAll(filepath.Join(clientKeystorePath, file.Name())))
+			}
+		}
+	}
+	require.False(s.T(), containsKeystoreFile(clientKeystorePath, clientSeedPhraseKp.DerivedFrom[2:]))
+
+	// transfer
+	var config = KeystoreFilesSenderServerConfig{
+		SenderConfig: &KeystoreFilesSenderConfig{
+			KeystoreFilesConfig: KeystoreFilesConfig{
+				KeystorePath:   serverKeystorePath,
+				LoggedInKeyUID: serverActiveAccount.KeyUID,
+				Password:       s.password,
+			},
+			KeypairsToExport: []string{serverSeedPhraseKp.KeyUID},
+		},
+		ServerConfig: new(ServerConfig),
+	}
+	configBytes, err := json.Marshal(config)
+	require.NoError(s.T(), err)
+	cs, err := StartUpKeystoreFilesSenderServer(serverBackend, string(configBytes))
+	require.NoError(s.T(), err)
+
+	clientPayloadSourceConfig := KeystoreFilesReceiverClientConfig{
+		ReceiverConfig: &KeystoreFilesReceiverConfig{
+			KeystoreFilesConfig: KeystoreFilesConfig{
+				KeystorePath:   clientKeystorePath,
+				LoggedInKeyUID: clientActiveAccount.KeyUID,
+				Password:       s.password,
+			},
+			KeypairsToImport: []string{serverSeedPhraseKp.KeyUID},
+		},
+		ClientConfig: new(ClientConfig),
+	}
+	err = StartUpKeystoreFilesReceivingClient(clientBackend, cs, &clientPayloadSourceConfig)
+	require.NoError(s.T(), err)
+
+	// the client received the files and stored them under its own DEK
+	require.True(s.T(), containsKeystoreFile(clientKeystorePath, clientSeedPhraseKp.DerivedFrom[2:]))
+	for _, acc := range clientSeedPhraseKp.Accounts {
+		require.True(s.T(), containsKeystoreFile(clientKeystorePath, acc.Address.String()[2:]))
+	}
+
+	clientDek, _, err := envelope.Unwrap(clientTmpDir, clientActiveAccount.KeyUID, s.password)
+	require.NoError(s.T(), err)
+	require.NoError(s.T(), keystorepkg.VerifyKeyStoreDirAtPath(clientKeystorePath, clientDek))
+
+	// the server keystore is untouched, still legacy
+	require.NoError(s.T(), keystorepkg.VerifyKeyStoreDirAtPath(serverKeystorePath, s.password))
+	require.False(s.T(), envelope.Exists(serverTmpDir, serverActiveAccount.KeyUID))
+
+	// keys remain loadable on the client through the resolver
+	accountsManager := clientBackend.AccountsManager()
+	require.NoError(s.T(), accountsManager.ReloadKeystore())
+	genAcc, err := accountsManager.LoadAccount(types.HexToAddress(clientSeedPhraseKp.DerivedFrom), s.password)
+	require.NoError(s.T(), err)
+	require.Equal(s.T(), clientSeedPhraseKp.KeyUID, genAcc.ToIdentifiedAccountInfo().KeyUID)
 }
 
 func (s *SyncDeviceSuite) TestTransferringKeystoreFilesSkipsAlreadyStoredKeystores() {

--- a/test/functional/clients/status_backend.py
+++ b/test/functional/clients/status_backend.py
@@ -699,12 +699,20 @@ class StatusBackend(RpcClient, SignalClient, ApiClient):
         url = f"{self.base_url}/statusgo/debug/FreeOSMemory"
         requests.post(url)
 
-    def change_database_password(self, old_password, new_password):
+    def change_database_password(self, old_password, new_password, rekey=False):
         method = "ChangeDatabasePasswordV2"
         data = {
             "keyUid": self.key_uid,
             "oldPassword": old_password,
             "newPassword": new_password,
+            "rekey": rekey,
+        }
+        return self.api_request_json(method, data)
+
+    def get_profile_encryption_info(self):
+        method = "GetProfileEncryptionInfo"
+        data = {
+            "keyUid": self.key_uid,
         }
         return self.api_request_json(method, data)
 

--- a/test/functional/tests/test_password.py
+++ b/test/functional/tests/test_password.py
@@ -31,20 +31,9 @@ class TestPassword:
         with pytest.raises(ApiResponseError, match=re.escape("incorrect current password")):
             backend.backend.change_database_password(backend.backend.password + "-wrong", new_password)
 
-        # Try a correct password - RPC call triggers all signals
+        # Try a correct password - profiles are on the DEK scheme, so this is a fast re-wrap of the profile
+        # envelope: no re-encryption signals and no node restart are expected
         backend.backend.change_database_password(backend.backend.password, new_password)
-
-        # Wait for all signals in sequence (check_buffer=True to find signals that arrived during RPC)
-        await backend.wait_for_signals_sequence(
-            [
-                SignalType.DB_REENCRYPTION_STARTED,
-                SignalType.DB_REENCRYPTION_FINISHED,
-                SignalType.NODE_STOPPED,
-                SignalType.NODE_STARTED,
-                SignalType.NODE_READY,
-            ],
-            timeout=120,
-        )
 
         # Logout
         backend.backend.logout()
@@ -54,6 +43,47 @@ class TestPassword:
         logging.info(f"Logging in with old password: {backend.backend.password}, key uid: {backend.backend.key_uid}")
         backend.backend.login(backend.backend.key_uid, backend.backend.password)
         signal = await backend.wait_for_signal(SignalType.NODE_LOGIN, timeout=60, check_buffer=True)
+        event = signal.raw.get("event")
+        assert "error" in event
+        assert "failed to open database" in event.get("error")
+
+        # Login with the new password - use after_seq to skip the previous signal
+        backend.backend.login(backend.backend.key_uid, new_password)
+        signal = await backend.wait_for_signal(SignalType.NODE_LOGIN, timeout=60, check_buffer=True, after_seq=signal.seq)
+        # Verify successful login (no error)
+        event = signal.raw.get("event")
+        assert "error" not in event or not event.get("error")
+
+    async def test_change_password_with_rekey(self, async_backend_new_profile):
+        new_password = fake.profile_password(8)
+        backend = await async_backend_new_profile("user")
+
+        # A deep rekey generates a fresh data-encryption key and re-encrypts the databases and
+        # keystore with it. The node is logged out mid-rekey (to release the database files before
+        # swapping them) and restarted once the rekey is done, hence NODE_STOPPED arrives before
+        # DB_REENCRYPTION_FINISHED.
+        backend.backend.change_database_password(backend.backend.password, new_password, rekey=True)
+
+        # Wait for all signals in sequence (check_buffer=True to find signals that arrived during RPC)
+        signals = await backend.wait_for_signals_sequence(
+            [
+                SignalType.DB_REENCRYPTION_STARTED,
+                SignalType.NODE_STOPPED,
+                SignalType.DB_REENCRYPTION_FINISHED,
+                SignalType.NODE_STARTED,
+                SignalType.NODE_READY,
+            ],
+            timeout=120,
+        )
+
+        # Logout - use after_seq to skip the signals emitted by the rekey restart (including its
+        # successful node.login)
+        backend.backend.logout()
+        signal = await backend.wait_for_signal(SignalType.NODE_STOPPED, timeout=60, check_buffer=True, after_seq=signals[-1].seq)
+
+        # Try login with the old password
+        backend.backend.login(backend.backend.key_uid, backend.backend.password)
+        signal = await backend.wait_for_signal(SignalType.NODE_LOGIN, timeout=60, check_buffer=True, after_seq=signal.seq)
         event = signal.raw.get("event")
         assert "error" in event
         assert "failed to open database" in event.get("error")


### PR DESCRIPTION
New profiles use the DEK scheme from day one (kdf_iter 3200).

Password change now auto-detects the profile's encryption scheme:
- profile on the DEK scheme, rekey=false → fast path: only the wrapped-DEK file is re-wrapped (no new DEK is generated)
- profile on the DEK scheme, rekey=true → deep rekey: fresh DEK, databases and keystore re-encrypted (new DEK is generated)
- legacy profile → one-time migration to the DEK scheme (full re-encryption, new DEK is generated)

Api changes:
- GetProfileEncryptionInfo endpoint added
- a rekey flag on ChangeDatabasePasswordV2

The wire format stays password-encrypted keystore files, so pairing works across app versions (not migrated and DEK migrated profiles) in both directions (sender/receiver):
- sender: migrated profiles re-encrypt keystore files in memory from the DEK to the transfer
  password before marshalling
- receiver (account transfer): a brand-new profile adopts a fresh device-local DEK
- receiver (keystore-files transfer): received files are re-encrypted per file to the logged-in
profile's keystore secret
- every failure after the profile keystore directory is created cleans up the profile state

unwrap-kek (for developers) prints the DEK given a profile's wrapped-DEK file and the profile password.
Printed data are the secret the profile's databases and keystore files are encrypted with and the sqlcipher pragmas needed to open the databases manually.