### PR TITLE
fix(collectibles): fixes 16s cold-start spinner on empty accounts

### DIFF
--- a/services/wallet/collectibles/ownership/controller.go
+++ b/services/wallet/collectibles/ownership/controller.go
@@ -473,6 +473,13 @@ func (c *Controller) loadWithPeriodicalLoaderIfFound(ctx context.Context, chainI
 
 	found = true
 
+	// Events are matched on the loader that published them: this loader can be
+	// replaced (by a restart) while its load is running, and the replaced
+	// loader's load can end at any time afterwards. Matching on chainID+account
+	// alone would let the end of a load this caller has nothing to do with
+	// report back as the end of the load it is waiting for.
+	loaderID := loader.loaderID()
+
 	finishedCh, finishedUnsubFn := pubsub.Subscribe[EventOwnedCollectiblesLoadFinished](c.collectiblesPublisher, 10)
 	defer finishedUnsubFn()
 
@@ -499,14 +506,14 @@ func (c *Controller) loadWithPeriodicalLoaderIfFound(ctx context.Context, chainI
 			if !ok {
 				return
 			}
-			if finishedEvent.ChainID == chainID && finishedEvent.Account == account {
+			if finishedEvent.LoaderID == loaderID {
 				return
 			}
 		case errEvent, ok := <-errCh:
 			if !ok {
 				return
 			}
-			if errEvent.ChainID == chainID && errEvent.Account == account {
+			if errEvent.LoaderID == loaderID {
 				err = errEvent.Error
 				return
 			}
@@ -514,7 +521,7 @@ func (c *Controller) loadWithPeriodicalLoaderIfFound(ctx context.Context, chainI
 			if !ok {
 				return
 			}
-			if cancelledEvent.ChainID == chainID && cancelledEvent.Account == account {
+			if cancelledEvent.LoaderID == loaderID {
 				err = context.Canceled
 				return
 			}

--- a/services/wallet/collectibles/ownership/controller.go
+++ b/services/wallet/collectibles/ownership/controller.go
@@ -61,6 +61,11 @@ type Controller struct {
 
 	networksProvider NetworksProvider
 
+	// Optional. When set, no loader is created for chains it rejects: their
+	// state stays LoaderStateNotAvailable instead of erroring on every load
+	// attempt against a chain no provider serves.
+	chainSupported func(walletCommon.ChainID) bool
+
 	walletEventsWatcher *walletevent.Watcher
 
 	collectiblesPublisher *pubsub.Publisher
@@ -100,6 +105,12 @@ func NewController(
 		collectiblesPublisher:         collectiblesPublisher,
 		logger:                        logger.Named("OwnershipController"),
 	}
+}
+
+// SetChainSupportedCheck installs the predicate deciding which chains get an
+// ownership loader. Call before Start.
+func (c *Controller) SetChainSupportedCheck(check func(walletCommon.ChainID) bool) {
+	c.chainSupported = check
 }
 
 func (c *Controller) StartWithLoaderParams(params PeriodicalLoaderParams) {
@@ -404,6 +415,14 @@ func (c *Controller) TriggerLoad(ctx context.Context, chainID walletCommon.Chain
 		zap.Stringer("chainID", chainID),
 	)
 
+	if c.chainSupported != nil && !c.chainSupported(chainID) {
+		// No collectibles provider serves this chain; loading would only error.
+		c.logger.Debug("skipping on-demand load for unsupported chain",
+			zap.Stringer("chainID", chainID),
+		)
+		return nil
+	}
+
 	found, err := c.loadWithPeriodicalLoaderIfFound(ctx, chainID, account)
 	if err != nil {
 		return err
@@ -460,6 +479,11 @@ func (c *Controller) loadWithPeriodicalLoaderIfFound(ctx context.Context, chainI
 	errCh, errUnsubFn := pubsub.Subscribe[EventOwnedCollectiblesLoadError](c.collectiblesPublisher, 10)
 	defer errUnsubFn()
 
+	// A load cancelled by a loader stop/restart publishes neither finished nor
+	// error — without this subscription the waiter would hang until ctx expires.
+	cancelledCh, cancelledUnsubFn := pubsub.Subscribe[EventOwnedCollectiblesLoadCancelled](c.collectiblesPublisher, 10)
+	defer cancelledUnsubFn()
+
 	go func() {
 		defer gocommon.LogOnPanic()
 		// Trigger load in case it's not already in progress
@@ -484,6 +508,14 @@ func (c *Controller) loadWithPeriodicalLoaderIfFound(ctx context.Context, chainI
 			}
 			if errEvent.ChainID == chainID && errEvent.Account == account {
 				err = errEvent.Error
+				return
+			}
+		case cancelledEvent, ok := <-cancelledCh:
+			if !ok {
+				return
+			}
+			if cancelledEvent.ChainID == chainID && cancelledEvent.Account == account {
+				err = context.Canceled
 				return
 			}
 		}
@@ -514,7 +546,11 @@ func (c *Controller) checkPeriodicalLoaders() {
 	newLoaderKeys := make(map[loaderKey]struct{})
 	for _, address := range newAddresses {
 		for _, network := range newNetworks {
-			newLoaderKeys[loaderKey{address: common.Address(address), chainID: walletCommon.ChainID(network.ChainID)}] = struct{}{}
+			chainID := walletCommon.ChainID(network.ChainID)
+			if c.chainSupported != nil && !c.chainSupported(chainID) {
+				continue
+			}
+			newLoaderKeys[loaderKey{address: common.Address(address), chainID: chainID}] = struct{}{}
 		}
 	}
 

--- a/services/wallet/collectibles/ownership/controller_test.go
+++ b/services/wallet/collectibles/ownership/controller_test.go
@@ -774,6 +774,222 @@ func TestControllerTriggerLoadUnblocksOnCancelledLoad(t *testing.T) {
 	}
 }
 
+// parkedFetch is a single in-flight fetch the test holds parked until it
+// decides that the load owning it may unwind.
+type parkedFetch struct {
+	release  chan struct{}
+	released bool
+}
+
+// Release lets the parked fetch return. Safe to call more than once, so that a
+// cleanup can release whatever the test body left parked.
+func (p *parkedFetch) Release() {
+	if p.released {
+		return
+	}
+	p.released = true
+	close(p.release)
+}
+
+func waitForParkedFetch(t *testing.T, fetches <-chan *parkedFetch, what string) *parkedFetch {
+	t.Helper()
+	select {
+	case fetch := <-fetches:
+		return fetch
+	case <-time.After(5 * time.Second):
+		t.Fatalf("timed out waiting for %s", what)
+		return nil
+	}
+}
+
+// TestControllerTriggerLoadIgnoresStaleCancellation verifies that an on-demand
+// load waiting on the load of the current loader is not woken up by the
+// cancellation of a load belonging to a loader that has already been replaced.
+//
+// A loader restart (a detected balance change here) cancels the running load and
+// installs a replacement loader. The cancelled load unwinds asynchronously, so
+// its cancellation can be published long after the restart — possibly while a
+// waiter is already blocked on the replacement's load. Load events identify a
+// load only by (ChainID, Account), so such a stale event looks exactly like the
+// end of the load the waiter cares about, and TriggerLoad reports
+// context.Canceled for a request that is in fact still running.
+func TestControllerTriggerLoadIgnoresStaleCancellation(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	chainID := walletCommon.ChainID(1)
+	fakeAddress := types.HexToAddress("0x123")
+	account := common.Address(fakeAddress)
+
+	accountsProvider := mock_ownership.NewMockAccountsProvider(mockCtrl)
+	accountsProvider.EXPECT().GetWalletAddresses().Return([]types.Address{fakeAddress}, nil).AnyTimes()
+
+	accountsPublisher := pubsub.NewPublisher()
+	networksProvider := mock_ownership.NewMockNetworksProvider(mockCtrl)
+	networksPublisher := pubsub.NewPublisher()
+
+	networksProvider.EXPECT().GetActiveNetworks().Return([]*params.Network{
+		{ChainID: uint64(chainID), IsActive: true},
+	}, nil).AnyTimes()
+	networksProvider.EXPECT().GetPublisher().Return(networksPublisher).AnyTimes()
+
+	walletDB, err := testutils.SetupTestMemorySQLDB(walletdatabase.DbInitializer{})
+	require.NoError(t, err)
+
+	ownershipDB := ownership.NewOwnershipDB(walletDB)
+
+	// Record a previous successful load, so that a detected balance change is a
+	// reason to refetch (and therefore to restart the loader) instead of being
+	// ignored for an account whose ownership was never fetched.
+	_, _, _, err = ownershipDB.Update(chainID, account, []thirdparty.CollectibleIDBalance{}, time.Now().Unix()-100)
+	require.NoError(t, err)
+
+	emptyCollectiblesContainer := &thirdparty.CollectibleOwnershipContainer{
+		Items:          []thirdparty.CollectibleIDBalance{},
+		NextCursor:     "",
+		PreviousCursor: "",
+		Provider:       "mockProvider",
+	}
+
+	// Every fetch parks until the test releases it, no matter what happens to its
+	// context in the meantime: the test alone decides when each load unwinds,
+	// which is what makes the ordering of the events deterministic.
+	parkedFetches := make(chan *parkedFetch, 10)
+	ownershipFetcher := mock_ownership.NewMockCollectibleOwnershipFetcher(mockCtrl)
+	ownershipFetcher.EXPECT().FetchCollectibleOwnershipByOwner(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+		func(ctx context.Context, chainID walletCommon.ChainID, owner common.Address, cursor string, limit int, providerID string) (*thirdparty.CollectibleOwnershipContainer, error) {
+			fetch := &parkedFetch{release: make(chan struct{})}
+			parkedFetches <- fetch
+			<-fetch.release
+			if ctx.Err() != nil {
+				return nil, ctx.Err()
+			}
+			return emptyCollectiblesContainer, nil
+		}).AnyTimes()
+
+	multistandardBalancePublisher := pubsub.NewPublisher()
+	transferDetectorPublisher := pubsub.NewPublisher()
+	blockChainStateProvider := mock_ownership.NewMockBlockChainStateProvider(mockCtrl)
+	publisher := pubsub.NewPublisher()
+	logger := zaptest.NewLogger(t).WithOptions(zap.AddCallerSkip(1))
+
+	controller := ownership.NewController(
+		ownershipDB,
+		accountsProvider,
+		accountsPublisher,
+		networksProvider,
+		multistandardBalancePublisher,
+		transferDetectorPublisher,
+		blockChainStateProvider,
+		ownershipFetcher,
+		publisher,
+		logger,
+	)
+
+	// The cancellation of the replaced loader's load is what the test needs to
+	// observe, to be sure the stale event really was published before asserting
+	// that the waiter ignored it. The end of the on-demand load is observed to
+	// let every load quiesce before the test returns.
+	cancelledCh, cancelledUnsub := pubsub.Subscribe[ownership.EventOwnedCollectiblesLoadCancelled](publisher, 10)
+	defer cancelledUnsub()
+
+	finishedCh, finishedUnsub := pubsub.Subscribe[ownership.EventOwnedCollectiblesLoadFinished](publisher, 10)
+	defer finishedUnsub()
+
+	// The start delay only applies to loads triggered by a detected change, so
+	// the initial load starts fetching right away while the loader the restart
+	// installs stays idle until the on-demand load drives it.
+	controller.StartWithLoaderParams(
+		ownership.PeriodicalLoaderParams{
+			StartDelay:   1 * time.Hour,
+			LoadInterval: 1 * time.Hour,
+			LoaderParams: ownership.LoaderParams{
+				LoadDelay:  0 * time.Second,
+				FetchLimit: 50,
+			},
+		},
+	)
+	defer controller.Stop()
+
+	// The periodical load of the first loader is now parked mid-fetch.
+	firstLoadFetch := waitForParkedFetch(t, parkedFetches, "the periodical load to start fetching")
+	defer firstLoadFetch.Release()
+
+	// A detected balance change restarts the loader: the load above gets its
+	// context cancelled, but it can't notice while it is parked in the fetch.
+	pubsub.Publish(multistandardBalancePublisher, multistandardbalance.EventBalanceFetchFinished{
+		Key: multistandardbalance.BalancesKey{
+			ChainID: uint64(chainID),
+			Account: account,
+		},
+		ResultType:     multistandardfetcher.ResultTypeERC721,
+		BalanceChanged: true,
+		OldState: multistandardbalance.State{
+			FetchedAt: time.Now().Unix() - 1000,
+		},
+		NewState: multistandardbalance.State{
+			FetchedAt: time.Now().Unix(),
+		},
+	})
+
+	// The replacement loader is in place once the pair reports the delayed state:
+	// the replaced loader was fetching, and only the replacement waits out the
+	// start delay.
+	require.Eventually(t, func() bool {
+		return controller.GetLoaderState(chainID, account) == ownership.LoaderStateDelayed
+	}, 5*time.Second, 10*time.Millisecond, "the loader was never restarted")
+
+	// The on-demand load drives the replacement loader and waits for its load.
+	triggerDone := make(chan error, 1)
+	go func() {
+		triggerDone <- controller.TriggerLoad(context.Background(), chainID, account)
+	}()
+
+	// The only thing that can start a new fetch here is the on-demand load, so a
+	// second parked fetch proves that TriggerLoad already subscribed to the load
+	// events and is waiting on the load it just started.
+	secondLoadFetch := waitForParkedFetch(t, parkedFetches, "the on-demand load to start fetching")
+	defer secondLoadFetch.Release()
+
+	// Let the replaced loader's load unwind and publish its cancellation, late.
+	firstLoadFetch.Release()
+	select {
+	case <-cancelledCh:
+	case <-time.After(5 * time.Second):
+		t.Fatal("the replaced loader's load never published its cancellation")
+	}
+
+	// The waiter must ignore it: the load it is waiting on is still running.
+	wokenByStaleEvent := false
+	select {
+	case triggerErr := <-triggerDone:
+		wokenByStaleEvent = true
+		t.Errorf("TriggerLoad returned (%v) on the cancellation of an already replaced loader's load, while the load it was waiting on is still running", triggerErr)
+	case <-time.After(500 * time.Millisecond):
+	}
+
+	// The load the waiter really is waiting on now finishes successfully.
+	secondLoadFetch.Release()
+	select {
+	case <-finishedCh:
+	case <-time.After(5 * time.Second):
+		t.Fatal("the on-demand load never finished")
+	}
+
+	if wokenByStaleEvent {
+		// The waiter is long gone, there's nothing left to wait for. Returning
+		// only once the load it abandoned ended keeps the failure clean.
+		return
+	}
+
+	select {
+	case triggerErr := <-triggerDone:
+		require.NoError(t, triggerErr)
+	case <-time.After(5 * time.Second):
+		t.Fatal("TriggerLoad did not return after the load it was waiting on finished")
+	}
+}
+
 func TestControllerAccountsEvents(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()

--- a/services/wallet/collectibles/ownership/controller_test.go
+++ b/services/wallet/collectibles/ownership/controller_test.go
@@ -607,6 +607,100 @@ func TestControllerTriggerLoad(t *testing.T) {
 	controller.Stop()
 }
 
+// TestControllerTriggerLoadUnblocksOnCancelledLoad verifies that an on-demand
+// load waiting on an already running periodical load doesn't hang when that load
+// gets cancelled (the loader is stopped or restarted). The cancelled load
+// publishes neither a finished nor an error event, so the waiter has to be woken
+// up explicitly — a caller passing a context without a deadline would otherwise
+// wait forever.
+func TestControllerTriggerLoadUnblocksOnCancelledLoad(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	accountsProvider := mock_ownership.NewMockAccountsProvider(mockCtrl)
+	fakeAddress := types.HexToAddress("0x123")
+	accountsProvider.EXPECT().GetWalletAddresses().Return([]types.Address{fakeAddress}, nil).AnyTimes()
+
+	accountsPublisher := pubsub.NewPublisher()
+	networksProvider := mock_ownership.NewMockNetworksProvider(mockCtrl)
+	networksPublisher := pubsub.NewPublisher()
+
+	networksProvider.EXPECT().GetActiveNetworks().Return([]*params.Network{
+		{ChainID: 1, IsActive: true},
+	}, nil).AnyTimes()
+	networksProvider.EXPECT().GetPublisher().Return(networksPublisher).AnyTimes()
+
+	walletDB, err := testutils.SetupTestMemorySQLDB(walletdatabase.DbInitializer{})
+	require.NoError(t, err)
+
+	// The fetch stays in flight until the load is cancelled, so that the
+	// on-demand load has a running load to wait on.
+	fetchStarted := make(chan struct{}, 10)
+	ownershipFetcher := mock_ownership.NewMockCollectibleOwnershipFetcher(mockCtrl)
+	ownershipFetcher.EXPECT().FetchCollectibleOwnershipByOwner(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+		func(ctx context.Context, chainID walletCommon.ChainID, owner common.Address, cursor string, limit int, providerID string) (*thirdparty.CollectibleOwnershipContainer, error) {
+			fetchStarted <- struct{}{}
+			<-ctx.Done()
+			return nil, ctx.Err()
+		}).AnyTimes()
+
+	multistandardBalancePublisher := pubsub.NewPublisher()
+	transferDetectorPublisher := pubsub.NewPublisher()
+	blockChainStateProvider := mock_ownership.NewMockBlockChainStateProvider(mockCtrl)
+	publisher := pubsub.NewPublisher()
+	logger := zaptest.NewLogger(t).WithOptions(zap.AddCallerSkip(1))
+
+	controller := ownership.NewController(
+		ownership.NewOwnershipDB(walletDB),
+		accountsProvider,
+		accountsPublisher,
+		networksProvider,
+		multistandardBalancePublisher,
+		transferDetectorPublisher,
+		blockChainStateProvider,
+		ownershipFetcher,
+		publisher,
+		logger,
+	)
+
+	controller.StartWithLoaderParams(
+		ownership.PeriodicalLoaderParams{
+			StartDelay:   0 * time.Second,
+			LoadInterval: 10 * time.Second,
+			LoaderParams: ownership.LoaderParams{
+				LoadDelay:  0 * time.Second,
+				FetchLimit: 50,
+			},
+		},
+	)
+
+	select {
+	case <-fetchStarted:
+	case <-time.After(5 * time.Second):
+		controller.Stop()
+		t.Fatal("the periodical load never started fetching")
+	}
+
+	// The on-demand load finds the running load and waits for it to end.
+	triggerDone := make(chan error, 1)
+	go func() {
+		triggerDone <- controller.TriggerLoad(context.Background(), walletCommon.ChainID(1), common.Address(fakeAddress))
+	}()
+
+	// Give TriggerLoad time to subscribe and enter the wait.
+	time.Sleep(300 * time.Millisecond)
+
+	// Cancels the running load; the waiter must not be left hanging.
+	controller.Stop()
+
+	select {
+	case triggerErr := <-triggerDone:
+		require.ErrorIs(t, triggerErr, context.Canceled)
+	case <-time.After(3 * time.Second):
+		t.Fatal("TriggerLoad did not return after the load it was waiting on got cancelled")
+	}
+}
+
 func TestControllerAccountsEvents(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()

--- a/services/wallet/collectibles/ownership/controller_test.go
+++ b/services/wallet/collectibles/ownership/controller_test.go
@@ -607,6 +607,79 @@ func TestControllerTriggerLoad(t *testing.T) {
 	controller.Stop()
 }
 
+func TestControllerTriggerLoadUnsupportedChain(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	accountsProvider := mock_ownership.NewMockAccountsProvider(mockCtrl)
+	fakeAddress := types.HexToAddress("0x123")
+	accountsProvider.EXPECT().GetWalletAddresses().Return([]types.Address{fakeAddress}, nil).AnyTimes()
+
+	accountsPublisher := pubsub.NewPublisher()
+	networksProvider := mock_ownership.NewMockNetworksProvider(mockCtrl)
+	networksPublisher := pubsub.NewPublisher()
+
+	const unsupportedChainID = walletCommon.ChainID(56)
+
+	networksProvider.EXPECT().GetActiveNetworks().Return([]*params.Network{
+		{ChainID: uint64(unsupportedChainID), IsActive: true},
+	}, nil).AnyTimes()
+	networksProvider.EXPECT().GetPublisher().Return(networksPublisher).AnyTimes()
+
+	walletDB, err := testutils.SetupTestMemorySQLDB(walletdatabase.DbInitializer{})
+	require.NoError(t, err)
+
+	// The fetcher must never be called for a chain the predicate rejects —
+	// neither by the periodical loaders nor by the on-demand TriggerLoad path.
+	ownershipFetcher := mock_ownership.NewMockCollectibleOwnershipFetcher(mockCtrl)
+	ownershipFetcher.EXPECT().FetchCollectibleOwnershipByOwner(
+		gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(),
+	).Times(0)
+
+	multistandardBalancePublisher := pubsub.NewPublisher()
+	transferDetectorPublisher := pubsub.NewPublisher()
+	blockChainStateProvider := mock_ownership.NewMockBlockChainStateProvider(mockCtrl)
+	publisher := pubsub.NewPublisher()
+	logger := zaptest.NewLogger(t).WithOptions(zap.AddCallerSkip(1))
+
+	controller := ownership.NewController(
+		ownership.NewOwnershipDB(walletDB),
+		accountsProvider,
+		accountsPublisher,
+		networksProvider,
+		multistandardBalancePublisher,
+		transferDetectorPublisher,
+		blockChainStateProvider,
+		ownershipFetcher,
+		publisher,
+		logger,
+	)
+	controller.SetChainSupportedCheck(func(chainID walletCommon.ChainID) bool {
+		return chainID != unsupportedChainID
+	})
+
+	controller.StartWithLoaderParams(
+		ownership.PeriodicalLoaderParams{
+			StartDelay:   0 * time.Second,
+			LoadInterval: 10 * time.Second,
+			LoaderParams: ownership.LoaderParams{
+				LoadDelay:  0 * time.Second,
+				FetchLimit: 50,
+			},
+		},
+	)
+
+	// No loader is created for the unsupported chain
+	require.Equal(t, ownership.LoaderStateNotAvailable, controller.GetLoaderState(unsupportedChainID, common.Address(fakeAddress)))
+
+	// On-demand load is a successful no-op, without hitting the fetcher
+	err = controller.TriggerLoad(context.Background(), unsupportedChainID, common.Address(fakeAddress))
+	require.NoError(t, err)
+	require.Equal(t, ownership.LoaderStateNotAvailable, controller.GetLoaderState(unsupportedChainID, common.Address(fakeAddress)))
+
+	controller.Stop()
+}
+
 // TestControllerTriggerLoadUnblocksOnCancelledLoad verifies that an on-demand
 // load waiting on an already running periodical load doesn't hang when that load
 // gets cancelled (the loader is stopped or restarted). The cancelled load

--- a/services/wallet/collectibles/ownership/events.go
+++ b/services/wallet/collectibles/ownership/events.go
@@ -33,3 +33,11 @@ type EventOwnedCollectiblesLoadError struct {
 	Account common.Address
 	Error   error
 }
+
+// Published when a load ends because it was cancelled (loader stopped or
+// restarted). Internal: lets waiters on a running load unblock; not translated
+// into a client event.
+type EventOwnedCollectiblesLoadCancelled struct {
+	ChainID walletCommon.ChainID
+	Account common.Address
+}

--- a/services/wallet/collectibles/ownership/events.go
+++ b/services/wallet/collectibles/ownership/events.go
@@ -7,14 +7,20 @@ import (
 	"github.com/status-im/status-go/services/wallet/thirdparty"
 )
 
+// LoaderID identifies the Loader that published the event. A (ChainID, Account)
+// pair doesn't identify a load: a loader restart replaces the loader for the
+// pair while the replaced one is still unwinding, so events from both can reach
+// the same subscriber. Waiters interested in one specific load must match on it.
 type EventOwnedCollectiblesLoadStarted struct {
-	ChainID walletCommon.ChainID
-	Account common.Address
+	ChainID  walletCommon.ChainID
+	Account  common.Address
+	LoaderID uint64
 }
 
 type EventOwnedCollectiblesLoadPartial struct {
 	ChainID          walletCommon.ChainID
 	Account          common.Address
+	LoaderID         uint64
 	Added            []thirdparty.CollectibleUniqueID
 	PartialOwnership []thirdparty.CollectibleIDBalance
 }
@@ -22,6 +28,7 @@ type EventOwnedCollectiblesLoadPartial struct {
 type EventOwnedCollectiblesLoadFinished struct {
 	ChainID      walletCommon.ChainID
 	Account      common.Address
+	LoaderID     uint64
 	Added        []thirdparty.CollectibleUniqueID
 	Updated      []thirdparty.CollectibleUniqueID
 	Removed      []thirdparty.CollectibleUniqueID
@@ -29,15 +36,17 @@ type EventOwnedCollectiblesLoadFinished struct {
 }
 
 type EventOwnedCollectiblesLoadError struct {
-	ChainID walletCommon.ChainID
-	Account common.Address
-	Error   error
+	ChainID  walletCommon.ChainID
+	Account  common.Address
+	LoaderID uint64
+	Error    error
 }
 
 // Published when a load ends because it was cancelled (loader stopped or
 // restarted). Internal: lets waiters on a running load unblock; not translated
 // into a client event.
 type EventOwnedCollectiblesLoadCancelled struct {
-	ChainID walletCommon.ChainID
-	Account common.Address
+	ChainID  walletCommon.ChainID
+	Account  common.Address
+	LoaderID uint64
 }

--- a/services/wallet/collectibles/ownership/loader.go
+++ b/services/wallet/collectibles/ownership/loader.go
@@ -20,6 +20,12 @@ import (
 
 var ErrLoadAlreadyInProgress = errors.New("load already in progress")
 
+// Hands out an identity to every Loader, so that the events of a load can be
+// told apart from those of a load of another Loader serving the same
+// chain+account (a restart replaces the Loader while the old one is still
+// unwinding).
+var lastLoaderID atomic.Uint64
+
 type CollectibleOwnershipFetcher interface {
 	FetchCollectibleOwnershipByOwner(ctx context.Context, chainID walletCommon.ChainID, owner common.Address, cursor string, limit int, providerID string) (*thirdparty.CollectibleOwnershipContainer, error)
 }
@@ -49,6 +55,7 @@ func DefaultLoaderParams() LoaderParams {
 }
 
 type Loader struct {
+	id        uint64
 	chainID   walletCommon.ChainID
 	account   common.Address
 	fetcher   CollectibleOwnershipFetcher
@@ -63,6 +70,7 @@ type Loader struct {
 
 func NewLoader(chainID walletCommon.ChainID, account common.Address, fetcher CollectibleOwnershipFetcher, storage CollectibleOwnershipStorage, publisher *pubsub.Publisher, params LoaderParams, logger *zap.Logger) *Loader {
 	return &Loader{
+		id:        lastLoaderID.Add(1),
 		chainID:   chainID,
 		account:   account,
 		fetcher:   fetcher,
@@ -101,15 +109,17 @@ func (l *Loader) Load(ctx context.Context) ([]thirdparty.CollectibleIDBalance, e
 			// Deadline expiry is a real failure and is still reported.
 			// Waiters on this load still need to unblock, though.
 			pubsub.Publish(l.publisher, EventOwnedCollectiblesLoadCancelled{
-				ChainID: l.chainID,
-				Account: l.account,
+				ChainID:  l.chainID,
+				Account:  l.account,
+				LoaderID: l.id,
 			})
 			return
 		}
 		pubsub.Publish(l.publisher, EventOwnedCollectiblesLoadError{
-			ChainID: l.chainID,
-			Account: l.account,
-			Error:   err,
+			ChainID:  l.chainID,
+			Account:  l.account,
+			LoaderID: l.id,
+			Error:    err,
 		})
 	}()
 
@@ -140,8 +150,9 @@ func (l *Loader) Load(ctx context.Context) ([]thirdparty.CollectibleIDBalance, e
 	l.notifyStateChanged(LoaderStateUpdating)
 
 	pubsub.Publish(l.publisher, EventOwnedCollectiblesLoadStarted{
-		ChainID: l.chainID,
-		Account: l.account,
+		ChainID:  l.chainID,
+		Account:  l.account,
+		LoaderID: l.id,
 	})
 
 	// Start fetching collectibles in chunks
@@ -198,6 +209,7 @@ func (l *Loader) Load(ctx context.Context) ([]thirdparty.CollectibleIDBalance, e
 			partialEvent := EventOwnedCollectiblesLoadPartial{
 				ChainID:          l.chainID,
 				Account:          l.account,
+				LoaderID:         l.id,
 				PartialOwnership: accumulatedOwnership,
 			}
 
@@ -230,6 +242,7 @@ func (l *Loader) Load(ctx context.Context) ([]thirdparty.CollectibleIDBalance, e
 	finishedEvent := EventOwnedCollectiblesLoadFinished{
 		ChainID:      l.chainID,
 		Account:      l.account,
+		LoaderID:     l.id,
 		NewOwnership: accumulatedOwnership,
 	}
 

--- a/services/wallet/collectibles/ownership/loader.go
+++ b/services/wallet/collectibles/ownership/loader.go
@@ -39,7 +39,7 @@ type LoaderParams struct {
 
 func DefaultLoaderParams() LoaderParams {
 	return LoaderParams{
-		LoadDelay:  10 * time.Second,
+		LoadDelay:  1 * time.Second,
 		FetchLimit: 50,
 	}
 }

--- a/services/wallet/collectibles/ownership/loader.go
+++ b/services/wallet/collectibles/ownership/loader.go
@@ -92,14 +92,25 @@ func (l *Loader) Load(ctx context.Context) ([]thirdparty.CollectibleIDBalance, e
 	var err error
 	// Handle error at the end, if any
 	defer func() {
-		if err != nil {
-			pubsub.Publish(l.publisher, EventOwnedCollectiblesLoadError{
+		if err == nil {
+			return
+		}
+		if errors.Is(err, context.Canceled) || errors.Is(ctx.Err(), context.Canceled) {
+			// The load was cancelled (the loader is being stopped or restarted),
+			// not a failure — don't report an error for the client to surface.
+			// Deadline expiry is a real failure and is still reported.
+			// Waiters on this load still need to unblock, though.
+			pubsub.Publish(l.publisher, EventOwnedCollectiblesLoadCancelled{
 				ChainID: l.chainID,
 				Account: l.account,
-				Error:   err,
 			})
 			return
 		}
+		pubsub.Publish(l.publisher, EventOwnedCollectiblesLoadError{
+			ChainID: l.chainID,
+			Account: l.account,
+			Error:   err,
+		})
 	}()
 
 	var lastFetchTimestamp int64

--- a/services/wallet/collectibles/ownership/loader.go
+++ b/services/wallet/collectibles/ownership/loader.go
@@ -30,8 +30,11 @@ type CollectibleOwnershipStorage interface {
 }
 
 type LoaderParams struct {
-	LoadDelay  time.Duration // (Optional) Delay between notifying a Load start and actually triggering the first fetch, used to "debounce" fetches triggered by settings changes
-	FetchLimit int           // (Optional) Limit the number of collectibles to fetch per page during the initial load
+	// (Optional) Delay between triggering a Load and actually triggering the first fetch, used to
+	// "debounce" fetches triggered by settings changes. Skipped on the initial load, since there's
+	// nothing to debounce when the ownership was never fetched before.
+	LoadDelay  time.Duration
+	FetchLimit int // (Optional) Limit the number of collectibles to fetch per page during the initial load
 }
 
 func DefaultLoaderParams() LoaderParams {
@@ -126,7 +129,10 @@ func (l *Loader) Load(ctx context.Context) ([]thirdparty.CollectibleIDBalance, e
 		zap.Int("page", pageNr),
 	)
 
-	if l.params.LoadDelay.Seconds() > 0 {
+	// The delay coalesces bursts of load requests (settings changes, detected transfers).
+	// There's nothing to coalesce when the ownership for this account+chain was never
+	// fetched, so the initial load hits the provider right away.
+	if !isInitialLoad && l.params.LoadDelay > 0 {
 		if l.waitFor(ctx, l.params.LoadDelay) {
 			return nil, ctx.Err()
 		}

--- a/services/wallet/collectibles/ownership/loader.go
+++ b/services/wallet/collectibles/ownership/loader.go
@@ -35,6 +35,10 @@ type LoaderParams struct {
 	// nothing to debounce when the ownership was never fetched before.
 	LoadDelay  time.Duration
 	FetchLimit int // (Optional) Limit the number of collectibles to fetch per page during the initial load
+	// (Optional) Called by the goroutine owning the load whenever it moves between
+	// LoaderStateDelayed (waiting out LoadDelay) and LoaderStateUpdating (fetching), so that
+	// callers can tell a load that is still being debounced from one that is really running.
+	OnStateChanged func(state LoaderState)
 }
 
 func DefaultLoaderParams() LoaderParams {
@@ -85,11 +89,6 @@ func (l *Loader) Load(ctx context.Context) ([]thirdparty.CollectibleIDBalance, e
 		zap.String("account", gocommon.TruncateWithDot(l.account.String())),
 	)
 
-	pubsub.Publish(l.publisher, EventOwnedCollectiblesLoadStarted{
-		ChainID: l.chainID,
-		Account: l.account,
-	})
-
 	var err error
 	// Handle error at the end, if any
 	defer func() {
@@ -115,6 +114,25 @@ func (l *Loader) Load(ctx context.Context) ([]thirdparty.CollectibleIDBalance, e
 		pageSize = l.params.FetchLimit
 	}
 
+	// The delay coalesces bursts of load requests (settings changes, detected transfers).
+	// There's nothing to coalesce when the ownership for this account+chain was never
+	// fetched, so the initial load hits the provider right away.
+	if !isInitialLoad && l.params.LoadDelay > 0 {
+		l.notifyStateChanged(LoaderStateDelayed)
+		if l.waitFor(ctx, l.params.LoadDelay) {
+			return nil, ctx.Err()
+		}
+	}
+
+	// Only report (and notify) the load as started once the fetching really begins, so that
+	// the client doesn't show it as updating for the whole duration of the delay.
+	l.notifyStateChanged(LoaderStateUpdating)
+
+	pubsub.Publish(l.publisher, EventOwnedCollectiblesLoadStarted{
+		ChainID: l.chainID,
+		Account: l.account,
+	})
+
 	// Start fetching collectibles in chunks
 	pageNr := 0
 	cursor := thirdparty.FetchFromStartCursor
@@ -128,15 +146,6 @@ func (l *Loader) Load(ctx context.Context) ([]thirdparty.CollectibleIDBalance, e
 		zap.String("account", gocommon.TruncateWithDot(l.account.String())),
 		zap.Int("page", pageNr),
 	)
-
-	// The delay coalesces bursts of load requests (settings changes, detected transfers).
-	// There's nothing to coalesce when the ownership for this account+chain was never
-	// fetched, so the initial load hits the provider right away.
-	if !isInitialLoad && l.params.LoadDelay > 0 {
-		if l.waitFor(ctx, l.params.LoadDelay) {
-			return nil, ctx.Err()
-		}
-	}
 
 	start := time.Now()
 
@@ -221,6 +230,12 @@ func (l *Loader) Load(ctx context.Context) ([]thirdparty.CollectibleIDBalance, e
 	pubsub.Publish(l.publisher, finishedEvent)
 
 	return accumulatedOwnership, nil
+}
+
+func (l *Loader) notifyStateChanged(state LoaderState) {
+	if l.params.OnStateChanged != nil {
+		l.params.OnStateChanged(state)
+	}
 }
 
 func (l *Loader) waitFor(ctx context.Context, delay time.Duration) (cancelled bool) {

--- a/services/wallet/collectibles/ownership/periodical_loader.go
+++ b/services/wallet/collectibles/ownership/periodical_loader.go
@@ -2,6 +2,7 @@ package ownership
 
 import (
 	"context"
+	"errors"
 	"sync/atomic"
 	"time"
 
@@ -65,11 +66,19 @@ func NewPeriodicalLoader(
 	ret := &PeriodicalLoader{
 		chainID: chainID,
 		account: account,
-		loader:  NewLoader(chainID, account, fetcher, storage, publisher, params.LoaderParams, logger),
 		params:  params,
 		logger:  logger.Named("PeriodicalLoader"),
 	}
 	ret.state.Store(LoaderStateIdle)
+
+	// Let the Loader drive the delayed/updating states, so that a load that is still being
+	// debounced isn't reported as updating
+	loaderParams := params.LoaderParams
+	loaderParams.OnStateChanged = func(state LoaderState) {
+		ret.state.Store(state)
+	}
+	ret.loader = NewLoader(chainID, account, fetcher, storage, publisher, loaderParams, logger)
+
 	return ret
 }
 
@@ -149,27 +158,6 @@ func (pl *PeriodicalLoader) triggerLoadAsync(stopCh <-chan struct{}) {
 }
 
 func (pl *PeriodicalLoader) triggerLoad(stopCh <-chan struct{}) {
-	if pl.GetState() == LoaderStateUpdating {
-		// Another load is in progress which should've finished or have been cancelled at this point
-		pl.logger.Error("skipping Load because it's already in progress",
-			zap.Uint64("chain", uint64(pl.chainID)),
-			zap.String("account", gocommon.TruncateWithDot(pl.account.String())),
-		)
-		return
-	}
-
-	pl.state.Store(LoaderStateUpdating)
-
-	var err error
-	// Handle error at the end (if any) and set state
-	defer func() {
-		if err != nil {
-			pl.state.Store(LoaderStateError)
-			return
-		}
-		pl.state.Store(LoaderStateIdle)
-	}()
-
 	ctx, cancelFn := context.WithCancel(context.Background())
 	defer cancelFn() // Cancel ctx after Load ends
 	go func() {
@@ -181,12 +169,29 @@ func (pl *PeriodicalLoader) triggerLoad(stopCh <-chan struct{}) {
 		}
 	}()
 
-	err = pl.Load(ctx)
+	_ = pl.Load(ctx)
 }
 
-func (pl *PeriodicalLoader) Load(ctx context.Context) (err error) {
-	_, err = pl.loader.Load(ctx)
-	return
+// Runs a load, keeping the reported state in sync with its progress: the Loader reports
+// LoaderStateDelayed/LoaderStateUpdating while it runs, the terminal state is set here.
+func (pl *PeriodicalLoader) Load(ctx context.Context) error {
+	_, err := pl.loader.Load(ctx)
+	if errors.Is(err, ErrLoadAlreadyInProgress) {
+		// The load in progress owns the reported state, leave it alone
+		pl.logger.Error("skipping Load because it's already in progress",
+			zap.Uint64("chain", uint64(pl.chainID)),
+			zap.String("account", gocommon.TruncateWithDot(pl.account.String())),
+		)
+		return err
+	}
+
+	if err != nil {
+		pl.state.Store(LoaderStateError)
+	} else {
+		pl.state.Store(LoaderStateIdle)
+	}
+
+	return err
 }
 
 func (pl *PeriodicalLoader) waitFor(stopCh <-chan struct{}, delay time.Duration) (cancelled bool) {

--- a/services/wallet/collectibles/ownership/periodical_loader.go
+++ b/services/wallet/collectibles/ownership/periodical_loader.go
@@ -74,8 +74,12 @@ func NewPeriodicalLoader(
 	// Let the Loader drive the delayed/updating states, so that a load that is still being
 	// debounced isn't reported as updating
 	loaderParams := params.LoaderParams
+	callerOnStateChanged := loaderParams.OnStateChanged
 	loaderParams.OnStateChanged = func(state LoaderState) {
 		ret.state.Store(state)
+		if callerOnStateChanged != nil {
+			callerOnStateChanged(state)
+		}
 	}
 	ret.loader = NewLoader(chainID, account, fetcher, storage, publisher, loaderParams, logger)
 
@@ -185,9 +189,12 @@ func (pl *PeriodicalLoader) Load(ctx context.Context) error {
 		return err
 	}
 
-	if err != nil {
+	if err != nil && !errors.Is(err, context.Canceled) && !errors.Is(ctx.Err(), context.Canceled) {
 		pl.state.Store(LoaderStateError)
 	} else {
+		// Success, or the load was cancelled by a stop/restart — either way the
+		// pair is simply not loading anymore, which must not read as a failure.
+		// Deadline expiry is not a cancellation and still reads as an error.
 		pl.state.Store(LoaderStateIdle)
 	}
 

--- a/services/wallet/collectibles/ownership/periodical_loader.go
+++ b/services/wallet/collectibles/ownership/periodical_loader.go
@@ -150,6 +150,13 @@ func (pl *PeriodicalLoader) Stop() {
 	}
 }
 
+// Identifies the loads run by this PeriodicalLoader in the published events.
+// A restart builds a new PeriodicalLoader (and Loader) for the same
+// chain+account, so this is what tells their loads apart.
+func (pl *PeriodicalLoader) loaderID() uint64 {
+	return pl.loader.id
+}
+
 func (pl *PeriodicalLoader) GetState() LoaderState {
 	return pl.state.Load().(LoaderState)
 }

--- a/services/wallet/collectibles/ownership/periodical_loader.go
+++ b/services/wallet/collectibles/ownership/periodical_loader.go
@@ -195,7 +195,7 @@ func (pl *PeriodicalLoader) Load(ctx context.Context) error {
 }
 
 func (pl *PeriodicalLoader) waitFor(stopCh <-chan struct{}, delay time.Duration) (cancelled bool) {
-	delayTimer := time.NewTicker(delay)
+	delayTimer := time.NewTimer(delay)
 	defer delayTimer.Stop()
 	select {
 	case <-delayTimer.C:

--- a/services/wallet/collectibles/ownership/periodical_loader_test.go
+++ b/services/wallet/collectibles/ownership/periodical_loader_test.go
@@ -70,10 +70,13 @@ func (f *fakeFetcher) waitForReturn(t *testing.T) {
 }
 
 // fakeStorage satisfies CollectibleOwnershipStorage with no-ops.
-type fakeStorage struct{}
+// The zero value reports a timestamp of a previous successful fetch (non-initial load).
+type fakeStorage struct {
+	timestamp int64
+}
 
-func (fakeStorage) GetOwnershipUpdateTimestamp(_ common.Address, _ walletCommon.ChainID) (int64, error) {
-	return 0, nil // non-initial load (timestamp != InvalidTimestamp)
+func (s fakeStorage) GetOwnershipUpdateTimestamp(_ common.Address, _ walletCommon.ChainID) (int64, error) {
+	return s.timestamp, nil
 }
 
 func (fakeStorage) Update(_ walletCommon.ChainID, _ common.Address, _ []thirdparty.CollectibleIDBalance, _ int64) ([]thirdparty.CollectibleUniqueID, []thirdparty.CollectibleUniqueID, []thirdparty.CollectibleUniqueID, error) {
@@ -155,6 +158,70 @@ func TestPeriodicalLoaderRestartReleasesOldGoroutines(t *testing.T) {
 
 	// Clean up
 	pl.Stop()
+}
+
+// TestLoadDelaySkippedOnInitialLoad verifies that the first ever load for an
+// account+chain fetches right away instead of waiting out LoadDelay: there's
+// nothing to debounce yet, and the delay is fully visible to the user.
+func TestLoadDelaySkippedOnInitialLoad(t *testing.T) {
+	fetcher := newFakeFetcher()
+	params := PeriodicalLoaderParams{
+		LoadInterval: 1 * time.Minute,
+		LoaderParams: LoaderParams{
+			LoadDelay:  30 * time.Second,
+			FetchLimit: 50,
+		},
+	}
+	pl := newTestLoader(t, fetcher, fakeStorage{timestamp: InvalidTimestamp}, params)
+
+	pl.Start(false, false)
+
+	select {
+	case <-fetcher.entered:
+	case <-time.After(5 * time.Second):
+		pl.Stop()
+		t.Fatal("initial load waited for LoadDelay before fetching")
+	}
+
+	require.Equal(t, LoaderStateUpdating, pl.GetState())
+
+	pl.Stop()
+	waitForLoadToEnd(t, pl)
+}
+
+// waitForLoadToEnd waits for an interrupted load to unwind, so that the loader
+// goroutines don't outlive the test.
+func waitForLoadToEnd(t *testing.T, pl *PeriodicalLoader) {
+	t.Helper()
+	require.Eventually(t, func() bool {
+		state := pl.GetState()
+		return state == LoaderStateIdle || state == LoaderStateError
+	}, 5*time.Second, 10*time.Millisecond)
+}
+
+// TestLoadDelayReportedAsDelayed verifies that a subsequent load still waits out
+// LoadDelay, and that it is reported as delayed (not as updating) while doing so.
+func TestLoadDelayReportedAsDelayed(t *testing.T) {
+	fetcher := newFakeFetcher()
+	params := PeriodicalLoaderParams{
+		LoadInterval: 1 * time.Minute,
+		LoaderParams: LoaderParams{
+			LoadDelay:  5 * time.Second,
+			FetchLimit: 50,
+		},
+	}
+	pl := newTestLoader(t, fetcher, fakeStorage{}, params)
+
+	pl.Start(false, false)
+
+	require.Eventually(t, func() bool {
+		return pl.GetState() == LoaderStateDelayed
+	}, 1*time.Second, 10*time.Millisecond)
+
+	require.Equal(t, 0, fetcher.CallCount(), "no fetch should have been triggered during the load delay")
+
+	pl.Stop()
+	waitForLoadToEnd(t, pl)
 }
 
 // TestPeriodicalLoaderStopDuringDelay verifies that Stop cancels the start

--- a/services/wallet/collectibles/ownership/periodical_loader_test.go
+++ b/services/wallet/collectibles/ownership/periodical_loader_test.go
@@ -2,6 +2,7 @@ package ownership
 
 import (
 	"context"
+	"slices"
 	"sync"
 	"testing"
 	"time"
@@ -85,6 +86,14 @@ func (fakeStorage) Update(_ walletCommon.ChainID, _ common.Address, _ []thirdpar
 
 func newTestLoader(t *testing.T, fetcher CollectibleOwnershipFetcher, storage CollectibleOwnershipStorage, params PeriodicalLoaderParams) *PeriodicalLoader {
 	t.Helper()
+	pl, _ := newTestLoaderWithPublisher(t, fetcher, storage, params)
+	return pl
+}
+
+// newTestLoaderWithPublisher also returns the publisher the loader emits its
+// events on, for tests that need to observe them.
+func newTestLoaderWithPublisher(t *testing.T, fetcher CollectibleOwnershipFetcher, storage CollectibleOwnershipStorage, params PeriodicalLoaderParams) (*PeriodicalLoader, *pubsub.Publisher) {
+	t.Helper()
 	logger := zaptest.NewLogger(t)
 	publisher := pubsub.NewPublisher()
 	return NewPeriodicalLoader(
@@ -95,7 +104,7 @@ func newTestLoader(t *testing.T, fetcher CollectibleOwnershipFetcher, storage Co
 		publisher,
 		params,
 		logger,
-	)
+	), publisher
 }
 
 // TestPeriodicalLoaderStartStop verifies that Start followed by Stop cleanly
@@ -219,6 +228,117 @@ func TestLoadDelayReportedAsDelayed(t *testing.T) {
 	}, 1*time.Second, 10*time.Millisecond)
 
 	require.Equal(t, 0, fetcher.CallCount(), "no fetch should have been triggered during the load delay")
+
+	pl.Stop()
+	waitForLoadToEnd(t, pl)
+}
+
+// requireNoLoadError fails if a load error event is published within the given
+// observation window.
+func requireNoLoadError(t *testing.T, errCh chan EventOwnedCollectiblesLoadError, window time.Duration) {
+	t.Helper()
+	select {
+	case event := <-errCh:
+		require.FailNowf(t, "a cancelled load must not be reported as an error",
+			"unexpected load error event published: %v", event.Error)
+	case <-time.After(window):
+	}
+}
+
+// TestCancelledLoadDuringDelayIsNotReportedAsError verifies that stopping the
+// loader while a load is still waiting out LoadDelay ends that load silently:
+// the pair simply isn't loading anymore, which must not reach the client as a
+// failed load.
+func TestCancelledLoadDuringDelayIsNotReportedAsError(t *testing.T) {
+	fetcher := newFakeFetcher()
+	params := PeriodicalLoaderParams{
+		LoadInterval: 1 * time.Minute,
+		LoaderParams: LoaderParams{
+			LoadDelay:  5 * time.Second,
+			FetchLimit: 50,
+		},
+	}
+	pl, publisher := newTestLoaderWithPublisher(t, fetcher, fakeStorage{}, params)
+
+	errCh, unsubFn := pubsub.Subscribe[EventOwnedCollectiblesLoadError](publisher, 10)
+	defer unsubFn()
+
+	pl.Start(false, false)
+
+	require.Eventually(t, func() bool {
+		return pl.GetState() == LoaderStateDelayed
+	}, 1*time.Second, 10*time.Millisecond)
+
+	// Stop while the load is still being debounced.
+	pl.Stop()
+
+	requireNoLoadError(t, errCh, 500*time.Millisecond)
+	require.Equal(t, LoaderStateIdle, pl.GetState(), "a cancelled load must settle as idle, not as an error")
+	require.Equal(t, 0, fetcher.CallCount(), "no fetch should have been triggered during the load delay")
+}
+
+// TestCancelledLoadDuringFetchIsNotReportedAsError verifies the same for a load
+// that is already fetching when the loader is stopped.
+func TestCancelledLoadDuringFetchIsNotReportedAsError(t *testing.T) {
+	fetcher := newFakeFetcher()
+	params := PeriodicalLoaderParams{
+		LoadInterval: 1 * time.Minute,
+		LoaderParams: LoaderParams{FetchLimit: 50},
+	}
+	pl, publisher := newTestLoaderWithPublisher(t, fetcher, fakeStorage{}, params)
+
+	errCh, unsubFn := pubsub.Subscribe[EventOwnedCollectiblesLoadError](publisher, 10)
+	defer unsubFn()
+
+	pl.Start(false, false)
+
+	select {
+	case <-fetcher.entered:
+	case <-time.After(5 * time.Second):
+		pl.Stop()
+		t.Fatal("timed out waiting for the fetch to start")
+	}
+
+	// Stop while the fetch is in flight.
+	pl.Stop()
+	fetcher.waitForReturn(t)
+
+	requireNoLoadError(t, errCh, 500*time.Millisecond)
+	require.Equal(t, LoaderStateIdle, pl.GetState(), "a cancelled load must settle as idle, not as an error")
+}
+
+// TestLoaderStateChangesForwardedToCaller verifies that a caller-supplied
+// OnStateChanged callback still receives the load's state transitions. The
+// PeriodicalLoader wraps that callback to track the state itself, and must chain
+// to the caller's one instead of dropping it.
+func TestLoaderStateChangesForwardedToCaller(t *testing.T) {
+	fetcher := newFakeFetcher()
+
+	var mu sync.Mutex
+	var observedStates []LoaderState
+
+	params := PeriodicalLoaderParams{
+		LoadInterval: 1 * time.Minute,
+		LoaderParams: LoaderParams{
+			LoadDelay:  100 * time.Millisecond,
+			FetchLimit: 50,
+			OnStateChanged: func(state LoaderState) {
+				mu.Lock()
+				defer mu.Unlock()
+				observedStates = append(observedStates, state)
+			},
+		},
+	}
+	pl := newTestLoader(t, fetcher, fakeStorage{}, params)
+
+	pl.Start(false, false)
+
+	require.Eventually(t, func() bool {
+		mu.Lock()
+		defer mu.Unlock()
+		return slices.Contains(observedStates, LoaderStateDelayed) &&
+			slices.Contains(observedStates, LoaderStateUpdating)
+	}, 3*time.Second, 10*time.Millisecond, "the caller's OnStateChanged callback never saw the load progress")
 
 	pl.Stop()
 	waitForLoadToEnd(t, pl)

--- a/services/wallet/service.go
+++ b/services/wallet/service.go
@@ -290,6 +290,9 @@ func NewService(
 		collectiblesPublisher,
 		logutils.ZapLogger().Named("CollectiblesOwnershipController"),
 	)
+	collectiblesOwnershipController.SetChainSupportedCheck(func(chainID common.ChainID) bool {
+		return !collectibles.IsUnsupportedCollectibleChain(uint64(chainID))
+	})
 	collectibles := collectibles.NewService(
 		db,
 		feed,


### PR DESCRIPTION
* Skip 10s load delay on first fetch (collectibles)
* Cut default load delay to 1s
* Report Delayed state, not Updating, while debouncing
* Cancelled loads no longer reported as errors
* No loaders for unsupported chains (BSC etc.)

Closes status-im/status-app#21732
