### PR TITLE
test(functional): restore keycard coverage in cold-wallet vocabulary

### DIFF
--- a/tests-functional/tests/test_add_keypair_stored_to_cold_wallet.py
+++ b/tests-functional/tests/test_add_keypair_stored_to_cold_wallet.py
@@ -1,3 +1,4 @@
+import copy
 import re
 import pytest
 from clients.api import ApiResponseError
@@ -59,3 +60,115 @@ class TestAddKeypairStoredToColdWallet:
         for address in addresses:
             resp = backend.accounts_service.verify_keystore_file_for_account(address, backend.password)
             assert resp is False
+
+    def _add_then_delete_seed_keypair(self, backend):
+        add_resp = backend.accounts_service.add_keypair_via_seed_phrase(
+            user_1.passphrase,
+            backend.password,
+            keypair_name,
+            "",
+            wallet_account_details_derivation,
+        )
+        key_uid = add_resp.get("key-uid")
+        assert key_uid is not None, "Expected addKeypairViaSeedPhrase to return the created keypair's key-uid"
+        backend.accounts_service.delete_keypair(key_uid, backend.password)
+        return key_uid
+
+    def test_add_account_with_empty_password_on_cold_keypair_derives_from_xpub(self, backend):
+        key_uid = self._add_then_delete_seed_keypair(backend)
+
+        backend.accounts_service.add_keypair_stored_to_cold_wallet(
+            key_uid,
+            user_1.address,
+            "cold-keypair",
+            user_1.wallet_xpub,
+            "status-keycard",
+            [wallet_account_details_derivation],
+        )
+        kp = backend.accounts_service.get_keypair_by_key_uid(key_uid)
+        assert (
+            kp.get("cold-wallet") == "status-keycard"
+        ), "Expected the keypair to be cold-wallet backed because it was added via addKeypairStoredToColdWallet"
+
+        next_path = "m/44'/60'/0'/0/1"
+        derived = backend.wallet_service.get_derived_addresses_for_mnemonic(user_1.passphrase, [next_path])
+        template = copy.deepcopy(kp["accounts"][0])
+        template.update(
+            {
+                "address": derived[0].get("address"),
+                "public-key": derived[0].get("public-key"),
+                "path": next_path,
+                "name": "xpub-derived-cold",
+                "wallet": False,
+                "chat": False,
+                "key-uid": key_uid,
+            }
+        )
+        backend.accounts_service.add_account("", template)
+
+        kp_after_add = backend.accounts_service.get_keypair_by_key_uid(key_uid)
+        added = [a for a in kp_after_add.get("accounts", []) if a.get("path") == next_path]
+        assert (
+            len(added) == 1
+        ), "Expected the empty-password add_account to succeed because the cold keypair carries a wallet xpub to validate against"
+        assert (
+            added[0].get("address", "").lower() == derived[0].get("address", "").lower()
+        ), "Expected the stored account address to match the xpub-derived address for the requested path"
+        resp = backend.accounts_service.verify_keystore_file_for_account(added[0].get("address"), backend.password)
+        assert resp is False, "Expected no keystore file for the new account because cold-wallet keypair accounts must keep key material off disk"
+
+    def test_add_keypair_stored_to_cold_wallet_rejects_empty_wallet_accounts(self, backend):
+        key_uid = self._add_then_delete_seed_keypair(backend)
+
+        with pytest.raises(ApiResponseError, match=re.escape("keypair must have at least one wallet account")):
+            backend.accounts_service.add_keypair_stored_to_cold_wallet(
+                key_uid,
+                user_1.address,
+                "cold-keypair",
+                user_1.wallet_xpub,
+                "status-keycard",
+                [],
+            )
+        with pytest.raises(ApiResponseError, match=re.escape("keypair is not found")):
+            backend.accounts_service.get_keypair_by_key_uid(key_uid)
+
+    def test_add_keypair_stored_to_cold_wallet_rejects_non_wallet_path(self, backend):
+        key_uid = self._add_then_delete_seed_keypair(backend)
+
+        bad_account = copy.deepcopy(wallet_account_details_derivation)
+        bad_account["path"] = "m/43'/60'/0'/0/0"
+        with pytest.raises(ApiResponseError, match=re.escape("unsupported profile or seed imported key pair wallet account")):
+            backend.accounts_service.add_keypair_stored_to_cold_wallet(
+                key_uid,
+                user_1.address,
+                "cold-keypair",
+                user_1.wallet_xpub,
+                "status-keycard",
+                [bad_account],
+            )
+        with pytest.raises(ApiResponseError, match=re.escape("keypair is not found")):
+            backend.accounts_service.get_keypair_by_key_uid(key_uid)
+
+    def test_add_keypair_stored_to_cold_wallet_rejects_already_added_keypair(self, backend):
+        add_resp = backend.accounts_service.add_keypair_via_seed_phrase(
+            user_1.passphrase,
+            backend.password,
+            keypair_name,
+            "",
+            wallet_account_details_derivation,
+        )
+        key_uid = add_resp.get("key-uid")
+
+        with pytest.raises(ApiResponseError, match=re.escape("keypair already added")):
+            backend.accounts_service.add_keypair_stored_to_cold_wallet(
+                key_uid,
+                user_1.address,
+                "cold-keypair",
+                user_1.wallet_xpub,
+                "status-keycard",
+                [wallet_account_details_derivation],
+            )
+        kp = backend.accounts_service.get_keypair_by_key_uid(key_uid)
+        assert (
+            kp.get("name") == keypair_name
+        ), "Expected the original keypair untouched because addKeypairStoredToColdWallet must reject an already-added keypair"

--- a/tests-functional/tests/test_add_keypair_via_seed_phrase_cold_wallet.py
+++ b/tests-functional/tests/test_add_keypair_via_seed_phrase_cold_wallet.py
@@ -1,0 +1,31 @@
+# Ad-hoc test — no backend spec. Restores coverage deleted in 33be7c3e7 in cold-wallet vocabulary.
+import pytest
+from resources.constants import user_1, wallet_account_details_derivation, keypair_name
+
+
+@pytest.mark.rpc
+class TestAddKeypairViaSeedPhraseColdWallet:
+
+    @pytest.fixture()
+    def backend(self, backend_new_profile):
+        return backend_new_profile("account-backend")
+
+    def test_add_keypair_via_seed_phrase_as_cold_wallet_writes_no_keystore(self, backend):
+        add_resp = backend.accounts_service.add_keypair_via_seed_phrase(
+            user_1.passphrase,
+            backend.password,
+            keypair_name,
+            "status-keycard",
+            wallet_account_details_derivation,
+        )
+        key_uid = add_resp.get("key-uid")
+        assert key_uid is not None, "Expected addKeypairViaSeedPhrase to return the created keypair's key-uid"
+        addresses = [a.get("address") for a in add_resp.get("accounts", [])] + [add_resp.get("derived-from")]
+
+        kp = backend.accounts_service.get_keypair_by_key_uid(key_uid)
+        assert (
+            kp.get("cold-wallet") == "status-keycard"
+        ), "Expected the coldWallet argument to survive the RPC->messenger->manager pass-through unchanged"
+        for address in addresses:
+            resp = backend.accounts_service.verify_keystore_file_for_account(address, backend.password)
+            assert resp is False, f"Expected no keystore file for {address} because a keycard-created keypair must keep key material off disk"

--- a/tests-functional/tests/test_delete_cold_wallet_keypair.py
+++ b/tests-functional/tests/test_delete_cold_wallet_keypair.py
@@ -1,0 +1,74 @@
+# Ad-hoc test — no backend spec. Restores coverage deleted in 33be7c3e7 in cold-wallet vocabulary.
+import copy
+import re
+import pytest
+from clients.api import ApiResponseError
+from resources.constants import user_1, wallet_account_details_derivation, keypair_name
+
+
+@pytest.mark.rpc
+class TestDeleteColdWalletKeypair:
+
+    @pytest.fixture()
+    def backend(self, backend_new_profile):
+        return backend_new_profile("account-backend")
+
+    def _add_cold_keypair(self, backend):
+        add_resp = backend.accounts_service.add_keypair_via_seed_phrase(
+            user_1.passphrase,
+            backend.password,
+            keypair_name,
+            "",
+            wallet_account_details_derivation,
+        )
+        key_uid = add_resp.get("key-uid")
+        assert key_uid is not None, "Expected addKeypairViaSeedPhrase to return the created keypair's key-uid"
+        backend.accounts_service.migrate_non_profile_keypair_to_cold_wallet(key_uid, backend.password, "status-keycard")
+        return key_uid
+
+    def test_delete_cold_wallet_keypair_without_password(self, backend):
+        key_uid = self._add_cold_keypair(backend)
+
+        backend.accounts_service.delete_keypair(key_uid, "")
+
+        with pytest.raises(ApiResponseError, match=re.escape("keypair is not found")):
+            backend.accounts_service.get_keypair_by_key_uid(key_uid)
+
+    def test_delete_nonexistent_keypair_errors(self, backend):
+        unknown_key_uid = "0x3231d92c94548d14f097173765a50bebe28fbad8f2267c9e08cc4433a6f219a4"
+        with pytest.raises(ApiResponseError, match=re.escape("keypair is not found")):
+            backend.accounts_service.delete_keypair(unknown_key_uid, backend.password)
+
+    def test_delete_account_of_cold_wallet_keypair_without_password(self, backend):
+        add_resp = backend.accounts_service.add_keypair_via_seed_phrase(
+            user_1.passphrase,
+            backend.password,
+            keypair_name,
+            "",
+            wallet_account_details_derivation,
+        )
+        key_uid = add_resp.get("key-uid")
+        assert key_uid is not None, "Expected addKeypairViaSeedPhrase to return the created keypair's key-uid"
+
+        second_path = "m/44'/60'/0'/0/1"
+        derived = backend.wallet_service.get_derived_addresses_for_mnemonic(user_1.passphrase, [second_path])
+        template = copy.deepcopy(add_resp.get("accounts")[0])
+        template.update(
+            {
+                "address": derived[0].get("address"),
+                "public-key": derived[0].get("public-key"),
+                "path": second_path,
+                "name": "second-account",
+                "wallet": False,
+                "chat": False,
+            }
+        )
+        backend.accounts_service.add_account(backend.password, template)
+        backend.accounts_service.migrate_non_profile_keypair_to_cold_wallet(key_uid, backend.password, "status-keycard")
+        target_address = derived[0].get("address")
+
+        backend.accounts_service.delete_account(target_address, "")
+
+        kp = backend.accounts_service.get_keypair_by_key_uid(key_uid)
+        remaining = [a for a in kp.get("accounts", []) if a.get("address", "").lower() == target_address.lower()]
+        assert len(remaining) == 0, "Expected the account removed without a password because cold-wallet keypairs have no keystore files to unlock"

--- a/tests-functional/tests/test_login_after_cold_wallet_migration.py
+++ b/tests-functional/tests/test_login_after_cold_wallet_migration.py
@@ -1,0 +1,39 @@
+# Ad-hoc test — no backend spec. Restores coverage deleted in 33be7c3e7 in cold-wallet vocabulary.
+import pytest
+from resources.constants import user_1, wallet_account_details_derivation, keypair_name
+
+
+@pytest.mark.rpc
+class TestLoginAfterColdWalletMigration:
+
+    @pytest.fixture()
+    def backend(self, backend_new_profile):
+        return backend_new_profile("account-backend")
+
+    def test_login_succeeds_with_cold_wallet_keypair_present(self, backend):
+        add_resp = backend.accounts_service.add_keypair_via_seed_phrase(
+            user_1.passphrase,
+            backend.password,
+            keypair_name,
+            "",
+            wallet_account_details_derivation,
+        )
+        key_uid = add_resp.get("key-uid")
+        assert key_uid is not None, "Expected addKeypairViaSeedPhrase to return the created keypair's key-uid"
+        addresses = [a.get("address") for a in add_resp.get("accounts", [])] + [add_resp.get("derived-from")]
+        backend.accounts_service.migrate_non_profile_keypair_to_cold_wallet(key_uid, backend.password, "status-keycard")
+
+        backend.logout()
+        backend.login(backend.key_uid, backend.password)
+        backend.wait_for_login()
+        backend.wait_for_wakuext_ready(timeout=30)
+
+        kp = backend.accounts_service.get_keypair_by_key_uid(key_uid)
+        assert (
+            kp.get("cold-wallet") == "status-keycard"
+        ), "Expected the keypair to stay cold-wallet backed after relogin because login xpub backfill must skip cold keypairs"
+        for address in addresses:
+            resp = backend.accounts_service.verify_keystore_file_for_account(address, backend.password)
+            assert (
+                resp is False
+            ), f"Expected no keystore file for {address} after relogin because login must not restore key material for cold keypairs"

--- a/tests-functional/tests/test_migrate_non_profile_cold_wallet_keypair_to_app.py
+++ b/tests-functional/tests/test_migrate_non_profile_cold_wallet_keypair_to_app.py
@@ -1,4 +1,8 @@
+import copy
+import re
+
 import pytest
+from clients.api import ApiResponseError
 from resources.constants import (
     user_1,
     wallet_account_details_derivation,
@@ -13,8 +17,7 @@ class TestMigrateNonProfileColdWalletKeypairToApp:
     def backend(self, backend_new_profile):
         return backend_new_profile("account-backend")
 
-    def test_full_migrate_flow(self, backend):
-        # 1) Add a seed-derived keypair (regular, not cold-wallet)
+    def _add_seed_keypair(self, backend):
         add_resp = backend.accounts_service.add_keypair_via_seed_phrase(
             user_1.passphrase,
             backend.password,
@@ -22,33 +25,43 @@ class TestMigrateNonProfileColdWalletKeypairToApp:
             "",
             wallet_account_details_derivation,
         )
-        assert "error" not in add_resp
-        add_result = add_resp
-        assert add_result is not None
-        key_uid = add_result.get("key-uid")
-        assert key_uid is not None
+        assert add_resp is not None, "Expected addKeypairViaSeedPhrase to return the created keypair"
+        key_uid = add_resp.get("key-uid")
+        assert key_uid is not None, "Expected the created keypair to carry a key-uid"
+        accounts_list = add_resp.get("accounts", [])
+        assert len(accounts_list) > 0, "Expected the created keypair to have at least one account"
+        addresses = [a.get("address") for a in accounts_list] + [add_resp.get("derived-from")]
+        return key_uid, addresses
 
-        accounts_list = add_result.get("accounts", [])
-        assert len(accounts_list) > 0
-        addresses = [a.get("address") for a in accounts_list] + [add_result.get("derived-from")]
+    def _profile_addresses(self, backend):
+        kp = backend.accounts_service.get_keypair_by_key_uid(backend.key_uid)
+        assert kp is not None, "Expected the profile keypair to exist"
+        return [a.get("address") for a in kp.get("accounts", [])]
+
+    @pytest.mark.parametrize("cold_wallet_type", ["status-keycard", "ledger", "trezor"])
+    def test_full_migrate_flow(self, backend, cold_wallet_type):
+        # 1) Add a seed-derived keypair (regular, not cold-wallet)
+        key_uid, addresses = self._add_seed_keypair(backend)
 
         # Keystore files for the keypair accounts should exist
         for address in addresses:
             resp = backend.accounts_service.verify_keystore_file_for_account(address, backend.password)
-            assert resp is True
+            assert resp is True, f"Expected a keystore file for {address} because the keypair was just imported with a password"
 
-        # 2) Migrate the keypair to a cold wallet (status-keycard)
+        # 2) Migrate the keypair to a cold wallet
         # This should remove the keystore files
-        backend.accounts_service.migrate_non_profile_keypair_to_cold_wallet(key_uid, backend.password, "status-keycard")
+        backend.accounts_service.migrate_non_profile_keypair_to_cold_wallet(key_uid, backend.password, cold_wallet_type)
 
         for address in addresses:
             resp = backend.accounts_service.verify_keystore_file_for_account(address, backend.password)
-            assert resp is False
+            assert resp is False, f"Expected no keystore file for {address} because cold-wallet migration deletes keystore files"
 
-        # Verify the keypair is now flagged as cold-wallet backed
+        # Verify the keypair is now flagged as cold-wallet backed, with the exact type round-tripped
         kp_resp = backend.accounts_service.get_keypair_by_key_uid(key_uid)
         assert kp_resp is not None
-        assert kp_resp.get("cold-wallet") == "status-keycard"
+        assert (
+            kp_resp.get("cold-wallet") == cold_wallet_type
+        ), f"Expected cold-wallet '{cold_wallet_type}' to round-trip through the RPC layer unchanged"
 
         # 3) Migrate the non-profile cold-wallet keypair back to the app (full flow)
         # Keystore files should be restored and the cold-wallet flag cleared
@@ -58,11 +71,85 @@ class TestMigrateNonProfileColdWalletKeypairToApp:
 
         for address in addresses:
             resp = backend.accounts_service.verify_keystore_file_for_account(address, backend.password)
-            assert resp is True
+            assert resp is True, f"Expected the keystore file for {address} to be restored by migrate-to-app"
 
         # 4) Verify the keypair still exists, cold-wallet flag is cleared, and accounts remain
         kp_resp = backend.accounts_service.get_keypair_by_key_uid(key_uid)
         assert kp_resp is not None
-        assert kp_resp.get("cold-wallet", "") == ""
+        assert kp_resp.get("cold-wallet", "") == "", "Expected the cold-wallet flag cleared after migrate-to-app"
         assert isinstance(kp_resp.get("accounts"), list)
         assert len(kp_resp.get("accounts")) >= 1
+
+        # 5) The stored xpub must be RETAINED through migrate-to-app: adding a derived
+        # account with an EMPTY password still works (xpub-validated, no keystore derive)
+        next_path = "m/44'/60'/0'/0/1"
+        derived = backend.wallet_service.get_derived_addresses_for_mnemonic(user_1.passphrase, [next_path])
+        template = copy.deepcopy(kp_resp["accounts"][0])
+        template.update(
+            {
+                "address": derived[0].get("address"),
+                "public-key": derived[0].get("public-key"),
+                "path": next_path,
+                "name": "xpub-derived",
+                "wallet": False,
+                "chat": False,
+            }
+        )
+        backend.accounts_service.add_account("", template)
+        kp_resp = backend.accounts_service.get_keypair_by_key_uid(key_uid)
+        added = [a for a in kp_resp.get("accounts", []) if a.get("path") == next_path]
+        assert len(added) == 1, "Expected the empty-password add_account to succeed because migrate-to-app retains the stored xpub"
+
+    def test_remigrate_same_cold_wallet_type_is_idempotent(self, backend):
+        key_uid, addresses = self._add_seed_keypair(backend)
+        backend.accounts_service.migrate_non_profile_keypair_to_cold_wallet(key_uid, backend.password, "status-keycard")
+
+        backend.accounts_service.migrate_non_profile_keypair_to_cold_wallet(key_uid, backend.password, "status-keycard")
+
+        kp_resp = backend.accounts_service.get_keypair_by_key_uid(key_uid)
+        assert kp_resp.get("cold-wallet") == "status-keycard", "Expected re-migrating to the same cold-wallet type to be a no-op keeping the type"
+        for address in addresses:
+            resp = backend.accounts_service.verify_keystore_file_for_account(address, backend.password)
+            assert resp is False, f"Expected keystore files for {address} to stay absent after an idempotent re-migrate"
+
+    def test_migrate_profile_keypair_to_cold_wallet_is_rejected(self, backend):
+        profile_addresses = self._profile_addresses(backend)
+
+        with pytest.raises(ApiResponseError, match=re.escape("use ConvertToKeycardAccount instead")):
+            backend.accounts_service.migrate_non_profile_keypair_to_cold_wallet(backend.key_uid, backend.password, "status-keycard")
+
+        for address in profile_addresses:
+            resp = backend.accounts_service.verify_keystore_file_for_account(address, backend.password)
+            assert resp is True, f"Expected the profile keystore file for {address} untouched because the migrate RPC must reject profile keypairs"
+
+    def test_migrate_profile_keypair_to_app_is_rejected(self, backend):
+        with pytest.raises(ApiResponseError, match=re.escape("use ConvertToRegularAccount instead")):
+            backend.accounts_service.migrate_non_profile_cold_wallet_keypair_to_app(backend.mnemonic, backend.password)
+
+    def test_migrate_unknown_key_uid_to_cold_wallet_errors(self, backend):
+        unknown_key_uid = "0x3231d92c94548d14f097173765a50bebe28fbad8f2267c9e08cc4433a6f219a4"
+        with pytest.raises(ApiResponseError, match=re.escape("keypair is not found")):
+            backend.accounts_service.migrate_non_profile_keypair_to_cold_wallet(unknown_key_uid, backend.password, "status-keycard")
+
+    def test_migrate_to_app_rejects_non_cold_keypair(self, backend):
+        self._add_seed_keypair(backend)
+        with pytest.raises(ApiResponseError, match=re.escape("keypair is not a cold wallet keypair")):
+            backend.accounts_service.migrate_non_profile_cold_wallet_keypair_to_app(user_1.passphrase, backend.password)
+
+    def test_migrate_to_app_rejects_unknown_mnemonic(self, backend):
+        random_mnemonic = backend.accounts_service.get_random_mnemonic()
+        with pytest.raises(ApiResponseError, match=re.escape("keypair is not found")):
+            backend.accounts_service.migrate_non_profile_cold_wallet_keypair_to_app(random_mnemonic, backend.password)
+
+    def test_migrate_to_app_rejects_wrong_password(self, backend):
+        key_uid, addresses = self._add_seed_keypair(backend)
+        backend.accounts_service.migrate_non_profile_keypair_to_cold_wallet(key_uid, backend.password, "status-keycard")
+
+        with pytest.raises(ApiResponseError, match=re.escape("wrong password provided")):
+            backend.accounts_service.migrate_non_profile_cold_wallet_keypair_to_app(user_1.passphrase, "definitely-wrong-password")
+
+        for address in addresses:
+            resp = backend.accounts_service.verify_keystore_file_for_account(address, backend.password)
+            assert (
+                resp is False
+            ), f"Expected no keystore file for {address} because migrate-to-app with a wrong password must not write keystore files"


### PR DESCRIPTION
The keycard management API was removed in July 2026 (33be7c3e7 and related commits). A keycard is now a `cold_wallet` value on a keypair, with `ledger` and `trezor` as sibling values. Test coverage for this surface did not follow the change.

This PR restores functional (RPC-level) keycard coverage in cold-wallet vocabulary. The old keycard functional tests were deleted together with the API; 6 of the 21 deleted cases have direct successors, added here. The other cases covered entities that no longer exist (card lock state, card names, card UIDs, multiple cards per keypair).

- `test_full_migrate_flow` is now parametrized over `status-keycard`, `ledger`, and `trezor` — the first ledger/trezor coverage at this level. It also checks the stored xpub survives migrating back to app, by adding an account with an empty password afterwards.
- Migrate error paths: profile keypair rejected in both directions, unknown key UID, unknown mnemonic, wrong password, non-cold keypair.
- `addKeypairStoredToColdWallet` validation: empty accounts, non-wallet path, duplicate keypair; plus the no-password account derivation flow on a cold keypair.
- Creating a keypair as cold via `addKeypairViaSeedPhrase` writes no keystore files.
- Deleting a cold-wallet keypair, or one of its accounts, works without a password.
- Login after migration: the keypair stays cold and no keystore files reappear.

For every new test we temporarily broke the behavior it covers in production code, confirmed the test fails, then restored the code and confirmed the test passes. Production code is unchanged in this PR.

Part 6 of a 6-part series that restores keycard/cold-wallet test coverage.

Covers status-im/status-app#21626 together with the accounts-management PR of this series.
