### PR TITLE
feat(bot): send one-time support bot contact request

### DIFF
--- a/internal/db/appdatabase/migrations/sql/1787596546_add_support_bot_contact_request_state_to_settings_table.up.sql
+++ b/internal/db/appdatabase/migrations/sql/1787596546_add_support_bot_contact_request_state_to_settings_table.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE settings ADD COLUMN support_bot_contact_request_state INTEGER NOT NULL DEFAULT 0;

--- a/internal/db/multiaccounts/settings/columns.go
+++ b/internal/db/multiaccounts/settings/columns.go
@@ -454,6 +454,12 @@ var (
 		dBColumnName:   "auto_apply_keypair_migrations",
 		valueHandler:   BoolHandler,
 	}
+	SupportBotContactRequestState = SettingField{
+		reactFieldName:   "support-bot-contact-request-state",
+		dBColumnName:     "support_bot_contact_request_state",
+		valueHandler:     Int64Handler,
+		valueCastHandler: Float64ToInt64Handler,
+	}
 	URLUnfurlingMode = SettingField{
 		reactFieldName: "url-unfurling-mode",
 		dBColumnName:   "url_unfurling_mode",
@@ -562,6 +568,7 @@ var (
 		LastTokensUpdate,
 		ThirdpartyServicesEnabled,
 		AutoApplyKeypairMigrations,
+		SupportBotContactRequestState,
 	}
 )
 

--- a/internal/db/multiaccounts/settings/database.go
+++ b/internal/db/multiaccounts/settings/database.go
@@ -146,10 +146,11 @@ INSERT INTO settings (
   fleet,
   auto_refresh_tokens_enabled,
   thirdparty_services_enabled,
-  auto_apply_keypair_migrations
+  auto_apply_keypair_migrations,
+  support_bot_contact_request_state
 ) VALUES (
 ?,?,?,?,?,?,?,?,?,?,?,
-?,?,?,?,?,?,?,?,'id',?,?,?,?,?,?,?,?,?,?,?,?,?)`,
+?,?,?,?,?,?,?,?,'id',?,?,?,?,?,?,?,?,?,?,?,?,?,?)`,
 		s.Address,
 		s.Currency,
 		s.CurrentNetwork,
@@ -182,6 +183,7 @@ INSERT INTO settings (
 		s.AutoRefreshTokensEnabled,
 		s.ThirdpartyServicesEnabled,
 		s.AutoApplyKeypairMigrations,
+		s.SupportBotContactRequestState,
 	)
 	if err != nil {
 		return err
@@ -400,7 +402,8 @@ func (db *Database) GetSettings() (Settings, error) {
 		mnemonic_was_not_shown, wallet_show_community_asset_when_sending_tokens, wallet_display_assets_below_balance,
 		wallet_display_assets_below_balance_threshold, wallet_collectible_preferences_group_by_collection, wallet_collectible_preferences_group_by_community,
 		auto_refresh_tokens_enabled, last_tokens_update, backup_path,
-		thirdparty_services_enabled, messages_backup_enabled, auto_apply_keypair_migrations
+		thirdparty_services_enabled, messages_backup_enabled, auto_apply_keypair_migrations,
+		support_bot_contact_request_state
 	FROM
 		settings
 	WHERE
@@ -478,6 +481,7 @@ func (db *Database) GetSettings() (Settings, error) {
 		&s.ThirdpartyServicesEnabled,
 		&s.MessagesBackupEnabled,
 		&s.AutoApplyKeypairMigrations,
+		&s.SupportBotContactRequestState,
 	)
 
 	if err != nil {
@@ -764,6 +768,11 @@ func (db *Database) ProfileMigrationNeeded() (result bool, err error) {
 
 func (db *Database) AutoApplyKeypairMigrations() (result bool, err error) {
 	err = db.makeSelectRow(AutoApplyKeypairMigrations).Scan(&result)
+	return result, err
+}
+
+func (db *Database) SupportBotContactRequestState() (result int64, err error) {
+	err = db.makeSelectRow(SupportBotContactRequestState).Scan(&result)
 	return result, err
 }
 

--- a/internal/db/multiaccounts/settings/database_settings_manager.go
+++ b/internal/db/multiaccounts/settings/database_settings_manager.go
@@ -70,6 +70,7 @@ type DatabaseSettingsManager interface {
 	GifFavorites() (favorites json.RawMessage, err error)
 	ProfileMigrationNeeded() (result bool, err error)
 	AutoApplyKeypairMigrations() (result bool, err error)
+	SupportBotContactRequestState() (result int64, err error)
 	URLUnfurlingMode() (result int64, err error)
 	SubscribeToChanges() chan *SyncSettingField
 	MnemonicWasShown() error

--- a/internal/db/multiaccounts/settings/database_test.go
+++ b/internal/db/multiaccounts/settings/database_test.go
@@ -49,6 +49,7 @@ var (
 		ShowCommunityAssetWhenSendingTokens: true,
 		ThirdpartyServicesEnabled:           true,
 		AutoApplyKeypairMigrations:          true,
+		SupportBotContactRequestState:       SupportBotContactRequestStatePendingNew,
 	}
 )
 
@@ -145,6 +146,17 @@ func TestDatabase_CreateSettingsPreservesAutoApplyKeypairMigrations(t *testing.T
 	enabled, err := db.AutoApplyKeypairMigrations()
 	require.NoError(t, err)
 	require.False(t, enabled)
+}
+
+func TestDatabase_SupportBotContactRequestState(t *testing.T) {
+	db, stop := setupTestDB(t)
+	defer stop()
+
+	require.NoError(t, db.CreateSettings(settings, config))
+
+	state, err := db.SupportBotContactRequestState()
+	require.NoError(t, err)
+	require.Equal(t, int64(1), state)
 }
 
 func TestSaveSetting(t *testing.T) {

--- a/internal/db/multiaccounts/settings/structs.go
+++ b/internal/db/multiaccounts/settings/structs.go
@@ -18,6 +18,12 @@ type SyncSettingProtobufFactoryInterface func(interface{}, uint64, string) (*com
 type SyncSettingProtobufFactoryStruct func(Settings, uint64, string) (*common.RawMessage, *protobuf.SyncSetting, error)
 type SyncSettingProtobufToValue func(setting *protobuf.SyncSetting) interface{}
 
+const (
+	SupportBotContactRequestStatePendingExisting int64 = 0
+	SupportBotContactRequestStatePendingNew      int64 = 1
+	SupportBotContactRequestStateDone            int64 = 2
+)
+
 // SyncProtobufFactory represents a collection of functionality to generate and parse *protobuf.SyncSetting
 type SyncProtobufFactory struct {
 	inactive          bool
@@ -215,6 +221,7 @@ type Settings struct {
 	AutoRefreshTokensEnabled            bool                          `json:"auto-refresh-tokens-enabled,omitempty"`
 	LastTokensUpdate                    time.Time                     `json:"last-tokens-update,omitempty"`
 	ThirdpartyServicesEnabled           bool                          `json:"thirdparty_services_enabled"`
+	SupportBotContactRequestState       int64                         `json:"support-bot-contact-request-state"`
 }
 
 func (s Settings) MarshalJSON() ([]byte, error) {

--- a/internal/protocol/messenger.go
+++ b/internal/protocol/messenger.go
@@ -688,6 +688,15 @@ func (m *Messenger) Start() (*MessengerResponse, error) {
 			}
 		}()
 	}
+	if m.config.enableSupportBotContactRequest {
+		go func() {
+			defer panics.LogOnPanic()
+
+			if err := m.sendSupportBotContactRequest(); err != nil {
+				m.logger.Warn("failed to send support bot contact request", zap.Error(err))
+			}
+		}()
+	}
 
 	// Request any history missed while offline. The storenodes are resolved from
 	// the fleet inside the waku node at startup, so they are already configured

--- a/internal/protocol/messenger_config.go
+++ b/internal/protocol/messenger_config.go
@@ -109,8 +109,10 @@ type config struct {
 
 	onlineChecker func() bool
 
-	communitiesRekeyInterval time.Duration
-	enablePinnedBootstrap    bool
+	communitiesRekeyInterval       time.Duration
+	enablePinnedBootstrap          bool
+	enableSupportBotContactRequest bool
+	supportBotChatKey              string
 }
 
 func messengerDefaultConfig() config {
@@ -123,6 +125,7 @@ func messengerDefaultConfig() config {
 	c.codeControlFlags.CuratedCommunitiesUpdateLoopEnabled = true
 
 	c.tracer = trace.NewNoopTracer()
+	c.supportBotChatKey = supportBotChatKey
 
 	return c
 }
@@ -245,6 +248,20 @@ func WithClusterConfig(cc params.ClusterConfig) Option {
 func WithEnablePinnedBootstrap(enabled bool) Option {
 	return func(c *config) error {
 		c.enablePinnedBootstrap = enabled
+		return nil
+	}
+}
+
+func WithEnableSupportBotContactRequest(enabled bool) Option {
+	return func(c *config) error {
+		c.enableSupportBotContactRequest = enabled
+		return nil
+	}
+}
+
+func withSupportBotChatKey(chatKey string) Option {
+	return func(c *config) error {
+		c.supportBotChatKey = chatKey
 		return nil
 	}
 }

--- a/internal/protocol/messenger_support_bot.go
+++ b/internal/protocol/messenger_support_bot.go
@@ -1,0 +1,86 @@
+package protocol
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/status-im/status-go/internal/db/multiaccounts/settings"
+	"github.com/status-im/status-go/internal/protocol/requests"
+)
+
+const (
+	supportBotExistingUserMessage = "Hi, I just upgraded to the latest version of Status."
+	supportBotNewUserMessage      = "Hi, I'm a new Status user."
+)
+
+var supportBotChatKey = os.Getenv("STATUS_SUPPORT_BOT_CHAT_KEY")
+
+func (m *Messenger) sendSupportBotContactRequest() error {
+	if m.shouldAbortSupportBotContactRequest() {
+		return nil
+	}
+
+	state, err := m.settings.SupportBotContactRequestState()
+	if err != nil {
+		return err
+	}
+	if state == settings.SupportBotContactRequestStateDone {
+		return nil
+	}
+
+	chatID, err := requests.ConvertCompressedToLegacyKey(m.config.supportBotChatKey)
+	if err != nil {
+		return err
+	}
+	if strings.EqualFold(chatID, m.myHexIdentity()) {
+		return m.markSupportBotContactRequestDone()
+	}
+	if contact, ok := m.allContacts.Load(chatID); ok && contact.Added() {
+		return m.markSupportBotContactRequestDone()
+	}
+
+	message, err := supportBotContactRequestMessage(state)
+	if err != nil {
+		return err
+	}
+	response, err := m.SendContactRequest(m.ctx, &requests.SendContactRequest{
+		ID:      chatID,
+		Message: message,
+	})
+	if err != nil {
+		return err
+	}
+	if err := m.markSupportBotContactRequestDone(); err != nil {
+		return err
+	}
+
+	m.PublishMessengerResponse(response)
+	return nil
+}
+
+func (m *Messenger) shouldAbortSupportBotContactRequest() bool {
+	select {
+	case <-m.quit:
+		return true
+	case <-m.ctx.Done():
+		return true
+	default:
+		return false
+	}
+}
+
+func (m *Messenger) markSupportBotContactRequestDone() error {
+	return m.settings.SaveSettingField(settings.SupportBotContactRequestState, settings.SupportBotContactRequestStateDone)
+}
+
+func supportBotContactRequestMessage(state int64) (string, error) {
+	switch state {
+	case settings.SupportBotContactRequestStatePendingExisting:
+		return supportBotExistingUserMessage, nil
+	case settings.SupportBotContactRequestStatePendingNew:
+		return supportBotNewUserMessage, nil
+	default:
+		return "", fmt.Errorf("invalid support bot contact request state: %d", state)
+	}
+}

--- a/internal/protocol/messenger_support_bot.go
+++ b/internal/protocol/messenger_support_bot.go
@@ -1,7 +1,6 @@
 package protocol
 
 import (
-	"fmt"
 	"os"
 	"strings"
 
@@ -10,8 +9,7 @@ import (
 )
 
 const (
-	supportBotExistingUserMessage = "Hi, I just upgraded to the latest version of Status."
-	supportBotNewUserMessage      = "Hi, I'm a new Status user."
+	supportBotNewUserMessage = "->"
 )
 
 var supportBotChatKey = os.Getenv("STATUS_SUPPORT_BOT_CHAT_KEY")
@@ -28,6 +26,9 @@ func (m *Messenger) sendSupportBotContactRequest() error {
 	if state == settings.SupportBotContactRequestStateDone {
 		return nil
 	}
+	if state == settings.SupportBotContactRequestStatePendingExisting {
+		return m.markSupportBotContactRequestDone()
+	}
 
 	chatID, err := requests.ConvertCompressedToLegacyKey(m.config.supportBotChatKey)
 	if err != nil {
@@ -40,13 +41,9 @@ func (m *Messenger) sendSupportBotContactRequest() error {
 		return m.markSupportBotContactRequestDone()
 	}
 
-	message, err := supportBotContactRequestMessage(state)
-	if err != nil {
-		return err
-	}
 	response, err := m.SendContactRequest(m.ctx, &requests.SendContactRequest{
 		ID:      chatID,
-		Message: message,
+		Message: supportBotNewUserMessage,
 	})
 	if err != nil {
 		return err
@@ -72,15 +69,4 @@ func (m *Messenger) shouldAbortSupportBotContactRequest() bool {
 
 func (m *Messenger) markSupportBotContactRequestDone() error {
 	return m.settings.SaveSettingField(settings.SupportBotContactRequestState, settings.SupportBotContactRequestStateDone)
-}
-
-func supportBotContactRequestMessage(state int64) (string, error) {
-	switch state {
-	case settings.SupportBotContactRequestStatePendingExisting:
-		return supportBotExistingUserMessage, nil
-	case settings.SupportBotContactRequestStatePendingNew:
-		return supportBotNewUserMessage, nil
-	default:
-		return "", fmt.Errorf("invalid support bot contact request state: %d", state)
-	}
 }

--- a/internal/protocol/messenger_support_bot.go
+++ b/internal/protocol/messenger_support_bot.go
@@ -10,9 +10,17 @@ import (
 
 const (
 	supportBotNewUserMessage = "->"
+	defaultSupportBotChatKey = "zQ3shX8r9eRDTEQQhks4qciDunphxdY1w1KjvZ32Pn7dGdWTL"
 )
 
-var supportBotChatKey = os.Getenv("STATUS_SUPPORT_BOT_CHAT_KEY")
+var supportBotChatKey = supportBotChatKeyFromEnv()
+
+func supportBotChatKeyFromEnv() string {
+	if chatKey := os.Getenv("STATUS_SUPPORT_BOT_CHAT_KEY"); chatKey != "" {
+		return chatKey
+	}
+	return defaultSupportBotChatKey
+}
 
 func (m *Messenger) sendSupportBotContactRequest() error {
 	if m.shouldAbortSupportBotContactRequest() {

--- a/internal/protocol/messenger_support_bot_test.go
+++ b/internal/protocol/messenger_support_bot_test.go
@@ -14,19 +14,19 @@ import (
 
 func TestSendSupportBotContactRequest(t *testing.T) {
 	testCases := []struct {
-		name    string
-		state   int64
-		message string
+		name                  string
+		state                 int64
+		expectsContactRequest bool
 	}{
 		{
-			name:    "existing user",
-			state:   settings.SupportBotContactRequestStatePendingExisting,
-			message: supportBotExistingUserMessage,
+			name:                  "existing user",
+			state:                 settings.SupportBotContactRequestStatePendingExisting,
+			expectsContactRequest: false,
 		},
 		{
-			name:    "new user",
-			state:   settings.SupportBotContactRequestStatePendingNew,
-			message: supportBotNewUserMessage,
+			name:                  "new user",
+			state:                 settings.SupportBotContactRequestStatePendingNew,
+			expectsContactRequest: true,
 		},
 	}
 
@@ -42,8 +42,12 @@ func TestSendSupportBotContactRequest(t *testing.T) {
 			messages, _, err := m.persistence.MessageByChatID(chatID, "", 10)
 			require.NoError(t, err)
 			contactRequest := FindFirstByContentType(messages, protobuf.ChatMessage_CONTACT_REQUEST)
-			require.NotNil(t, contactRequest)
-			require.Equal(t, testCase.message, contactRequest.Text)
+			if testCase.expectsContactRequest {
+				require.NotNil(t, contactRequest)
+				require.Equal(t, supportBotNewUserMessage, contactRequest.Text)
+			} else {
+				require.Nil(t, contactRequest)
+			}
 
 			state, err := m.settings.SupportBotContactRequestState()
 			require.NoError(t, err)
@@ -63,7 +67,7 @@ func TestSendSupportBotContactRequest(t *testing.T) {
 	}
 }
 
-func TestMessengerStartSendsSupportBotContactRequest(t *testing.T) {
+func TestMessengerStartSkipsExistingUserSupportBotContactRequest(t *testing.T) {
 	messagingEnv, err := messaging.NewTestMessagingEnvironment()
 	require.NoError(t, err)
 	require.NoError(t, messagingEnv.Setup(t))
@@ -86,21 +90,7 @@ func TestMessengerStartSendsSupportBotContactRequest(t *testing.T) {
 	messages, _, err := m.persistence.MessageByChatID(chatID, "", 10)
 	require.NoError(t, err)
 	contactRequest := FindFirstByContentType(messages, protobuf.ChatMessage_CONTACT_REQUEST)
-	require.NotNil(t, contactRequest)
-	require.Equal(t, supportBotExistingUserMessage, contactRequest.Text)
-}
-
-func TestSupportBotContactRequestMessage(t *testing.T) {
-	message, err := supportBotContactRequestMessage(settings.SupportBotContactRequestStatePendingExisting)
-	require.NoError(t, err)
-	require.Equal(t, supportBotExistingUserMessage, message)
-
-	message, err = supportBotContactRequestMessage(settings.SupportBotContactRequestStatePendingNew)
-	require.NoError(t, err)
-	require.Equal(t, supportBotNewUserMessage, message)
-
-	_, err = supportBotContactRequestMessage(settings.SupportBotContactRequestStateDone)
-	require.Error(t, err)
+	require.Nil(t, contactRequest)
 }
 
 func newSupportBotTestMessenger(t *testing.T) *Messenger {

--- a/internal/protocol/messenger_support_bot_test.go
+++ b/internal/protocol/messenger_support_bot_test.go
@@ -1,6 +1,7 @@
 package protocol
 
 import (
+	"os"
 	"testing"
 	"time"
 
@@ -11,6 +12,14 @@ import (
 	"github.com/status-im/status-go/internal/protocol/requests"
 	"github.com/status-im/status-go/pkg/messaging"
 )
+
+func TestSupportBotChatKeyFromEnv(t *testing.T) {
+	t.Setenv("STATUS_SUPPORT_BOT_CHAT_KEY", testPK)
+	require.Equal(t, testPK, supportBotChatKeyFromEnv())
+
+	require.NoError(t, os.Unsetenv("STATUS_SUPPORT_BOT_CHAT_KEY"))
+	require.Equal(t, defaultSupportBotChatKey, supportBotChatKeyFromEnv())
+}
 
 func TestSendSupportBotContactRequest(t *testing.T) {
 	testCases := []struct {

--- a/internal/protocol/messenger_support_bot_test.go
+++ b/internal/protocol/messenger_support_bot_test.go
@@ -1,0 +1,118 @@
+package protocol
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/status-im/status-go/internal/db/multiaccounts/settings"
+	"github.com/status-im/status-go/internal/protocol/protobuf"
+	"github.com/status-im/status-go/internal/protocol/requests"
+	"github.com/status-im/status-go/pkg/messaging"
+)
+
+func TestSendSupportBotContactRequest(t *testing.T) {
+	testCases := []struct {
+		name    string
+		state   int64
+		message string
+	}{
+		{
+			name:    "existing user",
+			state:   settings.SupportBotContactRequestStatePendingExisting,
+			message: supportBotExistingUserMessage,
+		},
+		{
+			name:    "new user",
+			state:   settings.SupportBotContactRequestStatePendingNew,
+			message: supportBotNewUserMessage,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			m := newSupportBotTestMessenger(t)
+			require.NoError(t, m.settings.SaveSettingField(settings.SupportBotContactRequestState, testCase.state))
+
+			require.NoError(t, m.sendSupportBotContactRequest())
+
+			chatID, err := requests.ConvertCompressedToLegacyKey(testPK)
+			require.NoError(t, err)
+			messages, _, err := m.persistence.MessageByChatID(chatID, "", 10)
+			require.NoError(t, err)
+			contactRequest := FindFirstByContentType(messages, protobuf.ChatMessage_CONTACT_REQUEST)
+			require.NotNil(t, contactRequest)
+			require.Equal(t, testCase.message, contactRequest.Text)
+
+			state, err := m.settings.SupportBotContactRequestState()
+			require.NoError(t, err)
+			require.Equal(t, settings.SupportBotContactRequestStateDone, state)
+
+			require.NoError(t, m.settings.SaveSettingField(settings.SupportBotContactRequestState, testCase.state))
+			require.NoError(t, m.sendSupportBotContactRequest())
+
+			messagesAfterRetry, _, err := m.persistence.MessageByChatID(chatID, "", 10)
+			require.NoError(t, err)
+			require.Len(t, messagesAfterRetry, len(messages))
+
+			state, err = m.settings.SupportBotContactRequestState()
+			require.NoError(t, err)
+			require.Equal(t, settings.SupportBotContactRequestStateDone, state)
+		})
+	}
+}
+
+func TestMessengerStartSendsSupportBotContactRequest(t *testing.T) {
+	messagingEnv, err := messaging.NewTestMessagingEnvironment()
+	require.NoError(t, err)
+	require.NoError(t, messagingEnv.Setup(t))
+
+	m, err := newRunningTestMessenger(t, messagingEnv, testMessengerConfig{
+		extraOptions: []Option{
+			WithEnableSupportBotContactRequest(true),
+			withSupportBotChatKey(testPK),
+		},
+	})
+	require.NoError(t, err)
+
+	require.Eventually(t, func() bool {
+		state, err := m.settings.SupportBotContactRequestState()
+		return err == nil && state == settings.SupportBotContactRequestStateDone
+	}, 5*time.Second, 50*time.Millisecond)
+
+	chatID, err := requests.ConvertCompressedToLegacyKey(testPK)
+	require.NoError(t, err)
+	messages, _, err := m.persistence.MessageByChatID(chatID, "", 10)
+	require.NoError(t, err)
+	contactRequest := FindFirstByContentType(messages, protobuf.ChatMessage_CONTACT_REQUEST)
+	require.NotNil(t, contactRequest)
+	require.Equal(t, supportBotExistingUserMessage, contactRequest.Text)
+}
+
+func TestSupportBotContactRequestMessage(t *testing.T) {
+	message, err := supportBotContactRequestMessage(settings.SupportBotContactRequestStatePendingExisting)
+	require.NoError(t, err)
+	require.Equal(t, supportBotExistingUserMessage, message)
+
+	message, err = supportBotContactRequestMessage(settings.SupportBotContactRequestStatePendingNew)
+	require.NoError(t, err)
+	require.Equal(t, supportBotNewUserMessage, message)
+
+	_, err = supportBotContactRequestMessage(settings.SupportBotContactRequestStateDone)
+	require.Error(t, err)
+}
+
+func newSupportBotTestMessenger(t *testing.T) *Messenger {
+	t.Helper()
+
+	messagingEnv, err := messaging.NewTestMessagingEnvironment()
+	require.NoError(t, err)
+	require.NoError(t, messagingEnv.Setup(t))
+
+	m, err := newRunningTestMessenger(t, messagingEnv, testMessengerConfig{
+		extraOptions: []Option{withSupportBotChatKey(testPK)},
+	})
+	require.NoError(t, err)
+	return m
+}

--- a/pkg/backend/geth_backend.go
+++ b/pkg/backend/geth_backend.go
@@ -1826,6 +1826,7 @@ func (b *StatusBackend) prepareSettings(request *requests.CreateAccount, mnemoni
 	if !restoreAccount {
 		s.Mnemonic = &mnemonic
 		s.MnemonicWasNotShown = true
+		s.SupportBotContactRequestState = settings.SupportBotContactRequestStatePendingNew
 	}
 
 	if request.WakuV2Fleet != "" {

--- a/pkg/services/ext/service.go
+++ b/pkg/services/ext/service.go
@@ -65,6 +65,15 @@ func isPinnedBootstrapDisabledByEnv() bool {
 	}
 }
 
+func isSupportBotContactRequestDisabledByEnv() bool {
+	switch os.Getenv("STATUS_GO_DISABLE_SUPPORT_BOT_CONTACT_REQUEST") {
+	case "1", "true", "TRUE", "True", "yes", "YES", "Yes":
+		return true
+	default:
+		return false
+	}
+}
+
 // EnvelopeEventsHandler used for two different event types.
 type EnvelopeEventsHandler interface {
 	EnvelopeSent([][]byte)
@@ -348,10 +357,11 @@ func buildMessengerOptions(
 ) ([]protocol.Option, error) {
 	personalService := personal.New()
 	enablePinnedBootstrap := !isPinnedBootstrapDisabledByEnv()
+	enableSupportBotContactRequest := !isSupportBotContactRequestDisabledByEnv()
 	options := []protocol.Option{
 		protocol.WithCustomLogger(logger),
 		protocol.WithEnablePinnedBootstrap(enablePinnedBootstrap),
-		protocol.WithEnableSupportBotContactRequest(true),
+		protocol.WithEnableSupportBotContactRequest(enableSupportBotContactRequest),
 		protocol.WithPushNotifications(),
 		protocol.WithDatabase(appDb),
 		protocol.WithWalletDatabase(walletDb),

--- a/pkg/services/ext/service.go
+++ b/pkg/services/ext/service.go
@@ -351,6 +351,7 @@ func buildMessengerOptions(
 	options := []protocol.Option{
 		protocol.WithCustomLogger(logger),
 		protocol.WithEnablePinnedBootstrap(enablePinnedBootstrap),
+		protocol.WithEnableSupportBotContactRequest(true),
 		protocol.WithPushNotifications(),
 		protocol.WithDatabase(appDb),
 		protocol.WithWalletDatabase(walletDb),

--- a/pkg/services/pairing/payload_management.go
+++ b/pkg/services/pairing/payload_management.go
@@ -180,6 +180,7 @@ func (rmm *RawMessagePayloadMarshaller) UnmarshalProtobuf(data []byte) error {
 		if err != nil {
 			return err
 		}
+		rmm.payload.setting.SupportBotContactRequestState = settings.SupportBotContactRequestStateDone
 	}
 
 	rmm.payload.rawMessages = syncRawMessage.RawMessages

--- a/pkg/services/pairing/payload_management_test.go
+++ b/pkg/services/pairing/payload_management_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/status-im/status-go/internal/accounts-management/keystore/envelope"
 	"github.com/status-im/status-go/internal/db/dbsetup"
 	"github.com/status-im/status-go/internal/db/multiaccounts"
+	"github.com/status-im/status-go/internal/db/multiaccounts/settings"
 	"github.com/status-im/status-go/internal/httpserver/servertest"
 	"github.com/status-im/status-go/internal/platform"
 	"github.com/status-im/status-go/internal/protocol/protobuf"
@@ -62,6 +63,19 @@ func TestRawMessagePayloadMarshallerDefaultsAutoApplyKeypairMigrationsForOlderSe
 	require.NoError(t, NewRawMessagePayloadMarshaller(receiver).UnmarshalProtobuf(data))
 	require.Equal(t, keyUID, receiver.setting.KeyUID)
 	require.True(t, receiver.setting.AutoApplyKeypairMigrations)
+}
+
+func TestRawMessagePayloadMarshallerMarksSupportBotContactRequestDone(t *testing.T) {
+	sender := NewRawMessagesPayload()
+	sender.setting.KeyUID = keyUID
+	sender.setting.SupportBotContactRequestState = settings.SupportBotContactRequestStatePendingNew
+
+	data, err := NewRawMessagePayloadMarshaller(sender).MarshalProtobuf()
+	require.NoError(t, err)
+
+	receiver := NewRawMessagesPayload()
+	require.NoError(t, NewRawMessagePayloadMarshaller(receiver).UnmarshalProtobuf(data))
+	require.Equal(t, settings.SupportBotContactRequestStateDone, receiver.setting.SupportBotContactRequestState)
 }
 
 var (

--- a/test/functional/clients/statusgo_container.py
+++ b/test/functional/clients/statusgo_container.py
@@ -63,6 +63,7 @@ class StatusGoContainer:
                 "GOCOVERDIR": "/coverage/binary",
                 "STATUS_ALLOW_FORCE_REEVAL": "1",
                 "STATUS_GO_DISABLE_PINNED_BOOTSTRAP": "1",
+                "STATUS_GO_DISABLE_SUPPORT_BOT_CONTACT_REQUEST": "1",
             },
             "volumes": {
                 coverage_path: {


### PR DESCRIPTION
Needed for https://github.com/status-im/status-app/issues/21861
status-app PR: https://github.com/status-im/status-app/pull/21963

Automatically send a contact request to the Status support bot when a profile starts:

- Use a new-user or upgraded-user message based on account creation flow
- Persist request state to prevent repeat sends
- Suppress duplicates on paired devices and when the bot contact already exists
- Add settings migration, pairing handling, startup wiring, and focused tests

The feature flag is not activated yet. The chatkey of the bot has yet to be provided.


Env var needed to set the bot's chat key: `STATUS_SUPPORT_BOT_CHAT_KEY="zQ3..."`
