### PR TITLE
feat(wallet): privilegesLevel field added to token struct

### DIFF
--- a/services/communitytokens/communitytokensdatabase/database.go
+++ b/services/communitytokens/communitytokensdatabase/database.go
@@ -47,7 +47,7 @@ func (db *Database) GetTokenPrivilegesLevel(chainID uint64, contractAddress stri
 }
 
 func (db *Database) GetTokens() ([]*token.CommunityToken, error) {
-	rows, err := db.db.Query(`SELECT community_id, address, name, symbol, chain_id, decimals, type FROM community_tokens`)
+	rows, err := db.db.Query(`SELECT community_id, address, name, symbol, chain_id, decimals, type, transferable, privileges_level FROM community_tokens`)
 	if err != nil {
 		return nil, err
 	}
@@ -56,7 +56,8 @@ func (db *Database) GetTokens() ([]*token.CommunityToken, error) {
 	var result []*token.CommunityToken
 	for rows.Next() {
 		token := token.CommunityToken{}
-		err := rows.Scan(&token.CommunityID, &token.Address, &token.Name, &token.Symbol, &token.ChainID, &token.Decimals, &token.TokenType)
+		err := rows.Scan(&token.CommunityID, &token.Address, &token.Name, &token.Symbol, &token.ChainID, &token.Decimals,
+			&token.TokenType, &token.Transferable, &token.PrivilegesLevel)
 		if err != nil {
 			return nil, err
 		}

--- a/services/wallet/collectibles/ownership/ownership_db.go
+++ b/services/wallet/collectibles/ownership/ownership_db.go
@@ -8,11 +8,14 @@ import (
 	"math/big"
 	"sync"
 
+	"go.uber.org/zap"
+
 	"github.com/ethereum/go-ethereum/common"
 
 	"github.com/jmoiron/sqlx"
 
 	"github.com/status-im/status-go/internal/db/sqlite"
+	"github.com/status-im/status-go/internal/logutils"
 	"github.com/status-im/status-go/services/wallet/bigint"
 	w_common "github.com/status-im/status-go/services/wallet/common"
 	"github.com/status-im/status-go/services/wallet/thirdparty"
@@ -63,14 +66,14 @@ func insertTmpOwnership(
 	// NOTE: Temp table CREATE doesn't work with prepared statements,
 	// so we have to use Exec directly
 	_, err := db.Exec(fmt.Sprintf(`
-		DROP TABLE IF EXISTS temp.old_collectibles_ownership_cache_%[1]s; 
+		DROP TABLE IF EXISTS temp.old_collectibles_ownership_cache_%[1]s;
 		CREATE TABLE temp.old_collectibles_ownership_cache_%[1]s(
 			contract_address VARCHAR NOT NULL,
 			token_id BLOB NOT NULL,
 			balance BLOB NOT NULL,
 			last_tx_timestamp INTEGER NOT NULL
 		);
-		DROP TABLE IF EXISTS temp.new_collectibles_ownership_cache_%[1]s; 
+		DROP TABLE IF EXISTS temp.new_collectibles_ownership_cache_%[1]s;
 		CREATE TABLE temp.new_collectibles_ownership_cache_%[1]s(
 			contract_address VARCHAR NOT NULL,
 			token_id BLOB NOT NULL,
@@ -96,7 +99,7 @@ func insertTmpOwnership(
 	}
 
 	insertTmpNewOwnership, err := db.Prepare(fmt.Sprintf(`
-			INSERT INTO temp.new_collectibles_ownership_cache_%[1]s (contract_address, token_id, balance, last_tx_timestamp) 
+			INSERT INTO temp.new_collectibles_ownership_cache_%[1]s (contract_address, token_id, balance, last_tx_timestamp)
 			VALUES (?, ?, ?, ?)`, uuid))
 	if err != nil {
 		return err
@@ -130,11 +133,11 @@ func removeOldAddressOwnership(
 ) ([]thirdparty.CollectibleUniqueID, error) {
 	// Find collectibles in the DB that are not in the temp table
 	removedQuery, err := creator.Prepare(fmt.Sprintf(`
-	SELECT %[2]d, tOld.contract_address, tOld.token_id 
+	SELECT %[2]d, tOld.contract_address, tOld.token_id
 		FROM temp.old_collectibles_ownership_cache_%[1]s tOld
 		LEFT JOIN temp.new_collectibles_ownership_cache_%[1]s tNew ON
 			tOld.contract_address = tNew.contract_address AND tOld.token_id = tNew.token_id
-		WHERE 
+		WHERE
 			tNew.contract_address IS NULL
 	`, uuid, chainID))
 	if err != nil {
@@ -182,11 +185,11 @@ func updateChangedAddressOwnership(
 ) ([]thirdparty.CollectibleUniqueID, error) {
 	// Find collectibles in the temp table that are in the DB and have a different balance or timestamp
 	updatedQuery, err := creator.Prepare(fmt.Sprintf(`
-		SELECT %[2]d, tNew.contract_address, tNew.token_id 
+		SELECT %[2]d, tNew.contract_address, tNew.token_id
 		FROM temp.new_collectibles_ownership_cache_%[1]s tNew
 		LEFT JOIN temp.old_collectibles_ownership_cache_%[1]s tOld ON
 			tOld.contract_address = tNew.contract_address AND tOld.token_id = tNew.token_id
-		WHERE 
+		WHERE
 			tOld.contract_address IS NOT NULL AND (tOld.balance != tNew.balance OR tOld.last_tx_timestamp != tNew.last_tx_timestamp)
 	`, uuid, chainID))
 	if err != nil {
@@ -239,11 +242,11 @@ func insertNewAddressOwnership(
 ) ([]thirdparty.CollectibleUniqueID, error) {
 	// Find collectibles in the temp table that are not in the DB
 	insertedQuery, err := creator.Prepare(fmt.Sprintf(`
-		SELECT %[2]d, tNew.contract_address, tNew.token_id 
+		SELECT %[2]d, tNew.contract_address, tNew.token_id
 		FROM temp.new_collectibles_ownership_cache_%[1]s tNew
 		LEFT JOIN temp.old_collectibles_ownership_cache_%[1]s tOld ON
 			tOld.contract_address = tNew.contract_address AND tOld.token_id = tNew.token_id
-		WHERE 
+		WHERE
 			tOld.contract_address IS NULL
 	`, uuid, chainID))
 	if err != nil {
@@ -312,7 +315,7 @@ func updateAddressOwnership(
 }
 
 func updateAddressOwnershipTimestamp(creator sqlite.StatementCreator, ownerAddress common.Address, chainID w_common.ChainID, timestamp int64) error {
-	updateTimestamp, err := creator.Prepare(fmt.Sprintf(`INSERT OR REPLACE INTO collectibles_ownership_update_timestamps (%s) 
+	updateTimestamp, err := creator.Prepare(fmt.Sprintf(`INSERT OR REPLACE INTO collectibles_ownership_update_timestamps (%s)
 																				VALUES (?, ?, ?)`, ownershipTimestampColumns))
 	if err != nil {
 		return err
@@ -393,6 +396,23 @@ func (o *OwnershipDB) Update(chainID w_common.ChainID, ownerAddress common.Addre
 		return
 	}
 
+	// Trace every removal/insertion the fetched provider data causes
+	if len(removedIDs) > 0 || len(insertedIDs) > 0 {
+		idStrings := func(ids []thirdparty.CollectibleUniqueID) []string {
+			res := make([]string, 0, len(ids))
+			for _, id := range ids {
+				res = append(res, fmt.Sprintf("%d-%s-%s", id.ContractID.ChainID, id.ContractID.Address.Hex(), id.TokenID.String()))
+			}
+			return res
+		}
+		logutils.ZapLogger().Debug("collectibles ownership updated",
+			zap.Uint64("chainID", uint64(chainID)),
+			zap.String("owner", ownerAddress.Hex()),
+			zap.Int("fetchedBalances", len(balances)),
+			zap.Strings("removed", idStrings(removedIDs)),
+			zap.Strings("inserted", idStrings(insertedIDs)))
+	}
+
 	// Update timestamp
 	err = updateAddressOwnershipTimestamp(tx, ownerAddress, chainID, timestamp)
 
@@ -425,7 +445,7 @@ func (o *OwnershipDB) GetOwnedCollectibles(chainIDs []w_common.ChainID, ownerAdd
 
 func (o *OwnershipDB) FetchCachedCollectibleOwnersByContractAddress(chainID w_common.ChainID, contractAddress common.Address) (*thirdparty.CollectibleContractOwnership, error) {
 	query, args, err := sqlx.In(fmt.Sprintf(`SELECT %s
-		FROM collectibles_ownership_cache 
+		FROM collectibles_ownership_cache
 		WHERE chain_id = ? AND contract_address = ?`, collectiblesOwnershipColumns), chainID, contractAddress)
 	if err != nil {
 		return nil, err

--- a/services/wallet/router/router_helper.go
+++ b/services/wallet/router/router_helper.go
@@ -689,6 +689,7 @@ func findToken(sendType sendtype.SendType, tokenManager TokenManager, collectibl
 		return nil
 	}
 
+	name := "" // need it for display only, transfer itself needs just the contract address and token id
 	collectibleData, err := collectiblesManager.GetCacheCollectibleData(thirdparty.CollectibleUniqueID{
 		ContractID: thirdparty.ContractID{
 			ChainID: walletCommon.ChainID(chainID),
@@ -696,8 +697,8 @@ func findToken(sendType sendtype.SendType, tokenManager TokenManager, collectibl
 		},
 		TokenID: &bigint.BigInt{Int: collectibleTokenID},
 	})
-	if err != nil {
-		return nil
+	if err == nil {
+		name = collectibleData.Name
 	}
 
 	return &tokentypes.Token{
@@ -705,7 +706,7 @@ func findToken(sendType sendtype.SendType, tokenManager TokenManager, collectibl
 			Address:  contractAddress,
 			Decimals: 0,
 			ChainID:  chainID,
-			Name:     collectibleData.Name,
+			Name:     name,
 		},
 		CollectibleTokenID: (*hexutil.Big)(collectibleTokenID),
 	}

--- a/services/wallet/token/community_token.go
+++ b/services/wallet/token/community_token.go
@@ -16,7 +16,7 @@ import (
 	"github.com/status-im/status-go/internal/contracts/community-tokens/assets"
 	cryptotypes "github.com/status-im/status-go/internal/crypto/types"
 	"github.com/status-im/status-go/internal/logutils"
-	"github.com/status-im/status-go/protocol/communities/token"
+	communitytoken "github.com/status-im/status-go/protocol/communities/token"
 	"github.com/status-im/status-go/protocol/protobuf"
 	"github.com/status-im/status-go/services/utils"
 	tokentypes "github.com/status-im/status-go/services/wallet/token/types"
@@ -82,11 +82,11 @@ func (tm *Manager) GetCommunityTokenType(chainID uint64, tokenContractAddress st
 	return protobuf.CommunityTokenType_UNKNOWN_TOKEN_TYPE, nil
 }
 
-func (tm *Manager) GetCommunityTokenPrivilegesLevel(chainID uint64, tokenContractAddress string) (token.PrivilegesLevel, error) {
+func (tm *Manager) GetCommunityTokenPrivilegesLevel(chainID uint64, tokenContractAddress string) (communitytoken.PrivilegesLevel, error) {
 	if tm.communityTokensDB != nil {
 		return tm.communityTokensDB.GetTokenPrivilegesLevel(chainID, tokenContractAddress)
 	}
-	return token.CommunityLevel, nil
+	return communitytoken.CommunityLevel, nil
 }
 
 func (tm *Manager) getDiscoveredTokens(onlyCommunityCustoms bool) ([]*tokentypes.Token, error) {
@@ -117,6 +117,11 @@ func (tm *Manager) getDiscoveredTokens(onlyCommunityCustoms bool) ([]*tokentypes
 				ID: communityIDDB.String,
 			}
 
+			if lvl, err := tm.GetCommunityTokenPrivilegesLevel(token.ChainID, token.Address.Hex()); err == nil {
+				privilegesLevel := int(lvl)
+				token.PrivilegesLevel = &privilegesLevel
+			}
+
 			if tm.communityTokenImageBuilder != nil {
 				token.LogoURI = tm.communityTokenImageBuilder.MakeCommunityTokenImagesURL(token.CommunityData.ID, token.ChainID, token.Symbol)
 			}
@@ -143,6 +148,7 @@ func (tm *Manager) GetCustoms(onlyCommunityCustoms bool) ([]*tokentypes.Token, e
 		}
 
 		for _, communityToken := range communityTokens {
+			privilegesLevel := int(communityToken.PrivilegesLevel)
 			token := &tokentypes.Token{
 				Token: &types.Token{
 					Address:  common.HexToAddress(communityToken.Address),
@@ -155,6 +161,8 @@ func (tm *Manager) GetCustoms(onlyCommunityCustoms bool) ([]*tokentypes.Token, e
 				CommunityData: &tokentypes.CommunityData{
 					ID: communityToken.CommunityID,
 				},
+				Soulbound:       !communityToken.Transferable,
+				PrivilegesLevel: &privilegesLevel,
 			}
 
 			if tm.communityTokenImageBuilder != nil {

--- a/services/wallet/token/token_test.go
+++ b/services/wallet/token/token_test.go
@@ -25,8 +25,11 @@ import (
 	"github.com/status-im/status-go/internal/testutils"
 	"github.com/status-im/status-go/params"
 	"github.com/status-im/status-go/pkg/pubsub"
+	communitytoken "github.com/status-im/status-go/protocol/communities/token"
+	"github.com/status-im/status-go/protocol/protobuf"
 	protocolsqlite "github.com/status-im/status-go/protocol/sqlite"
 	"github.com/status-im/status-go/services/accounts/accountsevent"
+	"github.com/status-im/status-go/services/communitytokens/communitytokensdatabase"
 	walletcommon "github.com/status-im/status-go/services/wallet/common"
 	tokentypes "github.com/status-im/status-go/services/wallet/token/types"
 )
@@ -196,7 +199,99 @@ func TestCommunityTokens(t *testing.T) {
 	rst, err = manager.GetCustoms(true)
 	require.NoError(t, err)
 	require.Equal(t, 1, len(rst))
-	require.Equal(t, *communityToken, *rst[0])
+	// Discovered community tokens are annotated with a best-effort privileges
+	// level: CommunityLevel when the community-tokens DB has no information.
+	expectedCommunityToken := *communityToken
+	communityLevel := int(communitytoken.CommunityLevel)
+	expectedCommunityToken.PrivilegesLevel = &communityLevel
+	require.Equal(t, expectedCommunityToken, *rst[0])
+}
+
+func TestCommunityTokensPrivilegesAndSoulbound(t *testing.T) {
+	appDb, err := testutils.SetupTestMemorySQLDB(appdatabase.DbInitializer{})
+	require.NoError(t, err)
+	defer func() { require.NoError(t, appDb.Close()) }()
+	// community_tokens lives in the protocol migrations
+	require.NoError(t, protocolsqlite.Migrate(appDb))
+
+	walletDb, err := testutils.SetupTestMemorySQLDB(walletdatabase.DbInitializer{})
+	require.NoError(t, err)
+	defer func() { require.NoError(t, walletDb.Close()) }()
+
+	manager := &Manager{
+		walletDB:          walletDb,
+		communityTokensDB: communitytokensdatabase.NewCommunityTokensDatabase(appDb),
+	}
+
+	addMintedToken := func(address string, tokenType protobuf.CommunityTokenType, transferable bool, level communitytoken.PrivilegesLevel) {
+		_, err := appDb.Exec(`INSERT INTO community_tokens (community_id, address, type, name, symbol, description, supply_str,
+			infinite_supply, transferable, remote_self_destruct, chain_id, deploy_state, image_base64, decimals, deployer, privileges_level)
+			VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+			"community_id", address, tokenType, "name-"+address, "SYM", "desc", "1",
+			false, transferable, false, 777, communitytoken.Deployed, "", 0, "0xDEP", level)
+		require.NoError(t, err)
+	}
+
+	ownerAddress := common.Address{1}.Hex()
+	masterAddress := common.Address{2}.Hex()
+	assetAddress := common.Address{3}.Hex()
+	// the owner token is transferable by design (that is how community ownership moves)
+	addMintedToken(ownerAddress, protobuf.CommunityTokenType_ERC721, true, communitytoken.OwnerLevel)
+	// the TMaster token is non-transferable (soulbound)
+	addMintedToken(masterAddress, protobuf.CommunityTokenType_ERC721, false, communitytoken.MasterLevel)
+	// a regular community asset
+	addMintedToken(assetAddress, protobuf.CommunityTokenType_ERC20, true, communitytoken.CommunityLevel)
+
+	// A community token merely discovered on-chain: present in the wallet tokens
+	// table, absent from community_tokens — there is no metadata to annotate with.
+	discovered := &tokentypes.Token{
+		Token: &types.Token{
+			Address:  common.Address{4},
+			Name:     "Discovered",
+			Symbol:   "DIS",
+			Decimals: 12,
+			ChainID:  777,
+		},
+		CommunityData: &tokentypes.CommunityData{ID: "other_community"},
+	}
+	upsertCommunityToken(t, discovered, manager)
+
+	rst, err := manager.GetCustoms(true)
+	require.NoError(t, err)
+	require.Equal(t, 4, len(rst))
+
+	byAddress := make(map[common.Address]*tokentypes.Token)
+	for _, token := range rst {
+		byAddress[token.Address] = token
+	}
+
+	requireLevel := func(token *tokentypes.Token, level communitytoken.PrivilegesLevel) {
+		require.NotNil(t, token.PrivilegesLevel)
+		require.Equal(t, int(level), *token.PrivilegesLevel)
+	}
+
+	owner := byAddress[common.HexToAddress(ownerAddress)]
+	require.NotNil(t, owner)
+	requireLevel(owner, communitytoken.OwnerLevel)
+	require.False(t, owner.Soulbound)
+
+	master := byAddress[common.HexToAddress(masterAddress)]
+	require.NotNil(t, master)
+	requireLevel(master, communitytoken.MasterLevel)
+	require.True(t, master.Soulbound)
+
+	asset := byAddress[common.HexToAddress(assetAddress)]
+	require.NotNil(t, asset)
+	requireLevel(asset, communitytoken.CommunityLevel)
+	require.False(t, asset.Soulbound)
+
+	// Absent metadata: the community-tokens DB exists but has no row for the
+	// discovered token, so the privileges level stays unknown (nil) and the
+	// token is not marked soulbound.
+	discoveredResult := byAddress[discovered.Address]
+	require.NotNil(t, discoveredResult)
+	require.Nil(t, discoveredResult.PrivilegesLevel)
+	require.False(t, discoveredResult.Soulbound)
 }
 
 func TestMarkAsPreviouslyOwnedToken(t *testing.T) {

--- a/services/wallet/token/types/token.go
+++ b/services/wallet/token/types/token.go
@@ -22,6 +22,9 @@ type Token struct {
 
 	CollectibleTokenID *hexutil.Big   `json:"collectibleTokenID,omitempty"`
 	CommunityData      *CommunityData `json:"communityData,omitempty"`
+
+	Soulbound       bool `json:"soulbound,omitempty"`
+	PrivilegesLevel *int `json:"privilegesLevel,omitempty"`
 }
 
 // TODO: think about removing CommunityData field and fetch it when needed, that way `tokenlists.Token` can be used directly.


### PR DESCRIPTION
Added a new `privilegesLevel` field to the token struct, allowing the client to exclude owner and master tokens from the send flow. 