### PR TITLE
fix(messaging): missing ratchet key crash

### DIFF
--- a/pkg/messaging/controller/processor/processor.go
+++ b/pkg/messaging/controller/processor/processor.go
@@ -208,6 +208,11 @@ func (r *Processor) processQueuedHashRatchetMessages(hashRatchetInfos []*messagi
 			if err != nil {
 				continue
 			}
+			if r == nil {
+				// Not processed: the message is still incomplete (segmentation) or was
+				// re-queued waiting for its hash ratchet key — leave it in the queue.
+				continue
+			}
 
 			processedIds = append(processedIds, message.Hash)
 

--- a/pkg/messaging/controller/processor/processor_test.go
+++ b/pkg/messaging/controller/processor/processor_test.go
@@ -340,6 +340,95 @@ func (s *ProcessorSuite) TestHandleOutOfOrderHashRatchet() {
 	s.Require().Len(msgs, 0)
 }
 
+// A queued hash ratchet message can legitimately fail to complete on replay —
+// here, it is encrypted with a ratchet key that still hasn't arrived, so
+// processing it re-queues it and yields no response. That must not crash the
+// replay and must not lose the message.
+func (s *ProcessorSuite) TestQueuedHashRatchetMessageStillMissingItsKeySurvivesReplay() {
+	groupID := []byte("group-id")
+	otherGroupID := []byte("group-id-other")
+	senderKey, err := crypto.GenerateKey()
+	s.Require().NoError(err)
+
+	senderDatabase, err := testutils.SetupTestMemorySQLDB(testutils.NewTestDBInitializer([]*bindata.AssetSource{
+		{
+			Names:     encryptionmigrations.AssetNames(),
+			AssetFunc: encryptionmigrations.Asset,
+		},
+	}))
+	s.Require().NoError(err)
+
+	senderEncryptionProtocol := encryption.New(
+		encryption.NewSQLitePersistence(senderDatabase),
+		"installation-2",
+		s.logger,
+		trace.NewNoopTracer(),
+	)
+
+	ratchet, err := senderEncryptionProtocol.GenerateHashRatchetKey(groupID)
+	s.Require().NoError(err)
+	keyID, err := ratchet.GetKeyID()
+	s.Require().NoError(err)
+
+	// A second ratchet whose key exchange is never delivered to the receiver.
+	otherRatchet, err := senderEncryptionProtocol.GenerateHashRatchetKey(otherGroupID)
+	s.Require().NoError(err)
+	otherKeyID, err := otherRatchet.GetKeyID()
+	s.Require().NoError(err)
+
+	hashRatchetKeyExchangeMessage, err := senderEncryptionProtocol.BuildHashRatchetKeyExchangeMessage(context.Background(), senderKey, &s.processor.identity.PublicKey, groupID, []*encryption.HashRatchetKeyCompatibility{ratchet})
+	s.Require().NoError(err)
+	keyExchangePayload, err := proto.Marshal(hashRatchetKeyExchangeMessage.Message)
+	s.Require().NoError(err)
+
+	dataMessageSpec, err := senderEncryptionProtocol.BuildHashRatchetMessage(groupID, s.testPayload)
+	s.Require().NoError(err)
+	dataPayload, err := proto.Marshal(dataMessageSpec.Message)
+	s.Require().NoError(err)
+
+	strayMessageSpec, err := senderEncryptionProtocol.BuildHashRatchetMessage(otherGroupID, s.testPayload)
+	s.Require().NoError(err)
+	strayPayload, err := proto.Marshal(strayMessageSpec.Message)
+	s.Require().NoError(err)
+
+	// The data message arrives before its key and gets queued.
+	message := &types.ReceivedMessage{}
+	message.Sig = crypto.FromECDSAPub(&senderKey.PublicKey)
+	message.Hash = []byte{0x1}
+	message.Payload = dataPayload
+
+	_, err = s.processor.processMessage(message)
+	s.Require().NoError(err)
+
+	// A message for the other, still missing ratchet key sits in the same queue.
+	strayMessage := &types.ReceivedMessage{}
+	strayMessage.Sig = crypto.FromECDSAPub(&senderKey.PublicKey)
+	strayMessage.Hash = []byte{0x2}
+	strayMessage.Payload = strayPayload
+
+	err = s.processor.hashRatchetStorage.SaveMessage(groupID, keyID, strayMessage)
+	s.Require().NoError(err)
+
+	// The key arrives: the replay must decode the data message, not crash on the
+	// stray one, and re-queue the stray one under its own key.
+	message = &types.ReceivedMessage{}
+	message.Sig = crypto.FromECDSAPub(&senderKey.PublicKey)
+	message.Hash = []byte{0x3}
+	message.Payload = keyExchangePayload
+
+	response, err := s.processor.ProcessMessage(message)
+	s.Require().NoError(err)
+	s.Require().NotNil(response)
+
+	// The key exchange itself and the queued data message.
+	s.Require().Len(response.Messages, 2)
+
+	// The stray message is not lost: it waits for its own key.
+	msgs, err := s.processor.hashRatchetStorage.GetMessages(otherKeyID)
+	s.Require().NoError(err)
+	s.Require().Len(msgs, 1)
+}
+
 func (s *ProcessorSuite) TestHandleSegmentMessages() {
 	senderKey, err := crypto.GenerateKey()
 	s.Require().NoError(err)

--- a/services/wallet/collectibles/ownership/loader.go
+++ b/services/wallet/collectibles/ownership/loader.go
@@ -39,7 +39,7 @@ type LoaderParams struct {
 
 func DefaultLoaderParams() LoaderParams {
 	return LoaderParams{
-		LoadDelay:  10 * time.Second,
+		LoadDelay:  1 * time.Second,
 		FetchLimit: 50,
 	}
 }

--- a/services/wallet/collectibles/ownership/loader.go
+++ b/services/wallet/collectibles/ownership/loader.go
@@ -92,14 +92,19 @@ func (l *Loader) Load(ctx context.Context) ([]thirdparty.CollectibleIDBalance, e
 	var err error
 	// Handle error at the end, if any
 	defer func() {
-		if err != nil {
-			pubsub.Publish(l.publisher, EventOwnedCollectiblesLoadError{
-				ChainID: l.chainID,
-				Account: l.account,
-				Error:   err,
-			})
+		if err == nil {
 			return
 		}
+		if ctx.Err() != nil || errors.Is(err, context.Canceled) {
+			// The load was cancelled (the loader is being stopped or restarted),
+			// not a failure — don't report an error for the client to surface.
+			return
+		}
+		pubsub.Publish(l.publisher, EventOwnedCollectiblesLoadError{
+			ChainID: l.chainID,
+			Account: l.account,
+			Error:   err,
+		})
 	}()
 
 	var lastFetchTimestamp int64

--- a/services/wallet/collectibles/ownership/loader.go
+++ b/services/wallet/collectibles/ownership/loader.go
@@ -30,8 +30,11 @@ type CollectibleOwnershipStorage interface {
 }
 
 type LoaderParams struct {
-	LoadDelay  time.Duration // (Optional) Delay between notifying a Load start and actually triggering the first fetch, used to "debounce" fetches triggered by settings changes
-	FetchLimit int           // (Optional) Limit the number of collectibles to fetch per page during the initial load
+	// (Optional) Delay between triggering a Load and actually triggering the first fetch, used to
+	// "debounce" fetches triggered by settings changes. Skipped on the initial load, since there's
+	// nothing to debounce when the ownership was never fetched before.
+	LoadDelay  time.Duration
+	FetchLimit int // (Optional) Limit the number of collectibles to fetch per page during the initial load
 }
 
 func DefaultLoaderParams() LoaderParams {
@@ -126,7 +129,10 @@ func (l *Loader) Load(ctx context.Context) ([]thirdparty.CollectibleIDBalance, e
 		zap.Int("page", pageNr),
 	)
 
-	if l.params.LoadDelay.Seconds() > 0 {
+	// The delay coalesces bursts of load requests (settings changes, detected transfers).
+	// There's nothing to coalesce when the ownership for this account+chain was never
+	// fetched, so the initial load hits the provider right away.
+	if !isInitialLoad && l.params.LoadDelay > 0 {
 		if l.waitFor(ctx, l.params.LoadDelay) {
 			return nil, ctx.Err()
 		}

--- a/services/wallet/collectibles/ownership/loader.go
+++ b/services/wallet/collectibles/ownership/loader.go
@@ -35,6 +35,10 @@ type LoaderParams struct {
 	// nothing to debounce when the ownership was never fetched before.
 	LoadDelay  time.Duration
 	FetchLimit int // (Optional) Limit the number of collectibles to fetch per page during the initial load
+	// (Optional) Called by the goroutine owning the load whenever it moves between
+	// LoaderStateDelayed (waiting out LoadDelay) and LoaderStateUpdating (fetching), so that
+	// callers can tell a load that is still being debounced from one that is really running.
+	OnStateChanged func(state LoaderState)
 }
 
 func DefaultLoaderParams() LoaderParams {
@@ -85,11 +89,6 @@ func (l *Loader) Load(ctx context.Context) ([]thirdparty.CollectibleIDBalance, e
 		zap.String("account", gocommon.TruncateWithDot(l.account.String())),
 	)
 
-	pubsub.Publish(l.publisher, EventOwnedCollectiblesLoadStarted{
-		ChainID: l.chainID,
-		Account: l.account,
-	})
-
 	var err error
 	// Handle error at the end, if any
 	defer func() {
@@ -115,6 +114,25 @@ func (l *Loader) Load(ctx context.Context) ([]thirdparty.CollectibleIDBalance, e
 		pageSize = l.params.FetchLimit
 	}
 
+	// The delay coalesces bursts of load requests (settings changes, detected transfers).
+	// There's nothing to coalesce when the ownership for this account+chain was never
+	// fetched, so the initial load hits the provider right away.
+	if !isInitialLoad && l.params.LoadDelay > 0 {
+		l.notifyStateChanged(LoaderStateDelayed)
+		if l.waitFor(ctx, l.params.LoadDelay) {
+			return nil, ctx.Err()
+		}
+	}
+
+	// Only report (and notify) the load as started once the fetching really begins, so that
+	// the client doesn't show it as updating for the whole duration of the delay.
+	l.notifyStateChanged(LoaderStateUpdating)
+
+	pubsub.Publish(l.publisher, EventOwnedCollectiblesLoadStarted{
+		ChainID: l.chainID,
+		Account: l.account,
+	})
+
 	// Start fetching collectibles in chunks
 	pageNr := 0
 	cursor := thirdparty.FetchFromStartCursor
@@ -128,15 +146,6 @@ func (l *Loader) Load(ctx context.Context) ([]thirdparty.CollectibleIDBalance, e
 		zap.String("account", gocommon.TruncateWithDot(l.account.String())),
 		zap.Int("page", pageNr),
 	)
-
-	// The delay coalesces bursts of load requests (settings changes, detected transfers).
-	// There's nothing to coalesce when the ownership for this account+chain was never
-	// fetched, so the initial load hits the provider right away.
-	if !isInitialLoad && l.params.LoadDelay > 0 {
-		if l.waitFor(ctx, l.params.LoadDelay) {
-			return nil, ctx.Err()
-		}
-	}
 
 	start := time.Now()
 
@@ -221,6 +230,12 @@ func (l *Loader) Load(ctx context.Context) ([]thirdparty.CollectibleIDBalance, e
 	pubsub.Publish(l.publisher, finishedEvent)
 
 	return accumulatedOwnership, nil
+}
+
+func (l *Loader) notifyStateChanged(state LoaderState) {
+	if l.params.OnStateChanged != nil {
+		l.params.OnStateChanged(state)
+	}
 }
 
 func (l *Loader) waitFor(ctx context.Context, delay time.Duration) (cancelled bool) {

--- a/services/wallet/collectibles/ownership/periodical_loader.go
+++ b/services/wallet/collectibles/ownership/periodical_loader.go
@@ -185,9 +185,11 @@ func (pl *PeriodicalLoader) Load(ctx context.Context) error {
 		return err
 	}
 
-	if err != nil {
+	if err != nil && ctx.Err() == nil && !errors.Is(err, context.Canceled) {
 		pl.state.Store(LoaderStateError)
 	} else {
+		// Success, or the load was cancelled by a stop/restart — either way the
+		// pair is simply not loading anymore, which must not read as a failure.
 		pl.state.Store(LoaderStateIdle)
 	}
 

--- a/services/wallet/collectibles/ownership/periodical_loader.go
+++ b/services/wallet/collectibles/ownership/periodical_loader.go
@@ -2,6 +2,7 @@ package ownership
 
 import (
 	"context"
+	"errors"
 	"sync/atomic"
 	"time"
 
@@ -65,11 +66,19 @@ func NewPeriodicalLoader(
 	ret := &PeriodicalLoader{
 		chainID: chainID,
 		account: account,
-		loader:  NewLoader(chainID, account, fetcher, storage, publisher, params.LoaderParams, logger),
 		params:  params,
 		logger:  logger.Named("PeriodicalLoader"),
 	}
 	ret.state.Store(LoaderStateIdle)
+
+	// Let the Loader drive the delayed/updating states, so that a load that is still being
+	// debounced isn't reported as updating
+	loaderParams := params.LoaderParams
+	loaderParams.OnStateChanged = func(state LoaderState) {
+		ret.state.Store(state)
+	}
+	ret.loader = NewLoader(chainID, account, fetcher, storage, publisher, loaderParams, logger)
+
 	return ret
 }
 
@@ -149,27 +158,6 @@ func (pl *PeriodicalLoader) triggerLoadAsync(stopCh <-chan struct{}) {
 }
 
 func (pl *PeriodicalLoader) triggerLoad(stopCh <-chan struct{}) {
-	if pl.GetState() == LoaderStateUpdating {
-		// Another load is in progress which should've finished or have been cancelled at this point
-		pl.logger.Error("skipping Load because it's already in progress",
-			zap.Uint64("chain", uint64(pl.chainID)),
-			zap.String("account", gocommon.TruncateWithDot(pl.account.String())),
-		)
-		return
-	}
-
-	pl.state.Store(LoaderStateUpdating)
-
-	var err error
-	// Handle error at the end (if any) and set state
-	defer func() {
-		if err != nil {
-			pl.state.Store(LoaderStateError)
-			return
-		}
-		pl.state.Store(LoaderStateIdle)
-	}()
-
 	ctx, cancelFn := context.WithCancel(context.Background())
 	defer cancelFn() // Cancel ctx after Load ends
 	go func() {
@@ -181,12 +169,29 @@ func (pl *PeriodicalLoader) triggerLoad(stopCh <-chan struct{}) {
 		}
 	}()
 
-	err = pl.Load(ctx)
+	_ = pl.Load(ctx)
 }
 
-func (pl *PeriodicalLoader) Load(ctx context.Context) (err error) {
-	_, err = pl.loader.Load(ctx)
-	return
+// Runs a load, keeping the reported state in sync with its progress: the Loader reports
+// LoaderStateDelayed/LoaderStateUpdating while it runs, the terminal state is set here.
+func (pl *PeriodicalLoader) Load(ctx context.Context) error {
+	_, err := pl.loader.Load(ctx)
+	if errors.Is(err, ErrLoadAlreadyInProgress) {
+		// The load in progress owns the reported state, leave it alone
+		pl.logger.Error("skipping Load because it's already in progress",
+			zap.Uint64("chain", uint64(pl.chainID)),
+			zap.String("account", gocommon.TruncateWithDot(pl.account.String())),
+		)
+		return err
+	}
+
+	if err != nil {
+		pl.state.Store(LoaderStateError)
+	} else {
+		pl.state.Store(LoaderStateIdle)
+	}
+
+	return err
 }
 
 func (pl *PeriodicalLoader) waitFor(stopCh <-chan struct{}, delay time.Duration) (cancelled bool) {

--- a/services/wallet/collectibles/ownership/periodical_loader.go
+++ b/services/wallet/collectibles/ownership/periodical_loader.go
@@ -195,7 +195,7 @@ func (pl *PeriodicalLoader) Load(ctx context.Context) error {
 }
 
 func (pl *PeriodicalLoader) waitFor(stopCh <-chan struct{}, delay time.Duration) (cancelled bool) {
-	delayTimer := time.NewTicker(delay)
+	delayTimer := time.NewTimer(delay)
 	defer delayTimer.Stop()
 	select {
 	case <-delayTimer.C:

--- a/services/wallet/collectibles/ownership/periodical_loader_test.go
+++ b/services/wallet/collectibles/ownership/periodical_loader_test.go
@@ -70,10 +70,13 @@ func (f *fakeFetcher) waitForReturn(t *testing.T) {
 }
 
 // fakeStorage satisfies CollectibleOwnershipStorage with no-ops.
-type fakeStorage struct{}
+// The zero value reports a timestamp of a previous successful fetch (non-initial load).
+type fakeStorage struct {
+	timestamp int64
+}
 
-func (fakeStorage) GetOwnershipUpdateTimestamp(_ common.Address, _ walletCommon.ChainID) (int64, error) {
-	return 0, nil // non-initial load (timestamp != InvalidTimestamp)
+func (s fakeStorage) GetOwnershipUpdateTimestamp(_ common.Address, _ walletCommon.ChainID) (int64, error) {
+	return s.timestamp, nil
 }
 
 func (fakeStorage) Update(_ walletCommon.ChainID, _ common.Address, _ []thirdparty.CollectibleIDBalance, _ int64) ([]thirdparty.CollectibleUniqueID, []thirdparty.CollectibleUniqueID, []thirdparty.CollectibleUniqueID, error) {
@@ -155,6 +158,70 @@ func TestPeriodicalLoaderRestartReleasesOldGoroutines(t *testing.T) {
 
 	// Clean up
 	pl.Stop()
+}
+
+// TestLoadDelaySkippedOnInitialLoad verifies that the first ever load for an
+// account+chain fetches right away instead of waiting out LoadDelay: there's
+// nothing to debounce yet, and the delay is fully visible to the user.
+func TestLoadDelaySkippedOnInitialLoad(t *testing.T) {
+	fetcher := newFakeFetcher()
+	params := PeriodicalLoaderParams{
+		LoadInterval: 1 * time.Minute,
+		LoaderParams: LoaderParams{
+			LoadDelay:  30 * time.Second,
+			FetchLimit: 50,
+		},
+	}
+	pl := newTestLoader(t, fetcher, fakeStorage{timestamp: InvalidTimestamp}, params)
+
+	pl.Start(false, false)
+
+	select {
+	case <-fetcher.entered:
+	case <-time.After(5 * time.Second):
+		pl.Stop()
+		t.Fatal("initial load waited for LoadDelay before fetching")
+	}
+
+	require.Equal(t, LoaderStateUpdating, pl.GetState())
+
+	pl.Stop()
+	waitForLoadToEnd(t, pl)
+}
+
+// waitForLoadToEnd waits for an interrupted load to unwind, so that the loader
+// goroutines don't outlive the test.
+func waitForLoadToEnd(t *testing.T, pl *PeriodicalLoader) {
+	t.Helper()
+	require.Eventually(t, func() bool {
+		state := pl.GetState()
+		return state == LoaderStateIdle || state == LoaderStateError
+	}, 5*time.Second, 10*time.Millisecond)
+}
+
+// TestLoadDelayReportedAsDelayed verifies that a subsequent load still waits out
+// LoadDelay, and that it is reported as delayed (not as updating) while doing so.
+func TestLoadDelayReportedAsDelayed(t *testing.T) {
+	fetcher := newFakeFetcher()
+	params := PeriodicalLoaderParams{
+		LoadInterval: 1 * time.Minute,
+		LoaderParams: LoaderParams{
+			LoadDelay:  5 * time.Second,
+			FetchLimit: 50,
+		},
+	}
+	pl := newTestLoader(t, fetcher, fakeStorage{}, params)
+
+	pl.Start(false, false)
+
+	require.Eventually(t, func() bool {
+		return pl.GetState() == LoaderStateDelayed
+	}, 1*time.Second, 10*time.Millisecond)
+
+	require.Equal(t, 0, fetcher.CallCount(), "no fetch should have been triggered during the load delay")
+
+	pl.Stop()
+	waitForLoadToEnd(t, pl)
 }
 
 // TestPeriodicalLoaderStopDuringDelay verifies that Stop cancels the start


### PR DESCRIPTION
For the status-go PR:

- Queued hash ratchet replay crashed on nil
- `processMessage` may return nil without error
- Skip such messages, keep them queued
- Regression test: red first, fix second


Fixes status-im/status-app#21872
