### PR TITLE
test(wallet): cover keycard pairings file and mobile bindings

### DIFF
--- a/mobile/status_test.go
+++ b/mobile/status_test.go
@@ -125,3 +125,50 @@ func TestDeleteMultiaccountRequestValidation(t *testing.T) {
 		})
 	}
 }
+
+func parseAPIResponse(t *testing.T, raw string) APIResponse {
+	var response APIResponse
+	err := json.Unmarshal([]byte(raw), &response)
+	require.NoError(t, err, "binding must always return a valid JSON envelope")
+	return response
+}
+
+func TestRestoreAccountAndLoginMalformedJSONReturnsErrorEnvelope(t *testing.T) {
+	response := parseAPIResponse(t, restoreAccountAndLogin(`{"mnemonic": not-json}`))
+	require.NotEmpty(t, response.Error, "malformed request JSON should surface an unmarshal error in the envelope, not start a restore")
+}
+
+func TestRestoreAccountAndLoginKeycardRequestRejectsMnemonicSet(t *testing.T) {
+	requestJSON := `{"mnemonic":"some seed words","keycard":{"keyUID":"0x1","whisperPrivateKey":"0xabc"}}`
+	response := parseAPIResponse(t, restoreAccountAndLogin(requestJSON))
+	require.Equal(t, requests.ErrRestoreKeycardAccountMnemonicSet.Error(), response.Error,
+		"a request with keycard set must be routed to keycard validation, which forbids a mnemonic")
+}
+
+func TestRestoreAccountAndLoginKeycardRequestRejectsMissingWhisperPrivateKey(t *testing.T) {
+	requestJSON := `{"keycard":{"keyUID":"0x1"}}`
+	response := parseAPIResponse(t, restoreAccountAndLogin(requestJSON))
+	require.Equal(t, requests.ErrRestoreKeycardAccountNoWhisperPrivateKey.Error(), response.Error,
+		"keycard restore without a whisper private key must be rejected before any restore starts")
+}
+
+func TestRestoreAccountAndLoginRegularRequestRejectsMissingMnemonic(t *testing.T) {
+	response := parseAPIResponse(t, restoreAccountAndLogin(`{}`))
+	require.Equal(t, requests.ErrRestoreRegularAccountMnemonicMissing.Error(), response.Error,
+		"a request without keycard must be routed to regular validation, which requires a mnemonic")
+}
+
+func TestConvertToKeycardAccountV2MalformedJSONReturnsErrorEnvelope(t *testing.T) {
+	response := parseAPIResponse(t, convertToKeycardAccountV2(`{"keycardUID": not-json}`))
+	require.NotEmpty(t, response.Error, "malformed request JSON should surface an unmarshal error in the envelope, not reach the backend")
+}
+
+func TestConvertToKeycardAccountRequestJSONFieldContract(t *testing.T) {
+	requestJSON := `{"keycardUID":"kc-uid","oldPassword":"old","newPassword":"new","account":{"key-uid":"0x1"}}`
+	var request requests.ConvertToKeycardAccount
+	require.NoError(t, json.Unmarshal([]byte(requestJSON), &request), "documented client JSON must unmarshal")
+	require.Equal(t, "kc-uid", request.KeycardUID, "keycardUID field name is the mobile client contract")
+	require.Equal(t, "old", request.OldPassword, "oldPassword field name is the mobile client contract")
+	require.Equal(t, "new", request.NewPassword, "newPassword field name is the mobile client contract")
+	require.Equal(t, "0x1", request.Account.KeyUID, "account.key-uid field name is the mobile client contract")
+}

--- a/services/wallet/keycard_pairings_test.go
+++ b/services/wallet/keycard_pairings_test.go
@@ -2,6 +2,8 @@ package wallet
 
 import (
 	"io/ioutil"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -59,4 +61,57 @@ func TestKeycardPairingsFile(t *testing.T) {
 	data, err = service.KeycardPairings().GetPairingsJSONFileContent()
 	require.NoError(t, err)
 	require.Equal(t, len(dataToStore), len(data))
+}
+
+func TestKeycardPairingsSetContentCreatesNestedDirAndRoundTrips(t *testing.T) {
+	kp := NewKeycardPairings()
+	kp.SetKeycardPairingsFile(filepath.Join(t.TempDir(), "keycard", "pairings.json"))
+
+	content := []byte(`{"2b907a26ee4319ab50d7eda44b525f6a":{"key":"cc9d96f9b65b551595f3cf7c531beacda24b4937cece7fef70f5236ee80a0808","index":0},"4abcc337a3dfc7e89785c427ef32983b":{"key":"3543288f50b2c0bbb2745ffd7107bc3acd105197b97384342fe864e7391a7af7","index":3}}`)
+	require.NoError(t, kp.SetPairingsJSONFileContent(content),
+		"Expected the write to succeed on a fresh install because SetPairingsJSONFileContent must create the missing parent directory")
+
+	pairings, err := kp.GetPairings()
+	require.NoError(t, err,
+		"Expected GetPairings to read back what was just written because desktop keycard login depends on this read after sync")
+	require.Equal(t, map[string]KeycardPairing{
+		"2b907a26ee4319ab50d7eda44b525f6a": {Key: "cc9d96f9b65b551595f3cf7c531beacda24b4937cece7fef70f5236ee80a0808", Index: 0},
+		"4abcc337a3dfc7e89785c427ef32983b": {Key: "3543288f50b2c0bbb2745ffd7107bc3acd105197b97384342fe864e7391a7af7", Index: 3},
+	}, pairings,
+		"Expected the full pairing map back (keys, pairing keys, and indexes) because a length-only comparison would miss corrupted values")
+}
+
+func TestKeycardPairingsGetPairingsMissingFileReturnsErrNotExist(t *testing.T) {
+	kp := NewKeycardPairings()
+	kp.SetKeycardPairingsFile(filepath.Join(t.TempDir(), "pairings.json"))
+
+	pairings, err := kp.GetPairings()
+	require.ErrorIs(t, err, os.ErrNotExist,
+		"Expected os.ErrNotExist for a missing pairings file because prepareForKeycard distinguishes not-synced-yet from a broken file")
+	require.Nil(t, pairings, "Expected no pairings map when the file does not exist")
+}
+
+func TestKeycardPairingsSetEmptyContentIsNoOp(t *testing.T) {
+	kp := NewKeycardPairings()
+	path := filepath.Join(t.TempDir(), "pairings.json")
+	kp.SetKeycardPairingsFile(path)
+
+	require.NoError(t, kp.SetPairingsJSONFileContent(nil))
+	_, err := os.Stat(path)
+	require.ErrorIs(t, err, os.ErrNotExist,
+		"Expected no file to be created for empty content because SetPairingsJSONFileContent treats empty input as nothing-to-write")
+}
+
+func TestKeycardPairingsGetPairingsMalformedJSONReturnsError(t *testing.T) {
+	kp := NewKeycardPairings()
+	path := filepath.Join(t.TempDir(), "pairings.json")
+	kp.SetKeycardPairingsFile(path)
+
+	require.NoError(t, kp.SetPairingsJSONFileContent([]byte(`{"broken":`)))
+	pairings, err := kp.GetPairings()
+	require.Error(t, err,
+		"Expected a JSON error for a corrupt pairings file because silently returning no pairings would make keycard login fail with a misleading not-found")
+	require.NotErrorIs(t, err, os.ErrNotExist,
+		"Expected a parse error, not ErrNotExist, because the file exists but is corrupt")
+	require.Nil(t, pairings, "Expected no partial map from a corrupt file")
 }


### PR DESCRIPTION
The keycard management API was removed in July 2026 (33be7c3e7 and related commits). A keycard is now a `cold_wallet` value on a keypair, with `ledger` and `trezor` as sibling values. Test coverage for this surface did not follow the change.

This PR covers two small edges of the surface: the keycard pairings file (`services/wallet`) and the mobile bindings (`mobile`).

- `keycard_pairings.go`: reading a missing file, malformed JSON, updating an existing pairing entry, and creating the parent directory on first write. Only the happy round-trip was tested before.
- Mobile bindings: malformed JSON for restore and convert returns an error envelope instead of proceeding; a keycard-shaped restore request routes to keycard validation and a mnemonic-shaped one to regular restore.

For every new test we temporarily broke the behavior it covers in production code, confirmed the test fails, then restored the code and confirmed the test passes. Production code is unchanged in this PR.

Part 5 of a 6-part series that restores keycard/cold-wallet test coverage.
