### PR TITLE
fix: default emoji for newly created profiles

### DIFF
--- a/pkg/backend/defaults.go
+++ b/pkg/backend/defaults.go
@@ -24,8 +24,9 @@ import (
 )
 
 const (
-	defaultMnemonicLength    = 12
-	walletAccountDefaultName = "Account 1"
+	defaultMnemonicLength     = 12
+	walletAccountDefaultName  = "Account 1"
+	walletAccountDefaultEmoji = "🛡️"
 
 	DefaultKeystoreRelativePath               = "keystore"
 	DefaultKeycardPairingDataFileRelativePath = "/keycard/pairings.json"

--- a/pkg/backend/geth_backend.go
+++ b/pkg/backend/geth_backend.go
@@ -1529,6 +1529,7 @@ func (b *StatusBackend) prepareWalletAccount(request *requests.CreateAccount) *a
 	return &accsmanagementtypes.AccountCreationDetails{
 		Path:    common.PathDefaultWalletAccount,
 		Name:    walletAccountDefaultName,
+		Emoji:   walletAccountDefaultEmoji,
 		ColorID: request.CustomizationColor,
 	}
 }
@@ -1566,6 +1567,7 @@ func (b *StatusBackend) prepareKeypair(request *requests.CreateAccount, keyUID s
 		KeyUID:             keypair.KeyUID,
 		Address:            types.HexToAddress(walletDerivedAccount.Address),
 		ColorID:            multiacccommon.CustomizationColor(request.CustomizationColor),
+		Emoji:              walletAccountDefaultEmoji,
 		Wallet:             true,
 		Path:               common.PathDefaultWalletAccount,
 		Name:               walletAccountDefaultName,


### PR DESCRIPTION
Instead of setting "wallet" icon for Status profiles which didn't have emoji set, the app now uses "shield" emoji by default.

Closes https://github.com/status-im/status-app/issues/20720

<img width="1103" height="736" alt="image" src="https://github.com/user-attachments/assets/b2a55fba-525d-4c19-9f29-97a7061cfd02" />
