### PR TITLE
No prices for NVDA token on Robinhood chain

### DIFF
--- a/services/wallet/common/coingecko_platforms.go
+++ b/services/wallet/common/coingecko_platforms.go
@@ -1,0 +1,20 @@
+package common
+
+// When adding a new network, look up for the right patform name here https://api.coingecko.com/api/v3/asset_platforms
+var CoinGeckoPlatformChainMapper = map[string]uint64{
+	"ethereum":            EthereumMainnet,
+	"optimistic-ethereum": OptimismMainnet,
+	"arbitrum-one":        ArbitrumMainnet,
+	"base":                BaseMainnet,
+	"binance-smart-chain": BSCMainnet,
+	"linea":               LineaMainnet,
+	"unichain":            UnichainMainnet,
+	"katana":              KatanaMainnet,
+	"ink":                 InkMainnet,
+	"abstract":            AbstractMainnet,
+	"zksync":              ZkSyncMainnet,
+	"soneium":             SoneiumMainnet,
+	"scroll":              ScrollMainnet,
+	"blast":               BlastMainnet,
+	"robinhood":           RobinhoodMainnet,
+}

--- a/services/wallet/thirdparty/market/coingecko/client.go
+++ b/services/wallet/thirdparty/market/coingecko/client.go
@@ -138,8 +138,8 @@ func (c *Client) mapTokensToIds(tokens []*tokentypes.Token) (map[string][]string
 	mappedTokens := make(map[string][]string) // map[coingeckoId][]tokenKey
 	unmappedTokens := make([]string, 0)
 
-	// Coingecko doesn't provide prices for test tokens, so we need to map them to the mainnet tokens.
-	// We can do that only for test tokens that have a cross chain id.
+	// Coingecko doesn't list every token on every chain (and never lists testnet tokens), so tokens that
+	// aren't found directly are mapped to a mainnet sibling sharing the same cross chain id.
 	tokenKeysByCrossChainID := make(map[string][]string)
 	for _, token := range tokens {
 		// Skip tokens that don't have a cross chain id
@@ -156,12 +156,8 @@ func (c *Client) mapTokensToIds(tokens []*tokentypes.Token) (map[string][]string
 	for _, token := range tokens {
 		coingeckoToken, ok := coingeckoTokensByTokenKey[token.Key()]
 		if !ok {
-			if walletcommon.ChainID(token.ChainID).IsMainnet() {
-				unmappedTokens = append(unmappedTokens, token.Key())
-				continue
-			}
-
-			// Check by cross chain id if any of the test tokens have a coingecko token
+			// Check by cross chain id if any of the mainnet siblings have a coingecko token.
+			// This covers testnet tokens as well as mainnet tokens coingecko doesn't list on that some other chain (e.g. SNT is not listed on Base/Optimism).
 			crossChainID := token.CrossChainID
 			// Sepecial handling for status test token STT, cause even it's the same token belongs to different group and has different symbol SNT/STT.
 			if crossChainID == walletcommon.StatusTestTokenCrossChainID {

--- a/services/wallet/thirdparty/market/coingecko/request_coins_list.go
+++ b/services/wallet/thirdparty/market/coingecko/request_coins_list.go
@@ -8,7 +8,6 @@ import (
 
 	gethcommon "github.com/ethereum/go-ethereum/common"
 
-	"github.com/status-im/go-wallet-sdk/pkg/tokens/parsers"
 	"github.com/status-im/go-wallet-sdk/pkg/tokens/types"
 
 	walletcommon "github.com/status-im/status-go/services/wallet/common"
@@ -35,7 +34,7 @@ func (gt *GeckoToken) keys() []string {
 		if len(contractAddress) != walletcommon.HexAddressLength {
 			continue
 		}
-		chainID, ok := parsers.DefaultCoinGeckoChainsMapper[platform]
+		chainID, ok := walletcommon.CoinGeckoPlatformChainMapper[platform]
 		if !ok {
 			continue
 		}


### PR DESCRIPTION
Dropped dependency on parsers.DefaultCoinGeckoChainsMapper and the correct mapper is now maintained on the status-go side.

Coingecko tokens that are listed on mainnet but not on other chains now map to the correct cross chain id.


Fixes https://github.com/status-im/status-app/issues/21781