### PR TITLE
fix(connector): bind untrusted dApp URL to browser Origin

### DIFF
--- a/services/connector/api.go
+++ b/services/connector/api.go
@@ -116,6 +116,10 @@ func (api *API) CallRPC(ctx context.Context, inputJSON string) (interface{}, err
 		if request.ClientID != "" {
 			return "", ErrCannotOverrideClientIDForUntrustedConnection
 		}
+		// Bind dApp identity to the browser Origin (not client-supplied JSON "url").
+		if origin := GetRequestOrigin(ctx); origin != "" {
+			request.URL = origin
+		}
 	} else {
 		// Trusted connections MUST provide a ClientID
 		if request.ClientID == "" {

--- a/services/connector/api_origin_test.go
+++ b/services/connector/api_origin_test.go
@@ -1,0 +1,44 @@
+package connector
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/status-im/status-go/internal/crypto/types"
+	"github.com/status-im/status-go/services/connector/commands"
+	persistence "github.com/status-im/status-go/services/connector/database"
+)
+
+func TestCallRPC_UntrustedBindsURLToOrigin(t *testing.T) {
+	state := setupTests(t)
+
+	legit := "https://legit-dapp.test"
+	require.NoError(t, persistence.UpsertDApp(state.walletDb, &persistence.DApp{
+		URL:           legit,
+		Name:          "Legit",
+		IconURL:       "https://legit-dapp.test/icon.png",
+		SharedAccount: types.HexToAddress("0x1234567890123456789012345678901234567890"),
+		ChainID:       1,
+	}))
+	require.NoError(t, persistence.InsertPermission(state.walletDb, legit, "", commands.Method_EthAccounts, nil, 1))
+
+	// Browser Origin is evil, but JSON url claims to be legit.
+	ctx := WithConnectionType(context.Background(), ConnectionTypeUntrusted)
+	ctx = WithRequestOrigin(ctx, "https://evil.test")
+
+	request := `{
+		"method": "eth_accounts",
+		"params": [],
+		"url": "https://legit-dapp.test",
+		"name": "Legit",
+		"iconUrl": "https://legit-dapp.test/icon.png"
+	}`
+	res, err := state.api.CallRPC(ctx, request)
+	require.NoError(t, err)
+	// Bound to evil Origin: no permission → empty accounts (not legit's shared account).
+	accounts, ok := res.([]string)
+	require.True(t, ok)
+	require.Empty(t, accounts)
+}

--- a/services/connector/context.go
+++ b/services/connector/context.go
@@ -21,11 +21,26 @@ type ContextKey struct {
 
 var (
 	connectionTypeKey = ContextKey{Name: "connectionType"}
+	requestOriginKey  = ContextKey{Name: "requestOrigin"}
 )
 
 // WithConnectionType adds connection type to context
 func WithConnectionType(ctx context.Context, connType ConnectionType) context.Context {
 	return context.WithValue(ctx, connectionTypeKey, connType)
+}
+
+// WithRequestOrigin stores the HTTP Origin from an untrusted browser connection
+// (WebSocket / HTTP). Used to bind dApp identity instead of trusting JSON "url".
+func WithRequestOrigin(ctx context.Context, origin string) context.Context {
+	return context.WithValue(ctx, requestOriginKey, origin)
+}
+
+// GetRequestOrigin returns the browser Origin if present in context.
+func GetRequestOrigin(ctx context.Context) string {
+	if origin, ok := ctx.Value(requestOriginKey).(string); ok {
+		return origin
+	}
+	return ""
 }
 
 // GetConnectionType retrieves connection type from context

--- a/services/connector/service.go
+++ b/services/connector/service.go
@@ -175,11 +175,15 @@ func (s *Service) Start() error {
 			return
 		}
 
-		// Inject connection type into request context
+		// Inject connection type + browser Origin into request context.
+		// Permissions must key off Origin, not the client-supplied JSON "url".
 		ctx := WithConnectionType(r.Context(), ConnectionTypeUntrusted)
+		if origin := r.Header.Get("Origin"); origin != "" {
+			ctx = WithRequestOrigin(ctx, origin)
+		}
 		r = r.WithContext(ctx)
 
-		// FIXME: this is a temporary solution to allow all origins
+		// Handshake still accepts any Origin; CallRPC binds dApp URL to Origin below.
 		origins := []string{"*"}
 		wsHandler := s.rpcServer.WebsocketHandler(origins)
 		wsHandler.ServeHTTP(w, r)


### PR DESCRIPTION
## Summary
- Connector WebSocket handshake allowed any Origin (`origins: ["*"]`) while permissions keyed off the client-supplied JSON `url` field.
- A hostile page could open the local connector WS and reuse another dApp's grants (e.g. silent `eth_accounts`).
- Store the browser `Origin` on untrusted connections and override `request.URL` before command execution.
- Unit test: Origin `https://evil.test` + JSON url `https://legit-dapp.test` must not return the legit shared account.

## Test plan
- [ ] CI: `go test ./services/connector/ -run UntrustedBindsURLToOrigin`
- [ ] Manual: enable connector WS, confirm a real dApp still receives accounts when Origin matches its URL


Made with [Cursor](https://cursor.com)