### PR TITLE
chore: remove unnecessary numeric import aliases

### DIFF
--- a/internal/accounts-management/manager_test.go
+++ b/internal/accounts-management/manager_test.go
@@ -17,9 +17,9 @@ import (
 	generator "github.com/status-im/status-go/internal/accounts-management/generator"
 	"github.com/status-im/status-go/internal/accounts-management/keystore"
 	mock_persistence "github.com/status-im/status-go/internal/accounts-management/mock"
-	"github.com/status-im/status-go/internal/accounts-management/types"
+	accsmanagementtypes "github.com/status-im/status-go/internal/accounts-management/types"
 	"github.com/status-im/status-go/internal/crypto"
-	types2 "github.com/status-im/status-go/internal/crypto/types"
+	cryptotypes "github.com/status-im/status-go/internal/crypto/types"
 	"github.com/status-im/status-go/internal/testutils"
 )
 
@@ -126,7 +126,7 @@ func TestVerifyAccountPassword(t *testing.T) {
 			accManager.setKeystore(nil)
 		}
 
-		ok, err := accManager.VerifyAccountPassword(types2.HexToAddress(testCase.address), testCase.password)
+		ok, err := accManager.VerifyAccountPassword(cryptotypes.HexToAddress(testCase.address), testCase.password)
 		if testCase.expectedError != nil && err != nil {
 			if !errors.Is(err, testCase.expectedError) {
 				var accountsErr *customerrors.AccountsError
@@ -193,17 +193,17 @@ func TestVerifyAccountPasswordWithAccountBeforeEIP55(t *testing.T) {
 	require.Equal(t, ErrNoAccountSelected, err)
 
 	persistence.EXPECT().GetProfileKeypair().Return(
-		&types.Keypair{
+		&accsmanagementtypes.Keypair{
 			KeyUID: account3.KeyUID,
 		},
 		nil,
 	).Times(1)
 
 	// Set the chat account, this will create a new keystore
-	err = accManager.SetChatAccount(types2.HexToAddress(account3.ChatAddress), account3.Password, nil)
+	err = accManager.SetChatAccount(cryptotypes.HexToAddress(account3.ChatAddress), account3.Password, nil)
 	require.NoError(t, err)
 
-	address := types2.HexToAddress(account3.ChatAddress)
+	address := cryptotypes.HexToAddress(account3.ChatAddress)
 	ok, err := accManager.VerifyAccountPassword(address, account3.Password)
 	require.NoError(t, err)
 	require.True(t, ok)
@@ -223,9 +223,9 @@ type ManagerTestSuite struct {
 
 type testAccount struct {
 	password      string
-	walletAddress types2.Address
+	walletAddress cryptotypes.Address
 	walletPubKey  string
-	chatAddress   types2.Address
+	chatAddress   cryptotypes.Address
 	chatPubKey    string
 	mnemonic      string
 	masterAccount *generator.Account
@@ -270,9 +270,9 @@ func (s *ManagerTestSuite) getKeyDir() string {
 	return fmt.Sprintf("%s/keystore/%s", s.rootDataDir, s.masterAccount.KeyUID())
 }
 
-func (s *ManagerTestSuite) createAndStoreProfileKeypair() *types.Keypair {
+func (s *ManagerTestSuite) createAndStoreProfileKeypair() *accsmanagementtypes.Keypair {
 	s.persistence.EXPECT().GetKeypairByKeyUID(s.masterAccount.KeyUID()).Return(
-		nil, types.ErrDbKeypairNotFound,
+		nil, accsmanagementtypes.ErrDbKeypairNotFound,
 	).Times(1)
 
 	s.persistence.EXPECT().GetPositionForNextNewAccount().Return(int64(0), nil).Times(1)
@@ -280,17 +280,17 @@ func (s *ManagerTestSuite) createAndStoreProfileKeypair() *types.Keypair {
 	s.persistence.EXPECT().SaveOrUpdateKeypair(gomock.Any()).Return(nil).Times(1)
 
 	s.persistence.EXPECT().GetProfileKeypair().Return(
-		&types.Keypair{
+		&accsmanagementtypes.Keypair{
 			KeyUID: s.masterAccount.KeyUID(),
 		},
 		nil,
 	).Times(1)
 
-	walletAccount := &types.AccountCreationDetails{
+	walletAccount := &accsmanagementtypes.AccountCreationDetails{
 		Path: common.PathDefaultWalletAccount,
 	}
 
-	keypair, err := s.accManager.CreateKeypairFromMnemonicAndStore(s.mnemonic, s.password, "kp-name", types.ColdWalletTypeNone, walletAccount, true, 0)
+	keypair, err := s.accManager.CreateKeypairFromMnemonicAndStore(s.mnemonic, s.password, "kp-name", accsmanagementtypes.ColdWalletTypeNone, walletAccount, true, 0)
 	s.Require().NoError(err)
 	s.Require().NotEmpty(s.mnemonic)
 	s.Require().NotNil(keypair)
@@ -304,26 +304,26 @@ func (s *ManagerTestSuite) createAndStoreProfileKeypair() *types.Keypair {
 		if kpAcc.Chat {
 			chatAccountOk = kpAcc.Path == common.PathEIP1581Chat &&
 				kpAcc.Address == s.chatAddress &&
-				bytes.Equal(kpAcc.PublicKey, types2.Hex2Bytes(s.chatPubKey)) &&
+				bytes.Equal(kpAcc.PublicKey, cryptotypes.Hex2Bytes(s.chatPubKey)) &&
 				kpAcc.KeyUID == keypair.KeyUID &&
 				!kpAcc.Removed &&
 				kpAcc.Clock == 0 &&
 				!kpAcc.Wallet &&
 				kpAcc.AddressWasNotShown &&
 				kpAcc.Position == -1 &&
-				kpAcc.Operable == types.AccountFullyOperable
+				kpAcc.Operable == accsmanagementtypes.AccountFullyOperable
 		}
 		if kpAcc.Wallet {
 			walletAccountOk = kpAcc.Path == common.PathDefaultWalletAccount &&
 				kpAcc.Address == s.walletAddress &&
-				bytes.Equal(kpAcc.PublicKey, types2.Hex2Bytes(s.walletPubKey)) &&
+				bytes.Equal(kpAcc.PublicKey, cryptotypes.Hex2Bytes(s.walletPubKey)) &&
 				kpAcc.KeyUID == keypair.KeyUID &&
 				!kpAcc.Removed &&
 				kpAcc.Clock == 0 &&
 				!kpAcc.Chat &&
 				kpAcc.AddressWasNotShown &&
 				kpAcc.Position == 0 &&
-				kpAcc.Operable == types.AccountFullyOperable
+				kpAcc.Operable == accsmanagementtypes.AccountFullyOperable
 		}
 	}
 	s.Require().True(chatAccountOk)
@@ -341,19 +341,19 @@ func (s *ManagerTestSuite) TestSetChatAccountSuccess() {
 }
 
 func (s *ManagerTestSuite) TestSetChatAccountWrongAddress() {
-	s.testSetChatAccount(types2.HexToAddress("0x0000000000000000000000000000000000000001"), s.testAccount.password, keystore.ErrKeystoreFileMissing)
+	s.testSetChatAccount(cryptotypes.HexToAddress("0x0000000000000000000000000000000000000001"), s.testAccount.password, keystore.ErrKeystoreFileMissing)
 }
 
 func (s *ManagerTestSuite) TestSetChatAccountWrongPassword() {
 	s.testSetChatAccount(s.testAccount.chatAddress, "wrong", keystore.ErrIncorrectPasswordProvided)
 }
 
-func (s *ManagerTestSuite) testSetChatAccount(chat types2.Address, password string, expErr error) {
+func (s *ManagerTestSuite) testSetChatAccount(chat cryptotypes.Address, password string, expErr error) {
 	s.createAndStoreProfileKeypair()
 	s.accManager.setChatAccountAndProfileKeyUID(nil, "") // clear the chat account set by `createAndStoreProfileKeypair`
 
 	s.persistence.EXPECT().GetProfileKeypair().Return(
-		&types.Keypair{
+		&accsmanagementtypes.Keypair{
 			KeyUID: s.masterAccount.KeyUID(),
 		},
 		nil,
@@ -400,7 +400,7 @@ func (s *ManagerTestSuite) TestSetChatAccountForExistingProfile() {
 	s.Require().NoError(err)
 
 	s.persistence.EXPECT().GetProfileKeypair().Return(
-		&types.Keypair{
+		&accsmanagementtypes.Keypair{
 			KeyUID: s.masterAccount.KeyUID(),
 		},
 		nil,
@@ -444,7 +444,7 @@ func (s *ManagerTestSuite) TestLogout() {
 // TestAccounts tests cases for (*Manager).Accounts.
 func (s *ManagerTestSuite) TestAccounts() {
 	s.persistence.EXPECT().GetProfileKeypair().Return(
-		&types.Keypair{
+		&accsmanagementtypes.Keypair{
 			KeyUID: s.masterAccount.KeyUID(),
 		},
 		nil,
@@ -476,7 +476,7 @@ func (s *ManagerTestSuite) TestAccounts() {
 	s.NoError(err)
 	s.Len(accs, 3)
 
-	checkAccount := func(address types2.Address) bool {
+	checkAccount := func(address cryptotypes.Address) bool {
 		return address == s.chatAddress || address == s.walletAddress || address == s.masterAccount.Address()
 	}
 	s.True(checkAccount(accs[0]))
@@ -489,14 +489,14 @@ func (s *ManagerTestSuite) TestAddressToAccountSuccess() {
 }
 
 func (s *ManagerTestSuite) TestAddressToAccountWrongAddress() {
-	s.testAddressToAccount(types2.HexToAddress("0x0001"), s.password, keystore.ErrKeystoreFileMissing)
+	s.testAddressToAccount(cryptotypes.HexToAddress("0x0001"), s.password, keystore.ErrKeystoreFileMissing)
 }
 
 func (s *ManagerTestSuite) TestAddressToAccountWrongPassword() {
 	s.testAddressToAccount(s.walletAddress, "wrong", keystore.ErrIncorrectPasswordProvided)
 }
 
-func (s *ManagerTestSuite) testAddressToAccount(wallet types2.Address, password string, expErr error) {
+func (s *ManagerTestSuite) testAddressToAccount(wallet cryptotypes.Address, password string, expErr error) {
 	s.createAndStoreProfileKeypair()
 
 	key, err := s.accManager.LoadAccount(wallet, password)
@@ -546,11 +546,11 @@ func (s *ManagerTestSuite) TestReEncryptKeyStoreDir() {
 	}
 
 	for _, acc := range accountsToCheck {
-		account, err := s.accManager.LoadAccount(types2.HexToAddress(acc), testPassword)
+		account, err := s.accManager.LoadAccount(cryptotypes.HexToAddress(acc), testPassword)
 		s.Require().Error(err)
 		s.Require().Nil(account)
 
-		account, err = s.accManager.LoadAccount(types2.HexToAddress(acc), newTestPassword)
+		account, err = s.accManager.LoadAccount(cryptotypes.HexToAddress(acc), newTestPassword)
 		s.Require().NoError(err)
 		s.Require().NotNil(account)
 	}
@@ -574,7 +574,7 @@ func (s *ManagerTestSuite) TestReEncryptKeyStoreDirSkipsFilesystemMetadataFiles(
 	}
 
 	for _, acc := range accountsToCheck {
-		account, err := s.accManager.LoadAccount(types2.HexToAddress(acc), newTestPassword)
+		account, err := s.accManager.LoadAccount(cryptotypes.HexToAddress(acc), newTestPassword)
 		s.Require().NoError(err)
 		s.Require().NotNil(account)
 	}
@@ -620,7 +620,7 @@ func (s *ManagerTestSuite) TestDeleteAccount() {
 func (s *ManagerTestSuite) TestDeleteKeypair() {
 	keypair := s.createAndStoreProfileKeypair()
 
-	keypair.Type = types.KeypairTypeSeed
+	keypair.Type = accsmanagementtypes.KeypairTypeSeed
 
 	s.persistence.EXPECT().GetKeypairByKeyUID(keypair.KeyUID).Return(
 		keypair,
@@ -640,11 +640,11 @@ func (s *ManagerTestSuite) TestDeleteKeypair() {
 
 func (s *ManagerTestSuite) TestDeleteAccountOfColdWalletKeypairWithoutPassword() {
 	acc := s.deriveTestAccountAtPath(common.PathDefaultWalletAccount)
-	keypair := &types.Keypair{
+	keypair := &accsmanagementtypes.Keypair{
 		KeyUID:     s.masterAccount.KeyUID(),
-		Type:       types.KeypairTypeSeed,
-		ColdWallet: types.ColdWalletTypeStatusKeycard,
-		Accounts:   []*types.Account{acc},
+		Type:       accsmanagementtypes.KeypairTypeSeed,
+		ColdWallet: accsmanagementtypes.ColdWalletTypeStatusKeycard,
+		Accounts:   []*accsmanagementtypes.Account{acc},
 	}
 
 	s.persistence.EXPECT().GetAccountByAddress(acc.Address).Return(acc, nil).Times(2)
@@ -658,10 +658,10 @@ func (s *ManagerTestSuite) TestDeleteAccountOfColdWalletKeypairWithoutPassword()
 }
 
 func (s *ManagerTestSuite) TestDeleteColdWalletKeypairWithoutPassword() {
-	keypair := &types.Keypair{
+	keypair := &accsmanagementtypes.Keypair{
 		KeyUID:     s.masterAccount.KeyUID(),
-		Type:       types.KeypairTypeSeed,
-		ColdWallet: types.ColdWalletTypeStatusKeycard,
+		Type:       accsmanagementtypes.KeypairTypeSeed,
+		ColdWallet: accsmanagementtypes.ColdWalletTypeStatusKeycard,
 	}
 
 	s.persistence.EXPECT().GetKeypairByKeyUID(keypair.KeyUID).Return(keypair, nil).Times(1)
@@ -674,9 +674,9 @@ func (s *ManagerTestSuite) TestDeleteColdWalletKeypairWithoutPassword() {
 }
 
 func (s *ManagerTestSuite) TestDeleteRegularKeypairWithoutPasswordRejected() {
-	keypair := &types.Keypair{
+	keypair := &accsmanagementtypes.Keypair{
 		KeyUID: s.masterAccount.KeyUID(),
-		Type:   types.KeypairTypeSeed,
+		Type:   accsmanagementtypes.KeypairTypeSeed,
 	}
 
 	s.persistence.EXPECT().GetKeypairByKeyUID(keypair.KeyUID).Return(keypair, nil).Times(1)
@@ -691,34 +691,34 @@ func (s *ManagerTestSuite) TestDeleteRegularKeypairWithoutPasswordRejected() {
 // but the implementation always calls storeKeystoreFilesForAccounts.
 func (s *ManagerTestSuite) TestCreateKeypairFromMnemonicAndStoreDoesNotWriteKeystoreWhenCold() {
 	s.persistence.EXPECT().GetKeypairByKeyUID(s.masterAccount.KeyUID()).Return(
-		nil, types.ErrDbKeypairNotFound,
+		nil, accsmanagementtypes.ErrDbKeypairNotFound,
 	).Times(1)
 
 	s.persistence.EXPECT().GetPositionForNextNewAccount().Return(int64(0), nil).Times(1)
 
 	s.persistence.EXPECT().SaveOrUpdateKeypair(gomock.Any()).DoAndReturn(
-		func(kp *types.Keypair) error {
-			s.Require().Equal(types.ColdWalletTypeStatusKeycard, kp.ColdWallet)
+		func(kp *accsmanagementtypes.Keypair) error {
+			s.Require().Equal(accsmanagementtypes.ColdWalletTypeStatusKeycard, kp.ColdWallet)
 			return nil
 		},
 	).Times(1)
 
 	s.persistence.EXPECT().GetProfileKeypair().Return(
-		&types.Keypair{
+		&accsmanagementtypes.Keypair{
 			KeyUID: s.masterAccount.KeyUID(),
 		},
 		nil,
 	).Times(1)
 
-	walletAccount := &types.AccountCreationDetails{
+	walletAccount := &accsmanagementtypes.AccountCreationDetails{
 		Path: common.PathDefaultWalletAccount,
 	}
 
 	keypair, err := s.accManager.CreateKeypairFromMnemonicAndStore(
-		s.mnemonic, s.password, "kp-name", types.ColdWalletTypeStatusKeycard, walletAccount, true, 0)
+		s.mnemonic, s.password, "kp-name", accsmanagementtypes.ColdWalletTypeStatusKeycard, walletAccount, true, 0)
 	s.Require().NoError(err)
 	s.Require().NotNil(keypair)
-	s.Require().Equal(types.ColdWalletTypeStatusKeycard, keypair.ColdWallet)
+	s.Require().Equal(accsmanagementtypes.ColdWalletTypeStatusKeycard, keypair.ColdWallet)
 
 	files, err := os.ReadDir(s.getKeyDir())
 	s.Require().NoError(err)
@@ -729,11 +729,11 @@ func (s *ManagerTestSuite) TestCreateKeypairFromMnemonicAndStoreDoesNotWriteKeys
 // silently flipping cold_wallet while leaving keystore files on disk.
 func (s *ManagerTestSuite) TestMigrateKeypairToColdWalletRequiresPassword() {
 	keypair := s.createAndStoreProfileKeypair()
-	keypair.Type = types.KeypairTypeSeed
+	keypair.Type = accsmanagementtypes.KeypairTypeSeed
 
 	s.persistence.EXPECT().GetKeypairByKeyUID(keypair.KeyUID).Return(keypair, nil).Times(1)
 
-	err := s.accManager.MigrateKeypairToColdWallet(keypair.KeyUID, "", types.ColdWalletTypeStatusKeycard, 1)
+	err := s.accManager.MigrateKeypairToColdWallet(keypair.KeyUID, "", accsmanagementtypes.ColdWalletTypeStatusKeycard, 1)
 	s.Require().Error(err)
 	s.Require().ErrorIs(err, ErrNoPasswordProvided)
 
@@ -788,11 +788,11 @@ func (s *ManagerTestSuite) TestCleanKeystoreFiles() {
 			files, _ := os.ReadDir(s.getKeyDir())
 			s.Equal(3, len(files))
 
-			keypair.Type = types.KeypairTypeSeed
+			keypair.Type = accsmanagementtypes.KeypairTypeSeed
 			keypair.Removed = testCase.keypairRemoved
 
 			if testCase.keypairMigratedToKeycard {
-				keypair.ColdWallet = types.ColdWalletTypeStatusKeycard
+				keypair.ColdWallet = accsmanagementtypes.ColdWalletTypeStatusKeycard
 			}
 
 			if testCase.oneAccountRemoved {
@@ -805,7 +805,7 @@ func (s *ManagerTestSuite) TestCleanKeystoreFiles() {
 			}
 
 			s.persistence.EXPECT().GetAllKeypairs().Return(
-				[]*types.Keypair{keypair},
+				[]*accsmanagementtypes.Keypair{keypair},
 				nil,
 			).Times(1)
 

--- a/internal/accounts-management/persistence_operations.go
+++ b/internal/accounts-management/persistence_operations.go
@@ -11,8 +11,8 @@ import (
 	accsmanagementerrors "github.com/status-im/status-go/internal/accounts-management/errors"
 	generator "github.com/status-im/status-go/internal/accounts-management/generator"
 	"github.com/status-im/status-go/internal/accounts-management/keystore"
-	"github.com/status-im/status-go/internal/accounts-management/types"
-	types2 "github.com/status-im/status-go/internal/crypto/types"
+	accsmanagementtypes "github.com/status-im/status-go/internal/accounts-management/types"
+	cryptotypes "github.com/status-im/status-go/internal/crypto/types"
 	multiaccscommon "github.com/status-im/status-go/internal/db/multiaccounts/common"
 )
 
@@ -21,7 +21,7 @@ import (
 // If it's a profile keypair, it also sets the chat account.
 // Passed `walletAccount` is used to generate address using its path and set other details accordingly.
 func (m *AccountsManager) CreateKeypairFromMnemonicAndStore(mnemonic string, password string, keypairName string,
-	coldWallet types.ColdWalletType, walletAccount *types.AccountCreationDetails, profile bool, clock uint64) (keypair *types.Keypair, err error) {
+	coldWallet accsmanagementtypes.ColdWalletType, walletAccount *accsmanagementtypes.AccountCreationDetails, profile bool, clock uint64) (keypair *accsmanagementtypes.Keypair, err error) {
 
 	if walletAccount == nil {
 		err = ErrKeypairDoesNotHaveWalletAccount
@@ -59,7 +59,7 @@ func (m *AccountsManager) CreateKeypairFromMnemonicAndStore(mnemonic string, pas
 
 	dbKeypair, err := m.persistence.GetKeypairByKeyUID(masterAccount.KeyUID())
 	if err != nil {
-		if err != types.ErrDbKeypairNotFound {
+		if err != accsmanagementtypes.ErrDbKeypairNotFound {
 			return
 		}
 	}
@@ -68,10 +68,10 @@ func (m *AccountsManager) CreateKeypairFromMnemonicAndStore(mnemonic string, pas
 		return
 	}
 
-	keypairType := types.KeypairTypeSeed
+	keypairType := accsmanagementtypes.KeypairTypeSeed
 	// make sure the keystore is created for the profile keypair
 	if profile {
-		keypairType = types.KeypairTypeProfile
+		keypairType = accsmanagementtypes.KeypairTypeProfile
 
 		var keystore KeyStore
 		keystore, err = m.createKeystore(masterAccount.KeyUID())
@@ -100,7 +100,7 @@ func (m *AccountsManager) CreateKeypairFromMnemonicAndStore(mnemonic string, pas
 	}
 
 	// store accounts to keystore, unless the keypair lives on a cold wallet device
-	if coldWallet == types.ColdWalletTypeNone {
+	if coldWallet == accsmanagementtypes.ColdWalletTypeNone {
 		err = m.storeKeystoreFilesForAccounts(masterAccount, derivedAccounts, password)
 		if err != nil {
 			return
@@ -120,7 +120,7 @@ func (m *AccountsManager) CreateKeypairFromMnemonicAndStore(mnemonic string, pas
 }
 
 func (m *AccountsManager) AddKeypairStoredToColdWallet(keyUID string, masterAddress string, name string, walletXPub string,
-	coldWallet types.ColdWalletType, walletAccounts []*types.Account, clock uint64) (keypair *types.Keypair, err error) {
+	coldWallet accsmanagementtypes.ColdWalletType, walletAccounts []*accsmanagementtypes.Account, clock uint64) (keypair *accsmanagementtypes.Keypair, err error) {
 
 	if len(walletAccounts) == 0 {
 		err = ErrKeypairMustHaveAtLeastOneWalletAccount
@@ -143,10 +143,10 @@ func (m *AccountsManager) AddKeypairStoredToColdWallet(keyUID string, masterAddr
 		return nil, ErrPersistenceMissing
 	}
 
-	var dbKeypair *types.Keypair
+	var dbKeypair *accsmanagementtypes.Keypair
 	dbKeypair, err = m.persistence.GetKeypairByKeyUID(keyUID)
 	if err != nil {
-		if err != types.ErrDbKeypairNotFound {
+		if err != accsmanagementtypes.ErrDbKeypairNotFound {
 			return
 		}
 	}
@@ -162,15 +162,15 @@ func (m *AccountsManager) AddKeypairStoredToColdWallet(keyUID string, masterAddr
 
 	for _, walletAccount := range walletAccounts {
 		walletAccount.Position = position
-		walletAccount.Operable = types.AccountFullyOperable
+		walletAccount.Operable = accsmanagementtypes.AccountFullyOperable
 		position++
 	}
 
 	// prepare keypair
-	keypair = &types.Keypair{
+	keypair = &accsmanagementtypes.Keypair{
 		Name:                    name,
 		KeyUID:                  keyUID,
-		Type:                    types.KeypairTypeSeed,
+		Type:                    accsmanagementtypes.KeypairTypeSeed,
 		DerivedFrom:             masterAddress,
 		LastUsedDerivationIndex: 0,
 		Clock:                   clock,
@@ -186,10 +186,10 @@ func (m *AccountsManager) AddKeypairStoredToColdWallet(keyUID string, masterAddr
 }
 
 func (m *AccountsManager) prepareKeypair(account *generator.Account, derivedAccounts map[string]*generator.Account, keypairName string,
-	walletAccount *types.AccountCreationDetails, keypairType types.KeypairType, profile bool, walletXPub string, coldWallet types.ColdWalletType,
-	clock uint64) (*types.Keypair, error) {
+	walletAccount *accsmanagementtypes.AccountCreationDetails, keypairType accsmanagementtypes.KeypairType, profile bool, walletXPub string, coldWallet accsmanagementtypes.ColdWalletType,
+	clock uint64) (*accsmanagementtypes.Keypair, error) {
 	// set up keypair
-	keypair := &types.Keypair{
+	keypair := &accsmanagementtypes.Keypair{
 		Name:                    keypairName,
 		KeyUID:                  account.KeyUID(),
 		Type:                    keypairType,
@@ -203,15 +203,15 @@ func (m *AccountsManager) prepareKeypair(account *generator.Account, derivedAcco
 	// add chat account
 	chatDerivedAccount, ok := derivedAccounts[common.PathEIP1581Chat]
 	if ok {
-		keypair.Accounts = append(keypair.Accounts, &types.Account{
-			PublicKey:          types2.Hex2Bytes(chatDerivedAccount.PublicKeyHex()),
+		keypair.Accounts = append(keypair.Accounts, &accsmanagementtypes.Account{
+			PublicKey:          cryptotypes.Hex2Bytes(chatDerivedAccount.PublicKeyHex()),
 			KeyUID:             keypair.KeyUID,
 			Address:            chatDerivedAccount.Address(),
 			Chat:               profile,
 			Path:               common.PathEIP1581Chat,
 			AddressWasNotShown: true,
 			Position:           -1,
-			Operable:           types.AccountFullyOperable,
+			Operable:           accsmanagementtypes.AccountFullyOperable,
 		})
 	}
 
@@ -223,8 +223,8 @@ func (m *AccountsManager) prepareKeypair(account *generator.Account, derivedAcco
 	// add wallet accounts
 	walletDerivedAccount, ok := derivedAccounts[walletAccount.Path]
 	if ok {
-		keypair.Accounts = append(keypair.Accounts, &types.Account{
-			PublicKey:          types2.Hex2Bytes(walletDerivedAccount.PublicKeyHex()),
+		keypair.Accounts = append(keypair.Accounts, &accsmanagementtypes.Account{
+			PublicKey:          cryptotypes.Hex2Bytes(walletDerivedAccount.PublicKeyHex()),
 			KeyUID:             keypair.KeyUID,
 			Address:            walletDerivedAccount.Address(),
 			ColorID:            multiaccscommon.CustomizationColor(walletAccount.ColorID),
@@ -234,15 +234,15 @@ func (m *AccountsManager) prepareKeypair(account *generator.Account, derivedAcco
 			Name:               walletAccount.Name,
 			AddressWasNotShown: true,
 			Position:           position,
-			Operable:           types.AccountFullyOperable,
+			Operable:           accsmanagementtypes.AccountFullyOperable,
 		})
 	}
 
-	if keypairType == types.KeypairTypeKey {
+	if keypairType == accsmanagementtypes.KeypairTypeKey {
 		keypair.DerivedFrom = ""
 
-		keypair.Accounts = append(keypair.Accounts, &types.Account{
-			PublicKey:          types2.Hex2Bytes(account.PublicKeyHex()),
+		keypair.Accounts = append(keypair.Accounts, &accsmanagementtypes.Account{
+			PublicKey:          cryptotypes.Hex2Bytes(account.PublicKeyHex()),
 			KeyUID:             keypair.KeyUID,
 			Address:            account.Address(),
 			ColorID:            multiaccscommon.CustomizationColor(walletAccount.ColorID),
@@ -251,7 +251,7 @@ func (m *AccountsManager) prepareKeypair(account *generator.Account, derivedAcco
 			Name:               walletAccount.Name,
 			AddressWasNotShown: true,
 			Position:           position,
-			Operable:           types.AccountFullyOperable,
+			Operable:           accsmanagementtypes.AccountFullyOperable,
 		})
 	}
 
@@ -260,7 +260,7 @@ func (m *AccountsManager) prepareKeypair(account *generator.Account, derivedAcco
 
 // CreateKeypairFromPrivateKeyAndStore creates a keypair with a single master account.
 func (m *AccountsManager) CreateKeypairFromPrivateKeyAndStore(privateKey string, password string, keypairName string,
-	walletAccount *types.AccountCreationDetails, clock uint64) (keypair *types.Keypair, err error) {
+	walletAccount *accsmanagementtypes.AccountCreationDetails, clock uint64) (keypair *accsmanagementtypes.Keypair, err error) {
 	if walletAccount == nil {
 		err = ErrKeypairDoesNotHaveWalletAccount
 		return
@@ -286,7 +286,7 @@ func (m *AccountsManager) CreateKeypairFromPrivateKeyAndStore(privateKey string,
 
 	dbKeypair, err := m.persistence.GetKeypairByKeyUID(masterAccount.KeyUID())
 	if err != nil {
-		if err != types.ErrDbKeypairNotFound {
+		if err != accsmanagementtypes.ErrDbKeypairNotFound {
 			return
 		}
 	}
@@ -296,8 +296,8 @@ func (m *AccountsManager) CreateKeypairFromPrivateKeyAndStore(privateKey string,
 	}
 
 	// prepare keypair
-	keypair, err = m.prepareKeypair(masterAccount, nil, keypairName, walletAccount, types.KeypairTypeKey, false, "",
-		types.ColdWalletTypeNone, clock)
+	keypair, err = m.prepareKeypair(masterAccount, nil, keypairName, walletAccount, accsmanagementtypes.KeypairTypeKey, false, "",
+		accsmanagementtypes.ColdWalletTypeNone, clock)
 	if err != nil {
 		return nil, err
 	}
@@ -379,7 +379,7 @@ func (m *AccountsManager) MakePrivateKeyKeypairFullyOperable(privateKey string, 
 	return kp.KeyUID, m.persistence.MarkKeypairFullyOperable(kp.KeyUID, clock, true)
 }
 
-func (m *AccountsManager) MakePartiallyOperableAccoutsFullyOperable(password string) (addresses []types2.Address, err error) {
+func (m *AccountsManager) MakePartiallyOperableAccoutsFullyOperable(password string) (addresses []cryptotypes.Address, err error) {
 	if password == "" {
 		return nil, ErrNoPasswordProvided
 	}
@@ -402,10 +402,10 @@ func (m *AccountsManager) MakePartiallyOperableAccoutsFullyOperable(password str
 		}
 
 		for _, acc := range kp.Accounts {
-			if acc.Operable != types.AccountPartiallyOperable {
+			if acc.Operable != accsmanagementtypes.AccountPartiallyOperable {
 				continue
 			}
-			_, err = m.deriveChildAccountForPathAndStore(types2.HexToAddress(kp.DerivedFrom), acc.Path, password)
+			_, err = m.deriveChildAccountForPathAndStore(cryptotypes.HexToAddress(kp.DerivedFrom), acc.Path, password)
 			if err != nil {
 				return
 			}
@@ -420,7 +420,7 @@ func (m *AccountsManager) MakePartiallyOperableAccoutsFullyOperable(password str
 }
 
 // validateAccountAgainstKeypairXPub checks that the account's address matches the address derived from the keypair's xpub
-func validateAccountAgainstKeypairXPub(kp *types.Keypair, acc *types.Account) error {
+func validateAccountAgainstKeypairXPub(kp *accsmanagementtypes.Keypair, acc *accsmanagementtypes.Account) error {
 	prefix := common.PathWalletXPub + "/"
 	if !strings.HasPrefix(acc.Path, prefix) {
 		return ErrCannotDeriveAccountFromXPub.WithContext("path", acc.Path)
@@ -438,7 +438,7 @@ func validateAccountAgainstKeypairXPub(kp *types.Keypair, acc *types.Account) er
 	if !ok {
 		return ErrCannotDeriveAccountFromXPub.WithContext("path", acc.Path)
 	}
-	if types2.HexToAddress(info.Address) != acc.Address {
+	if cryptotypes.HexToAddress(info.Address) != acc.Address {
 		return ErrAccountMismatch.
 			WithContext("address", acc.Address.Hex()).
 			WithContext("derived address", info.Address)
@@ -447,7 +447,7 @@ func validateAccountAgainstKeypairXPub(kp *types.Keypair, acc *types.Account) er
 }
 
 // deriveKeypairXPubInternally derives the xpub for the passed master address using the provided password. Caller must hold m.mu.
-func (m *AccountsManager) deriveKeypairXPubInternally(deriveFrom types2.Address, password string) (string, error) {
+func (m *AccountsManager) deriveKeypairXPubInternally(deriveFrom cryptotypes.Address, password string) (string, error) {
 	childAccount, err := m.deriveChildAccountForPath(deriveFrom, common.PathWalletXPub, password)
 	if err != nil {
 		return "", err
@@ -461,11 +461,11 @@ func (m *AccountsManager) deriveKeypairXPubInternally(deriveFrom types2.Address,
 
 // backfillKeypairXPubInternally stores the keypair's xpub if it's missing, deriving it from the master keystore file
 // using the provided password. Caller must hold m.mu.
-func (m *AccountsManager) backfillKeypairXPubInternally(kp *types.Keypair, password string) error {
-	if kp.XPub != "" || kp.MigratedToColdWallet() || kp.Type == types.KeypairTypeKey || password == "" {
+func (m *AccountsManager) backfillKeypairXPubInternally(kp *accsmanagementtypes.Keypair, password string) error {
+	if kp.XPub != "" || kp.MigratedToColdWallet() || kp.Type == accsmanagementtypes.KeypairTypeKey || password == "" {
 		return nil
 	}
-	xpub, err := m.deriveKeypairXPubInternally(types2.HexToAddress(kp.DerivedFrom), password)
+	xpub, err := m.deriveKeypairXPubInternally(cryptotypes.HexToAddress(kp.DerivedFrom), password)
 	if err != nil {
 		var accountsErr *accsmanagementerrors.AccountsError
 		if goerrors.As(err, &accountsErr) &&
@@ -509,7 +509,7 @@ func (m *AccountsManager) BackfillKeypairsXPub(password string) error {
 	return goerrors.Join(errs...)
 }
 
-func (m *AccountsManager) AddAccounts(keyUID string, accounts []*types.Account, password string) error {
+func (m *AccountsManager) AddAccounts(keyUID string, accounts []*accsmanagementtypes.Account, password string) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
@@ -522,7 +522,7 @@ func (m *AccountsManager) AddAccounts(keyUID string, accounts []*types.Account, 
 		return err
 	}
 
-	if kp.Type == types.KeypairTypeKey {
+	if kp.Type == accsmanagementtypes.KeypairTypeKey {
 		return ErrCannotAddAccountsToKeypairImportedViaPrivateKey
 	}
 
@@ -533,7 +533,7 @@ func (m *AccountsManager) AddAccounts(keyUID string, accounts []*types.Account, 
 				WithContext("expected keyuid", keyUID)
 		}
 
-		if kp.Type == types.KeypairTypeProfile {
+		if kp.Type == accsmanagementtypes.KeypairTypeProfile {
 			if acc.Chat {
 				return ErrCannotAddDefaultChatAccount
 			}
@@ -553,7 +553,7 @@ func (m *AccountsManager) AddAccounts(keyUID string, accounts []*types.Account, 
 
 	if deriveFromKeystore {
 		for _, acc := range accounts {
-			childAccount, err := m.deriveChildAccountForPath(types2.HexToAddress(kp.DerivedFrom), acc.Path, password)
+			childAccount, err := m.deriveChildAccountForPath(cryptotypes.HexToAddress(kp.DerivedFrom), acc.Path, password)
 			if err != nil {
 				return err
 			}
@@ -580,7 +580,7 @@ func (m *AccountsManager) AddAccounts(keyUID string, accounts []*types.Account, 
 		}
 		if !kp.MigratedToColdWallet() {
 			for _, acc := range accounts {
-				acc.Operable = types.AccountPartiallyOperable
+				acc.Operable = accsmanagementtypes.AccountPartiallyOperable
 			}
 		}
 	}
@@ -592,7 +592,7 @@ func (m *AccountsManager) AddAccounts(keyUID string, accounts []*types.Account, 
 
 	if deriveFromKeystore {
 		for _, acc := range accounts {
-			_, err := m.deriveChildAccountForPathAndStore(types2.HexToAddress(kp.DerivedFrom), acc.Path, password)
+			_, err := m.deriveChildAccountForPathAndStore(cryptotypes.HexToAddress(kp.DerivedFrom), acc.Path, password)
 			if err != nil {
 				return err
 			}
@@ -632,14 +632,14 @@ func (m *AccountsManager) MigrateColdWalletKeypairToApp(mnemonic string, passwor
 		return "", ErrKeypairIsNotColdWallet
 	}
 
-	if kp.Type != types.KeypairTypeProfile {
+	if kp.Type != accsmanagementtypes.KeypairTypeProfile {
 		profileKeypair, err := m.persistence.GetProfileKeypair()
 		if err != nil {
 			return "", err
 		}
 
 		if !profileKeypair.MigratedToColdWallet() {
-			_, err = m.loadAccountInternally(types2.HexToAddress(profileKeypair.DerivedFrom), password)
+			_, err = m.loadAccountInternally(cryptotypes.HexToAddress(profileKeypair.DerivedFrom), password)
 			if err != nil {
 				return "", ErrWrongPasswordProvided(err)
 			}
@@ -656,12 +656,12 @@ func (m *AccountsManager) MigrateColdWalletKeypairToApp(mnemonic string, passwor
 		return "", err
 	}
 
-	return kp.KeyUID, m.persistence.UpdateKeypairXPub(kp.KeyUID, "", types.ColdWalletTypeNone, clock)
+	return kp.KeyUID, m.persistence.UpdateKeypairXPub(kp.KeyUID, "", accsmanagementtypes.ColdWalletTypeNone, clock)
 }
 
 // MigrateKeypairToColdWallet sets ColdWallet field of the keypair to the provided coldWallet type.
 // In case of migration to cold wallet, corresponding keystore files need to be deleted if the keypair being migrated is not already migrated.
-func (m *AccountsManager) MigrateKeypairToColdWallet(keyUID string, password string, coldWallet types.ColdWalletType, clock uint64) error {
+func (m *AccountsManager) MigrateKeypairToColdWallet(keyUID string, password string, coldWallet accsmanagementtypes.ColdWalletType, clock uint64) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
@@ -698,7 +698,7 @@ func (m *AccountsManager) MigrateKeypairToColdWallet(keyUID string, password str
 	return m.persistence.UpdateKeypairXPub(keyUID, "", coldWallet, clock)
 }
 
-func (m *AccountsManager) DeleteAccount(address types2.Address, password string, clock uint64) (account *types.Account, err error) {
+func (m *AccountsManager) DeleteAccount(address cryptotypes.Address, password string, clock uint64) (account *accsmanagementtypes.Account, err error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
@@ -732,7 +732,7 @@ func (m *AccountsManager) DeleteAccount(address types2.Address, password string,
 
 // DeleteKeypair removes a keypair and its keystore files. The password is required unless the
 // keypair is migrated to a cold wallet (no keystore files exist for it).
-func (m *AccountsManager) DeleteKeypair(keyUID string, password string, clock uint64) (keypair *types.Keypair, err error) {
+func (m *AccountsManager) DeleteKeypair(keyUID string, password string, clock uint64) (keypair *accsmanagementtypes.Keypair, err error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
@@ -745,7 +745,7 @@ func (m *AccountsManager) DeleteKeypair(keyUID string, password string, clock ui
 		return
 	}
 
-	if keypair.Type == types.KeypairTypeProfile {
+	if keypair.Type == accsmanagementtypes.KeypairTypeProfile {
 		err = ErrCannotRemoveProfileKeypair
 		return
 	}

--- a/internal/accounts-management/xpub_test.go
+++ b/internal/accounts-management/xpub_test.go
@@ -6,8 +6,8 @@ import (
 
 	common "github.com/status-im/status-go/internal/accounts-management/common"
 	generator "github.com/status-im/status-go/internal/accounts-management/generator"
-	"github.com/status-im/status-go/internal/accounts-management/types"
-	types2 "github.com/status-im/status-go/internal/crypto/types"
+	accsmanagementtypes "github.com/status-im/status-go/internal/accounts-management/types"
+	cryptotypes "github.com/status-im/status-go/internal/crypto/types"
 )
 
 func (s *ManagerTestSuite) expectedWalletXPub() string {
@@ -16,15 +16,15 @@ func (s *ManagerTestSuite) expectedWalletXPub() string {
 	return xpub
 }
 
-func (s *ManagerTestSuite) deriveTestAccountAtPath(path string) *types.Account {
+func (s *ManagerTestSuite) deriveTestAccountAtPath(path string) *accsmanagementtypes.Account {
 	_, derived, err := generator.CreateAndDeriveAccountsFromMnemonic(s.mnemonic, []string{path}, "")
 	s.Require().NoError(err)
-	return &types.Account{
+	return &accsmanagementtypes.Account{
 		Address:  derived[path].Address(),
 		KeyUID:   s.masterAccount.KeyUID(),
-		Type:     types.AccountTypeGenerated,
+		Type:     accsmanagementtypes.AccountTypeGenerated,
 		Path:     path,
-		Operable: types.AccountFullyOperable,
+		Operable: accsmanagementtypes.AccountFullyOperable,
 	}
 }
 
@@ -41,13 +41,13 @@ func (s *ManagerTestSuite) TestAddAccountsWithoutPasswordDerivesFromXPub() {
 	acc := s.deriveTestAccountAtPath(common.PathWalletRoot + "/1")
 
 	s.persistence.EXPECT().GetKeypairByKeyUID(keypair.KeyUID).Return(keypair, nil).Times(1)
-	s.persistence.EXPECT().SaveOrUpdateAccounts([]*types.Account{acc}, true).Return(nil).Times(1)
+	s.persistence.EXPECT().SaveOrUpdateAccounts([]*accsmanagementtypes.Account{acc}, true).Return(nil).Times(1)
 
 	filesBefore := s.countKeystoreFiles()
-	err := s.accManager.AddAccounts(keypair.KeyUID, []*types.Account{acc}, "")
+	err := s.accManager.AddAccounts(keypair.KeyUID, []*accsmanagementtypes.Account{acc}, "")
 	s.Require().NoError(err)
 	// no password -> the account has no keystore file and is only partially operable
-	s.Require().Equal(types.AccountPartiallyOperable, acc.Operable)
+	s.Require().Equal(accsmanagementtypes.AccountPartiallyOperable, acc.Operable)
 	s.Require().Equal(filesBefore, s.countKeystoreFiles())
 }
 
@@ -57,11 +57,11 @@ func (s *ManagerTestSuite) TestAddAccountsWithoutPasswordLedgerStylePath() {
 	acc := s.deriveTestAccountAtPath(common.PathWalletXPub + "/5")
 
 	s.persistence.EXPECT().GetKeypairByKeyUID(keypair.KeyUID).Return(keypair, nil).Times(1)
-	s.persistence.EXPECT().SaveOrUpdateAccounts([]*types.Account{acc}, true).Return(nil).Times(1)
+	s.persistence.EXPECT().SaveOrUpdateAccounts([]*accsmanagementtypes.Account{acc}, true).Return(nil).Times(1)
 
-	err := s.accManager.AddAccounts(keypair.KeyUID, []*types.Account{acc}, "")
+	err := s.accManager.AddAccounts(keypair.KeyUID, []*accsmanagementtypes.Account{acc}, "")
 	s.Require().NoError(err)
-	s.Require().Equal(types.AccountPartiallyOperable, acc.Operable)
+	s.Require().Equal(accsmanagementtypes.AccountPartiallyOperable, acc.Operable)
 }
 
 func (s *ManagerTestSuite) TestAddAccountsWithoutPasswordWrongAddressRejected() {
@@ -69,11 +69,11 @@ func (s *ManagerTestSuite) TestAddAccountsWithoutPasswordWrongAddressRejected() 
 
 	acc := s.deriveTestAccountAtPath(common.PathWalletRoot + "/1")
 	// address the claimed path doesn't derive to
-	acc.Address = types2.HexToAddress("0x000000000000000000000000000000000000dead")
+	acc.Address = cryptotypes.HexToAddress("0x000000000000000000000000000000000000dead")
 
 	s.persistence.EXPECT().GetKeypairByKeyUID(keypair.KeyUID).Return(keypair, nil).Times(1)
 
-	err := s.accManager.AddAccounts(keypair.KeyUID, []*types.Account{acc}, "")
+	err := s.accManager.AddAccounts(keypair.KeyUID, []*accsmanagementtypes.Account{acc}, "")
 	s.Require().Error(err)
 	s.Require().True(errors.Is(err, ErrAccountMismatch))
 }
@@ -86,16 +86,16 @@ func (s *ManagerTestSuite) TestAddAccountsWithoutPasswordNonDerivablePathsReject
 		"m/44'/61'/0'/0/1",              // out of the wallet xpub tree
 		"m",                             // master
 	} {
-		acc := &types.Account{
-			Address: types2.HexToAddress("0x000000000000000000000000000000000000dead"),
+		acc := &accsmanagementtypes.Account{
+			Address: cryptotypes.HexToAddress("0x000000000000000000000000000000000000dead"),
 			KeyUID:  keypair.KeyUID,
-			Type:    types.AccountTypeGenerated,
+			Type:    accsmanagementtypes.AccountTypeGenerated,
 			Path:    path,
 		}
 
 		s.persistence.EXPECT().GetKeypairByKeyUID(keypair.KeyUID).Return(keypair, nil).Times(1)
 
-		err := s.accManager.AddAccounts(keypair.KeyUID, []*types.Account{acc}, "")
+		err := s.accManager.AddAccounts(keypair.KeyUID, []*accsmanagementtypes.Account{acc}, "")
 		s.Require().Error(err, "path %s", path)
 		s.Require().True(errors.Is(err, ErrCannotDeriveAccountFromXPub), "path %s", path)
 	}
@@ -109,7 +109,7 @@ func (s *ManagerTestSuite) TestAddAccountsWithoutPasswordAndWithoutXPubRejected(
 
 	s.persistence.EXPECT().GetKeypairByKeyUID(keypair.KeyUID).Return(keypair, nil).Times(1)
 
-	err := s.accManager.AddAccounts(keypair.KeyUID, []*types.Account{acc}, "")
+	err := s.accManager.AddAccounts(keypair.KeyUID, []*accsmanagementtypes.Account{acc}, "")
 	s.Require().Error(err)
 	s.Require().True(errors.Is(err, ErrNoPasswordProvidedAndNoXPubStored))
 }
@@ -121,28 +121,28 @@ func (s *ManagerTestSuite) TestAddAccountsWithPasswordBackfillsXPub() {
 	acc := s.deriveTestAccountAtPath(common.PathWalletRoot + "/1")
 
 	s.persistence.EXPECT().GetKeypairByKeyUID(keypair.KeyUID).Return(keypair, nil).Times(1)
-	s.persistence.EXPECT().SaveOrUpdateAccounts([]*types.Account{acc}, true).Return(nil).Times(1)
-	s.persistence.EXPECT().UpdateKeypairXPub(keypair.KeyUID, s.expectedWalletXPub(), types.ColdWalletTypeNone, keypair.Clock).Return(nil).Times(1)
+	s.persistence.EXPECT().SaveOrUpdateAccounts([]*accsmanagementtypes.Account{acc}, true).Return(nil).Times(1)
+	s.persistence.EXPECT().UpdateKeypairXPub(keypair.KeyUID, s.expectedWalletXPub(), accsmanagementtypes.ColdWalletTypeNone, keypair.Clock).Return(nil).Times(1)
 
 	filesBefore := s.countKeystoreFiles()
-	err := s.accManager.AddAccounts(keypair.KeyUID, []*types.Account{acc}, s.password)
+	err := s.accManager.AddAccounts(keypair.KeyUID, []*accsmanagementtypes.Account{acc}, s.password)
 	s.Require().NoError(err)
 	// with a password the account gets its own keystore file, stays fully operable and the
 	// keypair's missing xpub is backfilled on the way
-	s.Require().Equal(types.AccountFullyOperable, acc.Operable)
+	s.Require().Equal(accsmanagementtypes.AccountFullyOperable, acc.Operable)
 	s.Require().Equal(filesBefore+1, s.countKeystoreFiles())
 	s.Require().Equal(s.expectedWalletXPub(), keypair.XPub)
 }
 
 func (s *ManagerTestSuite) TestAddAccountsToKeyKeypairRejected() {
-	keypair := &types.Keypair{
+	keypair := &accsmanagementtypes.Keypair{
 		KeyUID: "key-keypair",
-		Type:   types.KeypairTypeKey,
+		Type:   accsmanagementtypes.KeypairTypeKey,
 	}
 
 	s.persistence.EXPECT().GetKeypairByKeyUID(keypair.KeyUID).Return(keypair, nil).Times(1)
 
-	err := s.accManager.AddAccounts(keypair.KeyUID, []*types.Account{{KeyUID: keypair.KeyUID}}, "")
+	err := s.accManager.AddAccounts(keypair.KeyUID, []*accsmanagementtypes.Account{{KeyUID: keypair.KeyUID}}, "")
 	s.Require().Error(err)
 	s.Require().True(errors.Is(err, ErrCannotAddAccountsToKeypairImportedViaPrivateKey))
 }
@@ -163,15 +163,15 @@ func (s *ManagerTestSuite) TestGetVerifiedWalletAccountForPartiallyOperableAccou
 	address := derived2[accPath].Address()
 
 	s.persistence.EXPECT().AddressExists(address).Return(true, nil).Times(1)
-	s.persistence.EXPECT().GetAccountByAddress(address).Return(&types.Account{
+	s.persistence.EXPECT().GetAccountByAddress(address).Return(&accsmanagementtypes.Account{
 		Address:  address,
 		KeyUID:   master2.KeyUID(),
 		Path:     accPath,
-		Operable: types.AccountPartiallyOperable,
+		Operable: accsmanagementtypes.AccountPartiallyOperable,
 	}, nil).Times(1)
-	s.persistence.EXPECT().GetKeypairByKeyUID(master2.KeyUID()).Return(&types.Keypair{
+	s.persistence.EXPECT().GetKeypairByKeyUID(master2.KeyUID()).Return(&accsmanagementtypes.Keypair{
 		KeyUID:      master2.KeyUID(),
-		Type:        types.KeypairTypeSeed,
+		Type:        accsmanagementtypes.KeypairTypeSeed,
 		DerivedFrom: master2.Address().Hex(),
 	}, nil).Times(1)
 
@@ -184,22 +184,22 @@ func (s *ManagerTestSuite) TestBackfillKeypairsXPub() {
 	_ = s.createAndStoreProfileKeypair()
 	xpub := s.expectedWalletXPub()
 
-	kpRegular := &types.Keypair{
+	kpRegular := &accsmanagementtypes.Keypair{
 		KeyUID:      s.masterAccount.KeyUID(),
-		Type:        types.KeypairTypeProfile,
+		Type:        accsmanagementtypes.KeypairTypeProfile,
 		DerivedFrom: s.masterAccount.Address().Hex(),
 		Clock:       42,
 	}
-	kpKey := &types.Keypair{KeyUID: "key-kp", Type: types.KeypairTypeKey}
-	kpCold := &types.Keypair{KeyUID: "cold-kp", Type: types.KeypairTypeSeed, ColdWallet: types.ColdWalletTypeStatusKeycard}
-	kpDone := &types.Keypair{KeyUID: "done-kp", Type: types.KeypairTypeSeed, XPub: "already-set"}
+	kpKey := &accsmanagementtypes.Keypair{KeyUID: "key-kp", Type: accsmanagementtypes.KeypairTypeKey}
+	kpCold := &accsmanagementtypes.Keypair{KeyUID: "cold-kp", Type: accsmanagementtypes.KeypairTypeSeed, ColdWallet: accsmanagementtypes.ColdWalletTypeStatusKeycard}
+	kpDone := &accsmanagementtypes.Keypair{KeyUID: "done-kp", Type: accsmanagementtypes.KeypairTypeSeed, XPub: "already-set"}
 	// keypair with no master keystore file — skipped with a warning
-	kpNoKeystoreFile := &types.Keypair{KeyUID: "no-file-kp", Type: types.KeypairTypeSeed,
+	kpNoKeystoreFile := &accsmanagementtypes.Keypair{KeyUID: "no-file-kp", Type: accsmanagementtypes.KeypairTypeSeed,
 		DerivedFrom: "0x000000000000000000000000000000000000dead"}
 
-	s.persistence.EXPECT().GetActiveKeypairs().Return([]*types.Keypair{kpRegular, kpKey, kpCold, kpDone, kpNoKeystoreFile}, nil).Times(1)
+	s.persistence.EXPECT().GetActiveKeypairs().Return([]*accsmanagementtypes.Keypair{kpRegular, kpKey, kpCold, kpDone, kpNoKeystoreFile}, nil).Times(1)
 	// only the regular keypair with a decryptable master keystore file gets backfilled
-	s.persistence.EXPECT().UpdateKeypairXPub(kpRegular.KeyUID, xpub, types.ColdWalletTypeNone, uint64(42)).Return(nil).Times(1)
+	s.persistence.EXPECT().UpdateKeypairXPub(kpRegular.KeyUID, xpub, accsmanagementtypes.ColdWalletTypeNone, uint64(42)).Return(nil).Times(1)
 
 	err := s.accManager.BackfillKeypairsXPub(s.password)
 	s.Require().NoError(err)
@@ -210,15 +210,15 @@ func (s *ManagerTestSuite) TestBackfillKeypairsXPub() {
 func (s *ManagerTestSuite) TestBackfillKeypairsXPubReturnsPersistenceError() {
 	_ = s.createAndStoreProfileKeypair()
 
-	kpRegular := &types.Keypair{
+	kpRegular := &accsmanagementtypes.Keypair{
 		KeyUID:      s.masterAccount.KeyUID(),
-		Type:        types.KeypairTypeProfile,
+		Type:        accsmanagementtypes.KeypairTypeProfile,
 		DerivedFrom: s.masterAccount.Address().Hex(),
 		Clock:       42,
 	}
 
-	s.persistence.EXPECT().GetActiveKeypairs().Return([]*types.Keypair{kpRegular}, nil).Times(1)
-	s.persistence.EXPECT().UpdateKeypairXPub(kpRegular.KeyUID, s.expectedWalletXPub(), types.ColdWalletTypeNone, uint64(42)).
+	s.persistence.EXPECT().GetActiveKeypairs().Return([]*accsmanagementtypes.Keypair{kpRegular}, nil).Times(1)
+	s.persistence.EXPECT().UpdateKeypairXPub(kpRegular.KeyUID, s.expectedWalletXPub(), accsmanagementtypes.ColdWalletTypeNone, uint64(42)).
 		Return(errors.New("db failure")).Times(1)
 
 	err := s.accManager.BackfillKeypairsXPub(s.password)
@@ -233,11 +233,11 @@ func (s *ManagerTestSuite) TestMigrateKeypairToColdWalletBackfillsXPub() {
 
 	s.persistence.EXPECT().GetKeypairByKeyUID(keypair.KeyUID).Return(keypair, nil).Times(1)
 	// the xpub is captured from the master keystore file before the keystore files are deleted
-	s.persistence.EXPECT().UpdateKeypairXPub(keypair.KeyUID, s.expectedWalletXPub(), types.ColdWalletTypeNone, keypair.Clock).Return(nil).Times(1)
+	s.persistence.EXPECT().UpdateKeypairXPub(keypair.KeyUID, s.expectedWalletXPub(), accsmanagementtypes.ColdWalletTypeNone, keypair.Clock).Return(nil).Times(1)
 	s.persistence.EXPECT().MarkKeypairFullyOperable(keypair.KeyUID, uint64(99), true).Return(nil).Times(1)
-	s.persistence.EXPECT().UpdateKeypairXPub(keypair.KeyUID, "", types.ColdWalletTypeStatusKeycard, uint64(99)).Return(nil).Times(1)
+	s.persistence.EXPECT().UpdateKeypairXPub(keypair.KeyUID, "", accsmanagementtypes.ColdWalletTypeStatusKeycard, uint64(99)).Return(nil).Times(1)
 
-	err := s.accManager.MigrateKeypairToColdWallet(keypair.KeyUID, s.password, types.ColdWalletTypeStatusKeycard, 99)
+	err := s.accManager.MigrateKeypairToColdWallet(keypair.KeyUID, s.password, accsmanagementtypes.ColdWalletTypeStatusKeycard, 99)
 	s.Require().NoError(err)
 	s.Require().Equal(s.expectedWalletXPub(), keypair.XPub)
 	// all keystore files of the keypair are deleted

--- a/internal/contracts/contracts.go
+++ b/internal/contracts/contracts.go
@@ -13,8 +13,6 @@ import (
 	"github.com/status-im/status-go/internal/contracts/stickers"
 	"github.com/status-im/status-go/internal/contracts/universalresolver"
 	"github.com/status-im/status-go/internal/rpc"
-
-	stickers2 "github.com/status-im/status-go/internal/contracts/stickers"
 )
 
 type ContractMakerIface interface {
@@ -78,7 +76,7 @@ func (c *ContractMaker) NewSNT(chainID uint64) (*snt.SNT, error) {
 }
 
 func (c *ContractMaker) NewStickerType(chainID uint64) (*stickers.StickerType, error) {
-	contractAddr, err := stickers2.StickerTypeContractAddress(chainID)
+	contractAddr, err := stickers.StickerTypeContractAddress(chainID)
 	if err != nil {
 		return nil, err
 	}
@@ -95,7 +93,7 @@ func (c *ContractMaker) NewStickerType(chainID uint64) (*stickers.StickerType, e
 }
 
 func (c *ContractMaker) NewStickerMarket(chainID uint64) (*stickers.StickerMarket, error) {
-	contractAddr, err := stickers2.StickerMarketContractAddress(chainID)
+	contractAddr, err := stickers.StickerMarketContractAddress(chainID)
 	if err != nil {
 		return nil, err
 	}
@@ -112,7 +110,7 @@ func (c *ContractMaker) NewStickerMarket(chainID uint64) (*stickers.StickerMarke
 }
 
 func (c *ContractMaker) NewStickerPack(chainID uint64) (*stickers.StickerPack, error) {
-	contractAddr, err := stickers2.StickerPackContractAddress(chainID)
+	contractAddr, err := stickers.StickerPackContractAddress(chainID)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/transactions/transactor_test.go
+++ b/internal/transactions/transactor_test.go
@@ -11,9 +11,9 @@ import (
 
 	accsmanagement "github.com/status-im/status-go/internal/accounts-management"
 	"github.com/status-im/status-go/internal/accounts-management/generator"
-	"github.com/status-im/status-go/internal/accounts-management/types"
+	accsmanagementtypes "github.com/status-im/status-go/internal/accounts-management/types"
 	"github.com/status-im/status-go/internal/crypto"
-	types2 "github.com/status-im/status-go/internal/crypto/types"
+	cryptotypes "github.com/status-im/status-go/internal/crypto/types"
 	"github.com/status-im/status-go/internal/rpc/chain"
 	"github.com/status-im/status-go/internal/rpc/chain/ethclient"
 	"github.com/status-im/status-go/internal/rpc/chain/rpclimiter"
@@ -220,7 +220,7 @@ func (s *TransactorSuite) TestGasValues() {
 	}
 }
 
-func (s *TransactorSuite) setupBuildTransactionMocks(args wallettypes.SendTxArgs, account *types.SelectedExtKey) {
+func (s *TransactorSuite) setupBuildTransactionMocks(args wallettypes.SendTxArgs, account *accsmanagementtypes.SelectedExtKey) {
 	s.txServiceMock.EXPECT().GetTransactionCount(gomock.Any(), gomock.Eq(common.Address(account.Address)), gethrpc.PendingBlockNumber).Return(&testNonce, nil)
 
 	if !args.IsDynamicFeeTx() && args.GasPrice == nil {
@@ -237,9 +237,9 @@ func (s *TransactorSuite) TestBuildAndValidateTransaction() {
 	address2 := fakeAddress()
 
 	key, _ := gethcrypto.GenerateKey()
-	selectedAccount := &types.SelectedExtKey{
+	selectedAccount := &accsmanagementtypes.SelectedExtKey{
 		Address:    *address1,
-		AccountKey: &types.Key{PrivateKey: key},
+		AccountKey: &accsmanagementtypes.Key{PrivateKey: key},
 	}
 
 	chainID := s.nodeConfig.NetworkID
@@ -331,8 +331,8 @@ func (s *TransactorSuite) TestBuildAndValidateTransaction() {
 	})
 }
 
-func fakeAddress() *types2.Address {
-	var address types2.Address
+func fakeAddress() *cryptotypes.Address {
+	var address cryptotypes.Address
 	gofakeit.Slice(&address)
 	return &address
 }
@@ -341,8 +341,8 @@ func (s *TransactorSuite) TestArgsValidation() {
 	args := wallettypes.SendTxArgs{
 		From:  *fakeAddress(),
 		To:    fakeAddress(),
-		Data:  types2.HexBytes([]byte{0x01, 0x02}),
-		Input: types2.HexBytes([]byte{0x02, 0x01}),
+		Data:  cryptotypes.HexBytes([]byte{0x01, 0x02}),
+		Input: cryptotypes.HexBytes([]byte{0x02, 0x01}),
 	}
 	s.False(args.Valid())
 	selectedAccount := generator.NewAccount(nil, nil)

--- a/pkg/backend/node/get_status_node.go
+++ b/pkg/backend/node/get_status_node.go
@@ -30,7 +30,7 @@ import (
 	"github.com/status-im/status-go/internal/timesource"
 	"github.com/status-im/status-go/internal/transactions"
 	"github.com/status-im/status-go/params"
-	rpc2 "github.com/status-im/status-go/pkg/backend/node/rpc"
+	noderpc "github.com/status-im/status-go/pkg/backend/node/rpc"
 	"github.com/status-im/status-go/pkg/pubsub"
 	"github.com/status-im/status-go/server"
 	accountssvc "github.com/status-im/status-go/services/accounts"
@@ -609,7 +609,7 @@ func (n *StatusNode) Resume() error {
 }
 
 func (n *StatusNode) CallInProcessRPC(inputJSON string) string {
-	codec := rpc2.NewSingleRequestCodec(inputJSON)
+	codec := noderpc.NewSingleRequestCodec(inputJSON)
 	n.rpcServer.ServeCodec(codec.GethCodec(), 0)
 	return codec.Output()
 }

--- a/pkg/messaging/controller/processor/processor_test.go
+++ b/pkg/messaging/controller/processor/processor_test.go
@@ -33,7 +33,7 @@ import (
 	transport "github.com/status-im/status-go/pkg/messaging/layers/transport"
 	transportmigrations "github.com/status-im/status-go/pkg/messaging/layers/transport/migrations"
 	"github.com/status-im/status-go/pkg/messaging/types"
-	wakuv "github.com/status-im/status-go/pkg/messaging/waku"
+	wakuv2 "github.com/status-im/status-go/pkg/messaging/waku"
 )
 
 func TestProcessorSuite(t *testing.T) {
@@ -111,8 +111,8 @@ func (s *ProcessorSuite) SetupTest() {
 
 	stack := &common.MessagingStack{}
 
-	wakuConfig := wakuv.DefaultConfig
-	shh, err := wakuv.New(
+	wakuConfig := wakuv2.DefaultConfig
+	shh, err := wakuv2.New(
 		nil,
 		&wakuConfig,
 		s.logger,

--- a/pkg/messaging/controller/processor/processor_test.go
+++ b/pkg/messaging/controller/processor/processor_test.go
@@ -33,7 +33,7 @@ import (
 	transport "github.com/status-im/status-go/pkg/messaging/layers/transport"
 	transportmigrations "github.com/status-im/status-go/pkg/messaging/layers/transport/migrations"
 	"github.com/status-im/status-go/pkg/messaging/types"
-	wakuv2 "github.com/status-im/status-go/pkg/messaging/waku"
+	"github.com/status-im/status-go/pkg/messaging/waku"
 )
 
 func TestProcessorSuite(t *testing.T) {
@@ -111,8 +111,8 @@ func (s *ProcessorSuite) SetupTest() {
 
 	stack := &common.MessagingStack{}
 
-	wakuConfig := wakuv2.DefaultConfig
-	shh, err := wakuv2.New(
+	wakuConfig := waku.DefaultConfig
+	shh, err := waku.New(
 		nil,
 		&wakuConfig,
 		s.logger,

--- a/pkg/messaging/controller/sender/sender_private.go
+++ b/pkg/messaging/controller/sender/sender_private.go
@@ -11,15 +11,15 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/status-im/status-go/internal/crypto"
-	"github.com/status-im/status-go/internal/crypto/types"
+	cryptotypes "github.com/status-im/status-go/internal/crypto/types"
 	"github.com/status-im/status-go/pkg/messaging/layers/encryption"
-	types2 "github.com/status-im/status-go/pkg/messaging/types"
+	messagingtypes "github.com/status-im/status-go/pkg/messaging/types"
 	wakutypes "github.com/status-im/status-go/pkg/messaging/waku/types"
 	"github.com/status-im/status-go/pkg/pubsub"
 )
 
-func (s *Sender) SendPrivate(ctx context.Context, params types2.SendPrivateParams) error {
-	messageID := types2.MessageID(&params.Sender.PublicKey, params.Payload)
+func (s *Sender) SendPrivate(ctx context.Context, params messagingtypes.SendPrivateParams) error {
+	messageID := messagingtypes.MessageID(&params.Sender.PublicKey, params.Payload)
 
 	logger := s.logger.Named("sendPrivate").With(
 		zap.Stringer("messageID", messageID),
@@ -84,7 +84,7 @@ func (s *Sender) SendPrivate(ctx context.Context, params types2.SendPrivateParam
 	}
 
 	logger.Debug("sent-message",
-		zap.Strings("hashes", types.EncodeHexes(hashes)),
+		zap.Strings("hashes", cryptotypes.EncodeHexes(hashes)),
 	)
 
 	s.stack.Transport.Track(messageID, hashes, wakuMessages)
@@ -112,12 +112,12 @@ func (s *Sender) SendPrivateHashRatchetKeys(ctx context.Context, recipients []*e
 	for i, spec := range keyExMessageSpecs {
 		logger := s.logger.Named("sendPrivateHashRatchetKeys").With(
 			zap.String("recipient", crypto.PubkeyToHex(recipients[i])),
-			zap.Stringer("groupID", types.HexBytes(groupID)),
+			zap.Stringer("groupID", cryptotypes.HexBytes(groupID)),
 		)
 
 		ctx, span := s.tracer.Start(ctx, "Sender.SendPrivateHashRatchetKeys",
 			oteltrace.WithAttributes(
-				otelattribute.String("groupID", types.ToHex(groupID)),
+				otelattribute.String("groupID", cryptotypes.ToHex(groupID)),
 				otelattribute.String("recipient", crypto.PubkeyToHex(recipients[i])),
 			),
 		)
@@ -138,7 +138,7 @@ func (s *Sender) SendPrivateHashRatchetKeys(ctx context.Context, recipients []*e
 		}
 
 		logger.Debug("sent-message",
-			zap.Strings("hashes", types.EncodeHexes(hashes)),
+			zap.Strings("hashes", cryptotypes.EncodeHexes(hashes)),
 		)
 	}
 

--- a/pkg/messaging/controller/sender/sender_reliability.go
+++ b/pkg/messaging/controller/sender/sender_reliability.go
@@ -8,8 +8,8 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/status-im/status-go/internal/crypto"
-	types2 "github.com/status-im/status-go/internal/crypto/types"
-	"github.com/status-im/status-go/pkg/messaging/types"
+	cryptotypes "github.com/status-im/status-go/internal/crypto/types"
+	messagingtypes "github.com/status-im/status-go/pkg/messaging/types"
 	"github.com/status-im/status-go/pkg/pubsub"
 )
 
@@ -29,9 +29,9 @@ func (s *Sender) scheduleReliableSend(recipient *ecdsa.PublicKey, message []byte
 }
 
 func (s *Sender) SendPrivateReliability(recipient *ecdsa.PublicKey, wrappedPayload []byte, messages [][]byte) error {
-	messageIDs := make([]types2.HexBytes, 0, len(messages))
+	messageIDs := make([]cryptotypes.HexBytes, 0, len(messages))
 	for _, msgPayload := range messages {
-		messageIDs = append(messageIDs, types.MessageID(&s.identity.PublicKey, msgPayload))
+		messageIDs = append(messageIDs, messagingtypes.MessageID(&s.identity.PublicKey, msgPayload))
 	}
 
 	logger := s.logger.Named("sendPrivateReliability").With(
@@ -59,7 +59,7 @@ func (s *Sender) SendPrivateReliability(recipient *ecdsa.PublicKey, wrappedPaylo
 	}
 
 	logger.Debug("sent-message",
-		zap.Strings("hashes", types2.EncodeHexes(hashes)),
+		zap.Strings("hashes", cryptotypes.EncodeHexes(hashes)),
 	)
 
 	byteMessageIDs := make([][]byte, len(messageIDs))

--- a/pkg/messaging/core.go
+++ b/pkg/messaging/core.go
@@ -23,7 +23,7 @@ import (
 	reliabilitypb "github.com/status-im/status-go/pkg/messaging/layers/reliability/protobuf"
 	"github.com/status-im/status-go/pkg/messaging/layers/segmentation"
 	"github.com/status-im/status-go/pkg/messaging/layers/transport"
-	wakuv3 "github.com/status-im/status-go/pkg/messaging/waku"
+	wakuv2 "github.com/status-im/status-go/pkg/messaging/waku"
 	wakutypes "github.com/status-im/status-go/pkg/messaging/waku/types"
 	"github.com/status-im/status-go/pkg/messaging/wakumetrics"
 	"github.com/status-im/status-go/pkg/pubsub"
@@ -61,16 +61,16 @@ type sdsApplicationMessageIDTracker interface {
 // Mode selects Core (full/relay) vs Edge (light) operation. It is re-exported
 // from the waku layer so callers configure the messaging API without importing
 // the transport package directly.
-type Mode = wakuv3.Mode
+type Mode = wakuv2.Mode
 
 const (
-	ModeCore = wakuv3.ModeCore
-	ModeEdge = wakuv3.ModeEdge
+	ModeCore = wakuv2.ModeCore
+	ModeEdge = wakuv2.ModeEdge
 )
 
 // ModeFromLightClient maps the legacy WakuV2Config.LightClient boolean onto a Mode.
 func ModeFromLightClient(lightClient bool) Mode {
-	return wakuv3.ModeFromLightClient(lightClient)
+	return wakuv2.ModeFromLightClient(lightClient)
 }
 
 type CoreParams struct {
@@ -375,7 +375,7 @@ type wakuParams struct {
 	// fleet + mode fully determine the peer configuration and the Core/Edge
 	// policy; the waku node builds the rest of its config from them.
 	fleet string
-	mode  wakuv3.Mode
+	mode  wakuv2.Mode
 
 	// port / udpPort / nameserver are the only node settings a caller configures
 	// (zero/empty falls back to the waku defaults). Everything else — host,
@@ -392,8 +392,8 @@ type wakuParams struct {
 	logger *zap.Logger
 }
 
-func newWaku(params wakuParams) (*wakuv3.Waku, error) {
-	cfg := &wakuv3.Config{
+func newWaku(params wakuParams) (*wakuv2.Waku, error) {
+	cfg := &wakuv2.Config{
 		// Fleet + Mode drive peer resolution and the peer-exchange/discv5/
 		// light-client policy inside the waku node (see wakuv2.setDefaults). The
 		// host, discovery limit, max message size and default shard topic are
@@ -409,7 +409,7 @@ func newWaku(params wakuParams) (*wakuv3.Waku, error) {
 		MetricsEnabled:      params.metricsEnabled,
 	}
 
-	waku, err := wakuv3.New(
+	waku, err := wakuv2.New(
 		params.nodeKey,
 		cfg,
 		params.logger,
@@ -439,7 +439,7 @@ func (c *Core) startWakuMetrics() error {
 		}
 
 		// TODO: Remove type assertion once Waku metrics are fully integrated into the Messaging module.
-		c.waku.(*wakuv3.Waku).SetMetricsHandler(wakuMetricsHandler)
+		c.waku.(*wakuv2.Waku).SetMetricsHandler(wakuMetricsHandler)
 
 		c.wakumetrics = wakuMetricsHandler
 	}
@@ -449,7 +449,7 @@ func (c *Core) startWakuMetrics() error {
 
 func (c *Core) metrics() string {
 	// TODO: Remove type assertion once Waku metrics are fully integrated into the Messaging module.
-	return c.waku.(*wakuv3.Waku).Metrics()
+	return c.waku.(*wakuv2.Waku).Metrics()
 }
 
 func (c *Core) generateHashRatchetKey(groupID []byte) error {

--- a/pkg/messaging/core.go
+++ b/pkg/messaging/core.go
@@ -23,7 +23,7 @@ import (
 	reliabilitypb "github.com/status-im/status-go/pkg/messaging/layers/reliability/protobuf"
 	"github.com/status-im/status-go/pkg/messaging/layers/segmentation"
 	"github.com/status-im/status-go/pkg/messaging/layers/transport"
-	wakuv2 "github.com/status-im/status-go/pkg/messaging/waku"
+	"github.com/status-im/status-go/pkg/messaging/waku"
 	wakutypes "github.com/status-im/status-go/pkg/messaging/waku/types"
 	"github.com/status-im/status-go/pkg/messaging/wakumetrics"
 	"github.com/status-im/status-go/pkg/pubsub"
@@ -61,16 +61,16 @@ type sdsApplicationMessageIDTracker interface {
 // Mode selects Core (full/relay) vs Edge (light) operation. It is re-exported
 // from the waku layer so callers configure the messaging API without importing
 // the transport package directly.
-type Mode = wakuv2.Mode
+type Mode = waku.Mode
 
 const (
-	ModeCore = wakuv2.ModeCore
-	ModeEdge = wakuv2.ModeEdge
+	ModeCore = waku.ModeCore
+	ModeEdge = waku.ModeEdge
 )
 
 // ModeFromLightClient maps the legacy WakuV2Config.LightClient boolean onto a Mode.
 func ModeFromLightClient(lightClient bool) Mode {
-	return wakuv2.ModeFromLightClient(lightClient)
+	return waku.ModeFromLightClient(lightClient)
 }
 
 type CoreParams struct {
@@ -375,7 +375,7 @@ type wakuParams struct {
 	// fleet + mode fully determine the peer configuration and the Core/Edge
 	// policy; the waku node builds the rest of its config from them.
 	fleet string
-	mode  wakuv2.Mode
+	mode  waku.Mode
 
 	// port / udpPort / nameserver are the only node settings a caller configures
 	// (zero/empty falls back to the waku defaults). Everything else — host,
@@ -392,10 +392,10 @@ type wakuParams struct {
 	logger *zap.Logger
 }
 
-func newWaku(params wakuParams) (*wakuv2.Waku, error) {
-	cfg := &wakuv2.Config{
+func newWaku(params wakuParams) (*waku.Waku, error) {
+	cfg := &waku.Config{
 		// Fleet + Mode drive peer resolution and the peer-exchange/discv5/
-		// light-client policy inside the waku node (see wakuv2.setDefaults). The
+		// light-client policy inside the waku node (see waku.setDefaults). The
 		// host, discovery limit, max message size and default shard topic are
 		// filled by the waku layer's setDefaults.
 		Fleet:      params.fleet,
@@ -409,7 +409,7 @@ func newWaku(params wakuParams) (*wakuv2.Waku, error) {
 		MetricsEnabled:      params.metricsEnabled,
 	}
 
-	waku, err := wakuv2.New(
+	waku, err := waku.New(
 		params.nodeKey,
 		cfg,
 		params.logger,
@@ -439,7 +439,7 @@ func (c *Core) startWakuMetrics() error {
 		}
 
 		// TODO: Remove type assertion once Waku metrics are fully integrated into the Messaging module.
-		c.waku.(*wakuv2.Waku).SetMetricsHandler(wakuMetricsHandler)
+		c.waku.(*waku.Waku).SetMetricsHandler(wakuMetricsHandler)
 
 		c.wakumetrics = wakuMetricsHandler
 	}
@@ -449,7 +449,7 @@ func (c *Core) startWakuMetrics() error {
 
 func (c *Core) metrics() string {
 	// TODO: Remove type assertion once Waku metrics are fully integrated into the Messaging module.
-	return c.waku.(*wakuv2.Waku).Metrics()
+	return c.waku.(*waku.Waku).Metrics()
 }
 
 func (c *Core) generateHashRatchetKey(groupID []byte) error {

--- a/pkg/messaging/core.go
+++ b/pkg/messaging/core.go
@@ -18,14 +18,14 @@ import (
 	"github.com/status-im/status-go/pkg/messaging/common"
 	"github.com/status-im/status-go/pkg/messaging/controller"
 	"github.com/status-im/status-go/pkg/messaging/events"
-	encryption2 "github.com/status-im/status-go/pkg/messaging/layers/encryption"
+	"github.com/status-im/status-go/pkg/messaging/layers/encryption"
 	"github.com/status-im/status-go/pkg/messaging/layers/reliability"
 	reliabilitypb "github.com/status-im/status-go/pkg/messaging/layers/reliability/protobuf"
 	"github.com/status-im/status-go/pkg/messaging/layers/segmentation"
 	"github.com/status-im/status-go/pkg/messaging/layers/transport"
 	wakuv3 "github.com/status-im/status-go/pkg/messaging/waku"
 	wakutypes "github.com/status-im/status-go/pkg/messaging/waku/types"
-	wakumetrics2 "github.com/status-im/status-go/pkg/messaging/wakumetrics"
+	"github.com/status-im/status-go/pkg/messaging/wakumetrics"
 	"github.com/status-im/status-go/pkg/pubsub"
 )
 
@@ -47,7 +47,7 @@ type Core struct {
 
 	connectionState connection.State
 
-	wakumetrics *wakumetrics2.Client
+	wakumetrics *wakumetrics.Client
 }
 
 type sdsEnvelopeHashesTracker interface {
@@ -111,7 +111,7 @@ func newCore(waku wakutypes.Waku, params CoreParams, config *config) (*Core, err
 		config.logger,
 	)
 
-	stack.Encryption = encryption2.New(
+	stack.Encryption = encryption.New(
 		config.persistence.EncryptionStorage(),
 		params.InstallationID,
 		config.logger,
@@ -301,7 +301,7 @@ func (c *Core) stop() error {
 	}
 
 	if c.metricsEnabled {
-		err := wakumetrics2.UnregisterMetrics()
+		err := wakumetrics.UnregisterMetrics()
 		if err != nil {
 			return err
 		}
@@ -424,11 +424,11 @@ func newWaku(params wakuParams) (*wakuv3.Waku, error) {
 
 func (c *Core) startWakuMetrics() error {
 	if c.wakumetrics == nil {
-		options := []wakumetrics2.TelemetryClientOption{
-			wakumetrics2.WithPeerID(c.waku.PeerID().String()),
+		options := []wakumetrics.TelemetryClientOption{
+			wakumetrics.WithPeerID(c.waku.PeerID().String()),
 		}
 
-		wakuMetricsHandler, err := wakumetrics2.NewClient(options...)
+		wakuMetricsHandler, err := wakumetrics.NewClient(options...)
 		if err != nil {
 			return err
 		}
@@ -473,7 +473,7 @@ func (c *Core) generateHashRatchetKey(groupID []byte) error {
 
 func (c *Core) encryptWithHashRatchet(groupID []byte, payload []byte) ([]byte, []byte, uint32, error) {
 	encryptedPayload, ratchet, newSeqNo, err := c.stack.Encryption.EncryptWithHashRatchet(groupID, payload)
-	if err == encryption2.ErrNoEncryptionKey {
+	if err == encryption.ErrNoEncryptionKey {
 		_, err := c.stack.Encryption.GenerateHashRatchetKey(groupID)
 		if err != nil {
 			return nil, nil, 0, err
@@ -504,7 +504,7 @@ func (c *Core) buildHashRatchetMessage(groupID []byte, payload []byte) ([]byte, 
 }
 
 func (c *Core) decryptMessage(myIdentityKey *ecdsa.PrivateKey, theirPublicKey *ecdsa.PublicKey, data []byte) ([]byte, error) {
-	var encryptionMessage encryption2.ProtocolMessage
+	var encryptionMessage encryption.ProtocolMessage
 	err := proto.Unmarshal(data, &encryptionMessage)
 	if err != nil {
 		return nil, err

--- a/pkg/messaging/core_config.go
+++ b/pkg/messaging/core_config.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/status-im/status-go/internal/instrumentation/trace"
 	"github.com/status-im/status-go/pkg/messaging/layers/transport"
-	types2 "github.com/status-im/status-go/pkg/messaging/types"
+	"github.com/status-im/status-go/pkg/messaging/types"
 	wakutypes "github.com/status-im/status-go/pkg/messaging/waku/types"
 )
 
@@ -58,7 +58,7 @@ func WithTracer(tracer trace.Tracer) Options {
 	}
 }
 
-func WithEnvelopeEventsConfig(econf *types2.EnvelopeEventsConfig) Options {
+func WithEnvelopeEventsConfig(econf *types.EnvelopeEventsConfig) Options {
 	return func(c *config) {
 		if econf != nil {
 			c.envelopesMonitorConfig.EnvelopeEventsHandler = econf.EnvelopeEventsHandler

--- a/pkg/messaging/core_test_utils.go
+++ b/pkg/messaging/core_test_utils.go
@@ -8,7 +8,7 @@ import (
 
 	"go.uber.org/zap"
 
-	wakuv2 "github.com/status-im/status-go/pkg/messaging/waku"
+	"github.com/status-im/status-go/pkg/messaging/waku"
 	"github.com/status-im/status-go/pkg/messaging/waku/types"
 )
 
@@ -68,11 +68,11 @@ func (f *TestMessagingEnvironment) SimulateOffline() func() {
 }
 
 // Wraps waku to provide ability to subscribe to post events. It embeds the
-// concrete *wakuv2.Waku (not the types.Waku interface) so that the messaging
+// concrete *waku.Waku (not the types.Waku interface) so that the messaging
 // API methods that live on the backend — Send / Subscribe / Unsubscribe /
 // envelope events, i.e. transport.MessagingAPI — are promoted too.
 type testWakuWrapper struct {
-	*wakuv2.Waku
+	*waku.Waku
 	postSubscriptions []chan *PostMessageSubscription
 
 	// processMailserverBatchHook, when set, intercepts every store (mailserver)
@@ -145,9 +145,9 @@ func (ts *testTimeSource) Now() time.Time {
 }
 
 func newTestWakuWrapper() (*testWakuWrapper, error) {
-	w, err := wakuv2.New(
+	w, err := waku.New(
 		nil,
-		&wakuv2.DefaultConfig,
+		&waku.DefaultConfig,
 		zap.NewNop(),
 		&testTimeSource{},
 	)

--- a/pkg/messaging/core_test_utils.go
+++ b/pkg/messaging/core_test_utils.go
@@ -8,7 +8,7 @@ import (
 
 	"go.uber.org/zap"
 
-	wakuv3 "github.com/status-im/status-go/pkg/messaging/waku"
+	wakuv2 "github.com/status-im/status-go/pkg/messaging/waku"
 	"github.com/status-im/status-go/pkg/messaging/waku/types"
 )
 
@@ -68,11 +68,11 @@ func (f *TestMessagingEnvironment) SimulateOffline() func() {
 }
 
 // Wraps waku to provide ability to subscribe to post events. It embeds the
-// concrete *wakuv3.Waku (not the types.Waku interface) so that the messaging
+// concrete *wakuv2.Waku (not the types.Waku interface) so that the messaging
 // API methods that live on the backend — Send / Subscribe / Unsubscribe /
 // envelope events, i.e. transport.MessagingAPI — are promoted too.
 type testWakuWrapper struct {
-	*wakuv3.Waku
+	*wakuv2.Waku
 	postSubscriptions []chan *PostMessageSubscription
 
 	// processMailserverBatchHook, when set, intercepts every store (mailserver)
@@ -145,9 +145,9 @@ func (ts *testTimeSource) Now() time.Time {
 }
 
 func newTestWakuWrapper() (*testWakuWrapper, error) {
-	w, err := wakuv3.New(
+	w, err := wakuv2.New(
 		nil,
-		&wakuv3.DefaultConfig,
+		&wakuv2.DefaultConfig,
 		zap.NewNop(),
 		&testTimeSource{},
 	)

--- a/pkg/messaging/layers/encryption/encryptor.go
+++ b/pkg/messaging/layers/encryption/encryptor.go
@@ -13,7 +13,7 @@ import (
 	oteltrace "go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap"
 
-	crypto2 "github.com/status-im/status-go/internal/crypto"
+	"github.com/status-im/status-go/internal/crypto"
 	"github.com/status-im/status-go/internal/crypto/types"
 	"github.com/status-im/status-go/internal/instrumentation/trace"
 	"github.com/status-im/status-go/pkg/messaging/layers/encryption/multidevice"
@@ -118,7 +118,7 @@ func (s *encryptor) getDRSession(id []byte) (dr.Session, error) {
 		dr.WithMaxSkip(s.config.MaxSkip),
 		dr.WithMaxKeep(s.config.MaxKeep),
 		dr.WithMaxMessageKeysPerSession(s.config.MaxMessageKeysPerSession),
-		dr.WithCrypto(crypto2.EthereumCrypto{}),
+		dr.WithCrypto(crypto.EthereumCrypto{}),
 	)
 }
 
@@ -157,7 +157,7 @@ func (s *encryptor) ConfirmMessageProcessed(messageID []byte) error {
 
 // CreateBundle retrieves or creates an X3DH bundle given a private key
 func (s *encryptor) CreateBundle(privateKey *ecdsa.PrivateKey, installations []*multidevice.Installation) (*Bundle, error) {
-	ourIdentityKeyC := crypto2.CompressPubkey(&privateKey.PublicKey)
+	ourIdentityKeyC := crypto.CompressPubkey(&privateKey.PublicKey)
 
 	bundleContainer, err := s.persistence.GetAnyPrivateBundle(ourIdentityKeyC, installations)
 	if err != nil {
@@ -207,7 +207,7 @@ func (s *encryptor) keyFromPassiveX3DH(myIdentityKey *ecdsa.PrivateKey, theirIde
 		return nil, errSessionNotFound
 	}
 
-	signedPreKey, err := crypto2.ToECDSA(bundlePrivateKey)
+	signedPreKey, err := crypto.ToECDSA(bundlePrivateKey)
 	if err != nil {
 		s.logger.Error("could not convert to ecdsa", zap.Error(err))
 		return nil, err
@@ -246,8 +246,8 @@ func (s *encryptor) DecryptPayload(ctx context.Context, myIdentityKey *ecdsa.Pri
 
 	ctx, span := s.tracer.Start(ctx, "Encryptor.DecryptPayload",
 		oteltrace.WithAttributes(
-			otelattribute.String("myIdentityKey", crypto2.PubkeyToHex(&myIdentityKey.PublicKey)),
-			otelattribute.String("theirIdentityKey", crypto2.PubkeyToHex(theirIdentityKey)),
+			otelattribute.String("myIdentityKey", crypto.PubkeyToHex(&myIdentityKey.PublicKey)),
+			otelattribute.String("theirIdentityKey", crypto.PubkeyToHex(theirIdentityKey)),
 			otelattribute.String("myInstallationID", s.config.InstallationID),
 			otelattribute.String("theirInstallationID", theirInstallationID),
 		),
@@ -272,7 +272,7 @@ func (s *encryptor) DecryptPayload(ctx context.Context, myIdentityKey *ecdsa.Pri
 
 	if x3dhHeader := msg.GetX3DHHeader(); x3dhHeader != nil {
 		bundleID := x3dhHeader.GetId()
-		theirEphemeralKey, err := crypto2.DecompressPubkey(x3dhHeader.GetKey())
+		theirEphemeralKey, err := crypto.DecompressPubkey(x3dhHeader.GetKey())
 
 		if err != nil {
 			return nil, err
@@ -283,7 +283,7 @@ func (s *encryptor) DecryptPayload(ctx context.Context, myIdentityKey *ecdsa.Pri
 			return nil, err
 		}
 
-		theirIdentityKeyC := crypto2.CompressPubkey(theirIdentityKey)
+		theirIdentityKeyC := crypto.CompressPubkey(theirIdentityKey)
 		err = s.persistence.AddRatchetInfo(symmetricKey, theirIdentityKeyC, bundleID, nil, theirInstallationID)
 		if err != nil {
 			return nil, err
@@ -300,7 +300,7 @@ func (s *encryptor) DecryptPayload(ctx context.Context, myIdentityKey *ecdsa.Pri
 			Ciphertext: msg.GetPayload(),
 		}
 
-		theirIdentityKeyC := crypto2.CompressPubkey(theirIdentityKey)
+		theirIdentityKeyC := crypto.CompressPubkey(theirIdentityKey)
 
 		drInfo, err := s.persistence.GetRatchetInfo(drHeader.GetId(), theirIdentityKeyC, theirInstallationID)
 		if err != nil {
@@ -330,11 +330,11 @@ func (s *encryptor) DecryptPayload(ctx context.Context, myIdentityKey *ecdsa.Pri
 
 	// Try DH
 	if header := msg.GetDHHeader(); header != nil {
-		decompressedKey, err := crypto2.DecompressPubkey(header.GetKey())
+		decompressedKey, err := crypto.DecompressPubkey(header.GetKey())
 		if err != nil {
 			return nil, err
 		}
-		return crypto2.DecryptWithDH(myIdentityKey, decompressedKey, payload)
+		return crypto.DecryptWithDH(myIdentityKey, decompressedKey, payload)
 	}
 
 	// Try Hash Ratchet
@@ -359,7 +359,7 @@ func (s *encryptor) DecryptPayload(ctx context.Context, myIdentityKey *ecdsa.Pri
 	return nil, errors.New("no key specified")
 }
 
-func (s *encryptor) createNewSession(drInfo *RatchetInfo, sk []byte, keyPair crypto2.DHPair) (dr.Session, error) {
+func (s *encryptor) createNewSession(drInfo *RatchetInfo, sk []byte, keyPair crypto.DHPair) (dr.Session, error) {
 	var err error
 	var session dr.Session
 
@@ -373,7 +373,7 @@ func (s *encryptor) createNewSession(drInfo *RatchetInfo, sk []byte, keyPair cry
 			dr.WithMaxSkip(s.config.MaxSkip),
 			dr.WithMaxKeep(s.config.MaxKeep),
 			dr.WithMaxMessageKeysPerSession(s.config.MaxMessageKeysPerSession),
-			dr.WithCrypto(crypto2.EthereumCrypto{}))
+			dr.WithCrypto(crypto.EthereumCrypto{}))
 	} else {
 		session, err = dr.NewWithRemoteKey(
 			drInfo.ID,
@@ -384,7 +384,7 @@ func (s *encryptor) createNewSession(drInfo *RatchetInfo, sk []byte, keyPair cry
 			dr.WithMaxSkip(s.config.MaxSkip),
 			dr.WithMaxKeep(s.config.MaxKeep),
 			dr.WithMaxMessageKeysPerSession(s.config.MaxMessageKeysPerSession),
-			dr.WithCrypto(crypto2.EthereumCrypto{}))
+			dr.WithCrypto(crypto.EthereumCrypto{}))
 	}
 
 	return session, err
@@ -395,7 +395,7 @@ func (s *encryptor) encryptUsingDR(theirIdentityKey *ecdsa.PublicKey, drInfo *Ra
 
 	var session dr.Session
 
-	keyPair := crypto2.DHPair{
+	keyPair := crypto.DHPair{
 		PrvKey: drInfo.PrivateKey,
 		PubKey: drInfo.PublicKey,
 	}
@@ -435,7 +435,7 @@ func (s *encryptor) decryptUsingDR(theirIdentityKey *ecdsa.PublicKey, drInfo *Ra
 
 	var session dr.Session
 
-	keyPair := crypto2.DHPair{
+	keyPair := crypto.DHPair{
 		PrvKey: drInfo.PrivateKey,
 		PubKey: drInfo.PublicKey,
 	}
@@ -466,14 +466,14 @@ func (s *encryptor) encryptWithDH(theirIdentityKey *ecdsa.PublicKey, payload []b
 		return nil, err
 	}
 
-	encryptedPayload, err := crypto2.EncryptSymmetric(symmetricKey, payload)
+	encryptedPayload, err := crypto.EncryptSymmetric(symmetricKey, payload)
 	if err != nil {
 		return nil, err
 	}
 
 	return &EncryptedMessageProtocol{
 		DHHeader: &DHHeader{
-			Key: crypto2.CompressPubkey(ourEphemeralKey),
+			Key: crypto.CompressPubkey(ourEphemeralKey),
 		},
 		Payload: encryptedPayload,
 	}, nil
@@ -499,7 +499,7 @@ func (s *encryptor) GetPublicBundle(theirIdentityKey *ecdsa.PublicKey, installat
 func (s *encryptor) EncryptPayload(theirIdentityKey *ecdsa.PublicKey, myIdentityKey *ecdsa.PrivateKey, installations []*multidevice.Installation, payload []byte) (map[string]*EncryptedMessageProtocol, []*multidevice.Installation, error) {
 	logger := s.logger.With(
 		zap.String("site", "EncryptPayload"),
-		zap.String("their-identity-key", types.EncodeHex(crypto2.FromECDSAPub(theirIdentityKey))))
+		zap.String("their-identity-key", types.EncodeHex(crypto.FromECDSAPub(theirIdentityKey))))
 
 	// Which installations we are sending the message to
 	var targetedInstallations []*multidevice.Installation
@@ -514,7 +514,7 @@ func (s *encryptor) EncryptPayload(theirIdentityKey *ecdsa.PublicKey, myIdentity
 		return encryptedPayload, targetedInstallations, err
 	}
 
-	theirIdentityKeyC := crypto2.CompressPubkey(theirIdentityKey)
+	theirIdentityKeyC := crypto.CompressPubkey(theirIdentityKey)
 	response := make(map[string]*EncryptedMessageProtocol)
 
 	for _, installation := range installations {
@@ -578,8 +578,8 @@ func (s *encryptor) EncryptPayload(theirIdentityKey *ecdsa.PublicKey, myIdentity
 		if err != nil {
 			return nil, nil, err
 		}
-		theirIdentityKeyC := crypto2.CompressPubkey(theirIdentityKey)
-		ourEphemeralKeyC := crypto2.CompressPubkey(ourEphemeralKey)
+		theirIdentityKeyC := crypto.CompressPubkey(theirIdentityKey)
+		ourEphemeralKeyC := crypto.CompressPubkey(ourEphemeralKey)
 
 		err = s.persistence.AddRatchetInfo(sharedKey, theirIdentityKeyC, theirSignedPreKey, ourEphemeralKeyC, installationID)
 		if err != nil {
@@ -700,8 +700,8 @@ func (s *encryptor) EncryptWithHR(ratchet *HashRatchetKeyCompatibility, payload 
 		dbHash = hrCache.Hash
 	}
 
-	hash := crypto2.Keccak256Hash(dbHash)
-	encryptedPayload, err := crypto2.EncryptSymmetric(hash.Bytes(), payload)
+	hash := crypto.Keccak256Hash(dbHash)
+	encryptedPayload, err := crypto.EncryptSymmetric(hash.Bytes(), payload)
 	if err != nil {
 		return nil, 0, err
 	}
@@ -760,7 +760,7 @@ func (s *encryptor) DecryptWithHR(ctx context.Context, ratchet *HashRatchetKeyCo
 			return nil, ErrHashRatchetSeqNoTooHigh
 		}
 		for i := hrCache.SeqNo; i < seqNo; i++ {
-			hash = crypto2.Keccak256Hash(hash).Bytes()
+			hash = crypto.Keccak256Hash(hash).Bytes()
 			err := s.persistence.SaveHashRatchetKeyHash(ratchet, hash, i+1)
 			if err != nil {
 				return nil, err
@@ -768,7 +768,7 @@ func (s *encryptor) DecryptWithHR(ctx context.Context, ratchet *HashRatchetKeyCo
 		}
 	}
 
-	decryptedPayload, err := crypto2.DecryptSymmetric(hash, payload)
+	decryptedPayload, err := crypto.DecryptSymmetric(hash, payload)
 
 	if err != nil {
 		s.logger.Error("failed to decrypt hash", zap.Error(err))

--- a/pkg/messaging/layers/encryption/persistence.go
+++ b/pkg/messaging/layers/encryption/persistence.go
@@ -5,7 +5,7 @@ import (
 
 	dr "github.com/status-im/doubleratchet"
 
-	multidevice2 "github.com/status-im/status-go/pkg/messaging/layers/encryption/multidevice"
+	"github.com/status-im/status-go/pkg/messaging/layers/encryption/multidevice"
 	"github.com/status-im/status-go/pkg/messaging/layers/encryption/sharedsecret"
 )
 
@@ -34,14 +34,14 @@ type Persistence interface {
 	KeysStorage() dr.KeysStorage
 	SessionStorage() dr.SessionStorage
 	SharedSecretStorage() sharedsecret.Persistence
-	MultideviceStorage() multidevice2.Persistence
+	MultideviceStorage() multidevice.Persistence
 
 	AddPrivateBundle(bc *BundleContainer) error
 	AddPublicBundle(b *Bundle) error
-	GetAnyPrivateBundle(myIdentityKey []byte, installations []*multidevice2.Installation) (*BundleContainer, error)
+	GetAnyPrivateBundle(myIdentityKey []byte, installations []*multidevice.Installation) (*BundleContainer, error)
 	GetPrivateKeyBundle(bundleID []byte) ([]byte, error)
 	MarkBundleExpired(identity []byte) error
-	GetPublicBundle(publicKey *ecdsa.PublicKey, installations []*multidevice2.Installation) (*Bundle, error)
+	GetPublicBundle(publicKey *ecdsa.PublicKey, installations []*multidevice.Installation) (*Bundle, error)
 	AddRatchetInfo(key []byte, identity []byte, bundleID []byte, ephemeralKey []byte, installationID string) error
 	GetRatchetInfo(bundleID []byte, theirIdentity []byte, installationID string) (*RatchetInfo, error)
 	GetAnyRatchetInfo(identity []byte, installationID string) (*RatchetInfo, error)

--- a/pkg/messaging/layers/encryption/sqlite_persistence.go
+++ b/pkg/messaging/layers/encryption/sqlite_persistence.go
@@ -8,9 +8,9 @@ import (
 
 	dr "github.com/status-im/doubleratchet"
 
-	crypto2 "github.com/status-im/status-go/internal/crypto"
-	multidevice2 "github.com/status-im/status-go/pkg/messaging/layers/encryption/multidevice"
-	sharedsecret2 "github.com/status-im/status-go/pkg/messaging/layers/encryption/sharedsecret"
+	"github.com/status-im/status-go/internal/crypto"
+	"github.com/status-im/status-go/pkg/messaging/layers/encryption/multidevice"
+	"github.com/status-im/status-go/pkg/messaging/layers/encryption/sharedsecret"
 )
 
 // A safe max number of rows.
@@ -20,8 +20,8 @@ type SQLitePersistence struct {
 	DB                  *sql.DB
 	keysStorage         dr.KeysStorage
 	sessionStorage      dr.SessionStorage
-	sharedSecretStorage sharedsecret2.Persistence
-	multideviceStorage  multidevice2.Persistence
+	sharedSecretStorage sharedsecret.Persistence
+	multideviceStorage  multidevice.Persistence
 }
 
 var _ Persistence = (*SQLitePersistence)(nil)
@@ -31,8 +31,8 @@ func NewSQLitePersistence(db *sql.DB) *SQLitePersistence {
 		DB:                  db,
 		keysStorage:         newSQLiteKeysStorage(db),
 		sessionStorage:      newSQLiteSessionStorage(db),
-		sharedSecretStorage: sharedsecret2.NewSQLitePersistence(db),
-		multideviceStorage:  multidevice2.NewSQLitePersistence(db),
+		sharedSecretStorage: sharedsecret.NewSQLitePersistence(db),
+		multideviceStorage:  multidevice.NewSQLitePersistence(db),
 	}
 }
 
@@ -46,11 +46,11 @@ func (s *SQLitePersistence) SessionStorage() dr.SessionStorage {
 	return s.sessionStorage
 }
 
-func (s *SQLitePersistence) SharedSecretStorage() sharedsecret2.Persistence {
+func (s *SQLitePersistence) SharedSecretStorage() sharedsecret.Persistence {
 	return s.sharedSecretStorage
 }
 
-func (s *SQLitePersistence) MultideviceStorage() multidevice2.Persistence {
+func (s *SQLitePersistence) MultideviceStorage() multidevice.Persistence {
 	return s.multideviceStorage
 }
 
@@ -162,7 +162,7 @@ func (s *SQLitePersistence) AddPublicBundle(b *Bundle) error {
 }
 
 // GetAnyPrivateBundle retrieves any bundle from the database containing a private key
-func (s *SQLitePersistence) GetAnyPrivateBundle(myIdentityKey []byte, installations []*multidevice2.Installation) (*BundleContainer, error) {
+func (s *SQLitePersistence) GetAnyPrivateBundle(myIdentityKey []byte, installations []*multidevice.Installation) (*BundleContainer, error) {
 
 	versions := make(map[string]uint32)
 	/* #nosec */
@@ -282,14 +282,14 @@ func (s *SQLitePersistence) MarkBundleExpired(identity []byte) error {
 }
 
 // GetPublicBundle retrieves an existing Bundle for the specified public key from the database
-func (s *SQLitePersistence) GetPublicBundle(publicKey *ecdsa.PublicKey, installations []*multidevice2.Installation) (*Bundle, error) {
+func (s *SQLitePersistence) GetPublicBundle(publicKey *ecdsa.PublicKey, installations []*multidevice.Installation) (*Bundle, error) {
 
 	if len(installations) == 0 {
 		return nil, nil
 	}
 
 	versions := make(map[string]uint32)
-	identity := crypto2.CompressPubkey(publicKey)
+	identity := crypto.CompressPubkey(publicKey)
 
 	/* #nosec */
 	statement := `SELECT signed_pre_key,installation_id, version
@@ -712,7 +712,7 @@ func (s *sqliteSessionStorage) Load(id []byte) (*dr.State, error) {
 		state.Step = step
 		state.KeysCount = keysCount
 
-		state.DHs = crypto2.DHPair{
+		state.DHs = crypto.DHPair{
 			PrvKey: dhsPrivate,
 			PubKey: dhsPublic,
 		}

--- a/pkg/messaging/layers/reliability/reliability.go
+++ b/pkg/messaging/layers/reliability/reliability.go
@@ -16,7 +16,7 @@ import (
 	mvdsproto "github.com/status-im/mvds/protobuf"
 	mvdsstate "github.com/status-im/mvds/state"
 
-	datasync2 "github.com/status-im/status-go/pkg/messaging/layers/reliability/datasync"
+	"github.com/status-im/status-go/pkg/messaging/layers/reliability/datasync"
 	datasyncpeer "github.com/status-im/status-go/pkg/messaging/layers/reliability/datasync/peer"
 	"github.com/status-im/status-go/pkg/messaging/layers/reliability/protobuf"
 )
@@ -57,7 +57,7 @@ type Reliability struct {
 	// don't interleave. The hot path (Unwrap / WrapAndQueue) never takes mu;
 	// datasync uses atomic loads and SDS uses sdsOpsMu.
 	mu       sync.Mutex
-	datasync atomic.Pointer[datasync2.DataSync]
+	datasync atomic.Pointer[datasync.DataSync]
 	dispatch MessageDispatcher
 	paused   bool
 	tick     time.Duration // outbound-loop interval the active node was built with
@@ -223,7 +223,7 @@ func (r *Reliability) Start(dispatch MessageDispatcher) error {
 			return err
 		}
 	}
-	duration := datasync2.DatasyncTicker
+	duration := datasync.DatasyncTicker
 	if r.paused {
 		duration = pausedDuration
 	}
@@ -237,20 +237,20 @@ func (r *Reliability) Start(dispatch MessageDispatcher) error {
 // (SQLite) on construction, so the epoch counter survives a recreate; the
 // status-change channel is reused so peer-online events keep flowing.
 func (r *Reliability) buildNode(duration time.Duration) error {
-	transport := datasync2.NewNodeTransport()
+	transport := datasync.NewNodeTransport()
 	node, err := mvdsnode.NewPersistentNode(
 		r.mvdsPersistence,
 		transport,
 		datasyncpeer.PublicKeyToPeerID(r.identity.PublicKey),
 		mvdsnode.BATCH,
-		datasync2.CalculateSendTime,
+		datasync.CalculateSendTime,
 		r.mvdsStatusChangeEvent,
 		r.logger,
 	)
 	if err != nil {
 		return err
 	}
-	ds := datasync2.New(node, transport, true, r.logger)
+	ds := datasync.New(node, transport, true, r.logger)
 	ds.Init(r.mvdsDispatch, r.logger)
 	ds.Start(duration)
 	r.tick = duration
@@ -307,7 +307,7 @@ func (r *Reliability) SetPaused(paused bool) error {
 	old.SetSendingEnabled(false)
 	old.Stop()
 	stopDur := time.Since(start)
-	duration := datasync2.DatasyncTicker
+	duration := datasync.DatasyncTicker
 	if paused {
 		duration = pausedDuration
 	}
@@ -368,7 +368,7 @@ func (r *Reliability) WrapAndQueueMessageForDispatch(publicKey *ecdsa.PublicKey,
 	if ds == nil {
 		return mvdsstate.MessageID{}, errNotStarted
 	}
-	groupID := datasync2.ToOneToOneGroupID(&r.identity.PublicKey, publicKey)
+	groupID := datasync.ToOneToOneGroupID(&r.identity.PublicKey, publicKey)
 	peerID := datasyncpeer.PublicKeyToPeerID(*publicKey)
 	exist, err := ds.IsPeerInGroup(groupID, peerID)
 	if err != nil {

--- a/pkg/messaging/layers/transport/envelopes_monitor.go
+++ b/pkg/messaging/layers/transport/envelopes_monitor.go
@@ -7,8 +7,8 @@ import (
 	"go.uber.org/zap"
 
 	gocommon "github.com/status-im/status-go/common"
-	types2 "github.com/status-im/status-go/internal/crypto/types"
-	"github.com/status-im/status-go/pkg/messaging/waku/types"
+	cryptotypes "github.com/status-im/status-go/internal/crypto/types"
+	wakutypes "github.com/status-im/status-go/pkg/messaging/waku/types"
 )
 
 // EnvelopeState in local tracker
@@ -26,20 +26,20 @@ const (
 type EnvelopesMonitorConfig struct {
 	EnvelopeEventsHandler            EnvelopeEventsHandler
 	AwaitOnlyMailServerConfirmations bool
-	IsMailserver                     func(types.EnodeID) bool
+	IsMailserver                     func(wakutypes.EnodeID) bool
 	Logger                           *zap.Logger
 }
 
-// EnvelopeEventsHandler used for two different event types.
+// EnvelopeEventsHandler used for two different event wakutypes.
 type EnvelopeEventsHandler interface {
 	EnvelopeSent([][]byte)
 	EnvelopeExpired([][]byte, error)
-	MailServerRequestCompleted(types2.Hash, types2.Hash, []byte, error)
-	MailServerRequestExpired(types2.Hash)
+	MailServerRequestCompleted(cryptotypes.Hash, cryptotypes.Hash, []byte, error)
+	MailServerRequestExpired(cryptotypes.Hash)
 }
 
 // NewEnvelopesMonitor returns a pointer to an instance of the EnvelopesMonitor.
-func NewEnvelopesMonitor(w types.Waku, config EnvelopesMonitorConfig) *EnvelopesMonitor {
+func NewEnvelopesMonitor(w wakutypes.Waku, config EnvelopesMonitorConfig) *EnvelopesMonitor {
 	logger := config.Logger
 
 	if logger == nil {
@@ -54,13 +54,13 @@ func NewEnvelopesMonitor(w types.Waku, config EnvelopesMonitorConfig) *Envelopes
 		logger:                           logger.With(zap.Namespace("EnvelopesMonitor")),
 
 		// key is envelope hash (event.Hash)
-		envelopes: map[types2.Hash]*monitoredEnvelope{},
+		envelopes: map[cryptotypes.Hash]*monitoredEnvelope{},
 
 		// key is hash of the batch (event.Batch)
-		batches: map[types2.Hash]map[types2.Hash]struct{}{},
+		batches: map[cryptotypes.Hash]map[cryptotypes.Hash]struct{}{},
 
 		// key is stringified message identifier
-		messageEnvelopeHashes: make(map[string][]types2.Hash),
+		messageEnvelopeHashes: make(map[string][]cryptotypes.Hash),
 
 		// key is an SDS message identifier; value is its application message
 		// identifier. SDS aliases are tracked for retrieval hints but must never
@@ -70,7 +70,7 @@ func NewEnvelopesMonitor(w types.Waku, config EnvelopesMonitorConfig) *Envelopes
 }
 
 type monitoredEnvelope struct {
-	envelopeHashID types2.Hash
+	envelopeHashID cryptotypes.Hash
 	state          EnvelopeState
 	messageIDs     [][]byte
 }
@@ -79,21 +79,21 @@ type monitoredEnvelope struct {
 type EnvelopesMonitor struct {
 	gocommon.PauseBroadcaster
 
-	w       types.Waku
+	w       wakutypes.Waku
 	handler EnvelopeEventsHandler
 
 	mu sync.Mutex
 
-	envelopes                map[types2.Hash]*monitoredEnvelope
-	batches                  map[types2.Hash]map[types2.Hash]struct{}
-	messageEnvelopeHashes    map[string][]types2.Hash
+	envelopes                map[cryptotypes.Hash]*monitoredEnvelope
+	batches                  map[cryptotypes.Hash]map[cryptotypes.Hash]struct{}
+	messageEnvelopeHashes    map[string][]cryptotypes.Hash
 	sdsApplicationMessageIDs map[string]string
 
 	awaitOnlyMailServerConfirmations bool
 
 	wg           sync.WaitGroup
 	quit         chan struct{}
-	isMailserver func(peer types.EnodeID) bool
+	isMailserver func(peer wakutypes.EnodeID) bool
 
 	logger *zap.Logger
 }
@@ -106,8 +106,8 @@ func (m *EnvelopesMonitor) AddSDSAlias(applicationMessageID, sdsMessageID []byte
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	applicationKey := types2.HexBytes(applicationMessageID).String()
-	sdsKey := types2.HexBytes(sdsMessageID).String()
+	applicationKey := cryptotypes.HexBytes(applicationMessageID).String()
+	sdsKey := cryptotypes.HexBytes(sdsMessageID).String()
 	hashes, ok := m.messageEnvelopeHashes[applicationKey]
 	if !ok {
 		return
@@ -122,12 +122,12 @@ func (m *EnvelopesMonitor) TakeApplicationMessageIDForSDS(sdsMessageID []byte) (
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	sdsKey := types2.HexBytes(sdsMessageID).String()
+	sdsKey := cryptotypes.HexBytes(sdsMessageID).String()
 	applicationKey, ok := m.sdsApplicationMessageIDs[sdsKey]
 	if !ok {
 		return nil, false
 	}
-	applicationMessageID, err := types2.DecodeHex(applicationKey)
+	applicationMessageID, err := cryptotypes.DecodeHex(applicationKey)
 	if err != nil {
 		return nil, false
 	}
@@ -155,7 +155,7 @@ func (m *EnvelopesMonitor) Stop() {
 
 // Add hashes to a tracker.
 // Identifiers may be backed by multiple envelopes. It happens when message is split in segmentation layer.
-func (m *EnvelopesMonitor) Add(messageIDs [][]byte, envelopeHashes []types2.Hash, messages []*types.NewMessage) error {
+func (m *EnvelopesMonitor) Add(messageIDs [][]byte, envelopeHashes []cryptotypes.Hash, messages []*wakutypes.NewMessage) error {
 	if len(envelopeHashes) != len(messages) {
 		return errors.New("hashes don't match messages")
 	}
@@ -164,7 +164,7 @@ func (m *EnvelopesMonitor) Add(messageIDs [][]byte, envelopeHashes []types2.Hash
 	defer m.mu.Unlock()
 
 	for _, messageID := range messageIDs {
-		m.messageEnvelopeHashes[types2.HexBytes(messageID).String()] = envelopeHashes
+		m.messageEnvelopeHashes[cryptotypes.HexBytes(messageID).String()] = envelopeHashes
 	}
 
 	for _, envelopeHash := range envelopeHashes {
@@ -182,7 +182,7 @@ func (m *EnvelopesMonitor) Add(messageIDs [][]byte, envelopeHashes []types2.Hash
 	return nil
 }
 
-func (m *EnvelopesMonitor) GetState(hash types2.Hash) EnvelopeState {
+func (m *EnvelopesMonitor) GetState(hash cryptotypes.Hash) EnvelopeState {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	envelope, exist := m.envelopes[hash]
@@ -194,7 +194,7 @@ func (m *EnvelopesMonitor) GetState(hash types2.Hash) EnvelopeState {
 
 // handleEnvelopeEvents processes waku envelope events
 func (m *EnvelopesMonitor) handleEnvelopeEvents() {
-	events := make(chan types.EnvelopeEvent, 100) // must be buffered to prevent blocking waku
+	events := make(chan wakutypes.EnvelopeEvent, 100) // must be buffered to prevent blocking waku
 	sub := m.w.SubscribeEnvelopeEvents(events)
 	defer func() {
 		sub.Unsubscribe()
@@ -211,19 +211,19 @@ func (m *EnvelopesMonitor) handleEnvelopeEvents() {
 
 // handleEvent based on type of the event either triggers
 // confirmation handler or removes hash from tracker
-func (m *EnvelopesMonitor) handleEvent(event types.EnvelopeEvent) {
-	handlers := map[types.EventType]func(types.EnvelopeEvent){
-		types.EventEnvelopeSent:      m.handleEventEnvelopeSent,
-		types.EventEnvelopeExpired:   m.handleEventEnvelopeExpired,
-		types.EventBatchAcknowledged: m.handleAcknowledgedBatch,
-		types.EventEnvelopeReceived:  m.handleEventEnvelopeReceived,
+func (m *EnvelopesMonitor) handleEvent(event wakutypes.EnvelopeEvent) {
+	handlers := map[wakutypes.EventType]func(wakutypes.EnvelopeEvent){
+		wakutypes.EventEnvelopeSent:      m.handleEventEnvelopeSent,
+		wakutypes.EventEnvelopeExpired:   m.handleEventEnvelopeExpired,
+		wakutypes.EventBatchAcknowledged: m.handleAcknowledgedBatch,
+		wakutypes.EventEnvelopeReceived:  m.handleEventEnvelopeReceived,
 	}
 	if handler, ok := handlers[event.Event]; ok {
 		handler(event)
 	}
 }
 
-func (m *EnvelopesMonitor) handleEventEnvelopeSent(event types.EnvelopeEvent) {
+func (m *EnvelopesMonitor) handleEventEnvelopeSent(event wakutypes.EnvelopeEvent) {
 	// Mailserver confirmations for WakuV2 are disabled
 	if m.w == nil && m.awaitOnlyMailServerConfirmations {
 		if !m.isMailserver(event.Peer) {
@@ -234,7 +234,7 @@ func (m *EnvelopesMonitor) handleEventEnvelopeSent(event types.EnvelopeEvent) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	confirmationExpected := event.Batch != (types2.Hash{})
+	confirmationExpected := event.Batch != (cryptotypes.Hash{})
 
 	envelope, ok := m.envelopes[event.Hash]
 
@@ -252,7 +252,7 @@ func (m *EnvelopesMonitor) handleEventEnvelopeSent(event types.EnvelopeEvent) {
 	m.logger.Debug("envelope is sent", zap.String("hash", event.Hash.String()), zap.String("peer", event.Peer.String()))
 	if confirmationExpected {
 		if _, ok := m.batches[event.Batch]; !ok {
-			m.batches[event.Batch] = map[types2.Hash]struct{}{}
+			m.batches[event.Batch] = map[cryptotypes.Hash]struct{}{}
 		}
 		m.batches[event.Batch][event.Hash] = struct{}{}
 		m.logger.Debug("waiting for a confirmation", zap.String("batch", event.Batch.String()))
@@ -263,7 +263,7 @@ func (m *EnvelopesMonitor) handleEventEnvelopeSent(event types.EnvelopeEvent) {
 	}
 }
 
-func (m *EnvelopesMonitor) handleAcknowledgedBatch(event types.EnvelopeEvent) {
+func (m *EnvelopesMonitor) handleAcknowledgedBatch(event wakutypes.EnvelopeEvent) {
 
 	if m.awaitOnlyMailServerConfirmations && !m.isMailserver(event.Peer) {
 		return
@@ -277,11 +277,11 @@ func (m *EnvelopesMonitor) handleAcknowledgedBatch(event types.EnvelopeEvent) {
 		m.logger.Debug("batch is not found", zap.String("batch", event.Batch.String()))
 	}
 	m.logger.Debug("received a confirmation", zap.String("batch", event.Batch.String()), zap.String("peer", event.Peer.String()))
-	envelopeErrors, ok := event.Data.([]types.EnvelopeError)
+	envelopeErrors, ok := event.Data.([]wakutypes.EnvelopeError)
 	if event.Data != nil && !ok {
 		m.logger.Error("received unexpected data in the the confirmation event", zap.Any("data", event.Data))
 	}
-	failedEnvelopes := map[types2.Hash]struct{}{}
+	failedEnvelopes := map[cryptotypes.Hash]struct{}{}
 	for i := range envelopeErrors {
 		envelopeError := envelopeErrors[i]
 		_, exist := m.envelopes[envelopeError.Hash]
@@ -289,7 +289,7 @@ func (m *EnvelopesMonitor) handleAcknowledgedBatch(event types.EnvelopeEvent) {
 			m.logger.Warn("envelope that was posted by us is discarded", zap.String("hash", envelopeError.Hash.String()), zap.String("peer", event.Peer.String()), zap.String("error", envelopeError.Description))
 			var err error
 			switch envelopeError.Code {
-			case types.EnvelopeTimeNotSynced:
+			case wakutypes.EnvelopeTimeNotSynced:
 				err = errors.New("envelope wasn't delivered due to time sync issues")
 			}
 			m.handleEnvelopeFailure(envelopeError.Hash, err)
@@ -311,7 +311,7 @@ func (m *EnvelopesMonitor) handleAcknowledgedBatch(event types.EnvelopeEvent) {
 	delete(m.batches, event.Batch)
 }
 
-func (m *EnvelopesMonitor) handleEventEnvelopeExpired(event types.EnvelopeEvent) {
+func (m *EnvelopesMonitor) handleEventEnvelopeExpired(event wakutypes.EnvelopeEvent) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.handleEnvelopeFailure(event.Hash, errors.New("envelope expired due to connectivity issues"))
@@ -324,7 +324,7 @@ func (m *EnvelopesMonitor) handleEventEnvelopeExpired(event types.EnvelopeEvent)
 // performs retransmission internally. A failed envelope is now reported as
 // expired immediately; the message stays unconfirmed and the app layer (raw
 // message resend) remains the backstop until the Messaging API is integrated.
-func (m *EnvelopesMonitor) handleEnvelopeFailure(hash types2.Hash, err error) {
+func (m *EnvelopesMonitor) handleEnvelopeFailure(hash cryptotypes.Hash, err error) {
 	if envelope, ok := m.envelopes[hash]; ok {
 		m.clearMessageState(hash)
 		if envelope.state == EnvelopeSent {
@@ -337,7 +337,7 @@ func (m *EnvelopesMonitor) handleEnvelopeFailure(hash types2.Hash, err error) {
 	}
 }
 
-func (m *EnvelopesMonitor) handleEventEnvelopeReceived(event types.EnvelopeEvent) {
+func (m *EnvelopesMonitor) handleEventEnvelopeReceived(event wakutypes.EnvelopeEvent) {
 	if m.awaitOnlyMailServerConfirmations && !m.isMailserver(event.Peer) {
 		return
 	}
@@ -356,7 +356,7 @@ func (m *EnvelopesMonitor) processMessageIDs(messageIDs [][]byte) {
 	sentMessageIDs := make([][]byte, 0, len(messageIDs))
 
 	for _, messageID := range messageIDs {
-		hashes, ok := m.messageEnvelopeHashes[types2.HexBytes(messageID).String()]
+		hashes, ok := m.messageEnvelopeHashes[cryptotypes.HexBytes(messageID).String()]
 		if !ok {
 			continue
 		}
@@ -382,14 +382,14 @@ func (m *EnvelopesMonitor) processMessageIDs(messageIDs [][]byte) {
 
 // clearMessageState removes all message and envelope state.
 // not thread-safe, should be protected on a higher level.
-func (m *EnvelopesMonitor) clearMessageState(envelopeID types2.Hash) {
+func (m *EnvelopesMonitor) clearMessageState(envelopeID cryptotypes.Hash) {
 	envelope, ok := m.envelopes[envelopeID]
 	if !ok {
 		return
 	}
 	delete(m.envelopes, envelopeID)
 	for _, messageID := range envelope.messageIDs {
-		messageKey := types2.HexBytes(messageID).String()
+		messageKey := cryptotypes.HexBytes(messageID).String()
 		delete(m.messageEnvelopeHashes, messageKey)
 		for sdsKey, applicationKey := range m.sdsApplicationMessageIDs {
 			if applicationKey == messageKey {

--- a/pkg/messaging/layers/transport/envelopes_monitor_test.go
+++ b/pkg/messaging/layers/transport/envelopes_monitor_test.go
@@ -11,13 +11,13 @@ import (
 	"github.com/ethereum/go-ethereum/p2p/enode"
 
 	"github.com/status-im/status-go/internal/crypto"
-	"github.com/status-im/status-go/internal/crypto/types"
-	types2 "github.com/status-im/status-go/pkg/messaging/waku/types"
+	cryptotypes "github.com/status-im/status-go/internal/crypto/types"
+	wakutypes "github.com/status-im/status-go/pkg/messaging/waku/types"
 )
 
 var (
-	testHash   = types.Hash{0x01}
-	testHashes = []types.Hash{testHash}
+	testHash   = cryptotypes.Hash{0x01}
+	testHashes = []cryptotypes.Hash{testHash}
 	testIDs    = [][]byte{[]byte("id")}
 )
 
@@ -30,9 +30,9 @@ func (h *envelopeEventsHandlerMock) EnvelopeSent(identifiers [][]byte) {
 }
 func (h *envelopeEventsHandlerMock) EnvelopeExpired([][]byte, error) {
 }
-func (h *envelopeEventsHandlerMock) MailServerRequestCompleted(types.Hash, types.Hash, []byte, error) {
+func (h *envelopeEventsHandlerMock) MailServerRequestCompleted(cryptotypes.Hash, cryptotypes.Hash, []byte, error) {
 }
-func (h *envelopeEventsHandlerMock) MailServerRequestExpired(types.Hash) {
+func (h *envelopeEventsHandlerMock) MailServerRequestExpired(cryptotypes.Hash) {
 }
 
 type EnvelopesMonitorSuite struct {
@@ -53,19 +53,19 @@ func (s *EnvelopesMonitorSuite) SetupTest() {
 		EnvelopesMonitorConfig{
 			EnvelopeEventsHandler:            s.eventsHandlerMock,
 			AwaitOnlyMailServerConfirmations: false,
-			IsMailserver:                     func(types2.EnodeID) bool { return false },
+			IsMailserver:                     func(wakutypes.EnodeID) bool { return false },
 			Logger:                           zap.NewNop(),
 		},
 	)
 }
 
 func (s *EnvelopesMonitorSuite) TestEnvelopePosted() {
-	err := s.monitor.Add(testIDs, testHashes, []*types2.NewMessage{{}})
+	err := s.monitor.Add(testIDs, testHashes, []*wakutypes.NewMessage{{}})
 	s.Require().NoError(err)
 	s.Contains(s.monitor.envelopes, testHash)
 	s.Equal(EnvelopePosted, s.monitor.envelopes[testHash].state)
-	s.monitor.handleEvent(types2.EnvelopeEvent{
-		Event: types2.EventEnvelopeSent,
+	s.monitor.handleEvent(wakutypes.EnvelopeEvent{
+		Event: wakutypes.EventEnvelopeSent,
 		Hash:  testHash,
 	})
 	s.Contains(s.monitor.envelopes, testHash)
@@ -76,7 +76,7 @@ func (s *EnvelopesMonitorSuite) TestSDSAliasDoesNotProduceSeparateSentMessage() 
 	applicationMessageID := []byte{0x01, 0x02}
 	sdsMessageID := []byte{0x03, 0x04}
 
-	err := s.monitor.Add([][]byte{applicationMessageID}, testHashes, []*types2.NewMessage{{}})
+	err := s.monitor.Add([][]byte{applicationMessageID}, testHashes, []*wakutypes.NewMessage{{}})
 	s.Require().NoError(err)
 	s.monitor.AddSDSAlias(applicationMessageID, sdsMessageID)
 
@@ -86,8 +86,8 @@ func (s *EnvelopesMonitorSuite) TestSDSAliasDoesNotProduceSeparateSentMessage() 
 	_, ok = s.monitor.TakeApplicationMessageIDForSDS(sdsMessageID)
 	s.False(ok)
 
-	s.monitor.handleEvent(types2.EnvelopeEvent{
-		Event: types2.EventEnvelopeSent,
+	s.monitor.handleEvent(wakutypes.EnvelopeEvent{
+		Event: wakutypes.EventEnvelopeSent,
 		Hash:  testHash,
 	})
 	s.Require().Len(s.eventsHandlerMock.envelopeSentCalls, 1)
@@ -98,47 +98,47 @@ func (s *EnvelopesMonitorSuite) TestSDSAliasDoesNotProduceSeparateSentMessage() 
 }
 
 func (s *EnvelopesMonitorSuite) TestEnvelopePostedOutOfOrder() {
-	s.monitor.handleEvent(types2.EnvelopeEvent{
-		Event: types2.EventEnvelopeSent,
+	s.monitor.handleEvent(wakutypes.EnvelopeEvent{
+		Event: wakutypes.EventEnvelopeSent,
 		Hash:  testHash,
 	})
 
-	err := s.monitor.Add(testIDs, testHashes, []*types2.NewMessage{{}})
+	err := s.monitor.Add(testIDs, testHashes, []*wakutypes.NewMessage{{}})
 	s.Require().NoError(err)
 	s.Require().Contains(s.monitor.envelopes, testHash)
 	s.Require().Equal(EnvelopeSent, s.monitor.envelopes[testHash].state)
 }
 
 func (s *EnvelopesMonitorSuite) TestConfirmedWithAcknowledge() {
-	testBatch := types.Hash{1}
+	testBatch := cryptotypes.Hash{1}
 	pkey, err := crypto.GenerateKey()
 	s.Require().NoError(err)
 	node := enode.NewV4(&pkey.PublicKey, nil, 0, 0)
-	err = s.monitor.Add(testIDs, testHashes, []*types2.NewMessage{{}})
+	err = s.monitor.Add(testIDs, testHashes, []*wakutypes.NewMessage{{}})
 	s.Require().NoError(err)
 	s.Contains(s.monitor.envelopes, testHash)
 	s.Equal(EnvelopePosted, s.monitor.envelopes[testHash].state)
-	s.monitor.handleEvent(types2.EnvelopeEvent{
-		Event: types2.EventEnvelopeSent,
+	s.monitor.handleEvent(wakutypes.EnvelopeEvent{
+		Event: wakutypes.EventEnvelopeSent,
 		Hash:  testHash,
 		Batch: testBatch,
 	})
 	s.Equal(EnvelopePosted, s.monitor.envelopes[testHash].state)
-	s.monitor.handleEvent(types2.EnvelopeEvent{
-		Event: types2.EventBatchAcknowledged,
+	s.monitor.handleEvent(wakutypes.EnvelopeEvent{
+		Event: wakutypes.EventBatchAcknowledged,
 		Batch: testBatch,
-		Peer:  types2.EnodeID(node.ID()),
+		Peer:  wakutypes.EnodeID(node.ID()),
 	})
 	s.Contains(s.monitor.envelopes, testHash)
 	s.Equal(EnvelopeSent, s.monitor.envelopes[testHash].state)
 }
 
 func (s *EnvelopesMonitorSuite) TestRemoved() {
-	err := s.monitor.Add(testIDs, testHashes, []*types2.NewMessage{{}})
+	err := s.monitor.Add(testIDs, testHashes, []*wakutypes.NewMessage{{}})
 	s.Require().NoError(err)
 	s.Contains(s.monitor.envelopes, testHash)
-	s.monitor.handleEvent(types2.EnvelopeEvent{
-		Event: types2.EventEnvelopeExpired,
+	s.monitor.handleEvent(wakutypes.EnvelopeEvent{
+		Event: wakutypes.EventEnvelopeExpired,
 		Hash:  testHash,
 	})
 	s.NotContains(s.monitor.envelopes, testHash)
@@ -147,25 +147,25 @@ func (s *EnvelopesMonitorSuite) TestRemoved() {
 func (s *EnvelopesMonitorSuite) TestIgnoreNotFromMailserver() {
 	// enables filter in the tracker to drop confirmations from non-mailserver peers
 	s.monitor.awaitOnlyMailServerConfirmations = true
-	err := s.monitor.Add(testIDs, testHashes, []*types2.NewMessage{{}})
+	err := s.monitor.Add(testIDs, testHashes, []*wakutypes.NewMessage{{}})
 	s.Require().NoError(err)
-	s.monitor.handleEvent(types2.EnvelopeEvent{
-		Event: types2.EventEnvelopeSent,
+	s.monitor.handleEvent(wakutypes.EnvelopeEvent{
+		Event: wakutypes.EventEnvelopeSent,
 		Hash:  testHash,
-		Peer:  types2.EnodeID{1}, // could be empty, doesn't impact test behaviour
+		Peer:  wakutypes.EnodeID{1}, // could be empty, doesn't impact test behaviour
 	})
 	s.Require().Equal(EnvelopePosted, s.monitor.GetState(testHash))
 }
 
 func (s *EnvelopesMonitorSuite) TestReceived() {
-	s.monitor.isMailserver = func(peer types2.EnodeID) bool {
+	s.monitor.isMailserver = func(peer wakutypes.EnodeID) bool {
 		return true
 	}
-	err := s.monitor.Add(testIDs, testHashes, []*types2.NewMessage{{}})
+	err := s.monitor.Add(testIDs, testHashes, []*wakutypes.NewMessage{{}})
 	s.Require().NoError(err)
 	s.Contains(s.monitor.envelopes, testHash)
-	s.monitor.handleEvent(types2.EnvelopeEvent{
-		Event: types2.EventEnvelopeReceived,
+	s.monitor.handleEvent(wakutypes.EnvelopeEvent{
+		Event: wakutypes.EventEnvelopeReceived,
 		Hash:  testHash,
 	})
 	s.Require().Equal(EnvelopeSent, s.monitor.GetState(testHash))
@@ -173,8 +173,8 @@ func (s *EnvelopesMonitorSuite) TestReceived() {
 
 func (s *EnvelopesMonitorSuite) TestMultipleHashes() {
 	messageIDs := [][]byte{[]byte("id1"), []byte("id2")}
-	hashes := []types.Hash{{0x01}, {0x02}, {0x03}}
-	messages := []*types2.NewMessage{{}, {}, {}}
+	hashes := []cryptotypes.Hash{{0x01}, {0x02}, {0x03}}
+	messages := []*wakutypes.NewMessage{{}, {}, {}}
 
 	err := s.monitor.Add(messageIDs, hashes, messages)
 	s.Require().NoError(err)
@@ -186,8 +186,8 @@ func (s *EnvelopesMonitorSuite) TestMultipleHashes() {
 	s.Require().Equal(EnvelopePosted, s.monitor.envelopes[hashes[1]].state)
 	s.Require().Equal(EnvelopePosted, s.monitor.envelopes[hashes[2]].state)
 
-	s.monitor.handleEvent(types2.EnvelopeEvent{
-		Event: types2.EventEnvelopeSent,
+	s.monitor.handleEvent(wakutypes.EnvelopeEvent{
+		Event: wakutypes.EventEnvelopeSent,
 		Hash:  hashes[0],
 	})
 	s.Require().Empty(s.eventsHandlerMock.envelopeSentCalls)
@@ -195,8 +195,8 @@ func (s *EnvelopesMonitorSuite) TestMultipleHashes() {
 	s.Require().Equal(EnvelopePosted, s.monitor.envelopes[hashes[1]].state)
 	s.Require().Equal(EnvelopePosted, s.monitor.envelopes[hashes[2]].state)
 
-	s.monitor.handleEvent(types2.EnvelopeEvent{
-		Event: types2.EventEnvelopeSent,
+	s.monitor.handleEvent(wakutypes.EnvelopeEvent{
+		Event: wakutypes.EventEnvelopeSent,
 		Hash:  hashes[1],
 	})
 	s.Require().Empty(s.eventsHandlerMock.envelopeSentCalls)
@@ -204,8 +204,8 @@ func (s *EnvelopesMonitorSuite) TestMultipleHashes() {
 	s.Require().Equal(EnvelopeSent, s.monitor.envelopes[hashes[1]].state)
 	s.Require().Equal(EnvelopePosted, s.monitor.envelopes[hashes[2]].state)
 
-	s.monitor.handleEvent(types2.EnvelopeEvent{
-		Event: types2.EventEnvelopeSent,
+	s.monitor.handleEvent(wakutypes.EnvelopeEvent{
+		Event: wakutypes.EventEnvelopeSent,
 		Hash:  hashes[2],
 	})
 	// Identifiers should be marked as sent only if all corresponding envelopes are sent
@@ -218,23 +218,23 @@ func (s *EnvelopesMonitorSuite) TestMultipleHashes() {
 
 func (s *EnvelopesMonitorSuite) TestMultipleHashes_EnvelopeExpired() {
 	messageIDs := [][]byte{[]byte("id1"), []byte("id2")}
-	hashes := []types.Hash{{0x01}, {0x02}, {0x03}}
-	messages := []*types2.NewMessage{{}, {}, {}}
+	hashes := []cryptotypes.Hash{{0x01}, {0x02}, {0x03}}
+	messages := []*wakutypes.NewMessage{{}, {}, {}}
 
 	err := s.monitor.Add(messageIDs, hashes, messages)
 	s.Require().NoError(err)
 
 	// If any envelope fails, then messageIDs are considered as not sent
-	s.monitor.handleEvent(types2.EnvelopeEvent{
-		Event: types2.EventEnvelopeExpired,
+	s.monitor.handleEvent(wakutypes.EnvelopeEvent{
+		Event: wakutypes.EventEnvelopeExpired,
 		Hash:  hashes[0],
 	})
-	s.monitor.handleEvent(types2.EnvelopeEvent{
-		Event: types2.EventEnvelopeSent,
+	s.monitor.handleEvent(wakutypes.EnvelopeEvent{
+		Event: wakutypes.EventEnvelopeSent,
 		Hash:  hashes[1],
 	})
-	s.monitor.handleEvent(types2.EnvelopeEvent{
-		Event: types2.EventEnvelopeSent,
+	s.monitor.handleEvent(wakutypes.EnvelopeEvent{
+		Event: wakutypes.EventEnvelopeSent,
 		Hash:  hashes[2],
 	})
 
@@ -244,6 +244,6 @@ func (s *EnvelopesMonitorSuite) TestMultipleHashes_EnvelopeExpired() {
 }
 
 func (s *EnvelopesMonitorSuite) TestMultipleHashes_Failure() {
-	err := s.monitor.Add(testIDs, []types.Hash{{0x01}, {0x02}}, []*types2.NewMessage{{}})
+	err := s.monitor.Add(testIDs, []cryptotypes.Hash{{0x01}, {0x02}}, []*wakutypes.NewMessage{{}})
 	s.Require().Error(err)
 }

--- a/pkg/messaging/layers/transport/envelopes_monitor_test.go
+++ b/pkg/messaging/layers/transport/envelopes_monitor_test.go
@@ -11,13 +11,13 @@ import (
 	"github.com/ethereum/go-ethereum/p2p/enode"
 
 	"github.com/status-im/status-go/internal/crypto"
-	types3 "github.com/status-im/status-go/internal/crypto/types"
+	"github.com/status-im/status-go/internal/crypto/types"
 	types2 "github.com/status-im/status-go/pkg/messaging/waku/types"
 )
 
 var (
-	testHash   = types3.Hash{0x01}
-	testHashes = []types3.Hash{testHash}
+	testHash   = types.Hash{0x01}
+	testHashes = []types.Hash{testHash}
 	testIDs    = [][]byte{[]byte("id")}
 )
 
@@ -30,9 +30,9 @@ func (h *envelopeEventsHandlerMock) EnvelopeSent(identifiers [][]byte) {
 }
 func (h *envelopeEventsHandlerMock) EnvelopeExpired([][]byte, error) {
 }
-func (h *envelopeEventsHandlerMock) MailServerRequestCompleted(types3.Hash, types3.Hash, []byte, error) {
+func (h *envelopeEventsHandlerMock) MailServerRequestCompleted(types.Hash, types.Hash, []byte, error) {
 }
-func (h *envelopeEventsHandlerMock) MailServerRequestExpired(types3.Hash) {
+func (h *envelopeEventsHandlerMock) MailServerRequestExpired(types.Hash) {
 }
 
 type EnvelopesMonitorSuite struct {
@@ -110,7 +110,7 @@ func (s *EnvelopesMonitorSuite) TestEnvelopePostedOutOfOrder() {
 }
 
 func (s *EnvelopesMonitorSuite) TestConfirmedWithAcknowledge() {
-	testBatch := types3.Hash{1}
+	testBatch := types.Hash{1}
 	pkey, err := crypto.GenerateKey()
 	s.Require().NoError(err)
 	node := enode.NewV4(&pkey.PublicKey, nil, 0, 0)
@@ -173,7 +173,7 @@ func (s *EnvelopesMonitorSuite) TestReceived() {
 
 func (s *EnvelopesMonitorSuite) TestMultipleHashes() {
 	messageIDs := [][]byte{[]byte("id1"), []byte("id2")}
-	hashes := []types3.Hash{{0x01}, {0x02}, {0x03}}
+	hashes := []types.Hash{{0x01}, {0x02}, {0x03}}
 	messages := []*types2.NewMessage{{}, {}, {}}
 
 	err := s.monitor.Add(messageIDs, hashes, messages)
@@ -218,7 +218,7 @@ func (s *EnvelopesMonitorSuite) TestMultipleHashes() {
 
 func (s *EnvelopesMonitorSuite) TestMultipleHashes_EnvelopeExpired() {
 	messageIDs := [][]byte{[]byte("id1"), []byte("id2")}
-	hashes := []types3.Hash{{0x01}, {0x02}, {0x03}}
+	hashes := []types.Hash{{0x01}, {0x02}, {0x03}}
 	messages := []*types2.NewMessage{{}, {}, {}}
 
 	err := s.monitor.Add(messageIDs, hashes, messages)
@@ -244,6 +244,6 @@ func (s *EnvelopesMonitorSuite) TestMultipleHashes_EnvelopeExpired() {
 }
 
 func (s *EnvelopesMonitorSuite) TestMultipleHashes_Failure() {
-	err := s.monitor.Add(testIDs, []types3.Hash{{0x01}, {0x02}}, []*types2.NewMessage{{}})
+	err := s.monitor.Add(testIDs, []types.Hash{{0x01}, {0x02}}, []*types2.NewMessage{{}})
 	s.Require().Error(err)
 }

--- a/pkg/messaging/layers/transport/filter_subscriptions.go
+++ b/pkg/messaging/layers/transport/filter_subscriptions.go
@@ -6,7 +6,7 @@ import (
 
 	"go.uber.org/zap"
 
-	wakuv2 "github.com/status-im/status-go/pkg/messaging/waku"
+	"github.com/status-im/status-go/pkg/messaging/waku"
 	"github.com/status-im/status-go/pkg/messaging/waku/types"
 )
 
@@ -48,7 +48,7 @@ func newFilterSubscriptions(api MessagingAPI, logger *zap.Logger) *FilterSubscri
 func pairOf(filter *Filter) types.TopicSubscription {
 	pubsubTopic := filter.PubsubTopic
 	if pubsubTopic == "" {
-		pubsubTopic = wakuv2.DefaultShardPubsubTopic()
+		pubsubTopic = waku.DefaultShardPubsubTopic()
 	}
 	return types.TopicSubscription{PubsubTopic: pubsubTopic, ContentTopic: filter.ContentTopic}
 }

--- a/pkg/messaging/layers/transport/filters_manager.go
+++ b/pkg/messaging/layers/transport/filters_manager.go
@@ -12,7 +12,7 @@ import (
 	"golang.org/x/crypto/pbkdf2"
 
 	messagingtypes "github.com/status-im/status-go/pkg/messaging/types"
-	wakuv2 "github.com/status-im/status-go/pkg/messaging/waku"
+	"github.com/status-im/status-go/pkg/messaging/waku"
 	wakucommon "github.com/status-im/status-go/pkg/messaging/waku/common"
 	"github.com/status-im/status-go/pkg/messaging/waku/types"
 )
@@ -101,7 +101,7 @@ func (f *FiltersManager) WatchersByTopic(pubsubTopic, contentTopic string) []*Fi
 		}
 		filterPubsubTopic := filter.PubsubTopic
 		if filterPubsubTopic == "" {
-			filterPubsubTopic = wakuv2.DefaultShardPubsubTopic()
+			filterPubsubTopic = waku.DefaultShardPubsubTopic()
 		}
 		if filterPubsubTopic == pubsubTopic {
 			res = append(res, filter)
@@ -202,8 +202,8 @@ func (f *FiltersManager) InitCommunityFilters(communityFiltersToInitialize []Com
 		}
 
 		topics := make([]string, 0)
-		topics = append(topics, wakuv2.DefaultShardPubsubTopic())
-		topics = append(topics, wakuv2.DefaultNonProtectedPubsubTopic())
+		topics = append(topics, waku.DefaultShardPubsubTopic())
+		topics = append(topics, waku.DefaultNonProtectedPubsubTopic())
 
 		for _, pubsubTopic := range topics {
 			pk := &cf.PrivKey.PublicKey

--- a/pkg/messaging/layers/transport/messaging_api.go
+++ b/pkg/messaging/layers/transport/messaging_api.go
@@ -3,14 +3,14 @@ package transport
 import (
 	"context"
 
-	wakuv2 "github.com/status-im/status-go/pkg/messaging/waku"
+	"github.com/status-im/status-go/pkg/messaging/waku"
 	"github.com/status-im/status-go/pkg/messaging/waku/types"
 )
 
 // MessagingAPI is the transport-layer requirement for sending messages and
 // reading received envelopes from the underlying messaging backend.
 //
-// Currently satisfied by *wakuv2.Waku. The logos-delivery Messaging API will
+// Currently satisfied by *waku.Waku. The logos-delivery Messaging API will
 // satisfy it next, after which the waku adapter is retired (pm#380).
 type MessagingAPI interface {
 	// Send publishes a pre-encoded payload on the messaging network. The
@@ -44,4 +44,4 @@ type MessagingAPI interface {
 }
 
 // Compile-time assertion: the waku adapter satisfies MessagingAPI.
-var _ MessagingAPI = (*wakuv2.Waku)(nil)
+var _ MessagingAPI = (*waku.Waku)(nil)

--- a/pkg/messaging/layers/transport/tracked_envelope_hashes_test.go
+++ b/pkg/messaging/layers/transport/tracked_envelope_hashes_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 
-	types3 "github.com/status-im/status-go/internal/crypto/types"
+	"github.com/status-im/status-go/internal/crypto/types"
 	wakutypes "github.com/status-im/status-go/pkg/messaging/waku/types"
 )
 
@@ -18,7 +18,7 @@ func TestTrackedEnvelopeHashes_ReturnsAllHashes(t *testing.T) {
 	tr := &Transport{envelopesMonitor: monitor}
 
 	id := []byte("message-id")
-	hashes := []types3.Hash{{0x01}, {0x02}, {0x03}}
+	hashes := []types.Hash{{0x01}, {0x02}, {0x03}}
 	err := monitor.Add([][]byte{id}, hashes, []*wakutypes.NewMessage{{}, {}, {}})
 	require.NoError(t, err)
 

--- a/pkg/messaging/layers/transport/transport.go
+++ b/pkg/messaging/layers/transport/transport.go
@@ -16,10 +16,10 @@ import (
 	gocommon "github.com/status-im/status-go/common"
 	"github.com/status-im/status-go/internal/connection"
 	"github.com/status-im/status-go/internal/crypto"
-	types2 "github.com/status-im/status-go/internal/crypto/types"
+	cryptotypes "github.com/status-im/status-go/internal/crypto/types"
 	"github.com/status-im/status-go/pkg/messaging/layers/transport/rfc26"
 	messagingtypes "github.com/status-im/status-go/pkg/messaging/types"
-	"github.com/status-im/status-go/pkg/messaging/waku/types"
+	wakutypes "github.com/status-im/status-go/pkg/messaging/waku/types"
 	"github.com/status-im/status-go/pkg/pubsub"
 )
 
@@ -34,7 +34,7 @@ type Option func(*Transport) error
 type Transport struct {
 	gocommon.PauseBroadcaster
 
-	waku       types.Waku
+	waku       wakutypes.Waku
 	api        MessagingAPI      // backend used to send messages and read received envelopes
 	privateKey *ecdsa.PrivateKey // identity of the current user
 	filters    *FiltersManager
@@ -51,7 +51,7 @@ type Transport struct {
 	// stored only once — mirroring the hash-keyed per-filter store the waku
 	// adapter used to keep (the persistent cache only dedups across drains).
 	receivedMu sync.Mutex
-	received   map[string]map[string]*types.Message
+	received   map[string]map[string]*wakutypes.Message
 
 	// matchedPublisher notifies subscribers (the messenger's retrieve loop)
 	// whenever a received message matched at least one listening filter.
@@ -100,7 +100,7 @@ var cleanFiltersLoopInterval = 5 * time.Minute
 //	there are no other chats. It may happen that we leave a private chat
 //	but still have a public chat for a given public key.
 func NewTransport(
-	waku types.Waku,
+	waku wakutypes.Waku,
 	privateKey *ecdsa.PrivateKey,
 	keysPersistence KeysPersistence,
 	messageIDsCachePersistence ProcessedMessageIDsCachePersistence,
@@ -121,7 +121,7 @@ func NewTransport(
 
 	// The waku backend also satisfies MessagingAPI (Send / Subscribe /
 	// Unsubscribe / envelope events); those methods live on the concrete
-	// backend, not on the types.Waku lifecycle interface. Offline transports
+	// backend, not on the wakutypes.Waku lifecycle interface. Offline transports
 	// (tests) pass a nil waku and leave api nil.
 	var api MessagingAPI
 	if waku != nil {
@@ -136,7 +136,7 @@ func NewTransport(
 		privateKey:       privateKey,
 		filters:          filtersManager,
 		logger:           logger.With(zap.Namespace("Transport")),
-		received:         make(map[string]map[string]*types.Message),
+		received:         make(map[string]map[string]*wakutypes.Message),
 		matchedPublisher: pubsub.NewTypePublisher[struct{}](),
 		subs:             newFilterSubscriptions(api, logger),
 	}
@@ -166,7 +166,7 @@ func NewTransport(
 func (t *Transport) receiveLoop() {
 	defer gocommon.LogOnPanic()
 
-	events := make(chan types.EnvelopeEvent, 100)
+	events := make(chan wakutypes.EnvelopeEvent, 100)
 	sub := t.api.SubscribeEnvelopeEvents(events)
 	defer sub.Unsubscribe()
 
@@ -175,10 +175,10 @@ func (t *Transport) receiveLoop() {
 		case <-t.quit:
 			return
 		case event := <-events:
-			if event.Event != types.EventEnvelopeAvailable {
+			if event.Event != wakutypes.EventEnvelopeAvailable {
 				continue
 			}
-			msg, ok := event.Data.(*types.ReceivedMessage)
+			msg, ok := event.Data.(*wakutypes.ReceivedMessage)
 			if !ok {
 				continue
 			}
@@ -196,7 +196,7 @@ func (t *Transport) receiveLoop() {
 // are grouped by key: decoding is attempted at most once per distinct key,
 // stops at the first key that succeeds, and the decoded message is fanned out
 // to every filter sharing that key.
-func (t *Transport) handleReceivedMessage(msg *types.ReceivedMessage) {
+func (t *Transport) handleReceivedMessage(msg *wakutypes.ReceivedMessage) {
 	if msg == nil {
 		return
 	}
@@ -264,15 +264,15 @@ func (t *Transport) handleReceivedMessage(msg *types.ReceivedMessage) {
 
 // bufferMessage stores a decoded message in the per-filter receive buffer,
 // keyed by envelope hash, until RetrieveRawAll drains it.
-func (t *Transport) bufferMessage(filterID string, message *types.Message) {
+func (t *Transport) bufferMessage(filterID string, message *wakutypes.Message) {
 	t.receivedMu.Lock()
 	defer t.receivedMu.Unlock()
 	byHash := t.received[filterID]
 	if byHash == nil {
-		byHash = make(map[string]*types.Message)
+		byHash = make(map[string]*wakutypes.Message)
 		t.received[filterID] = byHash
 	}
-	byHash[types2.EncodeHex(message.Hash)] = message
+	byHash[cryptotypes.EncodeHex(message.Hash)] = message
 }
 
 // filterKeys resolves the key material used to decode messages received on a
@@ -299,7 +299,7 @@ func (t *Transport) filterKeys(filter *Filter) (symKey []byte, privKey *ecdsa.Pr
 // envelope is never genuine plaintext; once senders start advertising version==0
 // (a later migration step) those messages must still decrypt here. Previously
 // version==0 was passed through unencrypted — that phase-0 behaviour is removed.
-func (t *Transport) decode(msg *types.ReceivedMessage, symKey []byte, privKey *ecdsa.PrivateKey) (*rfc26.DecodedPayload, error) {
+func (t *Transport) decode(msg *wakutypes.ReceivedMessage, symKey []byte, privKey *ecdsa.PrivateKey) (*rfc26.DecodedPayload, error) {
 	keyInfo := &rfc26.KeyInfo{}
 	switch {
 	case privKey != nil:
@@ -315,10 +315,10 @@ func (t *Transport) decode(msg *types.ReceivedMessage, symKey []byte, privKey *e
 	return rfc26.Decode(msg.Payload, keyInfo)
 }
 
-// toMessage assembles the transport's *types.Message from a decoded payload,
+// toMessage assembles the transport's *wakutypes.Message from a decoded payload,
 // the matched filter and the raw received message.
-func toMessage(decoded *rfc26.DecodedPayload, filter *Filter, raw *types.ReceivedMessage, privKey *ecdsa.PrivateKey) *types.Message {
-	m := &types.Message{
+func toMessage(decoded *rfc26.DecodedPayload, filter *Filter, raw *wakutypes.ReceivedMessage, privKey *ecdsa.PrivateKey) *wakutypes.Message {
+	m := &wakutypes.Message{
 		Payload:   decoded.Data,
 		Padding:   decoded.Padding,
 		Timestamp: uint32(raw.Timestamp / int64(time.Second)),
@@ -463,13 +463,13 @@ func (t *Transport) JoinGroup(publicKeys []*ecdsa.PublicKey) ([]*Filter, error) 
 // RetrieveRawAll drains the messages pushed in by the waku adapter and decoded
 // by receiveLoop, dropping any the persistent processed-message cache has
 // already seen, and returns them grouped by filter.
-func (t *Transport) RetrieveRawAll() (map[Filter][]*types.Message, error) {
-	result := make(map[Filter][]*types.Message)
+func (t *Transport) RetrieveRawAll() (map[Filter][]*wakutypes.Message, error) {
+	result := make(map[Filter][]*wakutypes.Message)
 	logger := t.logger.With(zap.String("site", "retrieveRawAll"))
 
 	t.receivedMu.Lock()
 	drained := t.received
-	t.received = make(map[string]map[string]*types.Message)
+	t.received = make(map[string]map[string]*wakutypes.Message)
 	t.receivedMu.Unlock()
 
 	for filterID, byHash := range drained {
@@ -511,7 +511,7 @@ func (t *Transport) RetrieveRawAll() (map[Filter][]*types.Message, error) {
 // SendPublic sends a new message using the Whisper service.
 // For public filters, chat name is used as an ID as well as
 // a topic.
-func (t *Transport) SendPublic(ctx context.Context, newMessage *types.NewMessage, chatName string) ([]byte, error) {
+func (t *Transport) SendPublic(ctx context.Context, newMessage *wakutypes.NewMessage, chatName string) ([]byte, error) {
 	filter, err := t.filters.LoadPublic(chatName, newMessage.PubsubTopic)
 	if err != nil {
 		return nil, err
@@ -534,7 +534,7 @@ func (t *Transport) SendPublic(ctx context.Context, newMessage *types.NewMessage
 	return t.api.Send(ctx, filter.PubsubTopic, filter.ContentTopic.ContentTopic(), encoded, newMessage.Ephemeral, newMessage.Priority)
 }
 
-func (t *Transport) SendPrivateWithSharedSecret(ctx context.Context, newMessage *types.NewMessage, publicKey *ecdsa.PublicKey, secret []byte) ([]byte, error) {
+func (t *Transport) SendPrivateWithSharedSecret(ctx context.Context, newMessage *wakutypes.NewMessage, publicKey *ecdsa.PublicKey, secret []byte) ([]byte, error) {
 	filter, err := t.filters.LoadNegotiated(messagingtypes.NegotiatedSecret{
 		PublicKey: publicKey,
 		Key:       secret,
@@ -560,7 +560,7 @@ func (t *Transport) SendPrivateWithSharedSecret(ctx context.Context, newMessage 
 	return t.api.Send(ctx, filter.PubsubTopic, filter.ContentTopic.ContentTopic(), encoded, newMessage.Ephemeral, newMessage.Priority)
 }
 
-func (t *Transport) SendPrivateWithPartitioned(ctx context.Context, newMessage *types.NewMessage, publicKey *ecdsa.PublicKey) ([]byte, error) {
+func (t *Transport) SendPrivateWithPartitioned(ctx context.Context, newMessage *wakutypes.NewMessage, publicKey *ecdsa.PublicKey) ([]byte, error) {
 	filter, err := t.filters.LoadPartitioned(publicKey, t.privateKey, false)
 	if err != nil {
 		return nil, err
@@ -578,7 +578,7 @@ func (t *Transport) SendPrivateWithPartitioned(ctx context.Context, newMessage *
 	return t.api.Send(ctx, filter.PubsubTopic, filter.ContentTopic.ContentTopic(), encoded, newMessage.Ephemeral, newMessage.Priority)
 }
 
-func (t *Transport) SendPrivateOnPersonalTopic(ctx context.Context, newMessage *types.NewMessage, publicKey *ecdsa.PublicKey) ([]byte, error) {
+func (t *Transport) SendPrivateOnPersonalTopic(ctx context.Context, newMessage *wakutypes.NewMessage, publicKey *ecdsa.PublicKey) ([]byte, error) {
 	filter, err := t.filters.LoadPersonal(publicKey, t.privateKey, false)
 	if err != nil {
 		return nil, err
@@ -611,7 +611,7 @@ func (t *Transport) LoadKeyFilters(key *ecdsa.PrivateKey) (*Filter, error) {
 	return filter, nil
 }
 
-func (t *Transport) SendCommunityMessage(ctx context.Context, newMessage *types.NewMessage, publicKey *ecdsa.PublicKey) ([]byte, error) {
+func (t *Transport) SendCommunityMessage(ctx context.Context, newMessage *wakutypes.NewMessage, publicKey *ecdsa.PublicKey) ([]byte, error) {
 	// We load the filter to make sure we can post on it
 	filter, err := t.filters.LoadPublic(PubkeyToHex(publicKey)[2:], newMessage.PubsubTopic)
 	if err != nil {
@@ -654,18 +654,18 @@ func (t *Transport) encode(payload []byte, symKey []byte, recipient *ecdsa.Publi
 
 // Track records sent envelopes for delivery monitoring. It is the
 // single-identifier convenience wrapper around TrackMany.
-func (t *Transport) Track(identifier []byte, hashes [][]byte, newMessages []*types.NewMessage) {
+func (t *Transport) Track(identifier []byte, hashes [][]byte, newMessages []*wakutypes.NewMessage) {
 	t.TrackMany([][]byte{identifier}, hashes, newMessages)
 }
 
-func (t *Transport) TrackMany(identifiers [][]byte, hashes [][]byte, newMessages []*types.NewMessage) {
+func (t *Transport) TrackMany(identifiers [][]byte, hashes [][]byte, newMessages []*wakutypes.NewMessage) {
 	if t.envelopesMonitor == nil {
 		return
 	}
 
-	envelopeHashes := make([]types2.Hash, len(hashes))
+	envelopeHashes := make([]cryptotypes.Hash, len(hashes))
 	for i, hash := range hashes {
-		envelopeHashes[i] = types2.BytesToHash(hash)
+		envelopeHashes[i] = cryptotypes.BytesToHash(hash)
 	}
 
 	err := t.envelopesMonitor.Add(identifiers, envelopeHashes, newMessages)
@@ -676,7 +676,7 @@ func (t *Transport) TrackMany(identifiers [][]byte, hashes [][]byte, newMessages
 
 // TrackWithSDSAlias tracks an application message for publish confirmation and
 // associates its SDS ID solely for SDS retrieval hints and delivery callbacks.
-func (t *Transport) TrackWithSDSAlias(applicationMessageID, sdsMessageID []byte, hashes [][]byte, newMessages []*types.NewMessage) {
+func (t *Transport) TrackWithSDSAlias(applicationMessageID, sdsMessageID []byte, hashes [][]byte, newMessages []*wakutypes.NewMessage) {
 	if t.envelopesMonitor == nil {
 		return
 	}
@@ -701,7 +701,7 @@ func (t *Transport) TrackedEnvelopeHashes(identifier []byte) ([]string, error) {
 		return nil, errors.New("envelopes monitor not initialized")
 	}
 
-	key := types2.HexBytes(identifier).String()
+	key := cryptotypes.HexBytes(identifier).String()
 
 	t.envelopesMonitor.mu.Lock()
 	defer t.envelopesMonitor.mu.Unlock()
@@ -770,7 +770,7 @@ func (t *Transport) PeerCount() int {
 }
 
 // ConnectionState returns the waku node's current three-state connection status.
-func (t *Transport) ConnectionState() types.ConnectionState {
+func (t *Transport) ConnectionState() wakutypes.ConnectionState {
 	return t.waku.ConnectionState()
 }
 
@@ -778,14 +778,14 @@ func (t *Transport) ConnectionState() types.ConnectionState {
 // (#7568): fired periodically while connectivity is not reliable and once when
 // it recovers. Without a waku node (offline transport) it returns a nil
 // channel, which blocks forever — i.e. never signals.
-func (t *Transport) OnHistoryReconcileNeeded() <-chan types.HistoryReconcileWindow {
+func (t *Transport) OnHistoryReconcileNeeded() <-chan wakutypes.HistoryReconcileWindow {
 	if t.waku == nil {
 		return nil
 	}
 	return t.waku.OnHistoryReconcileNeeded()
 }
 
-func (t *Transport) Peers() types.PeerStats {
+func (t *Transport) Peers() wakutypes.PeerStats {
 	return t.waku.Peers()
 }
 
@@ -819,7 +819,7 @@ func (t *Transport) ClearProcessedMessageIDsCache() error {
 }
 
 func PubkeyToHex(key *ecdsa.PublicKey) string {
-	return types2.EncodeHex(crypto.FromECDSAPub(key))
+	return cryptotypes.EncodeHex(crypto.FromECDSAPub(key))
 }
 
 func (t *Transport) ConnectionChanged(state connection.State) {
@@ -859,7 +859,7 @@ func (t *Transport) UnsubscribeFilterMatched(ch chan struct{}) {
 // internally (no peer argument). See waku.StoreClient.
 func (t *Transport) Query(
 	ctx context.Context,
-	batch types.MailserverBatch,
+	batch wakutypes.MailserverBatch,
 	pageLimit uint64,
 	shouldProcessNextPage func(int) (bool, uint64),
 	processEnvelopes bool,

--- a/pkg/messaging/layers/transport/transport_test.go
+++ b/pkg/messaging/layers/transport/transport_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/status-im/status-go/internal/testutils"
 	"github.com/status-im/status-go/pkg/messaging/layers/transport/migrations"
 	"github.com/status-im/status-go/pkg/messaging/layers/transport/rfc26"
-	wakuv3 "github.com/status-im/status-go/pkg/messaging/waku"
+	wakuv2 "github.com/status-im/status-go/pkg/messaging/waku"
 	wakutypes "github.com/status-im/status-go/pkg/messaging/waku/types"
 )
 
@@ -48,7 +48,7 @@ func TestReceivePushPath(t *testing.T) {
 	logger := testutils.MustCreateTestLogger()
 	defer func() { _ = logger.Sync() }()
 
-	waku, err := wakuv3.New(nil, &wakuv3.DefaultConfig, logger, nil)
+	waku, err := wakuv2.New(nil, &wakuv2.DefaultConfig, logger, nil)
 	require.NoError(t, err)
 
 	identity, err := crypto.GenerateKey()
@@ -74,7 +74,7 @@ func TestReceivePushPath(t *testing.T) {
 	tr.handleReceivedMessage(&wakutypes.ReceivedMessage{
 		Hash:         hash,
 		ContentTopic: filter.ContentTopic.ContentTopic(),
-		PubsubTopic:  wakuv3.DefaultShardPubsubTopic(),
+		PubsubTopic:  wakuv2.DefaultShardPubsubTopic(),
 		Payload:      encoded,
 		Version:      1,
 		Timestamp:    time.Now().UnixNano(),
@@ -99,7 +99,7 @@ func TestReceivePushPath(t *testing.T) {
 	tr.handleReceivedMessage(&wakutypes.ReceivedMessage{
 		Hash:         []byte{0x01},
 		ContentTopic: "/waku/2/unknown/proto",
-		PubsubTopic:  wakuv3.DefaultShardPubsubTopic(),
+		PubsubTopic:  wakuv2.DefaultShardPubsubTopic(),
 		Payload:      encoded,
 		Version:      1,
 		Timestamp:    time.Now().UnixNano(),
@@ -119,7 +119,7 @@ func TestReceivePushPath(t *testing.T) {
 	tr.handleReceivedMessage(&wakutypes.ReceivedMessage{
 		Hash:         []byte{0x02},
 		ContentTopic: filter.ContentTopic.ContentTopic(),
-		PubsubTopic:  wakuv3.DefaultShardPubsubTopic(),
+		PubsubTopic:  wakuv2.DefaultShardPubsubTopic(),
 		Payload:      badPayload,
 		Version:      1,
 		Timestamp:    time.Now().UnixNano(),
@@ -143,7 +143,7 @@ func TestReceiveVersionZeroDecodesAsV1(t *testing.T) {
 	logger := testutils.MustCreateTestLogger()
 	defer func() { _ = logger.Sync() }()
 
-	waku, err := wakuv3.New(nil, &wakuv3.DefaultConfig, logger, nil)
+	waku, err := wakuv2.New(nil, &wakuv2.DefaultConfig, logger, nil)
 	require.NoError(t, err)
 
 	identity, err := crypto.GenerateKey()
@@ -167,7 +167,7 @@ func TestReceiveVersionZeroDecodesAsV1(t *testing.T) {
 	tr.handleReceivedMessage(&wakutypes.ReceivedMessage{
 		Hash:         []byte{0xde, 0xad},
 		ContentTopic: filter.ContentTopic.ContentTopic(),
-		PubsubTopic:  wakuv3.DefaultShardPubsubTopic(),
+		PubsubTopic:  wakuv2.DefaultShardPubsubTopic(),
 		Payload:      encoded,
 		Version:      0,
 		Timestamp:    time.Now().UnixNano(),
@@ -197,7 +197,7 @@ func TestReceiveSharedKeyFanOut(t *testing.T) {
 	logger := testutils.MustCreateTestLogger()
 	defer func() { _ = logger.Sync() }()
 
-	waku, err := wakuv3.New(nil, &wakuv3.DefaultConfig, logger, nil)
+	waku, err := wakuv2.New(nil, &wakuv2.DefaultConfig, logger, nil)
 	require.NoError(t, err)
 
 	identity, err := crypto.GenerateKey()
@@ -224,7 +224,7 @@ func TestReceiveSharedKeyFanOut(t *testing.T) {
 			ChatID:       chatID,
 			FilterID:     filterID,
 			ContentTopic: contentTopic,
-			PubsubTopic:  wakuv3.DefaultShardPubsubTopic(),
+			PubsubTopic:  wakuv2.DefaultShardPubsubTopic(),
 			Listen:       true,
 		}
 	}
@@ -242,7 +242,7 @@ func TestReceiveSharedKeyFanOut(t *testing.T) {
 	tr.handleReceivedMessage(&wakutypes.ReceivedMessage{
 		Hash:         []byte{0xfa, 0x07},
 		ContentTopic: contentTopic.ContentTopic(),
-		PubsubTopic:  wakuv3.DefaultShardPubsubTopic(),
+		PubsubTopic:  wakuv2.DefaultShardPubsubTopic(),
 		Payload:      encoded,
 		Version:      1,
 		Timestamp:    time.Now().UnixNano(),

--- a/pkg/messaging/layers/transport/transport_test.go
+++ b/pkg/messaging/layers/transport/transport_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/status-im/status-go/internal/testutils"
 	"github.com/status-im/status-go/pkg/messaging/layers/transport/migrations"
 	"github.com/status-im/status-go/pkg/messaging/layers/transport/rfc26"
-	wakuv2 "github.com/status-im/status-go/pkg/messaging/waku"
+	"github.com/status-im/status-go/pkg/messaging/waku"
 	wakutypes "github.com/status-im/status-go/pkg/messaging/waku/types"
 )
 
@@ -48,13 +48,13 @@ func TestReceivePushPath(t *testing.T) {
 	logger := testutils.MustCreateTestLogger()
 	defer func() { _ = logger.Sync() }()
 
-	waku, err := wakuv2.New(nil, &wakuv2.DefaultConfig, logger, nil)
+	wakuNode, err := waku.New(nil, &waku.DefaultConfig, logger, nil)
 	require.NoError(t, err)
 
 	identity, err := crypto.GenerateKey()
 	require.NoError(t, err)
 
-	tr, err := NewTransport(waku, identity, NewSQLiteKeysPersistence(db), NewSQLiteProcessedMessageIDsCachePersistence(db), nil, logger)
+	tr, err := NewTransport(wakuNode, identity, NewSQLiteKeysPersistence(db), NewSQLiteProcessedMessageIDsCachePersistence(db), nil, logger)
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = tr.Stop() })
 
@@ -74,7 +74,7 @@ func TestReceivePushPath(t *testing.T) {
 	tr.handleReceivedMessage(&wakutypes.ReceivedMessage{
 		Hash:         hash,
 		ContentTopic: filter.ContentTopic.ContentTopic(),
-		PubsubTopic:  wakuv2.DefaultShardPubsubTopic(),
+		PubsubTopic:  waku.DefaultShardPubsubTopic(),
 		Payload:      encoded,
 		Version:      1,
 		Timestamp:    time.Now().UnixNano(),
@@ -99,7 +99,7 @@ func TestReceivePushPath(t *testing.T) {
 	tr.handleReceivedMessage(&wakutypes.ReceivedMessage{
 		Hash:         []byte{0x01},
 		ContentTopic: "/waku/2/unknown/proto",
-		PubsubTopic:  wakuv2.DefaultShardPubsubTopic(),
+		PubsubTopic:  waku.DefaultShardPubsubTopic(),
 		Payload:      encoded,
 		Version:      1,
 		Timestamp:    time.Now().UnixNano(),
@@ -119,7 +119,7 @@ func TestReceivePushPath(t *testing.T) {
 	tr.handleReceivedMessage(&wakutypes.ReceivedMessage{
 		Hash:         []byte{0x02},
 		ContentTopic: filter.ContentTopic.ContentTopic(),
-		PubsubTopic:  wakuv2.DefaultShardPubsubTopic(),
+		PubsubTopic:  waku.DefaultShardPubsubTopic(),
 		Payload:      badPayload,
 		Version:      1,
 		Timestamp:    time.Now().UnixNano(),
@@ -143,13 +143,13 @@ func TestReceiveVersionZeroDecodesAsV1(t *testing.T) {
 	logger := testutils.MustCreateTestLogger()
 	defer func() { _ = logger.Sync() }()
 
-	waku, err := wakuv2.New(nil, &wakuv2.DefaultConfig, logger, nil)
+	wakuNode, err := waku.New(nil, &waku.DefaultConfig, logger, nil)
 	require.NoError(t, err)
 
 	identity, err := crypto.GenerateKey()
 	require.NoError(t, err)
 
-	tr, err := NewTransport(waku, identity, NewSQLiteKeysPersistence(db), NewSQLiteProcessedMessageIDsCachePersistence(db), nil, logger)
+	tr, err := NewTransport(wakuNode, identity, NewSQLiteKeysPersistence(db), NewSQLiteProcessedMessageIDsCachePersistence(db), nil, logger)
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = tr.Stop() })
 
@@ -167,7 +167,7 @@ func TestReceiveVersionZeroDecodesAsV1(t *testing.T) {
 	tr.handleReceivedMessage(&wakutypes.ReceivedMessage{
 		Hash:         []byte{0xde, 0xad},
 		ContentTopic: filter.ContentTopic.ContentTopic(),
-		PubsubTopic:  wakuv2.DefaultShardPubsubTopic(),
+		PubsubTopic:  waku.DefaultShardPubsubTopic(),
 		Payload:      encoded,
 		Version:      0,
 		Timestamp:    time.Now().UnixNano(),
@@ -197,13 +197,13 @@ func TestReceiveSharedKeyFanOut(t *testing.T) {
 	logger := testutils.MustCreateTestLogger()
 	defer func() { _ = logger.Sync() }()
 
-	waku, err := wakuv2.New(nil, &wakuv2.DefaultConfig, logger, nil)
+	wakuNode, err := waku.New(nil, &waku.DefaultConfig, logger, nil)
 	require.NoError(t, err)
 
 	identity, err := crypto.GenerateKey()
 	require.NoError(t, err)
 
-	tr, err := NewTransport(waku, identity, NewSQLiteKeysPersistence(db), NewSQLiteProcessedMessageIDsCachePersistence(db), nil, logger)
+	tr, err := NewTransport(wakuNode, identity, NewSQLiteKeysPersistence(db), NewSQLiteProcessedMessageIDsCachePersistence(db), nil, logger)
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = tr.Stop() })
 
@@ -224,7 +224,7 @@ func TestReceiveSharedKeyFanOut(t *testing.T) {
 			ChatID:       chatID,
 			FilterID:     filterID,
 			ContentTopic: contentTopic,
-			PubsubTopic:  wakuv2.DefaultShardPubsubTopic(),
+			PubsubTopic:  waku.DefaultShardPubsubTopic(),
 			Listen:       true,
 		}
 	}
@@ -242,7 +242,7 @@ func TestReceiveSharedKeyFanOut(t *testing.T) {
 	tr.handleReceivedMessage(&wakutypes.ReceivedMessage{
 		Hash:         []byte{0xfa, 0x07},
 		ContentTopic: contentTopic.ContentTopic(),
-		PubsubTopic:  wakuv2.DefaultShardPubsubTopic(),
+		PubsubTopic:  waku.DefaultShardPubsubTopic(),
 		Payload:      encoded,
 		Version:      1,
 		Timestamp:    time.Now().UnixNano(),

--- a/pkg/messaging/sqlite_persistence.go
+++ b/pkg/messaging/sqlite_persistence.go
@@ -10,11 +10,11 @@ import (
 	mvdsmigrations "github.com/status-im/mvds/persistenceutil"
 
 	"github.com/status-im/status-go/internal/db/sqlite"
-	common2 "github.com/status-im/status-go/pkg/messaging/common"
+	"github.com/status-im/status-go/pkg/messaging/common"
 	messagesendermigrations "github.com/status-im/status-go/pkg/messaging/common/migrations"
-	encryption2 "github.com/status-im/status-go/pkg/messaging/layers/encryption"
+	"github.com/status-im/status-go/pkg/messaging/layers/encryption"
 	encryptionmigrations "github.com/status-im/status-go/pkg/messaging/layers/encryption/migrations"
-	segmentation2 "github.com/status-im/status-go/pkg/messaging/layers/segmentation"
+	"github.com/status-im/status-go/pkg/messaging/layers/segmentation"
 	segmentationmigrations "github.com/status-im/status-go/pkg/messaging/layers/segmentation/migrations"
 	transport "github.com/status-im/status-go/pkg/messaging/layers/transport"
 	transportmigrations "github.com/status-im/status-go/pkg/messaging/layers/transport/migrations"
@@ -132,22 +132,22 @@ func (p *sqlitePersistence) TransportStorage() transport.Persistence {
 	return &sqliteTransportPersistence{db: p.db}
 }
 
-func (p *sqlitePersistence) SegmentationStorage() segmentation2.Persistence {
-	return segmentation2.NewSQLitePersistence(p.db)
+func (p *sqlitePersistence) SegmentationStorage() segmentation.Persistence {
+	return segmentation.NewSQLitePersistence(p.db)
 }
 
 func (p *sqlitePersistence) MVDSStorage() mvdsnode.Persistence {
 	return mvdsnode.NewSQLitePersistence(p.db)
 }
 
-func (p *sqlitePersistence) EncryptionStorage() encryption2.Persistence {
-	return encryption2.NewSQLitePersistence(p.db)
+func (p *sqlitePersistence) EncryptionStorage() encryption.Persistence {
+	return encryption.NewSQLitePersistence(p.db)
 }
 
-func (p *sqlitePersistence) MessageConfirmationStorage() common2.MessageConfirmationPersistence {
-	return common2.NewSQLiteMessageConfirmationPersistence(p.db)
+func (p *sqlitePersistence) MessageConfirmationStorage() common.MessageConfirmationPersistence {
+	return common.NewSQLiteMessageConfirmationPersistence(p.db)
 }
 
-func (p *sqlitePersistence) HashRatchetStorage() common2.HashRatchetPersistence {
-	return common2.NewSQLiteHashRatchetPersistence(p.db)
+func (p *sqlitePersistence) HashRatchetStorage() common.HashRatchetPersistence {
+	return common.NewSQLiteHashRatchetPersistence(p.db)
 }

--- a/pkg/messaging/waku/api.go
+++ b/pkg/messaging/waku/api.go
@@ -16,7 +16,7 @@
 // This software uses the go-ethereum library, which is licensed
 // under the GNU Lesser General Public Library, version 3 or any later.
 
-package wakuv2
+package waku
 
 import (
 	"context"

--- a/pkg/messaging/waku/bridge.go
+++ b/pkg/messaging/waku/bridge.go
@@ -1,4 +1,4 @@
-package wakuv2
+package waku
 
 import (
 	"github.com/ethereum/go-ethereum/event"

--- a/pkg/messaging/waku/config.go
+++ b/pkg/messaging/waku/config.go
@@ -16,7 +16,7 @@
 // This software uses the go-ethereum library, which is licensed
 // under the GNU Lesser General Public Library, version 3 or any later.
 
-package wakuv2
+package waku
 
 import (
 	"go.uber.org/zap"

--- a/pkg/messaging/waku/const.go
+++ b/pkg/messaging/waku/const.go
@@ -1,4 +1,4 @@
-package wakuv2
+package waku
 
 // Waku protocol parameters
 const (

--- a/pkg/messaging/waku/gowaku.go
+++ b/pkg/messaging/waku/gowaku.go
@@ -16,11 +16,11 @@
 // This software uses the go-ethereum library, which is licensed
 // under the GNU Lesser General Public Library, version 3 or any later.
 
-package wakuv2
+package waku
 
 // Generate a mock for peerAddressHandler. Keep it in same dir and package, as it's a private type.
 // Yet we name the file _test.go to keep it only available in testing environment.
-//go:generate go tool mockgen -source=gowaku.go -destination=gowaku_mock_test.go -package=wakuv2
+//go:generate go tool mockgen -source=gowaku.go -destination=gowaku_mock_test.go -package=waku
 
 import (
 	"context"

--- a/pkg/messaging/waku/gowaku_storm_test.go
+++ b/pkg/messaging/waku/gowaku_storm_test.go
@@ -1,4 +1,4 @@
-package wakuv2
+package waku
 
 import (
 	"fmt"

--- a/pkg/messaging/waku/gowaku_test.go
+++ b/pkg/messaging/waku/gowaku_test.go
@@ -1,4 +1,4 @@
-package wakuv2
+package waku
 
 import (
 	"context"

--- a/pkg/messaging/waku/history_processor_wrapper.go
+++ b/pkg/messaging/waku/history_processor_wrapper.go
@@ -1,4 +1,4 @@
-package wakuv2
+package waku
 
 import (
 	"github.com/waku-org/go-waku/waku/v2/protocol"

--- a/pkg/messaging/waku/history_reconcile.go
+++ b/pkg/messaging/waku/history_reconcile.go
@@ -1,4 +1,4 @@
-package wakuv2
+package waku
 
 import (
 	"time"

--- a/pkg/messaging/waku/history_reconcile_test.go
+++ b/pkg/messaging/waku/history_reconcile_test.go
@@ -1,4 +1,4 @@
-package wakuv2
+package waku
 
 import (
 	"testing"

--- a/pkg/messaging/waku/message_publishing.go
+++ b/pkg/messaging/waku/message_publishing.go
@@ -1,4 +1,4 @@
-package wakuv2
+package waku
 
 import (
 	"errors"

--- a/pkg/messaging/waku/mode.go
+++ b/pkg/messaging/waku/mode.go
@@ -1,4 +1,4 @@
-package wakuv2
+package waku
 
 import "fmt"
 

--- a/pkg/messaging/waku/service_pausable.go
+++ b/pkg/messaging/waku/service_pausable.go
@@ -1,4 +1,4 @@
-package wakuv2
+package waku
 
 func (w *Waku) PausableName() string { return "waku" }
 

--- a/pkg/messaging/waku/shard.go
+++ b/pkg/messaging/waku/shard.go
@@ -1,4 +1,4 @@
-package wakuv2
+package waku
 
 import (
 	wakuproto "github.com/waku-org/go-waku/waku/v2/protocol"

--- a/pkg/messaging/waku/store_client.go
+++ b/pkg/messaging/waku/store_client.go
@@ -1,4 +1,4 @@
-package wakuv2
+package waku
 
 import (
 	"context"

--- a/pkg/messaging/waku/store_internals_test.go
+++ b/pkg/messaging/waku/store_internals_test.go
@@ -1,4 +1,4 @@
-package wakuv2
+package waku
 
 import (
 	"context"

--- a/pkg/messaging/waku/store_pager.go
+++ b/pkg/messaging/waku/store_pager.go
@@ -1,4 +1,4 @@
-package wakuv2
+package waku
 
 import (
 	"context"

--- a/pkg/messaging/waku/store_requestor.go
+++ b/pkg/messaging/waku/store_requestor.go
@@ -1,4 +1,4 @@
-package wakuv2
+package waku
 
 import (
 	"context"

--- a/pkg/messaging/waku/store_selector.go
+++ b/pkg/messaging/waku/store_selector.go
@@ -1,4 +1,4 @@
-package wakuv2
+package waku
 
 import (
 	"math/rand"

--- a/pkg/messaging/waku/tracer.go
+++ b/pkg/messaging/waku/tracer.go
@@ -1,4 +1,4 @@
-package wakuv2
+package waku
 
 import (
 	"fmt"

--- a/pkg/messaging/waku/waku_test.go
+++ b/pkg/messaging/waku/waku_test.go
@@ -1,4 +1,4 @@
-package wakuv2
+package waku
 
 import (
 	"context"

--- a/pkg/messaging/wakumetrics/client.go
+++ b/pkg/messaging/wakumetrics/client.go
@@ -7,7 +7,7 @@ import (
 	wps "github.com/waku-org/go-waku/waku/v2/peerstore"
 
 	"github.com/status-im/status-go/pkg/messaging/types"
-	wakuv "github.com/status-im/status-go/pkg/messaging/waku"
+	wakuv2 "github.com/status-im/status-go/pkg/messaging/waku"
 	"github.com/status-im/status-go/pkg/messaging/waku/common"
 )
 
@@ -59,7 +59,7 @@ func (c *Client) PushReceivedMessages(receivedMessages ReceivedMessages) {
 	).Add(float64(len(receivedMessages.Messages)))
 }
 
-func (c *Client) PushSentEnvelope(sentEnvelope wakuv.SentEnvelope) {
+func (c *Client) PushSentEnvelope(sentEnvelope wakuv2.SentEnvelope) {
 	metrics.EnvelopeSentTotal.WithLabelValues(
 		sentEnvelope.Envelope.PubsubTopic(),
 		sentEnvelope.Envelope.Message().ContentTopic,
@@ -67,7 +67,7 @@ func (c *Client) PushSentEnvelope(sentEnvelope wakuv.SentEnvelope) {
 	).Inc()
 }
 
-func (c *Client) PushErrorSendingEnvelope(errorSendingEnvelope wakuv.ErrorSendingEnvelope) {
+func (c *Client) PushErrorSendingEnvelope(errorSendingEnvelope wakuv2.ErrorSendingEnvelope) {
 	metrics.EnvelopeSentErrors.WithLabelValues(
 		errorSendingEnvelope.SentEnvelope.Envelope.PubsubTopic(),
 		errorSendingEnvelope.SentEnvelope.Envelope.Message().ContentTopic,

--- a/pkg/messaging/wakumetrics/client.go
+++ b/pkg/messaging/wakumetrics/client.go
@@ -7,7 +7,7 @@ import (
 	wps "github.com/waku-org/go-waku/waku/v2/peerstore"
 
 	"github.com/status-im/status-go/pkg/messaging/types"
-	wakuv2 "github.com/status-im/status-go/pkg/messaging/waku"
+	"github.com/status-im/status-go/pkg/messaging/waku"
 	"github.com/status-im/status-go/pkg/messaging/waku/common"
 )
 
@@ -59,7 +59,7 @@ func (c *Client) PushReceivedMessages(receivedMessages ReceivedMessages) {
 	).Add(float64(len(receivedMessages.Messages)))
 }
 
-func (c *Client) PushSentEnvelope(sentEnvelope wakuv2.SentEnvelope) {
+func (c *Client) PushSentEnvelope(sentEnvelope waku.SentEnvelope) {
 	metrics.EnvelopeSentTotal.WithLabelValues(
 		sentEnvelope.Envelope.PubsubTopic(),
 		sentEnvelope.Envelope.Message().ContentTopic,
@@ -67,7 +67,7 @@ func (c *Client) PushSentEnvelope(sentEnvelope wakuv2.SentEnvelope) {
 	).Inc()
 }
 
-func (c *Client) PushErrorSendingEnvelope(errorSendingEnvelope wakuv2.ErrorSendingEnvelope) {
+func (c *Client) PushErrorSendingEnvelope(errorSendingEnvelope waku.ErrorSendingEnvelope) {
 	metrics.EnvelopeSentErrors.WithLabelValues(
 		errorSendingEnvelope.SentEnvelope.Envelope.PubsubTopic(),
 		errorSendingEnvelope.SentEnvelope.Envelope.Message().ContentTopic,

--- a/pkg/messaging/wakumetrics/client_test.go
+++ b/pkg/messaging/wakumetrics/client_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/waku-org/go-waku/waku/v2/protocol/pb"
 
 	"github.com/status-im/status-go/pkg/messaging/types"
-	wakuv2 "github.com/status-im/status-go/pkg/messaging/waku"
+	"github.com/status-im/status-go/pkg/messaging/waku"
 )
 
 var (
@@ -145,8 +145,8 @@ func TestClient_PushErrorSendingEnvelope(t *testing.T) {
 	}
 	envelope := v2protocol.NewEnvelope(msg, 0, "")
 
-	errorSendingEnvelope := wakuv2.ErrorSendingEnvelope{
-		SentEnvelope: wakuv2.SentEnvelope{
+	errorSendingEnvelope := waku.ErrorSendingEnvelope{
+		SentEnvelope: waku.SentEnvelope{
 			Envelope:      envelope,
 			PublishMethod: publish.LightPush,
 		},

--- a/pkg/messaging/wakumetrics/client_test.go
+++ b/pkg/messaging/wakumetrics/client_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/waku-org/go-waku/waku/v2/protocol/pb"
 
 	"github.com/status-im/status-go/pkg/messaging/types"
-	wakuv "github.com/status-im/status-go/pkg/messaging/waku"
+	wakuv2 "github.com/status-im/status-go/pkg/messaging/waku"
 )
 
 var (
@@ -145,8 +145,8 @@ func TestClient_PushErrorSendingEnvelope(t *testing.T) {
 	}
 	envelope := v2protocol.NewEnvelope(msg, 0, "")
 
-	errorSendingEnvelope := wakuv.ErrorSendingEnvelope{
-		SentEnvelope: wakuv.SentEnvelope{
+	errorSendingEnvelope := wakuv2.ErrorSendingEnvelope{
+		SentEnvelope: wakuv2.SentEnvelope{
 			Envelope:      envelope,
 			PublishMethod: publish.LightPush,
 		},

--- a/protocol/common/message_sender.go
+++ b/protocol/common/message_sender.go
@@ -12,11 +12,11 @@ import (
 
 	gocommon "github.com/status-im/status-go/common"
 	"github.com/status-im/status-go/internal/crypto"
-	types2 "github.com/status-im/status-go/internal/crypto/types"
+	cryptotypes "github.com/status-im/status-go/internal/crypto/types"
 	"github.com/status-im/status-go/internal/instrumentation/trace"
 	"github.com/status-im/status-go/pkg/messaging"
 	messagingevents "github.com/status-im/status-go/pkg/messaging/events"
-	"github.com/status-im/status-go/pkg/messaging/types"
+	messagingtypes "github.com/status-im/status-go/pkg/messaging/types"
 	"github.com/status-im/status-go/pkg/pubsub"
 	"github.com/status-im/status-go/protocol/protobuf"
 	v1protocol "github.com/status-im/status-go/protocol/v1"
@@ -28,7 +28,7 @@ func encodeCommunityID(communityID []byte) string {
 	if len(communityID) == 0 {
 		return ""
 	}
-	return types2.EncodeHex(communityID)
+	return cryptotypes.EncodeHex(communityID)
 }
 
 type MessageSender struct {
@@ -73,8 +73,8 @@ func EnsureMessageIDIntegrity(messageID string, rawMessage *RawMessage) error {
 	return nil
 }
 
-func setMessageID(messageID types2.HexBytes, rawMessage *RawMessage) error {
-	messageIDString := types2.EncodeHex(messageID)
+func setMessageID(messageID cryptotypes.HexBytes, rawMessage *RawMessage) error {
+	messageIDString := cryptotypes.EncodeHex(messageID)
 
 	err := EnsureMessageIDIntegrity(messageIDString, rawMessage)
 	if err != nil {
@@ -161,7 +161,7 @@ func (s *MessageSender) SendPublic(
 		}
 	}
 
-	messageID := types.MessageID(&rawMessage.Sender.PublicKey, wrappedMessage)
+	messageID := messagingtypes.MessageID(&rawMessage.Sender.PublicKey, wrappedMessage)
 	if err = setMessageID(messageID, &rawMessage); err != nil {
 		return nil, err
 	}
@@ -179,9 +179,9 @@ func (s *MessageSender) SendPublic(
 	// notify before dispatching
 	s.notifyOnScheduledMessage(nil, &rawMessage)
 
-	var hashRatchetParams *types.SendPublicHashRatchetParams
+	var hashRatchetParams *messagingtypes.SendPublicHashRatchetParams
 	if len(rawMessage.HashRatchetGroupID) != 0 {
-		hashRatchetParams = &types.SendPublicHashRatchetParams{
+		hashRatchetParams = &messagingtypes.SendPublicHashRatchetParams{
 			Encrypt:   false,
 			GroupID:   rawMessage.HashRatchetGroupID,
 			KeyExType: rawMessage.CommunityKeyExMsgType,
@@ -189,7 +189,7 @@ func (s *MessageSender) SendPublic(
 		}
 	}
 
-	err = s.messaging.SendPublic(ctx, types.SendPublicParams{
+	err = s.messaging.SendPublic(ctx, messagingtypes.SendPublicParams{
 		Sender:              &rawMessage.Sender.PublicKey,
 		Payload:             wrappedMessage,
 		PubsubTopic:         rawMessage.PubsubTopic,
@@ -245,7 +245,7 @@ func (s *MessageSender) sendPrivate(
 		}
 	}
 
-	messageID := types.MessageID(&rawMessage.Sender.PublicKey, wrappedMessage)
+	messageID := messagingtypes.MessageID(&rawMessage.Sender.PublicKey, wrappedMessage)
 	if err = setMessageID(messageID, rawMessage); err != nil {
 		return nil, err
 	}
@@ -266,14 +266,14 @@ func (s *MessageSender) sendPrivate(
 	}
 
 	var hashRatchetGroupID []byte
-	if rawMessage.CommunityKeyExMsgType == types.KeyExMsgReuse {
+	if rawMessage.CommunityKeyExMsgType == messagingtypes.KeyExMsgReuse {
 		hashRatchetGroupID = rawMessage.HashRatchetGroupID
 	}
 
 	for _, recipient := range rawMessage.Recipients {
 		s.notifyOnScheduledMessage(recipient, rawMessage)
 
-		err = s.messaging.SendPrivate(ctx, types.SendPrivateParams{
+		err = s.messaging.SendPrivate(ctx, messagingtypes.SendPrivateParams{
 			Sender:              rawMessage.Sender,
 			Recipient:           recipient,
 			Payload:             wrappedMessage,
@@ -351,7 +351,7 @@ func (s *MessageSender) SendCommunity(
 		return nil, err
 	}
 
-	messageID := types.MessageID(&rawMessage.Sender.PublicKey, wrappedMessage)
+	messageID := messagingtypes.MessageID(&rawMessage.Sender.PublicKey, wrappedMessage)
 	err = setMessageID(messageID, rawMessage)
 	if err != nil {
 		return nil, err
@@ -359,7 +359,7 @@ func (s *MessageSender) SendCommunity(
 
 	logger := s.logger.Named("sendCommunity").With(
 		zap.Stringer("messageID", messageID),
-		zap.String("communityID", types2.EncodeHex(rawMessage.CommunityID)),
+		zap.String("communityID", cryptotypes.EncodeHex(rawMessage.CommunityID)),
 		zap.String("sender", crypto.PubkeyToHex(&rawMessage.Sender.PublicKey)),
 	)
 
@@ -373,11 +373,11 @@ func (s *MessageSender) SendCommunity(
 	s.notifyOnScheduledMessage(nil, rawMessage)
 
 	// We want to fill up old keys to a given users
-	if rawMessage.CommunityKeyExMsgType == types.KeyExMsgReuse {
+	if rawMessage.CommunityKeyExMsgType == messagingtypes.KeyExMsgReuse {
 		return messageID, s.messaging.SendPrivateHashRatchetKeys(ctx, rawMessage.Recipients, rawMessage.HashRatchetGroupID)
 	}
 
-	hashRatchetParams := &types.SendPublicHashRatchetParams{
+	hashRatchetParams := &messagingtypes.SendPublicHashRatchetParams{
 		Encrypt:   false,
 		GroupID:   rawMessage.HashRatchetGroupID,
 		KeyExType: rawMessage.CommunityKeyExMsgType,
@@ -392,7 +392,7 @@ func (s *MessageSender) SendCommunity(
 
 		hashRatchetParams.Encrypt = true
 
-		err = s.messaging.SendPublic(ctx, types.SendPublicParams{
+		err = s.messaging.SendPublic(ctx, messagingtypes.SendPublicParams{
 			Sender:       &rawMessage.Sender.PublicKey,
 			Payload:      wrappedMessage,
 			PubsubTopic:  rawMessage.PubsubTopic,
@@ -408,7 +408,7 @@ func (s *MessageSender) SendCommunity(
 			return nil, errors.Wrap(err, "failed to decompress pubkey")
 		}
 
-		err = s.messaging.SendPublic(ctx, types.SendPublicParams{
+		err = s.messaging.SendPublic(ctx, messagingtypes.SendPublicParams{
 			Sender:             &rawMessage.Sender.PublicKey,
 			Payload:            wrappedMessage,
 			PubsubTopic:        rawMessage.PubsubTopic,
@@ -450,7 +450,7 @@ func (s *MessageSender) SendPairInstallation(
 	ctx, span := s.tracer.Start(ctx, "MessageSender.SendPairInstallation")
 	defer span.End()
 
-	s.logger.Debug("sending private message", zap.String("recipient", types2.EncodeHex(crypto.FromECDSAPub(recipient))))
+	s.logger.Debug("sending private message", zap.String("recipient", cryptotypes.EncodeHex(crypto.FromECDSAPub(recipient))))
 
 	if rawMessage.Sender == nil {
 		rawMessage.Sender = s.identity
@@ -461,7 +461,7 @@ func (s *MessageSender) SendPairInstallation(
 		return nil, errors.Wrap(err, "failed to wrap message")
 	}
 
-	messageID := types.MessageID(&s.identity.PublicKey, wrappedMessage)
+	messageID := messagingtypes.MessageID(&s.identity.PublicKey, wrappedMessage)
 	err = setMessageID(messageID, &rawMessage)
 	if err != nil {
 		return nil, err
@@ -469,7 +469,7 @@ func (s *MessageSender) SendPairInstallation(
 
 	s.notifyOnScheduledMessage(recipient, &rawMessage)
 
-	err = s.messaging.SendPrivate(ctx, types.SendPrivateParams{
+	err = s.messaging.SendPrivate(ctx, messagingtypes.SendPrivateParams{
 		Sender:     s.identity,
 		Recipient:  recipient,
 		Payload:    wrappedMessage,

--- a/protocol/communities/manager.go
+++ b/protocol/communities/manager.go
@@ -32,11 +32,11 @@ import (
 	accsmanagement "github.com/status-im/status-go/internal/accounts-management"
 	"github.com/status-im/status-go/internal/accounts-management/generator"
 	"github.com/status-im/status-go/internal/crypto"
-	types3 "github.com/status-im/status-go/internal/crypto/types"
+	cryptotypes "github.com/status-im/status-go/internal/crypto/types"
 	multiaccountscommon "github.com/status-im/status-go/internal/db/multiaccounts/common"
 	"github.com/status-im/status-go/internal/images"
 	"github.com/status-im/status-go/pkg/messaging"
-	types "github.com/status-im/status-go/pkg/messaging/types"
+	messagingtypes "github.com/status-im/status-go/pkg/messaging/types"
 	"github.com/status-im/status-go/protocol/common"
 	community_token "github.com/status-im/status-go/protocol/communities/token"
 	"github.com/status-im/status-go/protocol/ens"
@@ -84,9 +84,9 @@ var (
 )
 
 type MessageSigner interface {
-	Recover(rpcParams personal.RecoverParams) (addr types3.Address, err error)
-	CanRecover(rpcParams personal.RecoverParams, revealedAddress types3.Address) (bool, error)
-	Sign(rpcParams personal.SignParams, verifiedAccount *generator.Account) (result types3.HexBytes, err error)
+	Recover(rpcParams personal.RecoverParams) (addr cryptotypes.Address, err error)
+	CanRecover(rpcParams personal.RecoverParams, revealedAddress cryptotypes.Address) (bool, error)
+	Sign(rpcParams personal.SignParams, verifiedAccount *generator.Account) (result cryptotypes.HexBytes, err error)
 }
 
 type Manager struct {
@@ -133,9 +133,9 @@ func NewCommunityLock(logger *zap.Logger) *CommunityLock {
 	}
 }
 
-func (c *CommunityLock) Lock(communityID types3.HexBytes) {
+func (c *CommunityLock) Lock(communityID cryptotypes.HexBytes) {
 	c.mutex.Lock()
-	communityIDStr := types3.EncodeHex(communityID)
+	communityIDStr := cryptotypes.EncodeHex(communityID)
 	lock, ok := c.locks[communityIDStr]
 	if !ok {
 		lock = &sync.Mutex{}
@@ -146,9 +146,9 @@ func (c *CommunityLock) Lock(communityID types3.HexBytes) {
 	lock.Lock()
 }
 
-func (c *CommunityLock) Unlock(communityID types3.HexBytes) {
+func (c *CommunityLock) Unlock(communityID cryptotypes.HexBytes) {
 	c.mutex.Lock()
-	communityIDStr := types3.EncodeHex(communityID)
+	communityIDStr := cryptotypes.EncodeHex(communityID)
 	lock, ok := c.locks[communityIDStr]
 	c.mutex.Unlock()
 
@@ -415,8 +415,8 @@ type Subscription struct {
 	Community                            *Community
 	CommunityTokensMetadataLoaded        *Community
 	CommunityEventsMessage               *CommunityEventsMessage
-	AcceptedRequestsToJoin               []types3.HexBytes
-	RejectedRequestsToJoin               []types3.HexBytes
+	AcceptedRequestsToJoin               []cryptotypes.HexBytes
+	RejectedRequestsToJoin               []cryptotypes.HexBytes
 	CommunityPrivilegedMemberSyncMessage *CommunityPrivilegedMemberSyncMessage
 	TokenCommunityValidated              *CommunityResponse
 }
@@ -575,7 +575,7 @@ func (m *Manager) runOwnerVerificationLoop() {
 	}()
 }
 
-func (m *Manager) ValidateCommunityByID(communityID types3.HexBytes) (*CommunityResponse, error) {
+func (m *Manager) ValidateCommunityByID(communityID cryptotypes.HexBytes) (*CommunityResponse, error) {
 	communitiesToValidate, err := m.persistence.getCommunityToValidateByID(communityID)
 	if err != nil {
 		m.logger.Error("failed to validate community by ID", zap.String("id", utils.TruncateWithDot(communityID.String())), zap.Error(err))
@@ -600,12 +600,12 @@ func (m *Manager) validateCommunity(communityToValidateData []communityToValidat
 			continue
 		}
 
-		m.logger.Info("validating community", zap.String("id", types3.EncodeHex(community.id)), zap.String("signer", crypto.PubkeyToHex(signer)))
+		m.logger.Info("validating community", zap.String("id", cryptotypes.EncodeHex(community.id)), zap.String("signer", crypto.PubkeyToHex(signer)))
 
 		ctx, cancel := context.WithTimeout(context.Background(), time.Second*3)
 		defer cancel()
 
-		owner, err := m.ownerVerifier.SafeGetSignerPubKey(ctx, chainID, types3.EncodeHex(community.id))
+		owner, err := m.ownerVerifier.SafeGetSignerPubKey(ctx, chainID, cryptotypes.EncodeHex(community.id))
 		if err != nil {
 			m.logger.Error("failed to get owner", zap.Error(err))
 			continue
@@ -629,7 +629,7 @@ func (m *Manager) validateCommunity(communityToValidateData []communityToValidat
 
 		if response != nil {
 
-			m.logger.Info("community validated", zap.String("id", types3.EncodeHex(community.id)), zap.String("signer", crypto.PubkeyToHex(signer)))
+			m.logger.Info("community validated", zap.String("id", cryptotypes.EncodeHex(community.id)), zap.String("signer", crypto.PubkeyToHex(signer)))
 			m.publish(&Subscription{TokenCommunityValidated: response})
 			err := m.persistence.DeleteCommunitiesToValidateByCommunityID(community.id)
 			if err != nil {
@@ -696,12 +696,12 @@ func (m *Manager) GetStoredDescriptionForCommunities(communityIDs []string) (*Kn
 
 	for i := range communityIDs {
 		communityID := communityIDs[i]
-		communityIDBytes, err := types3.DecodeHex(communityID)
+		communityIDBytes, err := cryptotypes.DecodeHex(communityID)
 		if err != nil {
 			return nil, err
 		}
 
-		community, err := m.GetByID(types3.HexBytes(communityIDBytes))
+		community, err := m.GetByID(cryptotypes.HexBytes(communityIDBytes))
 		if err != nil && err != ErrOrgNotFound {
 			return nil, err
 		}
@@ -730,7 +730,7 @@ func (m *Manager) JoinedOrSpectated() ([]*Community, error) {
 	return m.persistence.JoinedOrSpectatedCommunities(&m.identity.PublicKey)
 }
 
-func (m *Manager) CommunityUpdateLastOpenedAt(communityID types3.HexBytes, timestamp int64) (*Community, error) {
+func (m *Manager) CommunityUpdateLastOpenedAt(communityID cryptotypes.HexBytes, timestamp int64) (*Community, error) {
 	m.communityLock.Lock(communityID)
 	defer m.communityLock.Unlock(communityID)
 
@@ -795,7 +795,7 @@ func (m *Manager) CreateCommunity(request *requests.CreateCommunity, publish boo
 		return nil, err
 	}
 
-	description.ID = types3.EncodeHex(crypto.CompressPubkey(&key.PublicKey))
+	description.ID = cryptotypes.EncodeHex(crypto.CompressPubkey(&key.PublicKey))
 
 	config := Config{
 		ID:                   &key.PublicKey,
@@ -988,7 +988,7 @@ func (m *Manager) fetchCollectiblesOwners(collectibles map[walletcommon.ChainID]
 }
 
 // use it only for testing purposes
-func (m *Manager) ReevaluateMembers(communityID types3.HexBytes) (*Community, map[protobuf.CommunityMember_Roles][]*ecdsa.PublicKey, error) {
+func (m *Manager) ReevaluateMembers(communityID cryptotypes.HexBytes) (*Community, map[protobuf.CommunityMember_Roles][]*ecdsa.PublicKey, error) {
 	return m.reevaluateMembers(communityID)
 }
 
@@ -1000,7 +1000,7 @@ func (m *Manager) ReevaluateMembers(communityID types3.HexBytes) (*Community, ma
 // and do not affect the result of this function.
 // If permissions are changed in the meantime,
 // they will be accommodated with the next reevaluation.
-func (m *Manager) reevaluateMembers(communityID types3.HexBytes) (*Community, map[protobuf.CommunityMember_Roles][]*ecdsa.PublicKey, error) {
+func (m *Manager) reevaluateMembers(communityID cryptotypes.HexBytes) (*Community, map[protobuf.CommunityMember_Roles][]*ecdsa.PublicKey, error) {
 	community, err := m.GetByID(communityID)
 	if err != nil {
 		return nil, nil, err
@@ -1118,7 +1118,7 @@ func (m *Manager) reevaluateMembers(communityID types3.HexBytes) (*Community, ma
 }
 
 // Apply results on the most up-to-date community.
-func (m *Manager) applyReevaluateMembersResult(communityID types3.HexBytes, result *reevaluateMembersResult) (*Community, error) {
+func (m *Manager) applyReevaluateMembersResult(communityID cryptotypes.HexBytes, result *reevaluateMembersResult) (*Community, error) {
 	m.communityLock.Lock(communityID)
 	defer m.communityLock.Unlock(communityID)
 
@@ -1288,7 +1288,7 @@ func (m *Manager) checkChannelsPermissions(channelsPermissionsPreParsedData map[
 	return m.checkChannelsPermissionsImpl(channelsPermissionsPreParsedData, accountsAndChainIDs, shortcircuit, nil)
 }
 
-func (m *Manager) StartMembersReevaluationLoop(communityID types3.HexBytes, reevaluateOnStart bool) {
+func (m *Manager) StartMembersReevaluationLoop(communityID cryptotypes.HexBytes, reevaluateOnStart bool) {
 	m.quitWg.Add(1)
 	go func() {
 		defer utils.LogOnPanic()
@@ -1297,7 +1297,7 @@ func (m *Manager) StartMembersReevaluationLoop(communityID types3.HexBytes, reev
 	}()
 }
 
-func (m *Manager) reevaluateMembersLoop(communityID types3.HexBytes, reevaluateOnStart bool) {
+func (m *Manager) reevaluateMembersLoop(communityID cryptotypes.HexBytes, reevaluateOnStart bool) {
 	if _, exists := m.membersReevaluationTasks.Load(communityID.String()); exists {
 		return
 	}
@@ -1412,18 +1412,18 @@ func (m *Manager) ForceMembersReevaluationAllowed() bool {
 	return m.forceMembersReevaluation != nil
 }
 
-func (m *Manager) ForceMembersReevaluation(communityID types3.HexBytes) error {
+func (m *Manager) ForceMembersReevaluation(communityID cryptotypes.HexBytes) error {
 	if m.forceMembersReevaluation == nil {
 		return errors.New("forcing members reevaluation is not allowed")
 	}
 	return m.scheduleMembersReevaluation(communityID, true)
 }
 
-func (m *Manager) ScheduleMembersReevaluation(communityID types3.HexBytes) error {
+func (m *Manager) ScheduleMembersReevaluation(communityID cryptotypes.HexBytes) error {
 	return m.scheduleMembersReevaluation(communityID, false)
 }
 
-func (m *Manager) scheduleMembersReevaluation(communityID types3.HexBytes, forceImmediateReevaluation bool) error {
+func (m *Manager) scheduleMembersReevaluation(communityID cryptotypes.HexBytes, forceImmediateReevaluation bool) error {
 	t, exists := m.membersReevaluationTasks.Load(communityID.String())
 	if !exists {
 		// No reevaluation task yet. We start the loop which will create it
@@ -1468,15 +1468,15 @@ func (m *Manager) DeleteCommunityTokenPermission(request *requests.DeleteCommuni
 	return community, changes, nil
 }
 
-func (m *Manager) reevaluateCommunityMembersPermissions(communityID types3.HexBytes) error {
+func (m *Manager) reevaluateCommunityMembersPermissions(communityID cryptotypes.HexBytes) error {
 	// Publish when the reevluation started since it can take a while
-	signal.SendCommunityMemberReevaluationStarted(types3.EncodeHex(communityID))
+	signal.SendCommunityMemberReevaluationStarted(cryptotypes.EncodeHex(communityID))
 
 	community, newPrivilegedMembers, err := m.reevaluateMembers(communityID)
 
 	// Publish the reevaluation ending, even if it errored
 	// A possible improvement would be to pass the error here
-	signal.SendCommunityMemberReevaluationEnded(types3.EncodeHex(communityID))
+	signal.SendCommunityMemberReevaluationEnded(cryptotypes.EncodeHex(communityID))
 
 	if err != nil {
 		return err
@@ -1485,7 +1485,7 @@ func (m *Manager) reevaluateCommunityMembersPermissions(communityID types3.HexBy
 	return m.ShareRequestsToJoinWithPrivilegedMembers(community, newPrivilegedMembers)
 }
 
-func (m *Manager) DeleteCommunity(id types3.HexBytes) error {
+func (m *Manager) DeleteCommunity(id cryptotypes.HexBytes) error {
 	m.communityLock.Lock(id)
 	defer m.communityLock.Unlock(id)
 
@@ -1575,7 +1575,7 @@ func (m *Manager) EditCommunity(request *requests.EditCommunity) (*Community, er
 	return community, nil
 }
 
-func (m *Manager) RemovePrivateKey(id types3.HexBytes) (*Community, error) {
+func (m *Manager) RemovePrivateKey(id cryptotypes.HexBytes) (*Community, error) {
 	m.communityLock.Lock(id)
 	defer m.communityLock.Unlock(id)
 
@@ -1596,7 +1596,7 @@ func (m *Manager) RemovePrivateKey(id types3.HexBytes) (*Community, error) {
 	return community, nil
 }
 
-func (m *Manager) ExportCommunity(id types3.HexBytes) (*ecdsa.PrivateKey, error) {
+func (m *Manager) ExportCommunity(id cryptotypes.HexBytes) (*ecdsa.PrivateKey, error) {
 	community, err := m.GetByID(id)
 	if err != nil {
 		return nil, err
@@ -1637,7 +1637,7 @@ func (m *Manager) ImportCommunity(key *ecdsa.PrivateKey, clock uint64) (*Communi
 		}
 
 		description.Clock = 1
-		description.ID = types3.EncodeHex(communityID)
+		description.ID = cryptotypes.EncodeHex(communityID)
 
 		config := Config{
 			ID:                   &key.PublicKey,
@@ -1694,7 +1694,7 @@ func (m *Manager) ImportCommunity(key *ecdsa.PrivateKey, clock uint64) (*Communi
 	return community, nil
 }
 
-func (m *Manager) CreateChat(communityID types3.HexBytes, chat *protobuf.CommunityChat, publish bool, thirdPartyID string) (*CommunityChanges, error) {
+func (m *Manager) CreateChat(communityID cryptotypes.HexBytes, chat *protobuf.CommunityChat, publish bool, thirdPartyID string) (*CommunityChanges, error) {
 	m.communityLock.Lock(communityID)
 	defer m.communityLock.Unlock(communityID)
 
@@ -1720,7 +1720,7 @@ func (m *Manager) CreateChat(communityID types3.HexBytes, chat *protobuf.Communi
 	return changes, nil
 }
 
-func (m *Manager) EditChat(communityID types3.HexBytes, chatID string, chat *protobuf.CommunityChat) (*Community, *CommunityChanges, error) {
+func (m *Manager) EditChat(communityID cryptotypes.HexBytes, chatID string, chat *protobuf.CommunityChat) (*Community, *CommunityChanges, error) {
 	m.communityLock.Lock(communityID)
 	defer m.communityLock.Unlock(communityID)
 
@@ -1756,7 +1756,7 @@ func (m *Manager) EditChat(communityID types3.HexBytes, chatID string, chat *pro
 	return community, changes, nil
 }
 
-func (m *Manager) DeleteChat(communityID types3.HexBytes, chatID string) (*Community, *CommunityChanges, error) {
+func (m *Manager) DeleteChat(communityID cryptotypes.HexBytes, chatID string) (*Community, *CommunityChanges, error) {
 	m.communityLock.Lock(communityID)
 	defer m.communityLock.Unlock(communityID)
 
@@ -1881,7 +1881,7 @@ func (m *Manager) EditCategory(request *requests.EditCommunityCategory) (*Commun
 	return community, changes, nil
 }
 
-func (m *Manager) EditChatFirstMessageTimestamp(communityID types3.HexBytes, chatID string, timestamp uint32) (*Community, *CommunityChanges, error) {
+func (m *Manager) EditChatFirstMessageTimestamp(communityID cryptotypes.HexBytes, chatID string, timestamp uint32) (*Community, *CommunityChanges, error) {
 	m.communityLock.Lock(communityID)
 	defer m.communityLock.Unlock(communityID)
 
@@ -1988,7 +1988,7 @@ func (m *Manager) DeleteCategory(request *requests.DeleteCommunityCategory) (*Co
 	return changes.Community, changes, nil
 }
 
-func (m *Manager) GenerateRequestsToJoinForAutoApprovalOnNewOwnership(communityID types3.HexBytes, kickedMembers map[string]*protobuf.CommunityMember) ([]*RequestToJoin, error) {
+func (m *Manager) GenerateRequestsToJoinForAutoApprovalOnNewOwnership(communityID cryptotypes.HexBytes, kickedMembers map[string]*protobuf.CommunityMember) ([]*RequestToJoin, error) {
 	var requestsToJoin []*RequestToJoin
 	clock := uint64(time.Now().Unix())
 	for pubKeyStr := range kickedMembers {
@@ -2039,7 +2039,7 @@ func (m *Manager) HandleCommunityDescriptionMessage(signer *ecdsa.PublicKey, des
 	var id []byte
 	var err error
 	if len(description.ID) != 0 {
-		id, err = types3.DecodeHex(description.ID)
+		id, err = cryptotypes.DecodeHex(description.ID)
 		if err != nil {
 			return nil, err
 		}
@@ -2137,14 +2137,14 @@ func (m *Manager) HandleCommunityDescriptionMessage(signer *ecdsa.PublicKey, des
 	return r, nil
 }
 
-func (m *Manager) NewHashRatchetKeys(keys []*types.HashRatchetInfo) error {
+func (m *Manager) NewHashRatchetKeys(keys []*messagingtypes.HashRatchetInfo) error {
 	return m.persistence.InvalidateDecryptedCommunityCacheForKeys(keys)
 }
 
 // NOTE: encrypted_community_description_cache is not a cache for the community description
 // The purpose of this cache is tightly coupled with the hash ratchet,
 // meaning the cache is invalidated whenever we receive a key that was previously missing for that community
-func (m *Manager) preprocessDescription(id types3.HexBytes, description *protobuf.CommunityDescription) ([]*CommunityPrivateDataFailedToDecrypt, *protobuf.CommunityDescription, error) {
+func (m *Manager) preprocessDescription(id cryptotypes.HexBytes, description *protobuf.CommunityDescription) ([]*CommunityPrivateDataFailedToDecrypt, *protobuf.CommunityDescription, error) {
 	decryptedCommunity, err := m.persistence.GetDecryptedCommunityDescription(id, description.Clock)
 	if err != nil {
 		return nil, nil, err
@@ -2424,7 +2424,7 @@ func (m *Manager) handleAdditionalAdminChanges(community *Community) (*Community
 	return &communityResponse, nil
 }
 
-func (m *Manager) saveOrUpdateRequestToJoin(communityID types3.HexBytes, requestToJoin *RequestToJoin) (bool, error) {
+func (m *Manager) saveOrUpdateRequestToJoin(communityID cryptotypes.HexBytes, requestToJoin *RequestToJoin) (bool, error) {
 	updated := false
 
 	existingRequestToJoin, err := m.persistence.GetRequestToJoin(requestToJoin.ID)
@@ -2457,7 +2457,7 @@ func (m *Manager) saveOrUpdateRequestToJoin(communityID types3.HexBytes, request
 }
 
 func (m *Manager) handleCommunityEventRequestAccepted(community *Community, communityEvent *CommunityEvent) ([]*RequestToJoin, error) {
-	acceptedRequestsToJoin := make([]types3.HexBytes, 0)
+	acceptedRequestsToJoin := make([]cryptotypes.HexBytes, 0)
 
 	requestsToJoin := make([]*RequestToJoin, 0)
 
@@ -2508,7 +2508,7 @@ func (m *Manager) handleCommunityEventRequestAccepted(community *Community, comm
 }
 
 func (m *Manager) handleCommunityEventRequestRejected(community *Community, communityEvent *CommunityEvent) ([]*RequestToJoin, error) {
-	rejectedRequestsToJoin := make([]types3.HexBytes, 0)
+	rejectedRequestsToJoin := make([]cryptotypes.HexBytes, 0)
 
 	requestsToJoin := make([]*RequestToJoin, 0)
 
@@ -2598,11 +2598,11 @@ func (m *Manager) DeletePendingRequestToJoin(request *RequestToJoin) error {
 	return nil
 }
 
-func (m *Manager) UpdateClockInRequestToJoin(id types3.HexBytes, clock uint64) error {
+func (m *Manager) UpdateClockInRequestToJoin(id cryptotypes.HexBytes, clock uint64) error {
 	return m.persistence.UpdateClockInRequestToJoin(id, clock)
 }
 
-func (m *Manager) SetMuted(id types3.HexBytes, muted bool) error {
+func (m *Manager) SetMuted(id cryptotypes.HexBytes, muted bool) error {
 	m.communityLock.Lock(id)
 	defer m.communityLock.Unlock(id)
 
@@ -2827,7 +2827,7 @@ func (m *Manager) AcceptRequestToJoin(dbRequest *RequestToJoin) (*Community, err
 	return community, nil
 }
 
-func (m *Manager) GetRequestToJoin(ID types3.HexBytes) (*RequestToJoin, error) {
+func (m *Manager) GetRequestToJoin(ID cryptotypes.HexBytes) (*RequestToJoin, error) {
 	return m.persistence.GetRequestToJoin(ID)
 }
 
@@ -2865,7 +2865,7 @@ func (m *Manager) DeclineRequestToJoin(dbRequest *RequestToJoin) (*Community, er
 }
 
 func (m *Manager) shouldUserRetainDeclined(signer *ecdsa.PublicKey, community *Community, requestClock uint64) (bool, error) {
-	requestID := CalculateRequestID(crypto.PubkeyToHex(signer), types3.HexBytes(community.IDString()))
+	requestID := CalculateRequestID(crypto.PubkeyToHex(signer), cryptotypes.HexBytes(community.IDString()))
 	request, err := m.persistence.GetRequestToJoin(requestID)
 	if err != nil {
 		if err == sql.ErrNoRows {
@@ -2999,11 +2999,11 @@ func (m *Manager) HandleCommunityRequestToJoin(signer *ecdsa.PublicKey, receiver
 		// verify if revealed addresses indeed belong to requester
 		for _, revealedAccount := range request.RevealedAccounts {
 			recoverParams := personal.RecoverParams{
-				Message:   types3.EncodeHex(crypto.Keccak256(crypto.CompressPubkey(signer), community.ID(), requestToJoin.ID)),
-				Signature: types3.EncodeHex(revealedAccount.Signature),
+				Message:   cryptotypes.EncodeHex(crypto.Keccak256(crypto.CompressPubkey(signer), community.ID(), requestToJoin.ID)),
+				Signature: cryptotypes.EncodeHex(revealedAccount.Signature),
 			}
 
-			matching, err := m.signer.CanRecover(recoverParams, types3.HexToAddress(revealedAccount.Address))
+			matching, err := m.signer.CanRecover(recoverParams, cryptotypes.HexToAddress(revealedAccount.Address))
 			if err != nil {
 				return nil, nil, err
 			}
@@ -3086,11 +3086,11 @@ func (m *Manager) HandleCommunityEditSharedAddresses(signer *ecdsa.PublicKey, re
 	// verify if revealed addresses indeed belong to requester
 	for _, revealedAccount := range request.RevealedAccounts {
 		recoverParams := personal.RecoverParams{
-			Message:   types3.EncodeHex(crypto.Keccak256(crypto.CompressPubkey(signer), community.ID())),
-			Signature: types3.EncodeHex(revealedAccount.Signature),
+			Message:   cryptotypes.EncodeHex(crypto.Keccak256(crypto.CompressPubkey(signer), community.ID())),
+			Signature: cryptotypes.EncodeHex(revealedAccount.Signature),
 		}
 
-		matching, err := m.signer.CanRecover(recoverParams, types3.HexToAddress(revealedAccount.Address))
+		matching, err := m.signer.CanRecover(recoverParams, cryptotypes.HexToAddress(revealedAccount.Address))
 		if err != nil {
 			return err
 		}
@@ -3131,7 +3131,7 @@ func (m *Manager) HandleCommunityEditSharedAddresses(signer *ecdsa.PublicKey, re
 	return nil
 }
 
-func (m *Manager) handleCommunityEditSharedAddresses(publicKey string, communityID types3.HexBytes, revealedAccounts []*protobuf.RevealedAccount, clock uint64) error {
+func (m *Manager) handleCommunityEditSharedAddresses(publicKey string, communityID cryptotypes.HexBytes, revealedAccounts []*protobuf.RevealedAccount, clock uint64) error {
 	requestToJoinID := CalculateRequestID(publicKey, communityID)
 	err := m.UpdateClockInRequestToJoin(requestToJoinID, clock)
 	if err != nil {
@@ -3209,7 +3209,7 @@ func (m *Manager) GetOwnedERC721Tokens(walletAddresses []gethcommon.Address, tok
 	return ownedERC721Tokens, nil
 }
 
-func (m *Manager) CheckChannelPermissions(communityID types3.HexBytes, chatID string, addresses []gethcommon.Address) (*CheckChannelPermissionsResponse, error) {
+func (m *Manager) CheckChannelPermissions(communityID cryptotypes.HexBytes, chatID string, addresses []gethcommon.Address) (*CheckChannelPermissionsResponse, error) {
 	m.communityLock.Lock(communityID)
 	defer m.communityLock.Unlock(communityID)
 
@@ -3328,7 +3328,7 @@ func computeCheckChannelPermissionsResponse(hasViewOnlyPermissions bool, hasView
 	return response
 }
 
-func (m *Manager) CheckAllChannelsPermissions(communityID types3.HexBytes, addresses []gethcommon.Address) (*CheckAllChannelsPermissionsResponse, error) {
+func (m *Manager) CheckAllChannelsPermissions(communityID cryptotypes.HexBytes, addresses []gethcommon.Address) (*CheckAllChannelsPermissionsResponse, error) {
 
 	community, err := m.GetByID(communityID)
 	if err != nil {
@@ -3397,7 +3397,7 @@ func (m *Manager) CheckAllChannelsPermissions(communityID types3.HexBytes, addre
 	return response, nil
 }
 
-func (m *Manager) GetCheckChannelPermissionResponses(communityID types3.HexBytes) (*CheckAllChannelsPermissionsResponse, error) {
+func (m *Manager) GetCheckChannelPermissionResponses(communityID cryptotypes.HexBytes) (*CheckAllChannelsPermissionsResponse, error) {
 
 	response, err := m.persistence.GetCheckChannelPermissionResponses(communityID.String())
 	if err != nil {
@@ -3497,7 +3497,7 @@ func UnwrapCommunityDescriptionMessage(payload []byte) (*ecdsa.PublicKey, *proto
 	return signer, description, nil
 }
 
-func (m *Manager) JoinCommunity(id types3.HexBytes, forceJoin bool) (*Community, error) {
+func (m *Manager) JoinCommunity(id cryptotypes.HexBytes, forceJoin bool) (*Community, error) {
 	m.communityLock.Lock(id)
 	defer m.communityLock.Unlock(id)
 
@@ -3517,7 +3517,7 @@ func (m *Manager) JoinCommunity(id types3.HexBytes, forceJoin bool) (*Community,
 	return community, nil
 }
 
-func (m *Manager) SpectateCommunity(id types3.HexBytes) (*Community, error) {
+func (m *Manager) SpectateCommunity(id cryptotypes.HexBytes) (*Community, error) {
 	m.communityLock.Lock(id)
 	defer m.communityLock.Unlock(id)
 
@@ -3536,12 +3536,12 @@ func (m *Manager) SpectateCommunity(id types3.HexBytes) (*Community, error) {
 	return community, nil
 }
 
-func (m *Manager) GetArchiveLinkMessageClock(communityID types3.HexBytes) (uint64, error) {
+func (m *Manager) GetArchiveLinkMessageClock(communityID cryptotypes.HexBytes) (uint64, error) {
 	return m.persistence.GetArchiveLinkMessageClock(communityID)
 }
 
 func (m *Manager) GetCommunityRequestToJoinClock(pk *ecdsa.PublicKey, communityID string) (uint64, error) {
-	communityIDBytes, err := types3.DecodeHex(communityID)
+	communityIDBytes, err := cryptotypes.DecodeHex(communityID)
 	if err != nil {
 		return 0, err
 	}
@@ -3561,7 +3561,7 @@ func (m *Manager) GetRequestToJoinByPkAndCommunityID(pk *ecdsa.PublicKey, commun
 	return m.persistence.GetRequestToJoinByPkAndCommunityID(crypto.PubkeyToHex(pk), communityID)
 }
 
-func (m *Manager) UpdateCommunityDescriptionArchiveLinkMessageClock(communityID types3.HexBytes, clock uint64) error {
+func (m *Manager) UpdateCommunityDescriptionArchiveLinkMessageClock(communityID cryptotypes.HexBytes, clock uint64) error {
 	m.communityLock.Lock(communityID)
 	defer m.communityLock.Unlock(communityID)
 
@@ -3573,19 +3573,19 @@ func (m *Manager) UpdateCommunityDescriptionArchiveLinkMessageClock(communityID 
 	return m.SaveCommunity(community)
 }
 
-func (m *Manager) UpdateArchiveLinkMessageClock(communityID types3.HexBytes, clock uint64) error {
+func (m *Manager) UpdateArchiveLinkMessageClock(communityID cryptotypes.HexBytes, clock uint64) error {
 	return m.persistence.UpdateArchiveLinkMessageClock(communityID, clock)
 }
 
-func (m *Manager) UpdateLastSeenArchiveLink(communityID types3.HexBytes, archiveLink string) error {
+func (m *Manager) UpdateLastSeenArchiveLink(communityID cryptotypes.HexBytes, archiveLink string) error {
 	return m.persistence.UpdateLastSeenArchiveLink(communityID, archiveLink)
 }
 
-func (m *Manager) GetLastSeenArchiveLink(communityID types3.HexBytes) (string, error) {
+func (m *Manager) GetLastSeenArchiveLink(communityID cryptotypes.HexBytes) (string, error) {
 	return m.persistence.GetLastSeenArchiveLink(communityID)
 }
 
-func (m *Manager) LeaveCommunity(id types3.HexBytes) (*Community, error) {
+func (m *Manager) LeaveCommunity(id cryptotypes.HexBytes) (*Community, error) {
 	m.communityLock.Lock(id)
 	defer m.communityLock.Unlock(id)
 
@@ -3610,7 +3610,7 @@ func (m *Manager) LeaveCommunity(id types3.HexBytes) (*Community, error) {
 }
 
 // Same as LeaveCommunity, but we have an option to stay spectating
-func (m *Manager) KickedOutOfCommunity(id types3.HexBytes, spectateMode bool) (*Community, error) {
+func (m *Manager) KickedOutOfCommunity(id cryptotypes.HexBytes, spectateMode bool) (*Community, error) {
 	m.communityLock.Lock(id)
 	defer m.communityLock.Unlock(id)
 
@@ -3632,7 +3632,7 @@ func (m *Manager) KickedOutOfCommunity(id types3.HexBytes, spectateMode bool) (*
 	return community, nil
 }
 
-func (m *Manager) AddMemberOwnerToCommunity(communityID types3.HexBytes, pk *ecdsa.PublicKey) (*Community, error) {
+func (m *Manager) AddMemberOwnerToCommunity(communityID cryptotypes.HexBytes, pk *ecdsa.PublicKey) (*Community, error) {
 	m.communityLock.Lock(communityID)
 	defer m.communityLock.Unlock(communityID)
 
@@ -3655,7 +3655,7 @@ func (m *Manager) AddMemberOwnerToCommunity(communityID types3.HexBytes, pk *ecd
 	return community, nil
 }
 
-func (m *Manager) RemoveUserFromCommunity(id types3.HexBytes, pk *ecdsa.PublicKey) (*Community, error) {
+func (m *Manager) RemoveUserFromCommunity(id cryptotypes.HexBytes, pk *ecdsa.PublicKey) (*Community, error) {
 	m.communityLock.Lock(id)
 	defer m.communityLock.Unlock(id)
 
@@ -3853,11 +3853,11 @@ func (m *Manager) GetByID(id []byte) (*Community, error) {
 }
 
 func (m *Manager) GetByIDReadonly(id []byte) (ReadonlyCommunity, error) {
-	return m.GetByIDStringReadonly(types3.EncodeHex(id))
+	return m.GetByIDStringReadonly(cryptotypes.EncodeHex(id))
 }
 
 func (m *Manager) GetByIDString(idString string) (*Community, error) {
-	id, err := types3.DecodeHex(idString)
+	id, err := cryptotypes.DecodeHex(idString)
 	if err != nil {
 		return nil, err
 	}
@@ -3879,11 +3879,11 @@ func (m *Manager) GetByIDStringReadonly(idString string) (ReadonlyCommunity, err
 	return ReadonlyCommunity(community), err
 }
 
-func (m *Manager) SaveRequestToJoinRevealedAddresses(requestID types3.HexBytes, revealedAccounts []*protobuf.RevealedAccount) error {
+func (m *Manager) SaveRequestToJoinRevealedAddresses(requestID cryptotypes.HexBytes, revealedAccounts []*protobuf.RevealedAccount) error {
 	return m.persistence.SaveRequestToJoinRevealedAddresses(requestID, revealedAccounts)
 }
 
-func (m *Manager) RemoveRequestToJoinRevealedAddresses(requestID types3.HexBytes) error {
+func (m *Manager) RemoveRequestToJoinRevealedAddresses(requestID cryptotypes.HexBytes) error {
 	return m.persistence.RemoveRequestToJoinRevealedAddresses(requestID)
 }
 
@@ -3922,7 +3922,7 @@ func (m *Manager) CreateRequestToJoin(request *requests.RequestToJoinCommunity, 
 	for i := range request.AddressesToReveal {
 		revealedAcc := &protobuf.RevealedAccount{
 			Address:          request.AddressesToReveal[i],
-			IsAirdropAddress: types3.HexToAddress(request.AddressesToReveal[i]) == types3.HexToAddress(request.AirdropAddress),
+			IsAirdropAddress: cryptotypes.HexToAddress(request.AddressesToReveal[i]) == cryptotypes.HexToAddress(request.AirdropAddress),
 		}
 
 		if addSignature {
@@ -3951,31 +3951,31 @@ func (m *Manager) PendingRequestsToJoinForUser(pk *ecdsa.PublicKey) ([]*RequestT
 	return m.persistence.RequestsToJoinForUserByState(crypto.PubkeyToHex(pk), RequestToJoinStatePending)
 }
 
-func (m *Manager) PendingRequestsToJoinForCommunity(id types3.HexBytes) ([]*RequestToJoin, error) {
+func (m *Manager) PendingRequestsToJoinForCommunity(id cryptotypes.HexBytes) ([]*RequestToJoin, error) {
 	m.logger.Info("fetching pending invitations", zap.String("community-id", id.String()))
 	return m.persistence.PendingRequestsToJoinForCommunity(id)
 }
 
-func (m *Manager) DeclinedRequestsToJoinForCommunity(id types3.HexBytes) ([]*RequestToJoin, error) {
+func (m *Manager) DeclinedRequestsToJoinForCommunity(id cryptotypes.HexBytes) ([]*RequestToJoin, error) {
 	m.logger.Info("fetching declined invitations", zap.String("community-id", id.String()))
 	return m.persistence.DeclinedRequestsToJoinForCommunity(id)
 }
 
-func (m *Manager) CanceledRequestsToJoinForCommunity(id types3.HexBytes) ([]*RequestToJoin, error) {
+func (m *Manager) CanceledRequestsToJoinForCommunity(id cryptotypes.HexBytes) ([]*RequestToJoin, error) {
 	m.logger.Info("fetching canceled invitations", zap.String("community-id", id.String()))
 	return m.persistence.CanceledRequestsToJoinForCommunity(id)
 }
 
-func (m *Manager) AcceptedRequestsToJoinForCommunity(id types3.HexBytes) ([]*RequestToJoin, error) {
+func (m *Manager) AcceptedRequestsToJoinForCommunity(id cryptotypes.HexBytes) ([]*RequestToJoin, error) {
 	m.logger.Info("fetching canceled invitations", zap.String("community-id", id.String()))
 	return m.persistence.AcceptedRequestsToJoinForCommunity(id)
 }
 
-func (m *Manager) AcceptedPendingRequestsToJoinForCommunity(id types3.HexBytes) ([]*RequestToJoin, error) {
+func (m *Manager) AcceptedPendingRequestsToJoinForCommunity(id cryptotypes.HexBytes) ([]*RequestToJoin, error) {
 	return m.persistence.AcceptedPendingRequestsToJoinForCommunity(id)
 }
 
-func (m *Manager) DeclinedPendingRequestsToJoinForCommunity(id types3.HexBytes) ([]*RequestToJoin, error) {
+func (m *Manager) DeclinedPendingRequestsToJoinForCommunity(id cryptotypes.HexBytes) ([]*RequestToJoin, error) {
 	return m.persistence.DeclinedPendingRequestsToJoinForCommunity(id)
 }
 
@@ -3984,7 +3984,7 @@ func (m *Manager) AllNonApprovedCommunitiesRequestsToJoin() ([]*RequestToJoin, e
 	return m.persistence.AllNonApprovedCommunitiesRequestsToJoin()
 }
 
-func (m *Manager) RequestsToJoinForCommunityAwaitingAddresses(id types3.HexBytes) ([]*RequestToJoin, error) {
+func (m *Manager) RequestsToJoinForCommunityAwaitingAddresses(id cryptotypes.HexBytes) ([]*RequestToJoin, error) {
 	m.logger.Info("fetching ownership changed invitations", zap.String("community-id", id.String()))
 	return m.persistence.RequestsToJoinForCommunityAwaitingAddresses(id)
 }
@@ -4025,7 +4025,7 @@ func (m *Manager) ShouldHandleSyncCommunitySettings(communitySettings *protobuf.
 }
 
 func (m *Manager) HandleSyncCommunitySettings(syncCommunitySettings *protobuf.SyncCommunitySettings) (*CommunitySettings, error) {
-	id, err := types3.DecodeHex(syncCommunitySettings.CommunityId)
+	id, err := cryptotypes.DecodeHex(syncCommunitySettings.CommunityId)
 	if err != nil {
 		return nil, err
 	}
@@ -4068,7 +4068,7 @@ func (m *Manager) GetSyncedRawCommunity(id []byte) (*RawCommunityRow, error) {
 	return m.persistence.getSyncedRawCommunity(id)
 }
 
-func (m *Manager) GetCommunitySettingsByID(id types3.HexBytes) (*CommunitySettings, error) {
+func (m *Manager) GetCommunitySettingsByID(id cryptotypes.HexBytes) (*CommunitySettings, error) {
 	return m.persistence.GetCommunitySettingsByID(id)
 }
 
@@ -4080,7 +4080,7 @@ func (m *Manager) SaveCommunitySettings(settings CommunitySettings) error {
 	return m.persistence.SaveCommunitySettings(settings)
 }
 
-func (m *Manager) CommunitySettingsExist(id types3.HexBytes) (bool, error) {
+func (m *Manager) CommunitySettingsExist(id cryptotypes.HexBytes) (bool, error) {
 	return m.persistence.CommunitySettingsExist(id)
 }
 
@@ -4117,7 +4117,7 @@ func (m *Manager) EnsureCommunitySettings(org *Community) error {
 	return nil
 }
 
-func (m *Manager) DeleteCommunitySettings(id types3.HexBytes) error {
+func (m *Manager) DeleteCommunitySettings(id cryptotypes.HexBytes) error {
 	return m.persistence.DeleteCommunitySettings(id)
 }
 
@@ -4156,15 +4156,15 @@ func (m *Manager) GetOwnedCommunitiesUniversalChatIDs() (map[string]bool, error)
 	return chatIDs, nil
 }
 
-func (m *Manager) StoreWakuMessage(message *types.ReceivedMessage) error {
+func (m *Manager) StoreWakuMessage(message *messagingtypes.ReceivedMessage) error {
 	return m.persistence.SaveWakuMessage(message)
 }
 
-func (m *Manager) StoreWakuMessages(messages []*types.ReceivedMessage) error {
+func (m *Manager) StoreWakuMessages(messages []*messagingtypes.ReceivedMessage) error {
 	return m.persistence.SaveWakuMessages(messages)
 }
 
-func (m *Manager) GetLatestWakuMessageTimestamp(topics []types.ContentTopic) (uint64, error) {
+func (m *Manager) GetLatestWakuMessageTimestamp(topics []messagingtypes.ContentTopic) (uint64, error) {
 	return m.persistence.GetLatestWakuMessageTimestamp(topics)
 }
 
@@ -4243,7 +4243,7 @@ func (m *Manager) AddCommunityToken(token *community_token.CommunityToken, clock
 		return nil, errors.New("Token is absent in database")
 	}
 
-	communityID, err := types3.DecodeHex(token.CommunityID)
+	communityID, err := cryptotypes.DecodeHex(token.CommunityID)
 	if err != nil {
 		return nil, err
 	}
@@ -4335,7 +4335,7 @@ func (m *Manager) RemoveCommunityToken(chainID int, contractAddress string) erro
 }
 
 func (m *Manager) SetCommunityActiveMembersCount(communityID string, activeMembersCount uint64) error {
-	id, err := types3.DecodeHex(communityID)
+	id, err := cryptotypes.DecodeHex(communityID)
 	if err != nil {
 		return err
 	}
@@ -4430,7 +4430,7 @@ func (m *Manager) saveAndPublish(community *Community) error {
 	return nil
 }
 
-func (m *Manager) GetRevealedAddresses(communityID types3.HexBytes, memberPk string) ([]*protobuf.RevealedAccount, error) {
+func (m *Manager) GetRevealedAddresses(communityID cryptotypes.HexBytes, memberPk string) ([]*protobuf.RevealedAccount, error) {
 	logger := m.logger.Named("GetRevealedAddresses")
 
 	requestID := CalculateRequestID(memberPk, communityID)
@@ -4941,7 +4941,7 @@ func (m *Manager) shareAcceptedRequestToJoinWithPrivilegedMembers(community *Com
 	return nil
 }
 
-func (m *Manager) GetCommunityRequestsToJoinWithRevealedAddresses(communityID types3.HexBytes) ([]*RequestToJoin, error) {
+func (m *Manager) GetCommunityRequestsToJoinWithRevealedAddresses(communityID cryptotypes.HexBytes) ([]*RequestToJoin, error) {
 	return m.persistence.GetCommunityRequestsToJoinWithRevealedAddresses(communityID)
 }
 
@@ -4965,15 +4965,15 @@ func (m *Manager) CreateCommunityTokenDeploymentSignature(ctx context.Context, c
 	return crypto.Sign(digest, community.PrivateKey())
 }
 
-func (m *Manager) GetSyncControlNode(id types3.HexBytes) (*protobuf.SyncCommunityControlNode, error) {
+func (m *Manager) GetSyncControlNode(id cryptotypes.HexBytes) (*protobuf.SyncCommunityControlNode, error) {
 	return m.persistence.GetSyncControlNode(id)
 }
 
-func (m *Manager) SaveSyncControlNode(id types3.HexBytes, syncControlNode *protobuf.SyncCommunityControlNode) error {
+func (m *Manager) SaveSyncControlNode(id cryptotypes.HexBytes, syncControlNode *protobuf.SyncCommunityControlNode) error {
 	return m.persistence.SaveSyncControlNode(id, syncControlNode.Clock, syncControlNode.InstallationId)
 }
 
-func (m *Manager) SetSyncControlNode(id types3.HexBytes, syncControlNode *protobuf.SyncCommunityControlNode) error {
+func (m *Manager) SetSyncControlNode(id cryptotypes.HexBytes, syncControlNode *protobuf.SyncCommunityControlNode) error {
 	existingSyncControlNode, err := m.GetSyncControlNode(id)
 	if err != nil {
 		return err
@@ -4986,7 +4986,7 @@ func (m *Manager) SetSyncControlNode(id types3.HexBytes, syncControlNode *protob
 	return nil
 }
 
-func (m *Manager) GetCommunityRequestToJoinWithRevealedAddresses(pubKey string, communityID types3.HexBytes) (*RequestToJoin, error) {
+func (m *Manager) GetCommunityRequestToJoinWithRevealedAddresses(pubKey string, communityID cryptotypes.HexBytes) (*RequestToJoin, error) {
 	return m.persistence.GetCommunityRequestToJoinWithRevealedAddresses(pubKey, communityID)
 }
 
@@ -5018,8 +5018,8 @@ func (m *Manager) encryptCommunityDescriptionImpl(groupID []byte, d *protobuf.Co
 
 	m.logger.Debug("encrypting community description",
 		zap.Any("communityID", d.ID),
-		zap.String("groupID", types3.EncodeHex(groupID)),
-		zap.String("keyID", types3.EncodeHex(keyID)))
+		zap.String("groupID", cryptotypes.EncodeHex(groupID)),
+		zap.String("keyID", cryptotypes.EncodeHex(keyID)))
 
 	keyIDSeqNo := fmt.Sprintf("%s%d", hex.EncodeToString(keyID), newSeqNo)
 
@@ -5063,7 +5063,7 @@ func (m *Manager) decryptCommunityDescription(keyIDSeqNo string, d []byte) (*Dec
 	}
 
 	decryptedPayload, err := m.messaging.DecryptWithHashRatchet(keyID, uint32(seqNo), d)
-	if err == types.ErrNoRatchetKey {
+	if err == messagingtypes.ErrNoRatchetKey {
 		return &DecryptCommunityResponse{
 			KeyID: keyID,
 		}, err
@@ -5223,11 +5223,11 @@ func (m *Manager) DetermineChannelsForHRKeysRequest() ([]*CommunityWithChannelID
 	return result, nil
 }
 
-func (m *Manager) updateEncryptionKeysRequests(communityID types3.HexBytes, channelIDs []string, now int64) error {
+func (m *Manager) updateEncryptionKeysRequests(communityID cryptotypes.HexBytes, channelIDs []string, now int64) error {
 	return m.persistence.UpdateAndPruneEncryptionKeyRequests(communityID, channelIDs, now)
 }
 
-func (m *Manager) UpdateEncryptionKeysRequests(communityID types3.HexBytes, channelIDs []string) error {
+func (m *Manager) UpdateEncryptionKeysRequests(communityID cryptotypes.HexBytes, channelIDs []string) error {
 	return m.updateEncryptionKeysRequests(communityID, channelIDs, time.Now().UnixMilli())
 }
 

--- a/protocol/communities/persistence.go
+++ b/protocol/communities/persistence.go
@@ -14,7 +14,7 @@ import (
 	"github.com/golang/protobuf/proto"
 
 	"github.com/status-im/status-go/internal/crypto"
-	types3 "github.com/status-im/status-go/internal/crypto/types"
+	"github.com/status-im/status-go/internal/crypto/types"
 	types2 "github.com/status-im/status-go/pkg/messaging/types"
 	"github.com/status-im/status-go/protocol/communities/token"
 	"github.com/status-im/status-go/protocol/protobuf"
@@ -183,7 +183,7 @@ func (p *Persistence) SaveCommunity(community *Community) error {
 	return p.saveCommunity(record)
 }
 
-func (p *Persistence) DeleteCommunityEvents(id types3.HexBytes) error {
+func (p *Persistence) DeleteCommunityEvents(id types.HexBytes) error {
 	_, err := p.db.Exec(`DELETE FROM communities_events WHERE id = ?;`, id)
 	return err
 }
@@ -205,7 +205,7 @@ func (p *Persistence) SaveCommunityEvents(community *Community) error {
 	return p.saveCommunityEvents(record)
 }
 
-func (p *Persistence) DeleteCommunity(id types3.HexBytes) error {
+func (p *Persistence) DeleteCommunity(id types.HexBytes) error {
 	_, err := p.db.Exec(`DELETE FROM communities_communities WHERE id = ?;
 						 DELETE FROM communities_events WHERE id = ?;`, id, id)
 	return err
@@ -275,7 +275,7 @@ func (p *Persistence) JoinedCommunities(memberIdentity *ecdsa.PublicKey) ([]*Com
 	return p.queryCommunities(memberIdentity, query)
 }
 
-func (p *Persistence) UpdateLastOpenedAt(communityID types3.HexBytes, timestamp int64) error {
+func (p *Persistence) UpdateLastOpenedAt(communityID types.HexBytes, timestamp int64) error {
 	_, err := p.db.Exec(`UPDATE communities_communities SET last_opened_at = ? WHERE id = ?`, timestamp, communityID)
 	return err
 }
@@ -418,7 +418,7 @@ func (p *Persistence) SaveRequestToJoin(request *RequestToJoin) (err error) {
 	return err
 }
 
-func (p *Persistence) SaveRequestToJoinRevealedAddresses(requestID types3.HexBytes, revealedAccounts []*protobuf.RevealedAccount) (err error) {
+func (p *Persistence) SaveRequestToJoinRevealedAddresses(requestID types.HexBytes, revealedAccounts []*protobuf.RevealedAccount) (err error) {
 	tx, err := p.db.BeginTx(context.Background(), &sql.TxOptions{})
 	if err != nil {
 		return
@@ -843,7 +843,7 @@ func (p *Persistence) GetRequestToJoin(id []byte) (*RequestToJoin, error) {
 	return request, nil
 }
 
-func (p *Persistence) GetNumberOfPendingRequestsToJoin(communityID types3.HexBytes) (int, error) {
+func (p *Persistence) GetNumberOfPendingRequestsToJoin(communityID types.HexBytes) (int, error) {
 	var count int
 	err := p.db.QueryRow(`SELECT count(1) FROM communities_requests_to_join WHERE community_id = ? AND state = ?`, communityID, RequestToJoinStatePending).Scan(&count)
 	if err != nil {
@@ -852,7 +852,7 @@ func (p *Persistence) GetNumberOfPendingRequestsToJoin(communityID types3.HexByt
 	return count, nil
 }
 
-func (p *Persistence) GetRequestToJoinClockByPkAndCommunityID(pk string, communityID types3.HexBytes) (uint64, error) {
+func (p *Persistence) GetRequestToJoinClockByPkAndCommunityID(pk string, communityID types.HexBytes) (uint64, error) {
 	var clock uint64
 
 	err := p.db.QueryRow(`
@@ -918,7 +918,7 @@ func (p *Persistence) SaveWakuMessages(messages []*types2.ReceivedMessage) (err 
 			msg.Topic.String(),
 			msg.Payload,
 			msg.Padding,
-			types3.Bytes2Hex(msg.Hash),
+			types.Bytes2Hex(msg.Hash),
 			msg.ThirdPartyID,
 		)
 		if err != nil {
@@ -935,7 +935,7 @@ func (p *Persistence) SaveWakuMessage(message *types2.ReceivedMessage) error {
 		message.Topic.String(),
 		message.Payload,
 		message.Padding,
-		types3.Bytes2Hex(message.Hash),
+		types.Bytes2Hex(message.Hash),
 		message.ThirdPartyID,
 	)
 	return err
@@ -996,19 +996,19 @@ func (p *Persistence) GetWakuMessagesByFilterTopic(topics []types2.ContentTopic,
 			return nil, err
 		}
 		msg.Topic = types2.StringToContentTopic(topicStr)
-		msg.Hash = types3.Hex2Bytes(hashStr)
+		msg.Hash = types.Hex2Bytes(hashStr)
 		messages = append(messages, msg)
 	}
 
 	return messages, nil
 }
 
-func (p *Persistence) HasCommunityArchiveInfo(communityID types3.HexBytes) (exists bool, err error) {
+func (p *Persistence) HasCommunityArchiveInfo(communityID types.HexBytes) (exists bool, err error) {
 	err = p.db.QueryRow(`SELECT EXISTS(SELECT 1 FROM communities_archive_info WHERE community_id = ?)`, communityID.String()).Scan(&exists)
 	return exists, err
 }
 
-func (p *Persistence) GetLastSeenArchiveLink(communityID types3.HexBytes) (string, error) {
+func (p *Persistence) GetLastSeenArchiveLink(communityID types.HexBytes) (string, error) {
 	var archiveLink string
 	err := p.db.QueryRow(`SELECT last_archive_link FROM communities_archive_info WHERE community_id = ?`, communityID.String()).Scan(&archiveLink)
 	if err == sql.ErrNoRows {
@@ -1017,7 +1017,7 @@ func (p *Persistence) GetLastSeenArchiveLink(communityID types3.HexBytes) (strin
 	return archiveLink, err
 }
 
-func (p *Persistence) GetArchiveLinkMessageClock(communityID types3.HexBytes) (uint64, error) {
+func (p *Persistence) GetArchiveLinkMessageClock(communityID types.HexBytes) (uint64, error) {
 	var archiveLinkClock uint64
 	err := p.db.QueryRow(`SELECT archive_link_clock FROM communities_archive_info WHERE community_id = ?`, communityID.String()).Scan(&archiveLinkClock)
 	if err == sql.ErrNoRows {
@@ -1026,7 +1026,7 @@ func (p *Persistence) GetArchiveLinkMessageClock(communityID types3.HexBytes) (u
 	return archiveLinkClock, err
 }
 
-func (p *Persistence) SaveCommunityArchiveInfo(communityID types3.HexBytes, archiveLinkClock uint64, lastArchiveEndDate uint64) error {
+func (p *Persistence) SaveCommunityArchiveInfo(communityID types.HexBytes, archiveLinkClock uint64, lastArchiveEndDate uint64) error {
 	_, err := p.db.Exec(`
 		INSERT INTO communities_archive_info (
 			community_id, archive_link_clock, last_message_archive_end_date
@@ -1041,7 +1041,7 @@ func (p *Persistence) SaveCommunityArchiveInfo(communityID types3.HexBytes, arch
 	return err
 }
 
-func (p *Persistence) UpdateArchiveLinkMessageClock(communityID types3.HexBytes, archiveLinkClock uint64) error {
+func (p *Persistence) UpdateArchiveLinkMessageClock(communityID types.HexBytes, archiveLinkClock uint64) error {
 	_, err := p.db.Exec(`
 		INSERT INTO communities_archive_info (community_id, archive_link_clock)
 		VALUES (?, ?)
@@ -1053,7 +1053,7 @@ func (p *Persistence) UpdateArchiveLinkMessageClock(communityID types3.HexBytes,
 	return err
 }
 
-func (p *Persistence) UpdateLastSeenArchiveLink(communityID types3.HexBytes, archiveLink string) error {
+func (p *Persistence) UpdateLastSeenArchiveLink(communityID types.HexBytes, archiveLink string) error {
 	_, err := p.db.Exec(`
 		INSERT INTO communities_archive_info (community_id, last_archive_link)
 		VALUES (?, ?)
@@ -1065,7 +1065,7 @@ func (p *Persistence) UpdateLastSeenArchiveLink(communityID types3.HexBytes, arc
 	return err
 }
 
-func (p *Persistence) SaveLastMessageArchiveEndDate(communityID types3.HexBytes, endDate uint64) error {
+func (p *Persistence) SaveLastMessageArchiveEndDate(communityID types.HexBytes, endDate uint64) error {
 	_, err := p.db.Exec(`
 		INSERT INTO communities_archive_info (community_id, last_message_archive_end_date) VALUES (?, ?)
 		ON CONFLICT(community_id) DO UPDATE SET
@@ -1076,7 +1076,7 @@ func (p *Persistence) SaveLastMessageArchiveEndDate(communityID types3.HexBytes,
 	return err
 }
 
-func (p *Persistence) UpdateLastMessageArchiveEndDate(communityID types3.HexBytes, endDate uint64) error {
+func (p *Persistence) UpdateLastMessageArchiveEndDate(communityID types.HexBytes, endDate uint64) error {
 	_, err := p.db.Exec(`
 		INSERT INTO communities_archive_info (community_id, last_message_archive_end_date)
 		VALUES (?, ?)
@@ -1088,7 +1088,7 @@ func (p *Persistence) UpdateLastMessageArchiveEndDate(communityID types3.HexByte
 	return err
 }
 
-func (p *Persistence) GetLastMessageArchiveEndDate(communityID types3.HexBytes) (uint64, error) {
+func (p *Persistence) GetLastMessageArchiveEndDate(communityID types.HexBytes) (uint64, error) {
 
 	var lastMessageArchiveEndDate uint64
 	err := p.db.QueryRow(`SELECT last_message_archive_end_date FROM communities_archive_info WHERE community_id = ?`, communityID.String()).Scan(&lastMessageArchiveEndDate)
@@ -1100,7 +1100,7 @@ func (p *Persistence) GetLastMessageArchiveEndDate(communityID types3.HexBytes) 
 	return lastMessageArchiveEndDate, nil
 }
 
-func (p *Persistence) GetMessageArchiveIDsToImport(communityID types3.HexBytes) ([]string, error) {
+func (p *Persistence) GetMessageArchiveIDsToImport(communityID types.HexBytes) ([]string, error) {
 	rows, err := p.db.Query("SELECT hash FROM community_message_archive_hashes WHERE community_id = ? AND NOT(imported)", communityID.String())
 	if err != nil {
 		return nil, err
@@ -1118,7 +1118,7 @@ func (p *Persistence) GetMessageArchiveIDsToImport(communityID types3.HexBytes) 
 	return ids, err
 }
 
-func (p *Persistence) GetDownloadedMessageArchiveIDs(communityID types3.HexBytes) ([]string, error) {
+func (p *Persistence) GetDownloadedMessageArchiveIDs(communityID types.HexBytes) ([]string, error) {
 	rows, err := p.db.Query("SELECT hash FROM community_message_archive_hashes WHERE community_id = ?", communityID.String())
 	if err != nil {
 		return nil, err
@@ -1136,12 +1136,12 @@ func (p *Persistence) GetDownloadedMessageArchiveIDs(communityID types3.HexBytes
 	return ids, err
 }
 
-func (p *Persistence) SetMessageArchiveIDImported(communityID types3.HexBytes, hash string, imported bool) error {
+func (p *Persistence) SetMessageArchiveIDImported(communityID types.HexBytes, hash string, imported bool) error {
 	_, err := p.db.Exec(`UPDATE community_message_archive_hashes SET imported = ? WHERE hash = ? AND community_id = ?`, imported, hash, communityID.String())
 	return err
 }
 
-func (p *Persistence) HasMessageArchiveID(communityID types3.HexBytes, hash string) (exists bool, err error) {
+func (p *Persistence) HasMessageArchiveID(communityID types.HexBytes, hash string) (exists bool, err error) {
 	err = p.db.QueryRow(`SELECT EXISTS (SELECT 1 FROM community_message_archive_hashes WHERE community_id = ? AND hash = ?)`,
 		communityID.String(),
 		hash,
@@ -1149,7 +1149,7 @@ func (p *Persistence) HasMessageArchiveID(communityID types3.HexBytes, hash stri
 	return exists, err
 }
 
-func (p *Persistence) SaveMessageArchiveID(communityID types3.HexBytes, hash string) error {
+func (p *Persistence) SaveMessageArchiveID(communityID types.HexBytes, hash string) error {
 	_, err := p.db.Exec(`INSERT INTO community_message_archive_hashes (community_id, hash) VALUES (?, ?)`,
 		communityID.String(),
 		hash,
@@ -1176,7 +1176,7 @@ func (p *Persistence) GetCommunitiesSettings() ([]CommunitySettings, error) {
 	return communitiesSettings, err
 }
 
-func (p *Persistence) CommunitySettingsExist(communityID types3.HexBytes) (bool, error) {
+func (p *Persistence) CommunitySettingsExist(communityID types.HexBytes) (bool, error) {
 	var count int
 	err := p.db.QueryRow(`SELECT count(1) FROM communities_settings WHERE community_id = ?`, communityID.String()).Scan(&count)
 	if err != nil {
@@ -1185,7 +1185,7 @@ func (p *Persistence) CommunitySettingsExist(communityID types3.HexBytes) (bool,
 	return count > 0, nil
 }
 
-func (p *Persistence) GetCommunitySettingsByID(communityID types3.HexBytes) (*CommunitySettings, error) {
+func (p *Persistence) GetCommunitySettingsByID(communityID types.HexBytes) (*CommunitySettings, error) {
 	settings := CommunitySettings{}
 	err := p.db.QueryRow(`SELECT community_id, message_archive_seeding_enabled, message_archive_fetching_enabled, clock FROM communities_settings WHERE community_id = ?`, communityID.String()).Scan(&settings.CommunityID, &settings.HistoryArchiveSupportEnabled, &settings.HistoryArchiveSupportEnabled, &settings.Clock)
 	if err == sql.ErrNoRows {
@@ -1196,7 +1196,7 @@ func (p *Persistence) GetCommunitySettingsByID(communityID types3.HexBytes) (*Co
 	return &settings, nil
 }
 
-func (p *Persistence) DeleteCommunitySettings(communityID types3.HexBytes) error {
+func (p *Persistence) DeleteCommunitySettings(communityID types.HexBytes) error {
 	_, err := p.db.Exec("DELETE FROM communities_settings WHERE community_id = ?", communityID.String())
 	return err
 }
@@ -1230,7 +1230,7 @@ func (p *Persistence) UpdateCommunitySettings(communitySettings CommunitySetting
 	return err
 }
 
-func (p *Persistence) GetCommunityChatIDs(communityID types3.HexBytes) ([]string, error) {
+func (p *Persistence) GetCommunityChatIDs(communityID types.HexBytes) ([]string, error) {
 	rows, err := p.db.Query(`SELECT id FROM chats WHERE community_id = ?`, communityID.String())
 	if err != nil {
 		return nil, err
@@ -1479,7 +1479,7 @@ func (p *Persistence) GetCommunityRequestsToJoinWithRevealedAddresses(communityI
 			return nil, err
 		}
 
-		if types3.EncodeHex(prevRequest.ID) == types3.EncodeHex(request.ID) {
+		if types.EncodeHex(prevRequest.ID) == types.EncodeHex(request.ID) {
 			if revealedAccount != nil {
 				prevRequest.RevealedAccounts = append(prevRequest.RevealedAccounts, revealedAccount)
 			}
@@ -1573,14 +1573,14 @@ func (p *Persistence) getCommunitiesToValidate() (map[string][]communityToValida
 		if err != nil {
 			return nil, err
 		}
-		communitiesToValidate[types3.EncodeHex(communityToValidate.id)] = append(communitiesToValidate[types3.EncodeHex(communityToValidate.id)], communityToValidate)
+		communitiesToValidate[types.EncodeHex(communityToValidate.id)] = append(communitiesToValidate[types.EncodeHex(communityToValidate.id)], communityToValidate)
 	}
 
 	return communitiesToValidate, nil
 
 }
 
-func (p *Persistence) getCommunityToValidateByID(communityID types3.HexBytes) ([]communityToValidate, error) {
+func (p *Persistence) getCommunityToValidateByID(communityID types.HexBytes) ([]communityToValidate, error) {
 	communityToValidateArray := []communityToValidate{}
 	rows, err := p.db.Query(`SELECT id, clock, payload, signer FROM communities_validate_signer WHERE id = ? AND validate_at <= ? ORDER BY clock DESC`, communityID, time.Now().UnixNano())
 
@@ -1614,7 +1614,7 @@ func (p *Persistence) DeleteCommunityToValidate(communityID []byte, clock uint64
 	return err
 }
 
-func (p *Persistence) GetSyncControlNode(communityID types3.HexBytes) (*protobuf.SyncCommunityControlNode, error) {
+func (p *Persistence) GetSyncControlNode(communityID types.HexBytes) (*protobuf.SyncCommunityControlNode, error) {
 	result := &protobuf.SyncCommunityControlNode{}
 
 	err := p.db.QueryRow(`
@@ -1633,7 +1633,7 @@ func (p *Persistence) GetSyncControlNode(communityID types3.HexBytes) (*protobuf
 	return result, nil
 }
 
-func (p *Persistence) SaveSyncControlNode(communityID types3.HexBytes, clock uint64, installationID string) error {
+func (p *Persistence) SaveSyncControlNode(communityID types.HexBytes, clock uint64, installationID string) error {
 	_, err := p.db.Exec(
 		`INSERT INTO communities_control_node (
 			community_id,
@@ -1795,7 +1795,7 @@ func (p *Persistence) AllNonApprovedCommunitiesRequestsToJoin() ([]*RequestToJoi
 	return nonApprovedRequestsToJoin, nil
 }
 
-func (p *Persistence) GetAppliedCommunityEvents(communityID types3.HexBytes) (map[string]uint64, error) {
+func (p *Persistence) GetAppliedCommunityEvents(communityID types.HexBytes) (map[string]uint64, error) {
 	rows, err := p.db.Query(`SELECT event_type_id, clock FROM applied_community_events WHERE community_id = ?`, communityID.String())
 	if err != nil {
 		return nil, err
@@ -1818,7 +1818,7 @@ func (p *Persistence) GetAppliedCommunityEvents(communityID types3.HexBytes) (ma
 	return result, nil
 }
 
-func (p *Persistence) UpsertAppliedCommunityEvents(communityID types3.HexBytes, processedEvents map[string]uint64) error {
+func (p *Persistence) UpsertAppliedCommunityEvents(communityID types.HexBytes, processedEvents map[string]uint64) error {
 	tx, err := p.db.BeginTx(context.Background(), &sql.TxOptions{})
 	if err != nil {
 		return err
@@ -2106,7 +2106,7 @@ func (p *Persistence) GetEncryptionKeyRequests(communityID []byte, channelIDs ma
 	return result, nil
 }
 
-func (p *Persistence) UpdateAndPruneEncryptionKeyRequests(communityID types3.HexBytes, channelIDs []string, requestedAt int64) error {
+func (p *Persistence) UpdateAndPruneEncryptionKeyRequests(communityID types.HexBytes, channelIDs []string, requestedAt int64) error {
 	tx, err := p.db.Begin()
 	if err != nil {
 		return err

--- a/protocol/communities/persistence.go
+++ b/protocol/communities/persistence.go
@@ -14,8 +14,8 @@ import (
 	"github.com/golang/protobuf/proto"
 
 	"github.com/status-im/status-go/internal/crypto"
-	"github.com/status-im/status-go/internal/crypto/types"
-	types2 "github.com/status-im/status-go/pkg/messaging/types"
+	cryptotypes "github.com/status-im/status-go/internal/crypto/types"
+	messagingtypes "github.com/status-im/status-go/pkg/messaging/types"
 	"github.com/status-im/status-go/protocol/communities/token"
 	"github.com/status-im/status-go/protocol/protobuf"
 	"github.com/status-im/status-go/services/wallet/bigint"
@@ -183,7 +183,7 @@ func (p *Persistence) SaveCommunity(community *Community) error {
 	return p.saveCommunity(record)
 }
 
-func (p *Persistence) DeleteCommunityEvents(id types.HexBytes) error {
+func (p *Persistence) DeleteCommunityEvents(id cryptotypes.HexBytes) error {
 	_, err := p.db.Exec(`DELETE FROM communities_events WHERE id = ?;`, id)
 	return err
 }
@@ -205,7 +205,7 @@ func (p *Persistence) SaveCommunityEvents(community *Community) error {
 	return p.saveCommunityEvents(record)
 }
 
-func (p *Persistence) DeleteCommunity(id types.HexBytes) error {
+func (p *Persistence) DeleteCommunity(id cryptotypes.HexBytes) error {
 	_, err := p.db.Exec(`DELETE FROM communities_communities WHERE id = ?;
 						 DELETE FROM communities_events WHERE id = ?;`, id, id)
 	return err
@@ -275,7 +275,7 @@ func (p *Persistence) JoinedCommunities(memberIdentity *ecdsa.PublicKey) ([]*Com
 	return p.queryCommunities(memberIdentity, query)
 }
 
-func (p *Persistence) UpdateLastOpenedAt(communityID types.HexBytes, timestamp int64) error {
+func (p *Persistence) UpdateLastOpenedAt(communityID cryptotypes.HexBytes, timestamp int64) error {
 	_, err := p.db.Exec(`UPDATE communities_communities SET last_opened_at = ? WHERE id = ?`, timestamp, communityID)
 	return err
 }
@@ -418,7 +418,7 @@ func (p *Persistence) SaveRequestToJoin(request *RequestToJoin) (err error) {
 	return err
 }
 
-func (p *Persistence) SaveRequestToJoinRevealedAddresses(requestID types.HexBytes, revealedAccounts []*protobuf.RevealedAccount) (err error) {
+func (p *Persistence) SaveRequestToJoinRevealedAddresses(requestID cryptotypes.HexBytes, revealedAccounts []*protobuf.RevealedAccount) (err error) {
 	tx, err := p.db.BeginTx(context.Background(), &sql.TxOptions{})
 	if err != nil {
 		return
@@ -843,7 +843,7 @@ func (p *Persistence) GetRequestToJoin(id []byte) (*RequestToJoin, error) {
 	return request, nil
 }
 
-func (p *Persistence) GetNumberOfPendingRequestsToJoin(communityID types.HexBytes) (int, error) {
+func (p *Persistence) GetNumberOfPendingRequestsToJoin(communityID cryptotypes.HexBytes) (int, error) {
 	var count int
 	err := p.db.QueryRow(`SELECT count(1) FROM communities_requests_to_join WHERE community_id = ? AND state = ?`, communityID, RequestToJoinStatePending).Scan(&count)
 	if err != nil {
@@ -852,7 +852,7 @@ func (p *Persistence) GetNumberOfPendingRequestsToJoin(communityID types.HexByte
 	return count, nil
 }
 
-func (p *Persistence) GetRequestToJoinClockByPkAndCommunityID(pk string, communityID types.HexBytes) (uint64, error) {
+func (p *Persistence) GetRequestToJoinClockByPkAndCommunityID(pk string, communityID cryptotypes.HexBytes) (uint64, error) {
 	var clock uint64
 
 	err := p.db.QueryRow(`
@@ -892,7 +892,7 @@ func (p *Persistence) SetPrivateKey(id []byte, privKey *ecdsa.PrivateKey) error 
 	return err
 }
 
-func (p *Persistence) SaveWakuMessages(messages []*types2.ReceivedMessage) (err error) {
+func (p *Persistence) SaveWakuMessages(messages []*messagingtypes.ReceivedMessage) (err error) {
 	tx, err := p.db.BeginTx(context.Background(), &sql.TxOptions{})
 	if err != nil {
 		return
@@ -918,7 +918,7 @@ func (p *Persistence) SaveWakuMessages(messages []*types2.ReceivedMessage) (err 
 			msg.Topic.String(),
 			msg.Payload,
 			msg.Padding,
-			types.Bytes2Hex(msg.Hash),
+			cryptotypes.Bytes2Hex(msg.Hash),
 			msg.ThirdPartyID,
 		)
 		if err != nil {
@@ -928,20 +928,20 @@ func (p *Persistence) SaveWakuMessages(messages []*types2.ReceivedMessage) (err 
 	return
 }
 
-func (p *Persistence) SaveWakuMessage(message *types2.ReceivedMessage) error {
+func (p *Persistence) SaveWakuMessage(message *messagingtypes.ReceivedMessage) error {
 	_, err := p.db.Exec(`INSERT OR REPLACE INTO waku_messages (sig, timestamp, topic, payload, padding, hash, third_party_id) VALUES (?, ?, ?, ?, ?, ?, ?)`,
 		message.Sig,
 		message.Timestamp,
 		message.Topic.String(),
 		message.Payload,
 		message.Padding,
-		types.Bytes2Hex(message.Hash),
+		cryptotypes.Bytes2Hex(message.Hash),
 		message.ThirdPartyID,
 	)
 	return err
 }
 
-func wakuMessageTimestampQuery(topics []types2.ContentTopic) string {
+func wakuMessageTimestampQuery(topics []messagingtypes.ContentTopic) string {
 	query := " FROM waku_messages WHERE "
 	for i, topic := range topics {
 		query += `topic = "` + topic.String() + `"`
@@ -952,7 +952,7 @@ func wakuMessageTimestampQuery(topics []types2.ContentTopic) string {
 	return query
 }
 
-func (p *Persistence) GetOldestWakuMessageTimestamp(topics []types2.ContentTopic) (uint64, error) {
+func (p *Persistence) GetOldestWakuMessageTimestamp(topics []messagingtypes.ContentTopic) (uint64, error) {
 	var timestamp sql.NullInt64
 	query := "SELECT MIN(timestamp)"
 	query += wakuMessageTimestampQuery(topics)
@@ -960,7 +960,7 @@ func (p *Persistence) GetOldestWakuMessageTimestamp(topics []types2.ContentTopic
 	return uint64(timestamp.Int64), err
 }
 
-func (p *Persistence) GetLatestWakuMessageTimestamp(topics []types2.ContentTopic) (uint64, error) {
+func (p *Persistence) GetLatestWakuMessageTimestamp(topics []messagingtypes.ContentTopic) (uint64, error) {
 	var timestamp sql.NullInt64
 	query := "SELECT MAX(timestamp)"
 	query += wakuMessageTimestampQuery(topics)
@@ -968,7 +968,7 @@ func (p *Persistence) GetLatestWakuMessageTimestamp(topics []types2.ContentTopic
 	return uint64(timestamp.Int64), err
 }
 
-func (p *Persistence) GetWakuMessagesByFilterTopic(topics []types2.ContentTopic, from uint64, to uint64) ([]types2.ReceivedMessage, error) {
+func (p *Persistence) GetWakuMessagesByFilterTopic(topics []messagingtypes.ContentTopic, from uint64, to uint64) ([]messagingtypes.ReceivedMessage, error) {
 
 	query := "SELECT sig, timestamp, topic, payload, padding, hash, third_party_id FROM waku_messages WHERE timestamp >= " + fmt.Sprint(from) + " AND timestamp < " + fmt.Sprint(to) + " AND (" //nolint: gosec
 
@@ -985,30 +985,30 @@ func (p *Persistence) GetWakuMessagesByFilterTopic(topics []types2.ContentTopic,
 		return nil, err
 	}
 	defer rows.Close()
-	messages := []types2.ReceivedMessage{}
+	messages := []messagingtypes.ReceivedMessage{}
 
 	for rows.Next() {
-		msg := types2.ReceivedMessage{}
+		msg := messagingtypes.ReceivedMessage{}
 		var topicStr string
 		var hashStr string
 		err := rows.Scan(&msg.Sig, &msg.Timestamp, &topicStr, &msg.Payload, &msg.Padding, &hashStr, &msg.ThirdPartyID)
 		if err != nil {
 			return nil, err
 		}
-		msg.Topic = types2.StringToContentTopic(topicStr)
-		msg.Hash = types.Hex2Bytes(hashStr)
+		msg.Topic = messagingtypes.StringToContentTopic(topicStr)
+		msg.Hash = cryptotypes.Hex2Bytes(hashStr)
 		messages = append(messages, msg)
 	}
 
 	return messages, nil
 }
 
-func (p *Persistence) HasCommunityArchiveInfo(communityID types.HexBytes) (exists bool, err error) {
+func (p *Persistence) HasCommunityArchiveInfo(communityID cryptotypes.HexBytes) (exists bool, err error) {
 	err = p.db.QueryRow(`SELECT EXISTS(SELECT 1 FROM communities_archive_info WHERE community_id = ?)`, communityID.String()).Scan(&exists)
 	return exists, err
 }
 
-func (p *Persistence) GetLastSeenArchiveLink(communityID types.HexBytes) (string, error) {
+func (p *Persistence) GetLastSeenArchiveLink(communityID cryptotypes.HexBytes) (string, error) {
 	var archiveLink string
 	err := p.db.QueryRow(`SELECT last_archive_link FROM communities_archive_info WHERE community_id = ?`, communityID.String()).Scan(&archiveLink)
 	if err == sql.ErrNoRows {
@@ -1017,7 +1017,7 @@ func (p *Persistence) GetLastSeenArchiveLink(communityID types.HexBytes) (string
 	return archiveLink, err
 }
 
-func (p *Persistence) GetArchiveLinkMessageClock(communityID types.HexBytes) (uint64, error) {
+func (p *Persistence) GetArchiveLinkMessageClock(communityID cryptotypes.HexBytes) (uint64, error) {
 	var archiveLinkClock uint64
 	err := p.db.QueryRow(`SELECT archive_link_clock FROM communities_archive_info WHERE community_id = ?`, communityID.String()).Scan(&archiveLinkClock)
 	if err == sql.ErrNoRows {
@@ -1026,7 +1026,7 @@ func (p *Persistence) GetArchiveLinkMessageClock(communityID types.HexBytes) (ui
 	return archiveLinkClock, err
 }
 
-func (p *Persistence) SaveCommunityArchiveInfo(communityID types.HexBytes, archiveLinkClock uint64, lastArchiveEndDate uint64) error {
+func (p *Persistence) SaveCommunityArchiveInfo(communityID cryptotypes.HexBytes, archiveLinkClock uint64, lastArchiveEndDate uint64) error {
 	_, err := p.db.Exec(`
 		INSERT INTO communities_archive_info (
 			community_id, archive_link_clock, last_message_archive_end_date
@@ -1041,7 +1041,7 @@ func (p *Persistence) SaveCommunityArchiveInfo(communityID types.HexBytes, archi
 	return err
 }
 
-func (p *Persistence) UpdateArchiveLinkMessageClock(communityID types.HexBytes, archiveLinkClock uint64) error {
+func (p *Persistence) UpdateArchiveLinkMessageClock(communityID cryptotypes.HexBytes, archiveLinkClock uint64) error {
 	_, err := p.db.Exec(`
 		INSERT INTO communities_archive_info (community_id, archive_link_clock)
 		VALUES (?, ?)
@@ -1053,7 +1053,7 @@ func (p *Persistence) UpdateArchiveLinkMessageClock(communityID types.HexBytes, 
 	return err
 }
 
-func (p *Persistence) UpdateLastSeenArchiveLink(communityID types.HexBytes, archiveLink string) error {
+func (p *Persistence) UpdateLastSeenArchiveLink(communityID cryptotypes.HexBytes, archiveLink string) error {
 	_, err := p.db.Exec(`
 		INSERT INTO communities_archive_info (community_id, last_archive_link)
 		VALUES (?, ?)
@@ -1065,7 +1065,7 @@ func (p *Persistence) UpdateLastSeenArchiveLink(communityID types.HexBytes, arch
 	return err
 }
 
-func (p *Persistence) SaveLastMessageArchiveEndDate(communityID types.HexBytes, endDate uint64) error {
+func (p *Persistence) SaveLastMessageArchiveEndDate(communityID cryptotypes.HexBytes, endDate uint64) error {
 	_, err := p.db.Exec(`
 		INSERT INTO communities_archive_info (community_id, last_message_archive_end_date) VALUES (?, ?)
 		ON CONFLICT(community_id) DO UPDATE SET
@@ -1076,7 +1076,7 @@ func (p *Persistence) SaveLastMessageArchiveEndDate(communityID types.HexBytes, 
 	return err
 }
 
-func (p *Persistence) UpdateLastMessageArchiveEndDate(communityID types.HexBytes, endDate uint64) error {
+func (p *Persistence) UpdateLastMessageArchiveEndDate(communityID cryptotypes.HexBytes, endDate uint64) error {
 	_, err := p.db.Exec(`
 		INSERT INTO communities_archive_info (community_id, last_message_archive_end_date)
 		VALUES (?, ?)
@@ -1088,7 +1088,7 @@ func (p *Persistence) UpdateLastMessageArchiveEndDate(communityID types.HexBytes
 	return err
 }
 
-func (p *Persistence) GetLastMessageArchiveEndDate(communityID types.HexBytes) (uint64, error) {
+func (p *Persistence) GetLastMessageArchiveEndDate(communityID cryptotypes.HexBytes) (uint64, error) {
 
 	var lastMessageArchiveEndDate uint64
 	err := p.db.QueryRow(`SELECT last_message_archive_end_date FROM communities_archive_info WHERE community_id = ?`, communityID.String()).Scan(&lastMessageArchiveEndDate)
@@ -1100,7 +1100,7 @@ func (p *Persistence) GetLastMessageArchiveEndDate(communityID types.HexBytes) (
 	return lastMessageArchiveEndDate, nil
 }
 
-func (p *Persistence) GetMessageArchiveIDsToImport(communityID types.HexBytes) ([]string, error) {
+func (p *Persistence) GetMessageArchiveIDsToImport(communityID cryptotypes.HexBytes) ([]string, error) {
 	rows, err := p.db.Query("SELECT hash FROM community_message_archive_hashes WHERE community_id = ? AND NOT(imported)", communityID.String())
 	if err != nil {
 		return nil, err
@@ -1118,7 +1118,7 @@ func (p *Persistence) GetMessageArchiveIDsToImport(communityID types.HexBytes) (
 	return ids, err
 }
 
-func (p *Persistence) GetDownloadedMessageArchiveIDs(communityID types.HexBytes) ([]string, error) {
+func (p *Persistence) GetDownloadedMessageArchiveIDs(communityID cryptotypes.HexBytes) ([]string, error) {
 	rows, err := p.db.Query("SELECT hash FROM community_message_archive_hashes WHERE community_id = ?", communityID.String())
 	if err != nil {
 		return nil, err
@@ -1136,12 +1136,12 @@ func (p *Persistence) GetDownloadedMessageArchiveIDs(communityID types.HexBytes)
 	return ids, err
 }
 
-func (p *Persistence) SetMessageArchiveIDImported(communityID types.HexBytes, hash string, imported bool) error {
+func (p *Persistence) SetMessageArchiveIDImported(communityID cryptotypes.HexBytes, hash string, imported bool) error {
 	_, err := p.db.Exec(`UPDATE community_message_archive_hashes SET imported = ? WHERE hash = ? AND community_id = ?`, imported, hash, communityID.String())
 	return err
 }
 
-func (p *Persistence) HasMessageArchiveID(communityID types.HexBytes, hash string) (exists bool, err error) {
+func (p *Persistence) HasMessageArchiveID(communityID cryptotypes.HexBytes, hash string) (exists bool, err error) {
 	err = p.db.QueryRow(`SELECT EXISTS (SELECT 1 FROM community_message_archive_hashes WHERE community_id = ? AND hash = ?)`,
 		communityID.String(),
 		hash,
@@ -1149,7 +1149,7 @@ func (p *Persistence) HasMessageArchiveID(communityID types.HexBytes, hash strin
 	return exists, err
 }
 
-func (p *Persistence) SaveMessageArchiveID(communityID types.HexBytes, hash string) error {
+func (p *Persistence) SaveMessageArchiveID(communityID cryptotypes.HexBytes, hash string) error {
 	_, err := p.db.Exec(`INSERT INTO community_message_archive_hashes (community_id, hash) VALUES (?, ?)`,
 		communityID.String(),
 		hash,
@@ -1176,7 +1176,7 @@ func (p *Persistence) GetCommunitiesSettings() ([]CommunitySettings, error) {
 	return communitiesSettings, err
 }
 
-func (p *Persistence) CommunitySettingsExist(communityID types.HexBytes) (bool, error) {
+func (p *Persistence) CommunitySettingsExist(communityID cryptotypes.HexBytes) (bool, error) {
 	var count int
 	err := p.db.QueryRow(`SELECT count(1) FROM communities_settings WHERE community_id = ?`, communityID.String()).Scan(&count)
 	if err != nil {
@@ -1185,7 +1185,7 @@ func (p *Persistence) CommunitySettingsExist(communityID types.HexBytes) (bool, 
 	return count > 0, nil
 }
 
-func (p *Persistence) GetCommunitySettingsByID(communityID types.HexBytes) (*CommunitySettings, error) {
+func (p *Persistence) GetCommunitySettingsByID(communityID cryptotypes.HexBytes) (*CommunitySettings, error) {
 	settings := CommunitySettings{}
 	err := p.db.QueryRow(`SELECT community_id, message_archive_seeding_enabled, message_archive_fetching_enabled, clock FROM communities_settings WHERE community_id = ?`, communityID.String()).Scan(&settings.CommunityID, &settings.HistoryArchiveSupportEnabled, &settings.HistoryArchiveSupportEnabled, &settings.Clock)
 	if err == sql.ErrNoRows {
@@ -1196,7 +1196,7 @@ func (p *Persistence) GetCommunitySettingsByID(communityID types.HexBytes) (*Com
 	return &settings, nil
 }
 
-func (p *Persistence) DeleteCommunitySettings(communityID types.HexBytes) error {
+func (p *Persistence) DeleteCommunitySettings(communityID cryptotypes.HexBytes) error {
 	_, err := p.db.Exec("DELETE FROM communities_settings WHERE community_id = ?", communityID.String())
 	return err
 }
@@ -1230,7 +1230,7 @@ func (p *Persistence) UpdateCommunitySettings(communitySettings CommunitySetting
 	return err
 }
 
-func (p *Persistence) GetCommunityChatIDs(communityID types.HexBytes) ([]string, error) {
+func (p *Persistence) GetCommunityChatIDs(communityID cryptotypes.HexBytes) ([]string, error) {
 	rows, err := p.db.Query(`SELECT id FROM chats WHERE community_id = ?`, communityID.String())
 	if err != nil {
 		return nil, err
@@ -1479,7 +1479,7 @@ func (p *Persistence) GetCommunityRequestsToJoinWithRevealedAddresses(communityI
 			return nil, err
 		}
 
-		if types.EncodeHex(prevRequest.ID) == types.EncodeHex(request.ID) {
+		if cryptotypes.EncodeHex(prevRequest.ID) == cryptotypes.EncodeHex(request.ID) {
 			if revealedAccount != nil {
 				prevRequest.RevealedAccounts = append(prevRequest.RevealedAccounts, revealedAccount)
 			}
@@ -1573,14 +1573,14 @@ func (p *Persistence) getCommunitiesToValidate() (map[string][]communityToValida
 		if err != nil {
 			return nil, err
 		}
-		communitiesToValidate[types.EncodeHex(communityToValidate.id)] = append(communitiesToValidate[types.EncodeHex(communityToValidate.id)], communityToValidate)
+		communitiesToValidate[cryptotypes.EncodeHex(communityToValidate.id)] = append(communitiesToValidate[cryptotypes.EncodeHex(communityToValidate.id)], communityToValidate)
 	}
 
 	return communitiesToValidate, nil
 
 }
 
-func (p *Persistence) getCommunityToValidateByID(communityID types.HexBytes) ([]communityToValidate, error) {
+func (p *Persistence) getCommunityToValidateByID(communityID cryptotypes.HexBytes) ([]communityToValidate, error) {
 	communityToValidateArray := []communityToValidate{}
 	rows, err := p.db.Query(`SELECT id, clock, payload, signer FROM communities_validate_signer WHERE id = ? AND validate_at <= ? ORDER BY clock DESC`, communityID, time.Now().UnixNano())
 
@@ -1614,7 +1614,7 @@ func (p *Persistence) DeleteCommunityToValidate(communityID []byte, clock uint64
 	return err
 }
 
-func (p *Persistence) GetSyncControlNode(communityID types.HexBytes) (*protobuf.SyncCommunityControlNode, error) {
+func (p *Persistence) GetSyncControlNode(communityID cryptotypes.HexBytes) (*protobuf.SyncCommunityControlNode, error) {
 	result := &protobuf.SyncCommunityControlNode{}
 
 	err := p.db.QueryRow(`
@@ -1633,7 +1633,7 @@ func (p *Persistence) GetSyncControlNode(communityID types.HexBytes) (*protobuf.
 	return result, nil
 }
 
-func (p *Persistence) SaveSyncControlNode(communityID types.HexBytes, clock uint64, installationID string) error {
+func (p *Persistence) SaveSyncControlNode(communityID cryptotypes.HexBytes, clock uint64, installationID string) error {
 	_, err := p.db.Exec(
 		`INSERT INTO communities_control_node (
 			community_id,
@@ -1795,7 +1795,7 @@ func (p *Persistence) AllNonApprovedCommunitiesRequestsToJoin() ([]*RequestToJoi
 	return nonApprovedRequestsToJoin, nil
 }
 
-func (p *Persistence) GetAppliedCommunityEvents(communityID types.HexBytes) (map[string]uint64, error) {
+func (p *Persistence) GetAppliedCommunityEvents(communityID cryptotypes.HexBytes) (map[string]uint64, error) {
 	rows, err := p.db.Query(`SELECT event_type_id, clock FROM applied_community_events WHERE community_id = ?`, communityID.String())
 	if err != nil {
 		return nil, err
@@ -1818,7 +1818,7 @@ func (p *Persistence) GetAppliedCommunityEvents(communityID types.HexBytes) (map
 	return result, nil
 }
 
-func (p *Persistence) UpsertAppliedCommunityEvents(communityID types.HexBytes, processedEvents map[string]uint64) error {
+func (p *Persistence) UpsertAppliedCommunityEvents(communityID cryptotypes.HexBytes, processedEvents map[string]uint64) error {
 	tx, err := p.db.BeginTx(context.Background(), &sql.TxOptions{})
 	if err != nil {
 		return err
@@ -1858,7 +1858,7 @@ func (p *Persistence) UpsertAppliedCommunityEvents(communityID types.HexBytes, p
 	return err
 }
 
-func (p *Persistence) InvalidateDecryptedCommunityCacheForKeys(keys []*types2.HashRatchetInfo) error {
+func (p *Persistence) InvalidateDecryptedCommunityCacheForKeys(keys []*messagingtypes.HashRatchetInfo) error {
 	tx, err := p.db.BeginTx(context.Background(), &sql.TxOptions{})
 	if err != nil {
 		return err
@@ -2106,7 +2106,7 @@ func (p *Persistence) GetEncryptionKeyRequests(communityID []byte, channelIDs ma
 	return result, nil
 }
 
-func (p *Persistence) UpdateAndPruneEncryptionKeyRequests(communityID types.HexBytes, channelIDs []string, requestedAt int64) error {
+func (p *Persistence) UpdateAndPruneEncryptionKeyRequests(communityID cryptotypes.HexBytes, channelIDs []string, requestedAt int64) error {
 	tx, err := p.db.Begin()
 	if err != nil {
 		return err

--- a/protocol/communities_events_utils_test.go
+++ b/protocol/communities_events_utils_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/ethereum/go-ethereum/common/hexutil"
 
 	"github.com/status-im/status-go/internal/crypto"
-	types2 "github.com/status-im/status-go/internal/crypto/types"
+	"github.com/status-im/status-go/internal/crypto/types"
 	"github.com/status-im/status-go/internal/testutils"
 	"github.com/status-im/status-go/protocol/common"
 	"github.com/status-im/status-go/protocol/communities"
@@ -545,7 +545,7 @@ func deleteCommunityCategory(base CommunityEventsTestsInterface, communityID str
 
 func reorderCategory(base CommunityEventsTestsInterface, reorderRequest *requests.ReorderCommunityCategories) {
 	checkCategoryReorder := func(response *MessengerResponse) error {
-		modifiedCommmunity, err := getModifiedCommunity(response, types2.EncodeHex(reorderRequest.CommunityID))
+		modifiedCommmunity, err := getModifiedCommunity(response, types.EncodeHex(reorderRequest.CommunityID))
 		if err != nil {
 			return err
 		}
@@ -573,7 +573,7 @@ func reorderCategory(base CommunityEventsTestsInterface, reorderRequest *request
 
 func reorderChannel(base CommunityEventsTestsInterface, reorderRequest *requests.ReorderCommunityChat) {
 	checkChannelReorder := func(response *MessengerResponse) error {
-		modifiedCommmunity, err := getModifiedCommunity(response, types2.EncodeHex(reorderRequest.CommunityID))
+		modifiedCommmunity, err := getModifiedCommunity(response, types.EncodeHex(reorderRequest.CommunityID))
 		if err != nil {
 			return err
 		}
@@ -603,9 +603,9 @@ func reorderChannel(base CommunityEventsTestsInterface, reorderRequest *requests
 	checkClientsReceivedAdminEvent(base, checkChannelReorder)
 }
 
-func kickMember(base CommunityEventsTestsInterface, communityID types2.HexBytes, pubkey string) {
+func kickMember(base CommunityEventsTestsInterface, communityID types.HexBytes, pubkey string) {
 	checkKicked := func(response *MessengerResponse) error {
-		modifiedCommmunity, err := getModifiedCommunity(response, types2.EncodeHex(communityID))
+		modifiedCommmunity, err := getModifiedCommunity(response, types.EncodeHex(communityID))
 		if err != nil {
 			return err
 		}
@@ -630,14 +630,14 @@ func kickMember(base CommunityEventsTestsInterface, communityID types2.HexBytes,
 	s.Require().NoError(err)
 
 	// 1. event sender should get pending state for kicked member
-	modifiedCommmunity, err := getModifiedCommunity(response, types2.EncodeHex(communityID))
+	modifiedCommmunity, err := getModifiedCommunity(response, types.EncodeHex(communityID))
 	s.Require().NoError(err)
 	s.Require().True(modifiedCommmunity.HasMember(&base.GetMember().identity.PublicKey))
 	s.Require().Equal(communities.CommunityMemberKickPending, modifiedCommmunity.PendingAndBannedMembers()[pubkey])
 
 	// 2. wait for event as a sender
 	waitOnMessengerResponse(s, func(response *MessengerResponse) error {
-		modifiedCommmunity, err := getModifiedCommunity(response, types2.EncodeHex(communityID))
+		modifiedCommmunity, err := getModifiedCommunity(response, types.EncodeHex(communityID))
 		if err != nil {
 			return err
 		}
@@ -655,7 +655,7 @@ func kickMember(base CommunityEventsTestsInterface, communityID types2.HexBytes,
 
 	// 3. wait for event as the community member and check we are still until control node gets it
 	waitOnMessengerResponse(s, func(response *MessengerResponse) error {
-		modifiedCommmunity, err := getModifiedCommunity(response, types2.EncodeHex(communityID))
+		modifiedCommmunity, err := getModifiedCommunity(response, types.EncodeHex(communityID))
 		if err != nil {
 			return err
 		}
@@ -686,7 +686,7 @@ func banMember(base CommunityEventsTestsInterface, banRequest *requests.BanUserF
 	communityStr := banRequest.CommunityID.String()
 
 	checkBanned := func(response *MessengerResponse) error {
-		modifiedCommmunity, err := getModifiedCommunity(response, types2.EncodeHex(banRequest.CommunityID))
+		modifiedCommmunity, err := getModifiedCommunity(response, types.EncodeHex(banRequest.CommunityID))
 		if err != nil {
 			return err
 		}
@@ -723,14 +723,14 @@ func banMember(base CommunityEventsTestsInterface, banRequest *requests.BanUserF
 	s.Require().NoError(err)
 
 	// 1. event sender should get pending state for ban member
-	modifiedCommmunity, err := getModifiedCommunity(response, types2.EncodeHex(banRequest.CommunityID))
+	modifiedCommmunity, err := getModifiedCommunity(response, types.EncodeHex(banRequest.CommunityID))
 	s.Require().NoError(err)
 	s.Require().True(modifiedCommmunity.HasMember(&base.GetMember().identity.PublicKey))
 	s.Require().Equal(communities.CommunityMemberBanPending, modifiedCommmunity.PendingAndBannedMembers()[bannedPK])
 
 	verifier := "event sender"
 	verifyPendingState := func(response *MessengerResponse) error {
-		modifiedCommmunity, err := getModifiedCommunity(response, types2.EncodeHex(banRequest.CommunityID))
+		modifiedCommmunity, err := getModifiedCommunity(response, types.EncodeHex(banRequest.CommunityID))
 		if err != nil {
 			return err
 		}
@@ -789,7 +789,7 @@ func unbanMember(base CommunityEventsTestsInterface, unbanRequest *requests.Unba
 	pubkey := crypto.PubkeyToHex(&base.GetMember().identity.PublicKey)
 
 	checkUnbanned := func(response *MessengerResponse) error {
-		modifiedCommmunity, err := getModifiedCommunity(response, types2.EncodeHex(unbanRequest.CommunityID))
+		modifiedCommmunity, err := getModifiedCommunity(response, types.EncodeHex(unbanRequest.CommunityID))
 		if err != nil {
 			return err
 		}
@@ -811,13 +811,13 @@ func unbanMember(base CommunityEventsTestsInterface, unbanRequest *requests.Unba
 	s.Require().NoError(err)
 
 	// 1. event sender should get pending state for unban member
-	modifiedCommmunity, err := getModifiedCommunity(response, types2.EncodeHex(unbanRequest.CommunityID))
+	modifiedCommmunity, err := getModifiedCommunity(response, types.EncodeHex(unbanRequest.CommunityID))
 	s.Require().NoError(err)
 	s.Require().Equal(communities.CommunityMemberUnbanPending, modifiedCommmunity.PendingAndBannedMembers()[pubkey])
 
 	// 2. wait for event as a sender
 	waitOnMessengerResponse(s, func(response *MessengerResponse) error {
-		modifiedCommmunity, err := getModifiedCommunity(response, types2.EncodeHex(unbanRequest.CommunityID))
+		modifiedCommmunity, err := getModifiedCommunity(response, types.EncodeHex(unbanRequest.CommunityID))
 		if err != nil {
 			return err
 		}
@@ -831,7 +831,7 @@ func unbanMember(base CommunityEventsTestsInterface, unbanRequest *requests.Unba
 
 	// 3. wait for event as the community member and check we are still until control node gets it
 	waitOnMessengerResponse(s, func(response *MessengerResponse) error {
-		modifiedCommmunity, err := getModifiedCommunity(response, types2.EncodeHex(unbanRequest.CommunityID))
+		modifiedCommmunity, err := getModifiedCommunity(response, types.EncodeHex(unbanRequest.CommunityID))
 		if err != nil {
 			return err
 		}
@@ -2157,7 +2157,7 @@ func testMemberReceiveRequestsToJoinAfterGettingNewRole(base CommunityEventsTest
 	waitAndCheckRequestsToJoin(s, base.GetEventSender(), expectedLength, community.ID(), false)
 }
 
-func waitAndCheckRequestsToJoin(s *suite.Suite, user *Messenger, expectedLength int, communityID types2.HexBytes, checkRevealedAddresses bool) {
+func waitAndCheckRequestsToJoin(s *suite.Suite, user *Messenger, expectedLength int, communityID types.HexBytes, checkRevealedAddresses bool) {
 	_, err := WaitOnMessengerResponse(
 		user,
 		func(r *MessengerResponse) bool {
@@ -2474,7 +2474,7 @@ func testBanMemberWithDeletingAllMessages(base CommunityEventsTestsInterface, co
 	banMember(base, banRequest)
 }
 
-func testSendRequestToJoin(base CommunityEventsTestsInterface, user *Messenger, communityID types2.HexBytes) types2.HexBytes {
+func testSendRequestToJoin(base CommunityEventsTestsInterface, user *Messenger, communityID types.HexBytes) types.HexBytes {
 	s := base.GetSuite()
 	userPk := user.IdentityPublicKeyString()
 	userPassword := base.GetAccountsPasswords()[userPk]

--- a/protocol/communities_messenger_helpers_test.go
+++ b/protocol/communities_messenger_helpers_test.go
@@ -19,7 +19,7 @@ import (
 	"github.com/status-im/status-go/internal/accounts-management/generator"
 	accsmanagementtypes "github.com/status-im/status-go/internal/accounts-management/types"
 	"github.com/status-im/status-go/internal/crypto"
-	types2 "github.com/status-im/status-go/internal/crypto/types"
+	"github.com/status-im/status-go/internal/crypto/types"
 	"github.com/status-im/status-go/internal/db/multiaccounts/accounts"
 	"github.com/status-im/status-go/internal/db/multiaccounts/settings"
 	"github.com/status-im/status-go/params"
@@ -160,7 +160,7 @@ func (c *CollectiblesServiceMock) SetSignerPubkeyForCommunity(communityID []byte
 	if c.Signers == nil {
 		c.Signers = make(map[string]string)
 	}
-	c.Signers[types2.EncodeHex(communityID)] = signerPubKey
+	c.Signers[types.EncodeHex(communityID)] = signerPubKey
 }
 
 func (c *CollectiblesServiceMock) GetCollectibleContractData(chainID uint64, contractAddress string) (*communities.CollectibleContractData, error) {
@@ -265,9 +265,9 @@ func defaultTestCommunitiesMessengerNodeConfig() *params.NodeConfig {
 func defaultTestCommunitiesMessengerSettings() *settings.Settings {
 	networks := json.RawMessage("{}")
 	return &settings.Settings{
-		Address:                   types2.HexToAddress("0x1122334455667788990011223344556677889900"),
+		Address:                   types.HexToAddress("0x1122334455667788990011223344556677889900"),
 		CurrentNetwork:            "mainnet_rpc",
-		DappsAddress:              types2.HexToAddress("0x1122334455667788990011223344556677889900"),
+		DappsAddress:              types.HexToAddress("0x1122334455667788990011223344556677889900"),
 		InstallationID:            "d3efcff6-cffa-560e-a547-21d3858cbc51",
 		KeyUID:                    "0x1122334455667788990011223344556677889900",
 		Name:                      "Test",
@@ -283,7 +283,7 @@ func defaultTestCommunitiesMessengerSettings() *settings.Settings {
 		UseMailservers:            false,
 		LinkPreviewRequestEnabled: true,
 		SendStatusUpdates:         true,
-		WalletRootAddress:         types2.HexToAddress("0x1122334455667788990011223344556677889900")}
+		WalletRootAddress:         types.HexToAddress("0x1122334455667788990011223344556677889900")}
 }
 
 func newTestCommunitiesMessenger(s *suite.Suite, messagingEnv *messaging.TestMessagingEnvironment, config testCommunitiesMessengerConfig) *Messenger {
@@ -348,7 +348,7 @@ func newTestCommunitiesMessenger(s *suite.Suite, messagingEnv *messaging.TestMes
 	for _, walletAddress := range config.walletAddresses {
 		kp, _, _, err := accounts.GetProfileKeypairForTest(false, true, false)
 		s.Require().NoError(err)
-		kp.Accounts[0].Address = types2.HexToAddress(walletAddress)
+		kp.Accounts[0].Address = types.HexToAddress(walletAddress)
 		err = messenger.settings.SaveOrUpdateKeypair(kp)
 		s.Require().NoError(err)
 	}
@@ -472,7 +472,7 @@ func advertiseCommunityTo(s *suite.Suite, community *communities.Community, owne
 	s.Require().NoError(err)
 }
 
-func createRequestToJoinCommunity(s *suite.Suite, communityID types2.HexBytes, user *Messenger, password string, addresses []string) *requests.RequestToJoinCommunity {
+func createRequestToJoinCommunity(s *suite.Suite, communityID types.HexBytes, user *Messenger, password string, addresses []string) *requests.RequestToJoinCommunity {
 	airdropAddress := ""
 	if len(addresses) > 0 {
 		airdropAddress = addresses[0]
@@ -499,7 +499,7 @@ func createRequestToJoinCommunity(s *suite.Suite, communityID types2.HexBytes, u
 		}
 		for i := range signingParams {
 			request.AddressesToReveal[i] = signingParams[i].Address
-			request.Signatures = append(request.Signatures, types2.FromHex(signatures[i]))
+			request.Signatures = append(request.Signatures, types.FromHex(signatures[i]))
 		}
 		if updateAddresses {
 			request.AirdropAddress = request.AddressesToReveal[0]
@@ -509,7 +509,7 @@ func createRequestToJoinCommunity(s *suite.Suite, communityID types2.HexBytes, u
 	return request
 }
 
-func joinCommunity(s *suite.Suite, communityID types2.HexBytes, controlNode *Messenger, user *Messenger, password string, addresses []string) {
+func joinCommunity(s *suite.Suite, communityID types.HexBytes, controlNode *Messenger, user *Messenger, password string, addresses []string) {
 	requestToJoin := createRequestToJoinCommunity(s, communityID, user, password, addresses)
 	response, err := user.RequestToJoinCommunity(requestToJoin)
 	s.Require().NoError(err)
@@ -537,7 +537,7 @@ func joinCommunity(s *suite.Suite, communityID types2.HexBytes, controlNode *Mes
 	s.Require().NoError(err)
 }
 
-func requestToJoinCommunity(s *suite.Suite, controlNode *Messenger, user *Messenger, request *requests.RequestToJoinCommunity) types2.HexBytes {
+func requestToJoinCommunity(s *suite.Suite, controlNode *Messenger, user *Messenger, request *requests.RequestToJoinCommunity) types.HexBytes {
 	response, err := user.RequestToJoinCommunity(request)
 	s.Require().NoError(err)
 	s.Require().NotNil(response)
@@ -558,7 +558,7 @@ func requestToJoinCommunity(s *suite.Suite, controlNode *Messenger, user *Messen
 	return requestToJoin.ID
 }
 
-func joinOnRequestCommunity(s *suite.Suite, communityID types2.HexBytes, controlNode *Messenger, user *Messenger, password string, addresses []string) {
+func joinOnRequestCommunity(s *suite.Suite, communityID types.HexBytes, controlNode *Messenger, user *Messenger, password string, addresses []string) {
 	s.Require().NotEmpty(password)
 	s.Require().NotEmpty(addresses)
 	s.Require().NotEmpty(communityID)

--- a/protocol/communities_messenger_shared_member_address_test.go
+++ b/protocol/communities_messenger_shared_member_address_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/ethereum/go-ethereum/common/hexutil"
 
 	"github.com/status-im/status-go/internal/crypto"
-	types2 "github.com/status-im/status-go/internal/crypto/types"
+	"github.com/status-im/status-go/internal/crypto/types"
 	"github.com/status-im/status-go/protocol/communities"
 	"github.com/status-im/status-go/protocol/protobuf"
 	"github.com/status-im/status-go/protocol/requests"
@@ -74,7 +74,7 @@ func (s *MessengerCommunitiesSharedMemberAddressSuite) joinCommunity(community *
 	joinCommunity(&s.Suite, community.ID(), s.owner, user, password, addresses)
 }
 
-func (s *MessengerCommunitiesSharedMemberAddressSuite) checkRevealedAccounts(communityID types2.HexBytes, user *Messenger, expectedAccounts []*protobuf.RevealedAccount) {
+func (s *MessengerCommunitiesSharedMemberAddressSuite) checkRevealedAccounts(communityID types.HexBytes, user *Messenger, expectedAccounts []*protobuf.RevealedAccount) {
 	revealedAccounts, err := user.communitiesManager.GetRevealedAddresses(communityID, s.alice.IdentityPublicKeyString())
 	s.Require().NoError(err)
 	s.Require().Equal(revealedAccounts, expectedAccounts)
@@ -103,13 +103,13 @@ func createTokenMasterTokenCriteria() *protobuf.TokenCriteria {
 	}
 }
 
-func (s *MessengerCommunitiesSharedMemberAddressSuite) createEditSharedAddressesRequest(communityID types2.HexBytes) *requests.EditSharedAddresses {
+func (s *MessengerCommunitiesSharedMemberAddressSuite) createEditSharedAddressesRequest(communityID types.HexBytes) *requests.EditSharedAddresses {
 	request := &requests.EditSharedAddresses{CommunityID: communityID, AddressesToReveal: []string{aliceAddress2}, AirdropAddress: aliceAddress2}
 
 	signingParams, err := s.alice.GenerateJoiningCommunityRequestsForSigning(crypto.PubkeyToHex(&s.alice.identity.PublicKey), communityID, request.AddressesToReveal)
 	s.Require().NoError(err)
 
-	passwdHash := types2.EncodeHex(crypto.Keccak256([]byte(alicePassword)))
+	passwdHash := types.EncodeHex(crypto.Keccak256([]byte(alicePassword)))
 	for i := range signingParams {
 		signingParams[i].Password = passwdHash
 	}
@@ -122,7 +122,7 @@ func (s *MessengerCommunitiesSharedMemberAddressSuite) createEditSharedAddresses
 	}
 	for i := range signingParams {
 		request.AddressesToReveal[i] = signingParams[i].Address
-		request.Signatures = append(request.Signatures, types2.FromHex(signatures[i]))
+		request.Signatures = append(request.Signatures, types.FromHex(signatures[i]))
 	}
 	if updateAddresses {
 		request.AirdropAddress = request.AddressesToReveal[0]
@@ -163,7 +163,7 @@ func (s *MessengerCommunitiesSharedMemberAddressSuite) joinOnRequestCommunityAsT
 	s.Require().True(userCommunity.IsTokenMaster())
 }
 
-func (s *MessengerCommunitiesSharedMemberAddressSuite) waitForRevealedAddresses(receiver *Messenger, communityID types2.HexBytes, expectedAccounts []*protobuf.RevealedAccount) {
+func (s *MessengerCommunitiesSharedMemberAddressSuite) waitForRevealedAddresses(receiver *Messenger, communityID types.HexBytes, expectedAccounts []*protobuf.RevealedAccount) {
 	_, err := WaitOnMessengerResponse(receiver, func(r *MessengerResponse) bool {
 		revealedAccounts, err := receiver.communitiesManager.GetRevealedAddresses(communityID, s.alice.IdentityPublicKeyString())
 		if err != nil {

--- a/protocol/communities_messenger_test.go
+++ b/protocol/communities_messenger_test.go
@@ -24,13 +24,13 @@ import (
 	gethcommon "github.com/ethereum/go-ethereum/common"
 
 	"github.com/status-im/status-go/internal/crypto"
-	"github.com/status-im/status-go/internal/crypto/types"
+	cryptotypes "github.com/status-im/status-go/internal/crypto/types"
 	"github.com/status-im/status-go/internal/db/multiaccounts/accounts"
 	multiaccountscommon "github.com/status-im/status-go/internal/db/multiaccounts/common"
 	"github.com/status-im/status-go/internal/images"
 	"github.com/status-im/status-go/internal/testutils"
 	"github.com/status-im/status-go/pkg/messaging"
-	types2 "github.com/status-im/status-go/pkg/messaging/types"
+	messagingtypes "github.com/status-im/status-go/pkg/messaging/types"
 	"github.com/status-im/status-go/protocol/common"
 	"github.com/status-im/status-go/protocol/communities"
 	"github.com/status-im/status-go/protocol/discord"
@@ -1319,7 +1319,7 @@ func (s *MessengerCommunitiesSuite) TestDeletePendingRequestAccessWithDeclinedSt
 
 	// Alice deletes activity center notification
 	var updatedAt uint64 = 99
-	_, err = s.alice.MarkActivityCenterNotificationsDeleted(ctx, []types.HexBytes{notification.ID}, updatedAt, true)
+	_, err = s.alice.MarkActivityCenterNotificationsDeleted(ctx, []cryptotypes.HexBytes{notification.ID}, updatedAt, true)
 	s.Require().NoError(err)
 
 	// Check activity center notification for Bob after deleting
@@ -1433,7 +1433,7 @@ func (s *MessengerCommunitiesSuite) TestDeletePendingRequestAccessWithDeclinedSt
 
 	// Bob deletes activity center notification
 	updatedAt++
-	_, err = s.bob.MarkActivityCenterNotificationsDeleted(ctx, []types.HexBytes{notification.ID}, updatedAt, true)
+	_, err = s.bob.MarkActivityCenterNotificationsDeleted(ctx, []cryptotypes.HexBytes{notification.ID}, updatedAt, true)
 	s.Require().NoError(err)
 
 	// Check activity center notification for Bob after deleting
@@ -2267,7 +2267,7 @@ func (s *MessengerCommunitiesSuite) TestShareCommunity() {
 	// Alice shares community with Bob
 	response, err = s.owner.ShareCommunity(&requests.ShareCommunity{
 		CommunityID:   community.ID(),
-		Users:         []types.HexBytes{crypto.PubkeyToHexBytes(&s.alice.identity.PublicKey)},
+		Users:         []cryptotypes.HexBytes{crypto.PubkeyToHexBytes(&s.alice.identity.PublicKey)},
 		InviteMessage: inputMessageText,
 	})
 
@@ -2471,7 +2471,7 @@ func (s *MessengerCommunitiesSuite) createOtherDevice(m1 *Messenger) *Messenger 
 	s.Len(tcs, 0, "Must have 0 communities")
 
 	// Pair devices
-	metadata := &types2.InstallationMetadata{
+	metadata := &messagingtypes.InstallationMetadata{
 		Name:       "other-device",
 		DeviceType: "other-device-type",
 	}
@@ -2780,7 +2780,7 @@ func (s *MessengerCommunitiesSuite) TestSyncCommunity_EncryptionKeys() {
 // makes a request to join a community
 func (s *MessengerCommunitiesSuite) TestSyncCommunity_RequestToJoin() {
 	// Set Alice's installation metadata
-	aim := &types2.InstallationMetadata{
+	aim := &messagingtypes.InstallationMetadata{
 		Name:       "alice's-device",
 		DeviceType: "alice's-device-type",
 	}
@@ -3006,7 +3006,7 @@ func (s *MessengerCommunitiesSuite) TestSyncCommunity_Join() {
 
 func (s *MessengerCommunitiesSuite) TestSyncCommunity_Leave() {
 	// Set Alice's installation metadata
-	aim := &types2.InstallationMetadata{
+	aim := &messagingtypes.InstallationMetadata{
 		Name:       "alice's-device",
 		DeviceType: "alice's-device-type",
 	}
@@ -3749,12 +3749,12 @@ func (s *MessengerCommunitiesSuite) TestHandleImport() {
 	)
 	s.Require().NoError(err)
 
-	message := &types2.ReceivedMessage{}
+	message := &messagingtypes.ReceivedMessage{}
 	message.Sig = crypto.FromECDSAPub(&s.owner.identity.PublicKey)
 	message.Payload = wrappedPayload
 
 	filter := s.alice.messaging.ChatFilterByChatID(community.UniversalChatID())
-	importedMessages := make(map[types2.ChatFilter][]*types2.ReceivedMessage, 0)
+	importedMessages := make(map[messagingtypes.ChatFilter][]*messagingtypes.ReceivedMessage, 0)
 
 	importedMessages[*filter] = append(importedMessages[*filter], message)
 

--- a/protocol/communities_signer_test.go
+++ b/protocol/communities_signer_test.go
@@ -3,7 +3,7 @@ package protocol
 import (
 	"github.com/status-im/status-go/internal/accounts-management/generator"
 	"github.com/status-im/status-go/internal/crypto"
-	types2 "github.com/status-im/status-go/internal/crypto/types"
+	"github.com/status-im/status-go/internal/crypto/types"
 	"github.com/status-im/status-go/protocol/common"
 	"github.com/status-im/status-go/services/personal"
 )
@@ -14,28 +14,28 @@ func NewSignerStub() *SignerStub {
 	return &SignerStub{}
 }
 
-func (s *SignerStub) Recover(rpcParams personal.RecoverParams) (addr types2.Address, err error) {
-	sig := types2.HexBytes(rpcParams.Signature)
+func (s *SignerStub) Recover(rpcParams personal.RecoverParams) (addr types.Address, err error) {
+	sig := types.HexBytes(rpcParams.Signature)
 	if len(sig) != 65 {
-		return types2.Address{}, personal.ErrInvalidSignatureLength
+		return types.Address{}, personal.ErrInvalidSignatureLength
 	}
 	if sig[64] != 27 && sig[64] != 28 {
-		return types2.Address{}, personal.ErrInvalidSignatureV
+		return types.Address{}, personal.ErrInvalidSignatureV
 	}
 	sig[64] -= 27 // Transform yellow paper V from 27/28 to 0/1
-	hash := crypto.TextHash(types2.HexBytes(rpcParams.Message))
+	hash := crypto.TextHash(types.HexBytes(rpcParams.Message))
 	rpk, err := crypto.SigToPub(hash, sig)
 	if err != nil {
-		return types2.Address{}, err
+		return types.Address{}, err
 	}
 	return crypto.PubkeyToAddress(*rpk), nil
 }
 
-func (s *SignerStub) CanRecover(rpcParams personal.RecoverParams, revealedAddress types2.Address) (bool, error) {
+func (s *SignerStub) CanRecover(rpcParams personal.RecoverParams, revealedAddress types.Address) (bool, error) {
 	return true, nil
 }
 
-func (s *SignerStub) Sign(rpcParams personal.SignParams, verifiedAccount *generator.Account) (result types2.HexBytes, err error) {
+func (s *SignerStub) Sign(rpcParams personal.SignParams, verifiedAccount *generator.Account) (result types.HexBytes, err error) {
 	bytesArray := []byte(rpcParams.Address)
 	bytesArray = append(bytesArray, []byte(rpcParams.Password)...)
 	bytesArray = common.Shake256(bytesArray)

--- a/protocol/local_notification_settings_test.go
+++ b/protocol/local_notification_settings_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	"github.com/status-im/status-go/internal/crypto"
-	testutils2 "github.com/status-im/status-go/internal/testutils"
+	"github.com/status-im/status-go/internal/testutils"
 )
 
 func TestLocalNotificationSettingsSuite(t *testing.T) {
@@ -45,7 +45,7 @@ func (s *LocalNotificationSettingsSuite) TestOneToOneChatsTurnOff() {
 
 	// Sync until bob receives the message
 	var bobResponse *MessengerResponse
-	err = testutils2.RetryWithBackOff(func() error {
+	err = testutils.RetryWithBackOff(func() error {
 		_, err := alice.RetrieveAll()
 		if err != nil {
 			return err
@@ -86,7 +86,7 @@ func (s *LocalNotificationSettingsSuite) TestOneToOneChatsSendAlerts() {
 
 	// Sync until bob receives the message
 	var bobResponse *MessengerResponse
-	err = testutils2.RetryWithBackOff(func() error {
+	err = testutils.RetryWithBackOff(func() error {
 		_, err := alice.RetrieveAll()
 		if err != nil {
 			return err
@@ -145,7 +145,7 @@ func (s *LocalNotificationSettingsSuite) TestGroupChatsTurnOff() {
 	s.Require().NoError(err)
 
 	var bobResponse *MessengerResponse
-	err = testutils2.RetryWithBackOff(func() error {
+	err = testutils.RetryWithBackOff(func() error {
 		_, err := alice.RetrieveAll()
 		if err != nil {
 			return err

--- a/protocol/messenger.go
+++ b/protocol/messenger.go
@@ -33,11 +33,11 @@ import (
 	"github.com/status-im/status-go/internal/db/multiaccounts"
 	"github.com/status-im/status-go/internal/db/multiaccounts/accounts"
 	multiaccountscommon "github.com/status-im/status-go/internal/db/multiaccounts/common"
-	settings2 "github.com/status-im/status-go/internal/db/multiaccounts/settings"
+	"github.com/status-im/status-go/internal/db/multiaccounts/settings"
 	"github.com/status-im/status-go/internal/images"
 	"github.com/status-im/status-go/internal/instrumentation/trace"
-	messaging2 "github.com/status-im/status-go/pkg/messaging"
-	types2 "github.com/status-im/status-go/pkg/messaging/types"
+	"github.com/status-im/status-go/pkg/messaging"
+	"github.com/status-im/status-go/pkg/messaging/types"
 	"github.com/status-im/status-go/protocol/contacts"
 
 	"github.com/status-im/status-go/protocol/common"
@@ -96,7 +96,7 @@ type Messenger struct {
 	config                    *config
 	identity                  *ecdsa.PrivateKey
 	signer                    communities.MessageSigner
-	messaging                 *messaging2.API
+	messaging                 *messaging.API
 	sender                    *common.MessageSender
 	persistence               *sqlitePersistence
 	ensVerifier               *ens.Verifier
@@ -179,11 +179,11 @@ type Messenger struct {
 	unhandledMessagesTracker func(*common.StatusMessage, error)
 
 	// enables control over chat messages iteration
-	retrievedMessagesIteratorFactory func(map[types2.ChatFilter][]*types2.ReceivedMessage) MessagesIterator
+	retrievedMessagesIteratorFactory func(map[types.ChatFilter][]*types.ReceivedMessage) MessagesIterator
 }
 
 type EnvelopeEventsInterceptor struct {
-	EnvelopeEventsHandler types2.EnvelopeEventsHandler
+	EnvelopeEventsHandler types.EnvelopeEventsHandler
 	Messenger             *Messenger
 }
 
@@ -268,7 +268,7 @@ func (interceptor EnvelopeEventsInterceptor) MailServerRequestExpired(hash crypt
 
 func NewMessenger(
 	identity *ecdsa.PrivateKey,
-	messaging *messaging2.API,
+	messaging *messaging.API,
 	installationID string,
 	opts ...Option,
 ) (*Messenger, error) {
@@ -795,7 +795,7 @@ func (m *Messenger) cleanTopics() error {
 	if m.mailserversDatabase == nil {
 		return nil
 	}
-	var filters types2.ChatFilters
+	var filters types.ChatFilters
 	for _, f := range m.messaging.ChatFilters() {
 		if f.IsListening() && !f.IsEphemeral() {
 			filters = append(filters, f)
@@ -902,12 +902,12 @@ func (m *Messenger) publishContactCode() error {
 		return err
 	}
 
-	contactCodeTopic := messaging2.ContactCodeTopic(&m.identity.PublicKey)
+	contactCodeTopic := messaging.ContactCodeTopic(&m.identity.PublicKey)
 	rawMessage := common.RawMessage{
 		LocalChatID: contactCodeTopic,
 		MessageType: protobuf.ApplicationMetadataMessage_CONTACT_CODE_ADVERTISEMENT,
 		Payload:     payload,
-		Priority:    &types2.LowPriority,
+		Priority:    &types.LowPriority,
 	}
 	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
 	defer cancel()
@@ -937,7 +937,7 @@ func (m *Messenger) publishContactCode() error {
 // contactCodeAdvertisement attaches a protobuf.ChatIdentity to the given protobuf.ContactCodeAdvertisement,
 // if the `shouldPublish` conditions are met
 func (m *Messenger) attachChatIdentity(cca *protobuf.ContactCodeAdvertisement) error {
-	contactCodeTopic := messaging2.ContactCodeTopic(&m.identity.PublicKey)
+	contactCodeTopic := messaging.ContactCodeTopic(&m.identity.PublicKey)
 	shouldPublish, err := m.shouldPublishChatIdentity(contactCodeTopic)
 	if err != nil {
 		return err
@@ -1014,7 +1014,7 @@ func (m *Messenger) handleStandaloneChatIdentity(chat *Chat) error {
 		LocalChatID: chat.ID,
 		MessageType: protobuf.ApplicationMetadataMessage_CHAT_IDENTITY,
 		Payload:     payload,
-		Priority:    &types2.LowPriority,
+		Priority:    &types.LowPriority,
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
@@ -1186,7 +1186,7 @@ func (m *Messenger) attachIdentityImagesToChatIdentity(context ChatContext, ci *
 		return err
 	}
 
-	if s.ProfilePicturesShowTo == settings2.ProfilePicturesShowToNone {
+	if s.ProfilePicturesShowTo == settings.ProfilePicturesShowToNone {
 		m.logger.Info(fmt.Sprintf("settings.ProfilePicturesShowTo is set to '%d', skipping attaching IdentityImages", s.ProfilePicturesShowTo))
 		return nil
 	}
@@ -1226,7 +1226,7 @@ func (m *Messenger) attachIdentityImagesToChatIdentity(context ChatContext, ci *
 		return fmt.Errorf("unknown ChatIdentity context '%s'", context)
 	}
 
-	if s.ProfilePicturesShowTo == settings2.ProfilePicturesShowToContactsOnly {
+	if s.ProfilePicturesShowTo == settings.ProfilePicturesShowToContactsOnly {
 		err := EncryptIdentityImagesWithContactPubKeys(ci.Images, m)
 		if err != nil {
 			return err
@@ -1237,7 +1237,7 @@ func (m *Messenger) attachIdentityImagesToChatIdentity(context ChatContext, ci *
 }
 
 // handleInstallations adds the installations in the installations map
-func (m *Messenger) handleInstallations(installations []*types2.Installation) {
+func (m *Messenger) handleInstallations(installations []*types.Installation) {
 	for _, installation := range installations {
 		if installation.Identity == contacts.ContactIDFromPublicKey(&m.identity.PublicKey) {
 			if _, ok := m.allInstallations.Load(installation.ID); !ok {
@@ -1249,7 +1249,7 @@ func (m *Messenger) handleInstallations(installations []*types2.Installation) {
 }
 
 // handleEncryptionLayerSubscriptions handles events from the encryption layer
-func (m *Messenger) handleEncryptionLayerSubscriptions(subscriptions *types2.EncryptionSubscriptions) {
+func (m *Messenger) handleEncryptionLayerSubscriptions(subscriptions *types.EncryptionSubscriptions) {
 	m.shutdownWaitGroup.Add(1)
 	go func() {
 		defer gocommon.LogOnPanic()
@@ -1362,20 +1362,20 @@ func (m *Messenger) watchConnectionChange() {
 			case wasOnline && force && previousCheck.Before(historyNow):
 				// The process did not observe connectivity during this interval
 				// (typically system sleep), so treat it as unreliable.
-				m.asyncRequestHistoricMessages(types2.HistoryReconcileWindow{From: previousCheck, To: historyNow})
+				m.asyncRequestHistoricMessages(types.HistoryReconcileWindow{From: previousCheck, To: historyNow})
 			}
 			m.notifyHistoricSyncWorker()
 		}
 	}
 
-	subscribedConnectionStatus := func(subscription types2.ConnectionStatusSubscription) {
+	subscribedConnectionStatus := func(subscription types.ConnectionStatusSubscription) {
 		defer gocommon.LogOnPanic()
 		defer m.shutdownWaitGroup.Done()
 		defer subscription.Unsubscribe()
 		ticker := time.NewTicker(keepAlivePeriod)
 		defer ticker.Stop()
 		// Sentinel outside the valid enum range so the first event always emits.
-		lastConnState := types2.ConnectionState(-1)
+		lastConnState := types.ConnectionState(-1)
 		for {
 			select {
 			case status := <-subscription.C():
@@ -1787,7 +1787,7 @@ func (m *Messenger) hasPairedDevices() bool {
 	}
 
 	var count int
-	m.allInstallations.Range(func(installationID string, installation *types2.Installation) (shouldContinue bool) {
+	m.allInstallations.Range(func(installationID string, installation *types.Installation) (shouldContinue bool) {
 		if installation.Enabled {
 			count++
 		}
@@ -3124,7 +3124,7 @@ func (m *Messenger) buildMessageState() *ReceivedMessageState {
 	}
 }
 
-func (m *Messenger) outputToCSV(timestamp uint32, messageID cryptotypes.HexBytes, from string, topic types2.ContentTopic, chatID string, msgType protobuf.ApplicationMetadataMessage_Type, parsedMessage interface{}) {
+func (m *Messenger) outputToCSV(timestamp uint32, messageID cryptotypes.HexBytes, from string, topic types.ContentTopic, chatID string, msgType protobuf.ApplicationMetadataMessage_Type, parsedMessage interface{}) {
 	if !m.outputCSV {
 		return
 	}
@@ -3156,7 +3156,7 @@ func (m *Messenger) shouldSkipDuplicate(messageType protobuf.ApplicationMetadata
 	return true
 }
 
-func (m *Messenger) handleImportedMessages(messagesToHandle map[types2.ChatFilter][]*types2.ReceivedMessage) error {
+func (m *Messenger) handleImportedMessages(messagesToHandle map[types.ChatFilter][]*types.ReceivedMessage) error {
 
 	messageState := m.buildMessageState()
 
@@ -3310,7 +3310,7 @@ func (m *Messenger) handleImportedMessages(messagesToHandle map[types2.ChatFilte
 	return nil
 }
 
-func (m *Messenger) handleRetrievedMessages(chatWithMessages map[types2.ChatFilter][]*types2.ReceivedMessage, storeWakuMessages bool, fromArchive bool) (*MessengerResponse, error) {
+func (m *Messenger) handleRetrievedMessages(chatWithMessages map[types.ChatFilter][]*types.ReceivedMessage, storeWakuMessages bool, fromArchive bool) (*MessengerResponse, error) {
 
 	m.handleMessagesMutex.Lock()
 	defer m.handleMessagesMutex.Unlock()
@@ -3362,7 +3362,7 @@ func (m *Messenger) handleRetrievedMessages(chatWithMessages map[types2.ChatFilt
 				continue
 			}
 
-			m.messaging.MetricsPushReceivedMessages(types2.ReceivedMessages{
+			m.messaging.MetricsPushReceivedMessages(types.ReceivedMessages{
 				Filter:     filter,
 				SHHMessage: shhMessage,
 				Messages:   handleMessagesResponse.Messages,
@@ -3400,7 +3400,7 @@ func (m *Messenger) processStatusMessage(
 	hash []byte,
 	messageState *ReceivedMessageState,
 	msg *common.StatusMessage,
-	filter types2.ChatFilter,
+	filter types.ChatFilter,
 	fromArchive bool,
 	logger *zap.Logger) error {
 	messageID := cryptotypes.EncodeHex(msg.ApplicationLayer.ID)
@@ -4721,10 +4721,10 @@ func (m *Messenger) encodeChatEntity(chat *Chat, message ChatEntity) ([]byte, er
 	return encodedMessage, nil
 }
 
-func (m *Messenger) getSettings() (settings2.Settings, error) {
+func (m *Messenger) getSettings() (settings.Settings, error) {
 	sDB, err := accounts.NewDB(m.database)
 	if err != nil {
-		return settings2.Settings{}, err
+		return settings.Settings{}, err
 	}
 	return sDB.GetSettings()
 }
@@ -4857,7 +4857,7 @@ func (m *Messenger) FindStatusMessageIDForBridgeMessageID(bridgeMessageID string
 	return m.persistence.FindStatusMessageIDForBridgeMessageID(bridgeMessageID)
 }
 
-func (m *Messenger) Messaging() *messaging2.API {
+func (m *Messenger) Messaging() *messaging.API {
 	return m.messaging
 }
 

--- a/protocol/messenger_builder_test.go
+++ b/protocol/messenger_builder_test.go
@@ -19,14 +19,14 @@ import (
 	"github.com/status-im/status-go/internal/db/appdatabase"
 	"github.com/status-im/status-go/internal/db/multiaccounts"
 	"github.com/status-im/status-go/internal/db/multiaccounts/accounts"
-	settings2 "github.com/status-im/status-go/internal/db/multiaccounts/settings"
+	"github.com/status-im/status-go/internal/db/multiaccounts/settings"
 	"github.com/status-im/status-go/internal/db/walletdatabase"
 	"github.com/status-im/status-go/internal/instrumentation/trace"
 	"github.com/status-im/status-go/internal/rpc/network"
 	networktestutil "github.com/status-im/status-go/internal/rpc/network/testutil"
 	"github.com/status-im/status-go/internal/testutils"
 	"github.com/status-im/status-go/params"
-	messaging2 "github.com/status-im/status-go/pkg/messaging"
+	"github.com/status-im/status-go/pkg/messaging"
 	"github.com/status-im/status-go/protocol/common"
 	"github.com/status-im/status-go/protocol/ens"
 	"github.com/status-im/status-go/protocol/protobuf"
@@ -43,10 +43,10 @@ type testMessengerConfig struct {
 	unhandledMessagesTracker *unhandledMessagesTracker
 	messagesOrderController  *MessagesOrderController
 
-	appSettings      *settings2.Settings
+	appSettings      *settings.Settings
 	nodeConfig       *params.NodeConfig
 	extraOptions     []Option
-	messagingOptions []messaging2.Options
+	messagingOptions []messaging.Options
 }
 
 func (tmc *testMessengerConfig) complete(t *testing.T) error {
@@ -80,7 +80,7 @@ func (tmc *testMessengerConfig) complete(t *testing.T) error {
 	return nil
 }
 
-func newTestMessenger(t *testing.T, messagingEnv *messaging2.TestMessagingEnvironment, config testMessengerConfig) (*Messenger, error) {
+func newTestMessenger(t *testing.T, messagingEnv *messaging.TestMessagingEnvironment, config testMessengerConfig) (*Messenger, error) {
 	err := config.complete(t)
 	if err != nil {
 		return nil, err
@@ -146,15 +146,15 @@ func newTestMessenger(t *testing.T, messagingEnv *messaging2.TestMessagingEnviro
 
 	installationID := uuid.New().String()
 
-	messagingCoreOptions := []messaging2.Options{
-		messaging2.WithLogger(config.logger.Named("messaging")),
-		messaging2.WithTracer(trace.NewTracer(otel.Tracer("messaging_" + config.name))),
-		messaging2.WithSQLitePersistence(appDb),
+	messagingCoreOptions := []messaging.Options{
+		messaging.WithLogger(config.logger.Named("messaging")),
+		messaging.WithTracer(trace.NewTracer(otel.Tracer("messaging_" + config.name))),
+		messaging.WithSQLitePersistence(appDb),
 	}
 	messagingCoreOptions = append(messagingCoreOptions, config.messagingOptions...)
 
 	messaging, err := messagingEnv.NewTestCore(
-		messaging2.CoreParams{
+		messaging.CoreParams{
 			Identity:       config.privateKey,
 			InstallationID: installationID,
 			TimeSource:     &testTimeSource{},
@@ -234,7 +234,7 @@ func newTestMessenger(t *testing.T, messagingEnv *messaging2.TestMessagingEnviro
 	return m, nil
 }
 
-func newRunningTestMessenger(t *testing.T, messagingEnv *messaging2.TestMessagingEnvironment, config testMessengerConfig) (*Messenger, error) {
+func newRunningTestMessenger(t *testing.T, messagingEnv *messaging.TestMessagingEnvironment, config testMessengerConfig) (*Messenger, error) {
 	m, err := newTestMessenger(t, messagingEnv, config)
 	require.NoError(t, err)
 
@@ -278,12 +278,12 @@ func (u *unhandledMessagesTracker) addMessage(msg *common.StatusMessage, err err
 	u.messages[msgType] = append(u.messages[msgType], newMessage)
 }
 
-func newTestSettings() *settings2.Settings {
-	return &settings2.Settings{
+func newTestSettings() *settings.Settings {
+	return &settings.Settings{
 		DisplayName:                DefaultProfileDisplayName,
 		ProfilePicturesShowTo:      1,
 		ProfilePicturesVisibility:  1,
-		URLUnfurlingMode:           settings2.URLUnfurlingAlwaysAsk,
+		URLUnfurlingMode:           settings.URLUnfurlingAlwaysAsk,
 		AutoApplyKeypairMigrations: true,
 	}
 }

--- a/protocol/messenger_communities.go
+++ b/protocol/messenger_communities.go
@@ -29,10 +29,10 @@ import (
 	utils "github.com/status-im/status-go/common"
 	accsmanagementtypes "github.com/status-im/status-go/internal/accounts-management/types"
 	"github.com/status-im/status-go/internal/crypto"
-	"github.com/status-im/status-go/internal/crypto/types"
+	cryptotypes "github.com/status-im/status-go/internal/crypto/types"
 	multiaccountscommon "github.com/status-im/status-go/internal/db/multiaccounts/common"
 	"github.com/status-im/status-go/internal/images"
-	types2 "github.com/status-im/status-go/pkg/messaging/types"
+	messagingtypes "github.com/status-im/status-go/pkg/messaging/types"
 	"github.com/status-im/status-go/protocol/common"
 	"github.com/status-im/status-go/protocol/communities"
 	archivetypes "github.com/status-im/status-go/protocol/communities/archive/types"
@@ -100,7 +100,7 @@ func (r *FetchCommunityRequest) Validate() error {
 	if len(r.CommunityKey) <= 2 {
 		return fmt.Errorf("community key is too short")
 	}
-	if _, err := types.DecodeHex(r.CommunityKey); err != nil {
+	if _, err := cryptotypes.DecodeHex(r.CommunityKey); err != nil {
 		return fmt.Errorf("invalid community key")
 	}
 	return nil
@@ -114,7 +114,7 @@ func GetCommunityIDFromKey(communityKey string) string {
 	// Check if the key is a private key. strip the 0x at the start
 	if privateKey, err := crypto.HexToECDSA(communityKey[2:]); err == nil {
 		// It is a privateKey
-		return types.HexBytes(crypto.CompressPubkey(&privateKey.PublicKey)).String()
+		return cryptotypes.HexBytes(crypto.CompressPubkey(&privateKey.PublicKey)).String()
 	}
 
 	// Not a private key, use the public key
@@ -157,12 +157,12 @@ func (m *Messenger) publishOrg(org *communities.Community, shouldRekey bool) err
 		CommunityID:         org.ID(),
 		MessageType:         protobuf.ApplicationMetadataMessage_COMMUNITY_DESCRIPTION,
 		PubsubTopic:         org.PubsubTopic(), // TODO: confirm if it should be sent in community pubsub topic
-		Priority:            &types2.HighPriority,
+		Priority:            &messagingtypes.HighPriority,
 	}
 	if org.Encrypted() {
 		members := org.GetMemberPubkeys()
 		// Ensure encryption keys are attached to CommunityDescription to avoid timing issues
-		rawMessage.CommunityKeyExMsgType = types2.KeyExMsgReuse
+		rawMessage.CommunityKeyExMsgType = messagingtypes.KeyExMsgReuse
 		rawMessage.HashRatchetGroupID = org.ID()
 		rawMessage.Recipients = members
 	}
@@ -195,11 +195,11 @@ func (m *Messenger) publishCommunityEvents(community *communities.Community, msg
 		SkipEncryptionLayer: true,
 		MessageType:         protobuf.ApplicationMetadataMessage_COMMUNITY_EVENTS_MESSAGE,
 		PubsubTopic:         community.PubsubTopic(), // TODO: confirm if it should be sent in community pubsub topic
-		Priority:            &types2.LowPriority,
+		Priority:            &messagingtypes.LowPriority,
 	}
 
 	// TODO: resend in case of failure?
-	_, err = m.sender.SendPublic(context.Background(), types.EncodeHex(msg.CommunityID), rawMessage)
+	_, err = m.sender.SendPublic(context.Background(), cryptotypes.EncodeHex(msg.CommunityID), rawMessage)
 	return err
 }
 
@@ -368,7 +368,7 @@ func (m *Messenger) handleCommunitiesSubscription(c chan *communities.Subscripti
 					Sender:              community.PrivateKey(),
 					SkipEncryptionLayer: true,
 					MessageType:         protobuf.ApplicationMetadataMessage_COMMUNITY_USER_KICKED,
-					PubsubTopic:         types2.DefaultNonProtectedPubsubTopic(),
+					PubsubTopic:         messagingtypes.DefaultNonProtectedPubsubTopic(),
 				}
 
 				_, err = m.sender.SendPrivate(context.Background(), pk, rawMessage)
@@ -709,7 +709,7 @@ func (m *Messenger) handleCommunitySharedAddressesRequest(state *ReceivedMessage
 		CommunityID:         community.ID(),
 		SkipEncryptionLayer: true,
 		MessageType:         protobuf.ApplicationMetadataMessage_COMMUNITY_SHARED_ADDRESSES_RESPONSE,
-		PubsubTopic:         types2.DefaultNonProtectedPubsubTopic(),
+		PubsubTopic:         messagingtypes.DefaultNonProtectedPubsubTopic(),
 		ResendType:          common.ResendTypeRawMessage,
 		ResendMethod:        common.ResendMethodSendPrivate,
 		Recipients:          []*ecdsa.PublicKey{signer},
@@ -797,7 +797,7 @@ func (m *Messenger) publishGroupGrantMessage(community *communities.Community, t
 		SkipEncryptionLayer: true,
 		MessageType:         protobuf.ApplicationMetadataMessage_COMMUNITY_UPDATE_GRANT,
 		PubsubTopic:         community.PubsubTopic(),
-		Priority:            &types2.LowPriority,
+		Priority:            &messagingtypes.LowPriority,
 	}
 
 	_, err = m.sender.SendPublic(context.Background(), community.IDString(), rawMessage)
@@ -991,7 +991,7 @@ func (m *Messenger) initCommunityChats(community *communities.Community) ([]*Cha
 	if community.IsControlNode() {
 		// Init the community filter so we can receive messages on the community
 
-		communityFilters, err := m.InitCommunityFilters(types2.CommunitiesToInitialize{{
+		communityFilters, err := m.InitCommunityFilters(messagingtypes.CommunitiesToInitialize{{
 			PrivKey: community.PrivateKey(),
 		}})
 
@@ -1029,7 +1029,7 @@ func (m *Messenger) initCommunityChats(community *communities.Community) ([]*Cha
 	return chats, nil
 }
 
-func (m *Messenger) initCommunitySettings(communityID types.HexBytes) (*communities.CommunitySettings, error) {
+func (m *Messenger) initCommunitySettings(communityID cryptotypes.HexBytes) (*communities.CommunitySettings, error) {
 	communitySettings, err := m.communitiesManager.GetCommunitySettingsByID(communityID)
 	if err != nil {
 		return nil, err
@@ -1050,7 +1050,7 @@ func (m *Messenger) initCommunitySettings(communityID types.HexBytes) (*communit
 	return communitySettings, nil
 }
 
-func (m *Messenger) JoinCommunity(ctx context.Context, communityID types.HexBytes, forceJoin bool) (*MessengerResponse, error) {
+func (m *Messenger) JoinCommunity(ctx context.Context, communityID cryptotypes.HexBytes, forceJoin bool) (*MessengerResponse, error) {
 	mr, err := m.joinCommunity(ctx, communityID, forceJoin)
 	if err != nil {
 		return nil, err
@@ -1066,7 +1066,7 @@ func (m *Messenger) JoinCommunity(ctx context.Context, communityID types.HexByte
 	return mr, nil
 }
 
-func (m *Messenger) joinCommunity(ctx context.Context, communityID types.HexBytes, forceJoin bool) (*MessengerResponse, error) {
+func (m *Messenger) joinCommunity(ctx context.Context, communityID cryptotypes.HexBytes, forceJoin bool) (*MessengerResponse, error) {
 	logger := m.logger.Named("joinCommunity")
 	response := &MessengerResponse{}
 	community, _ := m.communitiesManager.GetByID(communityID)
@@ -1115,7 +1115,7 @@ func (m *Messenger) joinCommunity(ctx context.Context, communityID types.HexByte
 	// Was applicant not a member and successfully joined?
 	if !isCommunityMember && community.Joined() {
 		joinedNotification := &localnotifications.Notification{
-			ID:            gethcommon.Hash(types.BytesToHash([]byte(`you-joined-` + communityID.String()))),
+			ID:            gethcommon.Hash(cryptotypes.BytesToHash([]byte(`you-joined-` + communityID.String()))),
 			Title:         community.Name(),
 			Message:       community.Name(),
 			BodyType:      localnotifications.TypeMessage,
@@ -1150,7 +1150,7 @@ func (m *Messenger) joinCommunity(ctx context.Context, communityID types.HexByte
 	return response, nil
 }
 
-func (m *Messenger) SpectateCommunity(communityID types.HexBytes) (*MessengerResponse, error) {
+func (m *Messenger) SpectateCommunity(communityID cryptotypes.HexBytes) (*MessengerResponse, error) {
 	logger := m.logger.Named("SpectateCommunity")
 
 	response := &MessengerResponse{}
@@ -1306,7 +1306,7 @@ func (m *Messenger) SetMutePropertyOnChatsByCategory(request *requests.MuteCateg
 // Generates a single hash for each address that needs to be revealed to a community.
 // Each hash needs to be signed.
 // The order of retuned hashes corresponds to the order of addresses in addressesToReveal.
-func (m *Messenger) generateCommunityRequestsForSigning(memberPubKey string, communityID types.HexBytes, addressesToReveal []string, isEdit bool) ([]personal.SignParams, error) {
+func (m *Messenger) generateCommunityRequestsForSigning(memberPubKey string, communityID cryptotypes.HexBytes, addressesToReveal []string, isEdit bool) ([]personal.SignParams, error) {
 	walletAccounts, err := m.settings.GetActiveAccounts()
 	if err != nil {
 		return nil, err
@@ -1314,7 +1314,7 @@ func (m *Messenger) generateCommunityRequestsForSigning(memberPubKey string, com
 
 	containsAddress := func(addresses []string, targetAddress string) bool {
 		for _, address := range addresses {
-			if types.HexToAddress(address) == types.HexToAddress(targetAddress) {
+			if cryptotypes.HexToAddress(address) == cryptotypes.HexToAddress(targetAddress) {
 				return true
 			}
 		}
@@ -1336,7 +1336,7 @@ func (m *Messenger) generateCommunityRequestsForSigning(memberPubKey string, com
 			requestID = communities.CalculateRequestID(memberPubKey, communityID)
 		}
 		msgsToSign = append(msgsToSign, personal.SignParams{
-			Data:    types.EncodeHex(crypto.Keccak256(m.IdentityPublicKeyCompressed(), communityID, requestID)),
+			Data:    cryptotypes.EncodeHex(crypto.Keccak256(m.IdentityPublicKeyCompressed(), communityID, requestID)),
 			Address: walletAccount.Address.Hex(),
 		})
 	}
@@ -1344,14 +1344,14 @@ func (m *Messenger) generateCommunityRequestsForSigning(memberPubKey string, com
 	return msgsToSign, nil
 }
 
-func (m *Messenger) GenerateJoiningCommunityRequestsForSigning(memberPubKey string, communityID types.HexBytes, addressesToReveal []string) ([]personal.SignParams, error) {
+func (m *Messenger) GenerateJoiningCommunityRequestsForSigning(memberPubKey string, communityID cryptotypes.HexBytes, addressesToReveal []string) ([]personal.SignParams, error) {
 	if len(communityID) == 0 {
 		return nil, errors.New(ErrMissingCommunityID)
 	}
 	return m.generateCommunityRequestsForSigning(memberPubKey, communityID, addressesToReveal, false)
 }
 
-func (m *Messenger) GenerateEditCommunityRequestsForSigning(memberPubKey string, communityID types.HexBytes, addressesToReveal []string) ([]personal.SignParams, error) {
+func (m *Messenger) GenerateEditCommunityRequestsForSigning(memberPubKey string, communityID cryptotypes.HexBytes, addressesToReveal []string) ([]personal.SignParams, error) {
 	return m.generateCommunityRequestsForSigning(memberPubKey, communityID, addressesToReveal, true)
 }
 
@@ -1365,7 +1365,7 @@ func (m *Messenger) SignData(signParams []personal.SignParams) ([]string, error)
 			return nil, err
 		}
 
-		account, err := m.settings.GetAccountByAddress(types.HexToAddress(param.Address))
+		account, err := m.settings.GetAccountByAddress(cryptotypes.HexToAddress(param.Address))
 		if err != nil {
 			return nil, err
 		}
@@ -1383,7 +1383,7 @@ func (m *Messenger) SignData(signParams []personal.SignParams) ([]string, error)
 			return nil, errors.New(ErrSigningJoinRequestForColdWalletAccounts)
 		}
 
-		verifiedAccount, err := m.accountsManager.GetVerifiedWalletAccount(types.HexToAddress(param.Address), param.Password)
+		verifiedAccount, err := m.accountsManager.GetVerifiedWalletAccount(cryptotypes.HexToAddress(param.Address), param.Password)
 		if err != nil {
 			return nil, err
 		}
@@ -1393,7 +1393,7 @@ func (m *Messenger) SignData(signParams []personal.SignParams) ([]string, error)
 			return nil, err
 		}
 
-		signatures[i] = types.EncodeHex(signature)
+		signatures[i] = cryptotypes.EncodeHex(signature)
 	}
 
 	return signatures, nil
@@ -1482,8 +1482,8 @@ func (m *Messenger) RequestToJoinCommunity(request *requests.RequestToJoinCommun
 		ResendType:          common.ResendTypeRawMessage,
 		SkipEncryptionLayer: true,
 		MessageType:         protobuf.ApplicationMetadataMessage_COMMUNITY_REQUEST_TO_JOIN,
-		PubsubTopic:         types2.DefaultNonProtectedPubsubTopic(),
-		Priority:            &types2.HighPriority,
+		PubsubTopic:         messagingtypes.DefaultNonProtectedPubsubTopic(),
+		Priority:            &messagingtypes.HighPriority,
 	}
 
 	_, err = m.SendMessageToControlNode(ctx, community, rawMessage)
@@ -1565,7 +1565,7 @@ func (m *Messenger) RequestToJoinCommunity(request *requests.RequestToJoinCommun
 
 	// Activity center notification
 	notification := &ActivityCenterNotification{
-		ID:               types.FromHex(requestToJoin.ID.String()),
+		ID:               cryptotypes.FromHex(requestToJoin.ID.String()),
 		Type:             ActivityCenterNotificationTypeCommunityRequest,
 		Timestamp:        m.getTimesource().GetCurrentTime(),
 		CommunityID:      community.IDString(),
@@ -1582,7 +1582,7 @@ func (m *Messenger) RequestToJoinCommunity(request *requests.RequestToJoinCommun
 	}
 
 	for _, account := range requestToJoin.RevealedAccounts {
-		err := m.settings.AddressWasShown(types.HexToAddress(account.Address))
+		err := m.settings.AddressWasShown(cryptotypes.HexToAddress(account.Address))
 		if err != nil {
 			return nil, err
 		}
@@ -1632,7 +1632,7 @@ func (m *Messenger) EditSharedAddressesForCommunity(request *requests.EditShared
 	for i := range request.AddressesToReveal {
 		revealedAcc := &protobuf.RevealedAccount{
 			Address:          request.AddressesToReveal[i],
-			IsAirdropAddress: types.HexToAddress(request.AddressesToReveal[i]) == types.HexToAddress(request.AirdropAddress),
+			IsAirdropAddress: cryptotypes.HexToAddress(request.AddressesToReveal[i]) == cryptotypes.HexToAddress(request.AirdropAddress),
 			Signature:        request.Signatures[i],
 		}
 
@@ -1736,11 +1736,11 @@ func (m *Messenger) PublishTokenActionToPrivilegedMembers(communityID []byte, ch
 	return nil
 }
 
-func (m *Messenger) GetRevealedAccounts(communityID types.HexBytes, memberPk string) ([]*protobuf.RevealedAccount, error) {
+func (m *Messenger) GetRevealedAccounts(communityID cryptotypes.HexBytes, memberPk string) ([]*protobuf.RevealedAccount, error) {
 	return m.communitiesManager.GetRevealedAddresses(communityID, memberPk)
 }
 
-func (m *Messenger) GetRevealedAccountsForAllMembers(communityID types.HexBytes) (map[string][]*protobuf.RevealedAccount, error) {
+func (m *Messenger) GetRevealedAccountsForAllMembers(communityID cryptotypes.HexBytes) (map[string][]*protobuf.RevealedAccount, error) {
 	community, err := m.communitiesManager.GetByID(communityID)
 	if err != nil {
 		return nil, err
@@ -1873,9 +1873,9 @@ func (m *Messenger) CancelRequestToJoinCommunity(ctx context.Context, request *r
 		CommunityID:         community.ID(),
 		SkipEncryptionLayer: true,
 		MessageType:         protobuf.ApplicationMetadataMessage_COMMUNITY_CANCEL_REQUEST_TO_JOIN,
-		PubsubTopic:         types2.DefaultNonProtectedPubsubTopic(),
+		PubsubTopic:         messagingtypes.DefaultNonProtectedPubsubTopic(),
 		ResendType:          common.ResendTypeRawMessage,
-		Priority:            &types2.HighPriority,
+		Priority:            &messagingtypes.HighPriority,
 	}
 
 	_, err = m.SendMessageToControlNode(ctx, community, &rawMessage)
@@ -1942,7 +1942,7 @@ func (m *Messenger) CancelRequestToJoinCommunity(ctx context.Context, request *r
 
 	if notification != nil {
 		notification.IncrementUpdatedAt(m.getTimesource())
-		err = m.persistence.DeleteActivityCenterNotificationByID(types.FromHex(requestToJoin.ID.String()), notification.UpdatedAt)
+		err = m.persistence.DeleteActivityCenterNotificationByID(cryptotypes.FromHex(requestToJoin.ID.String()), notification.UpdatedAt)
 		if err != nil {
 			m.logger.Error("failed to delete notification from Activity Center", zap.Error(err))
 			return nil, err
@@ -1950,7 +1950,7 @@ func (m *Messenger) CancelRequestToJoinCommunity(ctx context.Context, request *r
 
 		// set notification as deleted, so that the client will remove the activity center notification from UI
 		notification.Deleted = true
-		err = m.syncActivityCenterDeletedByIDs(ctx, []types.HexBytes{notification.ID}, notification.UpdatedAt)
+		err = m.syncActivityCenterDeletedByIDs(ctx, []cryptotypes.HexBytes{notification.ID}, notification.UpdatedAt)
 		if err != nil {
 			m.logger.Error("CancelRequestToJoinCommunity, failed to sync activity center notification as deleted", zap.Error(err))
 			return nil, err
@@ -2029,11 +2029,11 @@ func (m *Messenger) acceptRequestToJoinCommunity(requestToJoin *communities.Requ
 			CommunityID:         community.ID(),
 			SkipEncryptionLayer: true,
 			MessageType:         protobuf.ApplicationMetadataMessage_COMMUNITY_REQUEST_TO_JOIN_RESPONSE,
-			PubsubTopic:         types2.DefaultNonProtectedPubsubTopic(),
+			PubsubTopic:         messagingtypes.DefaultNonProtectedPubsubTopic(),
 			ResendType:          common.ResendTypeRawMessage,
 			ResendMethod:        common.ResendMethodSendPrivate,
 			Recipients:          []*ecdsa.PublicKey{pk},
-			Priority:            &types2.HighPriority,
+			Priority:            &messagingtypes.HighPriority,
 		}
 
 		// Non-tokenized community treat community public key as the control node,
@@ -2048,7 +2048,7 @@ func (m *Messenger) acceptRequestToJoinCommunity(requestToJoin *communities.Requ
 
 		if community.Encrypted() {
 			rawMessage.HashRatchetGroupID = community.ID()
-			rawMessage.CommunityKeyExMsgType = types2.KeyExMsgReuse
+			rawMessage.CommunityKeyExMsgType = messagingtypes.KeyExMsgReuse
 		}
 
 		_, err = m.sender.SendPrivate(ctx, pk, rawMessage)
@@ -2188,7 +2188,7 @@ func (m *Messenger) DeclineRequestToJoinCommunity(request *requests.DeclineReque
 	return m.declineRequestToJoinCommunity(requestToJoin)
 }
 
-func (m *Messenger) LeaveCommunity(communityID types.HexBytes) (*MessengerResponse, error) {
+func (m *Messenger) LeaveCommunity(communityID cryptotypes.HexBytes) (*MessengerResponse, error) {
 	ctx, span := m.tracer.Start(context.Background(), "Messenger.LeaveCommunity")
 	defer span.End()
 
@@ -2242,7 +2242,7 @@ func (m *Messenger) LeaveCommunity(communityID types.HexBytes) (*MessengerRespon
 			MessageType:         protobuf.ApplicationMetadataMessage_COMMUNITY_REQUEST_TO_LEAVE,
 			PubsubTopic:         community.PubsubTopic(), // TODO: confirm if it should be sent in the community pubsub topic
 			ResendType:          common.ResendTypeRawMessage,
-			Priority:            &types2.HighPriority,
+			Priority:            &messagingtypes.HighPriority,
 		}
 
 		_, err = m.SendMessageToControlNode(ctx, community, &rawMessage)
@@ -2258,7 +2258,7 @@ func (m *Messenger) LeaveCommunity(communityID types.HexBytes) (*MessengerRespon
 	return mr, nil
 }
 
-func (m *Messenger) leaveCommunity(communityID types.HexBytes) (*MessengerResponse, error) {
+func (m *Messenger) leaveCommunity(communityID cryptotypes.HexBytes) (*MessengerResponse, error) {
 	response := &MessengerResponse{}
 
 	community, err := m.communitiesManager.LeaveCommunity(communityID)
@@ -2295,7 +2295,7 @@ func (m *Messenger) leaveCommunity(communityID types.HexBytes) (*MessengerRespon
 	return response, nil
 }
 
-func (m *Messenger) kickedOutOfCommunity(communityID types.HexBytes, spectateMode bool) (*MessengerResponse, error) {
+func (m *Messenger) kickedOutOfCommunity(communityID cryptotypes.HexBytes, spectateMode bool) (*MessengerResponse, error) {
 	response := &MessengerResponse{}
 
 	community, err := m.communitiesManager.KickedOutOfCommunity(communityID, spectateMode)
@@ -2355,7 +2355,7 @@ func (m *Messenger) CheckAndDeletePendingRequestToJoinCommunity(ctx context.Cont
 			if notification != nil {
 				// Delete activity centre notification for community admin
 				if notification.Type == ActivityCenterNotificationTypeCommunityMembershipRequest {
-					response2, err := m.MarkActivityCenterNotificationsDeleted(ctx, []types.HexBytes{notification.ID}, m.GetCurrentTimeInMillis(), true)
+					response2, err := m.MarkActivityCenterNotificationsDeleted(ctx, []cryptotypes.HexBytes{notification.ID}, m.GetCurrentTimeInMillis(), true)
 					if err != nil {
 						m.logger.Error("[CheckAndDeletePendingRequestToJoinCommunity] failed to mark notification as deleted", zap.Error(err))
 						return nil, err
@@ -2392,7 +2392,7 @@ func (m *Messenger) CheckAndDeletePendingRequestToJoinCommunity(ctx context.Cont
 	return nil, nil
 }
 
-func (m *Messenger) CreateCommunityChat(communityID types.HexBytes, c *protobuf.CommunityChat) (*MessengerResponse, error) {
+func (m *Messenger) CreateCommunityChat(communityID cryptotypes.HexBytes, c *protobuf.CommunityChat) (*MessengerResponse, error) {
 	var response MessengerResponse
 
 	c.Identity.FirstMessageTimestamp = FirstMessageTimestampNoMessage
@@ -2423,7 +2423,7 @@ func (m *Messenger) CreateCommunityChat(communityID types.HexBytes, c *protobuf.
 	return &response, nil
 }
 
-func (m *Messenger) EditCommunityChat(communityID types.HexBytes, chatID string, c *protobuf.CommunityChat) (*MessengerResponse, error) {
+func (m *Messenger) EditCommunityChat(communityID cryptotypes.HexBytes, chatID string, c *protobuf.CommunityChat) (*MessengerResponse, error) {
 	var response MessengerResponse
 	community, changes, err := m.communitiesManager.EditChat(communityID, chatID, c)
 	if err != nil {
@@ -2442,7 +2442,7 @@ func (m *Messenger) EditCommunityChat(communityID types.HexBytes, chatID string,
 	return &response, m.saveChats(chats)
 }
 
-func (m *Messenger) DeleteCommunityChat(communityID types.HexBytes, chatID string) (*MessengerResponse, error) {
+func (m *Messenger) DeleteCommunityChat(communityID cryptotypes.HexBytes, chatID string) (*MessengerResponse, error) {
 	response := &MessengerResponse{}
 
 	community, _, err := m.communitiesManager.DeleteChat(communityID, chatID)
@@ -2475,26 +2475,26 @@ func (m *Messenger) DeleteCommunityChat(communityID types.HexBytes, chatID strin
 	return response, nil
 }
 
-func (m *Messenger) InitCommunityFilters(c types2.CommunitiesToInitialize) (types2.ChatFilters, error) {
+func (m *Messenger) InitCommunityFilters(c messagingtypes.CommunitiesToInitialize) (messagingtypes.ChatFilters, error) {
 	return m.messaging.InitCommunities(c)
 }
 
-func (m *Messenger) DefaultFilters(o *communities.Community) types2.ChatsToInitialize {
+func (m *Messenger) DefaultFilters(o *communities.Community) messagingtypes.ChatsToInitialize {
 	cID := o.IDString()
 	uncompressedPubKey := crypto.PubkeyToHex(o.PublicKey())[2:]
 	memberUpdateChannelID := o.MemberUpdateChannelID()
 
 	communityPubsubTopic := o.PubsubTopic()
 
-	return types2.ChatsToInitialize{
+	return messagingtypes.ChatsToInitialize{
 		{ChatID: cID, PubsubTopic: communityPubsubTopic},
 		{ChatID: memberUpdateChannelID, PubsubTopic: communityPubsubTopic},
-		{ChatID: uncompressedPubKey, PubsubTopic: types2.DefaultNonProtectedPubsubTopic()},
+		{ChatID: uncompressedPubKey, PubsubTopic: messagingtypes.DefaultNonProtectedPubsubTopic()},
 		// Migration phase 1 (#7498): also listen for community control messages on
 		// the default shard (32), so that when publishing moves off the non-protected
 		// shard (64) to 32 (phase 2, separate PR) clients already receive them.
 		// Sending is unchanged here.
-		{ChatID: uncompressedPubKey, PubsubTopic: types2.DefaultShardPubsubTopic()},
+		{ChatID: uncompressedPubKey, PubsubTopic: messagingtypes.DefaultShardPubsubTopic()},
 	}
 }
 
@@ -2520,7 +2520,7 @@ func (m *Messenger) CreateCommunity(request *requests.CreateCommunity, createDef
 	}
 
 	// Init the community filter so we can receive messages on the community
-	_, err = m.InitCommunityFilters(types2.CommunitiesToInitialize{{
+	_, err = m.InitCommunityFilters(messagingtypes.CommunitiesToInitialize{{
 		PrivKey: community.PrivateKey(),
 	}})
 	if err != nil {
@@ -2773,7 +2773,7 @@ func (m *Messenger) EditCommunity(request *requests.EditCommunity) (*MessengerRe
 	return response, nil
 }
 
-func (m *Messenger) RemovePrivateKey(id types.HexBytes) (*MessengerResponse, error) {
+func (m *Messenger) RemovePrivateKey(id cryptotypes.HexBytes) (*MessengerResponse, error) {
 	community, err := m.communitiesManager.RemovePrivateKey(id)
 	if err != nil {
 		return nil, err
@@ -2785,7 +2785,7 @@ func (m *Messenger) RemovePrivateKey(id types.HexBytes) (*MessengerResponse, err
 	return response, nil
 }
 
-func (m *Messenger) ExportCommunity(id types.HexBytes) (*ecdsa.PrivateKey, error) {
+func (m *Messenger) ExportCommunity(id cryptotypes.HexBytes) (*ecdsa.PrivateKey, error) {
 	return m.communitiesManager.ExportCommunity(id)
 }
 
@@ -2840,7 +2840,7 @@ func (m *Messenger) ImportCommunity(ctx context.Context, key *ecdsa.PrivateKey) 
 	return response, nil
 }
 
-func (m *Messenger) GetCommunityByID(communityID types.HexBytes) (*communities.Community, error) {
+func (m *Messenger) GetCommunityByID(communityID cryptotypes.HexBytes) (*communities.Community, error) {
 	return m.communitiesManager.GetByID(communityID)
 }
 
@@ -2908,31 +2908,31 @@ func (m *Messenger) MyPendingRequestsToJoin() ([]*communities.RequestToJoin, err
 	return m.communitiesManager.PendingRequestsToJoinForUser(&m.identity.PublicKey)
 }
 
-func (m *Messenger) LatestRequestToJoinForCommunity(communityID types.HexBytes) (*communities.RequestToJoin, error) {
+func (m *Messenger) LatestRequestToJoinForCommunity(communityID cryptotypes.HexBytes) (*communities.RequestToJoin, error) {
 	return m.communitiesManager.GetCommunityRequestToJoinWithRevealedAddresses(m.myHexIdentity(), communityID)
 }
 
-func (m *Messenger) PendingRequestsToJoinForCommunity(id types.HexBytes) ([]*communities.RequestToJoin, error) {
+func (m *Messenger) PendingRequestsToJoinForCommunity(id cryptotypes.HexBytes) ([]*communities.RequestToJoin, error) {
 	return m.communitiesManager.PendingRequestsToJoinForCommunity(id)
 }
 
-func (m *Messenger) DeclinedRequestsToJoinForCommunity(id types.HexBytes) ([]*communities.RequestToJoin, error) {
+func (m *Messenger) DeclinedRequestsToJoinForCommunity(id cryptotypes.HexBytes) ([]*communities.RequestToJoin, error) {
 	return m.communitiesManager.DeclinedRequestsToJoinForCommunity(id)
 }
 
-func (m *Messenger) CanceledRequestsToJoinForCommunity(id types.HexBytes) ([]*communities.RequestToJoin, error) {
+func (m *Messenger) CanceledRequestsToJoinForCommunity(id cryptotypes.HexBytes) ([]*communities.RequestToJoin, error) {
 	return m.communitiesManager.CanceledRequestsToJoinForCommunity(id)
 }
 
-func (m *Messenger) AcceptedRequestsToJoinForCommunity(id types.HexBytes) ([]*communities.RequestToJoin, error) {
+func (m *Messenger) AcceptedRequestsToJoinForCommunity(id cryptotypes.HexBytes) ([]*communities.RequestToJoin, error) {
 	return m.communitiesManager.AcceptedRequestsToJoinForCommunity(id)
 }
 
-func (m *Messenger) AcceptedPendingRequestsToJoinForCommunity(id types.HexBytes) ([]*communities.RequestToJoin, error) {
+func (m *Messenger) AcceptedPendingRequestsToJoinForCommunity(id cryptotypes.HexBytes) ([]*communities.RequestToJoin, error) {
 	return m.communitiesManager.AcceptedPendingRequestsToJoinForCommunity(id)
 }
 
-func (m *Messenger) DeclinedPendingRequestsToJoinForCommunity(id types.HexBytes) ([]*communities.RequestToJoin, error) {
+func (m *Messenger) DeclinedPendingRequestsToJoinForCommunity(id cryptotypes.HexBytes) ([]*communities.RequestToJoin, error) {
 	return m.communitiesManager.DeclinedPendingRequestsToJoinForCommunity(id)
 }
 
@@ -2940,7 +2940,7 @@ func (m *Messenger) AllNonApprovedCommunitiesRequestsToJoin() ([]*communities.Re
 	return m.communitiesManager.AllNonApprovedCommunitiesRequestsToJoin()
 }
 
-func (m *Messenger) RemoveUserFromCommunity(id types.HexBytes, pkString string) (*MessengerResponse, error) {
+func (m *Messenger) RemoveUserFromCommunity(id cryptotypes.HexBytes, pkString string) (*MessengerResponse, error) {
 	publicKey, err := crypto.HexToPubkey(pkString)
 	if err != nil {
 		return nil, err
@@ -3103,7 +3103,7 @@ func (m *Messenger) handleCommunityDescription(state *ReceivedMessageState, sign
 		for _, r := range communityResponse.FailedToDecrypt {
 			if state.CurrentMessageState != nil && state.CurrentMessageState.StatusMessage != nil {
 				err := m.messaging.SaveHashRatchetMessage(r.GroupID, r.KeyID, state.CurrentMessageState.StatusMessage.TransportLayer.Message)
-				m.logger.Info("saving failed to decrypt community description", zap.String("hash", types.Bytes2Hex(state.CurrentMessageState.StatusMessage.TransportLayer.Message.Hash)))
+				m.logger.Info("saving failed to decrypt community description", zap.String("hash", cryptotypes.Bytes2Hex(state.CurrentMessageState.StatusMessage.TransportLayer.Message.Hash)))
 				if err != nil {
 					m.logger.Warn("failed to save waku message")
 				}
@@ -3674,7 +3674,7 @@ func (m *Messenger) InitHistoryArchiveTasks(communities []*communities.Community
 				continue
 			}
 
-			topics := []types2.ContentTopic{}
+			topics := []messagingtypes.ContentTopic{}
 
 			for _, filter := range filters {
 				topics = append(topics, filter.ContentTopic())
@@ -3771,7 +3771,7 @@ func (m *Messenger) enableHistoryArchivesImportAfterDelay() {
 	}()
 }
 
-func (m *Messenger) checkIfIMemberOfCommunity(communityID types.HexBytes) error {
+func (m *Messenger) checkIfIMemberOfCommunity(communityID cryptotypes.HexBytes) error {
 	community, err := m.communitiesManager.GetByID(communityID)
 	if err != nil {
 		m.logger.Error("couldn't get community to import archives", zap.Error(err))
@@ -3786,7 +3786,7 @@ func (m *Messenger) checkIfIMemberOfCommunity(communityID types.HexBytes) error 
 	return nil
 }
 
-func (m *Messenger) resumeHistoryArchivesImport(communityID types.HexBytes) error {
+func (m *Messenger) resumeHistoryArchivesImport(communityID cryptotypes.HexBytes) error {
 	archiveIDsToImport, err := m.archiveManager.GetMessageArchiveIDsToImport(communityID)
 	if err != nil {
 		return err
@@ -3832,7 +3832,7 @@ func (m *Messenger) resumeHistoryArchivesImport(communityID types.HexBytes) erro
 		if err != nil {
 			m.logger.Error("failed to import history archives", zap.Error(err))
 		}
-		m.config.messengerSignalsHandler.DownloadingHistoryArchivesFinished(types.EncodeHex(communityID))
+		m.config.messengerSignalsHandler.DownloadingHistoryArchivesFinished(cryptotypes.EncodeHex(communityID))
 	}()
 	return nil
 }
@@ -3845,7 +3845,7 @@ func (m *Messenger) SlowdownArchivesImport() {
 	m.importRateLimiter.SetLimit(rate.Every(importSlowRate))
 }
 
-func (m *Messenger) importHistoryArchives(communityID types.HexBytes, cancel chan struct{}, archiveLink string) error {
+func (m *Messenger) importHistoryArchives(communityID cryptotypes.HexBytes, cancel chan struct{}, archiveLink string) error {
 	importTicker := time.NewTicker(100 * time.Millisecond)
 	defer importTicker.Stop()
 
@@ -3906,7 +3906,7 @@ importMessageArchivesLoop:
 			archiveMessages, err := m.archiveManager.LoadArchiveMessages(ctx, communityID, archiveLink, downloadedArchiveID)
 
 			if err != nil {
-				if errors.Is(err, types2.ErrHashRatchetGroupIDNotFound) {
+				if errors.Is(err, messagingtypes.ErrHashRatchetGroupIDNotFound) {
 					// In case we're missing hash ratchet keys, best we can do is
 					// to wait for them to be received and try import again.
 					delayImport = true
@@ -3916,7 +3916,7 @@ importMessageArchivesLoop:
 				continue
 			}
 
-			m.config.messengerSignalsHandler.ImportingHistoryArchiveMessages(types.EncodeHex(communityID))
+			m.config.messengerSignalsHandler.ImportingHistoryArchiveMessages(cryptotypes.EncodeHex(communityID))
 
 			for _, messagesChunk := range chunkSlice(archiveMessages, importMessagesChunkSize) {
 				if err := m.importRateLimiter.Wait(ctx); err != nil {
@@ -3980,7 +3980,7 @@ func (m *Messenger) dispatchArchiveLinkMessage(communityID string) error {
 		MessageType:          protobuf.ApplicationMetadataMessage_COMMUNITY_MESSAGE_ARCHIVE_LINK,
 		SkipGroupMessageWrap: true,
 		PubsubTopic:          community.PubsubTopic(),
-		Priority:             &types2.LowPriority,
+		Priority:             &messagingtypes.LowPriority,
 	}
 
 	_, err = m.sender.SendPublic(context.Background(), chatID, rawMessage)
@@ -4203,8 +4203,8 @@ func (m *Messenger) generateSystemPinnedMessage(pinMessage *common.PinMessage, c
 	return systemMessage, nil
 }
 
-func (m *Messenger) pinMessagesToWakuMessages(pinMessages []*common.PinMessage, c *communities.Community) ([]*types2.ReceivedMessage, error) {
-	wakuMessages := make([]*types2.ReceivedMessage, 0)
+func (m *Messenger) pinMessagesToWakuMessages(pinMessages []*common.PinMessage, c *communities.Community) ([]*messagingtypes.ReceivedMessage, error) {
+	wakuMessages := make([]*messagingtypes.ReceivedMessage, 0)
 	for _, msg := range pinMessages {
 
 		filter := m.messaging.ChatFilterByChatID(msg.LocalChatID)
@@ -4221,7 +4221,7 @@ func (m *Messenger) pinMessagesToWakuMessages(pinMessages []*common.PinMessage, 
 		}
 
 		hash := crypto.Keccak256Hash(append([]byte(c.IDString()), wrappedPayload...))
-		wakuMessage := &types2.ReceivedMessage{
+		wakuMessage := &messagingtypes.ReceivedMessage{
 			Sig:          crypto.FromECDSAPub(&c.PrivateKey().PublicKey),
 			Timestamp:    uint32(msg.WhisperTimestamp / 1000),
 			Topic:        filter.ContentTopic(),
@@ -4236,8 +4236,8 @@ func (m *Messenger) pinMessagesToWakuMessages(pinMessages []*common.PinMessage, 
 	return wakuMessages, nil
 }
 
-func (m *Messenger) chatMessagesToWakuMessages(chatMessages []*common.Message, c *communities.Community) ([]*types2.ReceivedMessage, error) {
-	wakuMessages := make([]*types2.ReceivedMessage, 0)
+func (m *Messenger) chatMessagesToWakuMessages(chatMessages []*common.Message, c *communities.Community) ([]*messagingtypes.ReceivedMessage, error) {
+	wakuMessages := make([]*messagingtypes.ReceivedMessage, 0)
 	for _, msg := range chatMessages {
 
 		filter := m.messaging.ChatFilterByChatID(msg.LocalChatID)
@@ -4255,7 +4255,7 @@ func (m *Messenger) chatMessagesToWakuMessages(chatMessages []*common.Message, c
 		}
 
 		hash := crypto.Keccak256Hash([]byte(msg.ID))
-		wakuMessage := &types2.ReceivedMessage{
+		wakuMessage := &messagingtypes.ReceivedMessage{
 			Sig:          crypto.FromECDSAPub(&c.PrivateKey().PublicKey),
 			Timestamp:    uint32(msg.WhisperTimestamp / 1000),
 			Topic:        filter.ContentTopic(),
@@ -4375,7 +4375,7 @@ func (m *Messenger) CheckPermissionsToJoinCommunity(request *requests.CheckPermi
 	return m.communitiesManager.CheckPermissionToJoin(request.CommunityID, addresses)
 }
 
-func (m *Messenger) getSharedAddresses(communityID types.HexBytes, requestAddresses []string) ([]gethcommon.Address, error) {
+func (m *Messenger) getSharedAddresses(communityID cryptotypes.HexBytes, requestAddresses []string) ([]gethcommon.Address, error) {
 	addressesMap := make(map[string]struct{})
 
 	for _, v := range requestAddresses {
@@ -4438,7 +4438,7 @@ func (m *Messenger) CheckAllCommunityChannelsPermissions(request *requests.Check
 	return m.communitiesManager.CheckAllChannelsPermissions(request.CommunityID, addresses)
 }
 
-func (m *Messenger) GetCommunityCheckChannelPermissionResponses(communityID types.HexBytes) (*communities.CheckAllChannelsPermissionsResponse, error) {
+func (m *Messenger) GetCommunityCheckChannelPermissionResponses(communityID cryptotypes.HexBytes) (*communities.CheckAllChannelsPermissionsResponse, error) {
 	return m.communitiesManager.GetCheckChannelPermissionResponses(communityID)
 }
 
@@ -4572,7 +4572,7 @@ func (m *Messenger) rekeyCommunities(logger *zap.Logger) {
 	}
 }
 
-func (m *Messenger) GetCommunityMembersForWalletAddresses(communityID types.HexBytes, chainID uint64) (map[string]*contacts.Contact, error) {
+func (m *Messenger) GetCommunityMembersForWalletAddresses(communityID cryptotypes.HexBytes, chainID uint64) (map[string]*contacts.Contact, error) {
 	community, err := m.communitiesManager.GetByID(communityID)
 	if err != nil {
 		return nil, err
@@ -4636,11 +4636,11 @@ func (m *Messenger) processCommunityChanges(messageState *ReceivedMessageState) 
 	messageState.Response.CommunityChanges = nil
 }
 
-func (m *Messenger) PromoteSelfToControlNode(communityID types.HexBytes) (*MessengerResponse, error) {
+func (m *Messenger) PromoteSelfToControlNode(communityID cryptotypes.HexBytes) (*MessengerResponse, error) {
 	clock, _ := m.getLastClockWithRelatedChat()
 
 	community, err := m.FetchCommunity(&FetchCommunityRequest{
-		CommunityKey:    types.EncodeHex(communityID),
+		CommunityKey:    cryptotypes.EncodeHex(communityID),
 		TryDatabase:     true,
 		WaitForResponse: true,
 	})
@@ -4694,7 +4694,7 @@ func (m *Messenger) CreateResponseWithACNotification(communityID string, acType 
 	}
 	// Activity center notification
 	notification := &ActivityCenterNotification{
-		ID:          types.FromHex(uuid.New().String()),
+		ID:          cryptotypes.FromHex(uuid.New().String()),
 		Type:        acType,
 		Timestamp:   m.getTimesource().GetCurrentTime(),
 		CommunityID: communityID,
@@ -4746,7 +4746,7 @@ func (m *Messenger) SendMessageToControlNode(ctx context.Context, community *com
 func (m *Messenger) AddActivityCenterNotificationToResponse(communityID string, acType ActivityCenterType, response *MessengerResponse) {
 	// Activity Center notification
 	notification := &ActivityCenterNotification{
-		ID:          types.FromHex(uuid.New().String()),
+		ID:          cryptotypes.FromHex(uuid.New().String()),
 		Type:        acType,
 		Timestamp:   m.getTimesource().GetCurrentTime(),
 		CommunityID: communityID,
@@ -4770,7 +4770,7 @@ func (m *Messenger) leaveCommunityDueToKickOrBan(changes *communities.CommunityC
 
 	// Activity Center notification
 	notification := &ActivityCenterNotification{
-		ID:          types.FromHex(uuid.New().String()),
+		ID:          cryptotypes.FromHex(uuid.New().String()),
 		Type:        acType,
 		Timestamp:   m.getTimesource().GetCurrentTime(),
 		CommunityID: changes.Community.IDString(),
@@ -4897,18 +4897,18 @@ func (m *Messenger) HandleDeleteCommunityMemberMessages(ctx context.Context, sta
 func (m *Messenger) leaveCommunityOnSoftKick(community *communities.Community, messengerResponse *MessengerResponse) {
 	response, err := m.kickedOutOfCommunity(community.ID(), true)
 	if err != nil {
-		m.logger.Error("member soft kick error", zap.String("communityID", gocommon.TruncateWithDot(types.EncodeHex(community.ID()))), zap.Error(err))
+		m.logger.Error("member soft kick error", zap.String("communityID", gocommon.TruncateWithDot(cryptotypes.EncodeHex(community.ID()))), zap.Error(err))
 	}
 
 	if err := messengerResponse.Merge(response); err != nil {
-		m.logger.Error("cannot merge leaveCommunityOnSoftKick response", zap.String("communityID", gocommon.TruncateWithDot(types.EncodeHex(community.ID()))), zap.Error(err))
+		m.logger.Error("cannot merge leaveCommunityOnSoftKick response", zap.String("communityID", gocommon.TruncateWithDot(cryptotypes.EncodeHex(community.ID()))), zap.Error(err))
 	}
 }
 
 func (m *Messenger) shareRevealedAccountsOnSoftKick(community *communities.Community, messengerResponse *MessengerResponse) {
 	requestToJoin, err := m.sendSharedAddressToControlNode(community.ControlNode(), community)
 	if err != nil {
-		m.logger.Error("share address to control node failed", zap.String("id", gocommon.TruncateWithDot(types.EncodeHex(community.ID()))), zap.Error(err))
+		m.logger.Error("share address to control node failed", zap.String("id", gocommon.TruncateWithDot(cryptotypes.EncodeHex(community.ID()))), zap.Error(err))
 
 		if err == communities.ErrRevealedAccountsAbsent || err == communities.ErrNoRevealedAccountsSignature {
 			m.AddActivityCenterNotificationToResponse(community.IDString(), ActivityCenterNotificationTypeShareAccounts, messengerResponse)
@@ -4993,7 +4993,7 @@ func (m *Messenger) startRequestMissingCommunityChannelsHRKeysLoop() {
 	}()
 }
 
-func (m *Messenger) IsSeedingHistoryArchive(communityID types.HexBytes) bool {
+func (m *Messenger) IsSeedingHistoryArchive(communityID cryptotypes.HexBytes) bool {
 	lastSeenArchiveLink, err := m.communitiesManager.GetLastSeenArchiveLink(communityID)
 	if err != nil {
 		return false

--- a/protocol/messenger_communities.go
+++ b/protocol/messenger_communities.go
@@ -29,7 +29,7 @@ import (
 	utils "github.com/status-im/status-go/common"
 	accsmanagementtypes "github.com/status-im/status-go/internal/accounts-management/types"
 	"github.com/status-im/status-go/internal/crypto"
-	types3 "github.com/status-im/status-go/internal/crypto/types"
+	"github.com/status-im/status-go/internal/crypto/types"
 	multiaccountscommon "github.com/status-im/status-go/internal/db/multiaccounts/common"
 	"github.com/status-im/status-go/internal/images"
 	types2 "github.com/status-im/status-go/pkg/messaging/types"
@@ -100,7 +100,7 @@ func (r *FetchCommunityRequest) Validate() error {
 	if len(r.CommunityKey) <= 2 {
 		return fmt.Errorf("community key is too short")
 	}
-	if _, err := types3.DecodeHex(r.CommunityKey); err != nil {
+	if _, err := types.DecodeHex(r.CommunityKey); err != nil {
 		return fmt.Errorf("invalid community key")
 	}
 	return nil
@@ -114,7 +114,7 @@ func GetCommunityIDFromKey(communityKey string) string {
 	// Check if the key is a private key. strip the 0x at the start
 	if privateKey, err := crypto.HexToECDSA(communityKey[2:]); err == nil {
 		// It is a privateKey
-		return types3.HexBytes(crypto.CompressPubkey(&privateKey.PublicKey)).String()
+		return types.HexBytes(crypto.CompressPubkey(&privateKey.PublicKey)).String()
 	}
 
 	// Not a private key, use the public key
@@ -199,7 +199,7 @@ func (m *Messenger) publishCommunityEvents(community *communities.Community, msg
 	}
 
 	// TODO: resend in case of failure?
-	_, err = m.sender.SendPublic(context.Background(), types3.EncodeHex(msg.CommunityID), rawMessage)
+	_, err = m.sender.SendPublic(context.Background(), types.EncodeHex(msg.CommunityID), rawMessage)
 	return err
 }
 
@@ -1029,7 +1029,7 @@ func (m *Messenger) initCommunityChats(community *communities.Community) ([]*Cha
 	return chats, nil
 }
 
-func (m *Messenger) initCommunitySettings(communityID types3.HexBytes) (*communities.CommunitySettings, error) {
+func (m *Messenger) initCommunitySettings(communityID types.HexBytes) (*communities.CommunitySettings, error) {
 	communitySettings, err := m.communitiesManager.GetCommunitySettingsByID(communityID)
 	if err != nil {
 		return nil, err
@@ -1050,7 +1050,7 @@ func (m *Messenger) initCommunitySettings(communityID types3.HexBytes) (*communi
 	return communitySettings, nil
 }
 
-func (m *Messenger) JoinCommunity(ctx context.Context, communityID types3.HexBytes, forceJoin bool) (*MessengerResponse, error) {
+func (m *Messenger) JoinCommunity(ctx context.Context, communityID types.HexBytes, forceJoin bool) (*MessengerResponse, error) {
 	mr, err := m.joinCommunity(ctx, communityID, forceJoin)
 	if err != nil {
 		return nil, err
@@ -1066,7 +1066,7 @@ func (m *Messenger) JoinCommunity(ctx context.Context, communityID types3.HexByt
 	return mr, nil
 }
 
-func (m *Messenger) joinCommunity(ctx context.Context, communityID types3.HexBytes, forceJoin bool) (*MessengerResponse, error) {
+func (m *Messenger) joinCommunity(ctx context.Context, communityID types.HexBytes, forceJoin bool) (*MessengerResponse, error) {
 	logger := m.logger.Named("joinCommunity")
 	response := &MessengerResponse{}
 	community, _ := m.communitiesManager.GetByID(communityID)
@@ -1115,7 +1115,7 @@ func (m *Messenger) joinCommunity(ctx context.Context, communityID types3.HexByt
 	// Was applicant not a member and successfully joined?
 	if !isCommunityMember && community.Joined() {
 		joinedNotification := &localnotifications.Notification{
-			ID:            gethcommon.Hash(types3.BytesToHash([]byte(`you-joined-` + communityID.String()))),
+			ID:            gethcommon.Hash(types.BytesToHash([]byte(`you-joined-` + communityID.String()))),
 			Title:         community.Name(),
 			Message:       community.Name(),
 			BodyType:      localnotifications.TypeMessage,
@@ -1150,7 +1150,7 @@ func (m *Messenger) joinCommunity(ctx context.Context, communityID types3.HexByt
 	return response, nil
 }
 
-func (m *Messenger) SpectateCommunity(communityID types3.HexBytes) (*MessengerResponse, error) {
+func (m *Messenger) SpectateCommunity(communityID types.HexBytes) (*MessengerResponse, error) {
 	logger := m.logger.Named("SpectateCommunity")
 
 	response := &MessengerResponse{}
@@ -1306,7 +1306,7 @@ func (m *Messenger) SetMutePropertyOnChatsByCategory(request *requests.MuteCateg
 // Generates a single hash for each address that needs to be revealed to a community.
 // Each hash needs to be signed.
 // The order of retuned hashes corresponds to the order of addresses in addressesToReveal.
-func (m *Messenger) generateCommunityRequestsForSigning(memberPubKey string, communityID types3.HexBytes, addressesToReveal []string, isEdit bool) ([]personal.SignParams, error) {
+func (m *Messenger) generateCommunityRequestsForSigning(memberPubKey string, communityID types.HexBytes, addressesToReveal []string, isEdit bool) ([]personal.SignParams, error) {
 	walletAccounts, err := m.settings.GetActiveAccounts()
 	if err != nil {
 		return nil, err
@@ -1314,7 +1314,7 @@ func (m *Messenger) generateCommunityRequestsForSigning(memberPubKey string, com
 
 	containsAddress := func(addresses []string, targetAddress string) bool {
 		for _, address := range addresses {
-			if types3.HexToAddress(address) == types3.HexToAddress(targetAddress) {
+			if types.HexToAddress(address) == types.HexToAddress(targetAddress) {
 				return true
 			}
 		}
@@ -1336,7 +1336,7 @@ func (m *Messenger) generateCommunityRequestsForSigning(memberPubKey string, com
 			requestID = communities.CalculateRequestID(memberPubKey, communityID)
 		}
 		msgsToSign = append(msgsToSign, personal.SignParams{
-			Data:    types3.EncodeHex(crypto.Keccak256(m.IdentityPublicKeyCompressed(), communityID, requestID)),
+			Data:    types.EncodeHex(crypto.Keccak256(m.IdentityPublicKeyCompressed(), communityID, requestID)),
 			Address: walletAccount.Address.Hex(),
 		})
 	}
@@ -1344,14 +1344,14 @@ func (m *Messenger) generateCommunityRequestsForSigning(memberPubKey string, com
 	return msgsToSign, nil
 }
 
-func (m *Messenger) GenerateJoiningCommunityRequestsForSigning(memberPubKey string, communityID types3.HexBytes, addressesToReveal []string) ([]personal.SignParams, error) {
+func (m *Messenger) GenerateJoiningCommunityRequestsForSigning(memberPubKey string, communityID types.HexBytes, addressesToReveal []string) ([]personal.SignParams, error) {
 	if len(communityID) == 0 {
 		return nil, errors.New(ErrMissingCommunityID)
 	}
 	return m.generateCommunityRequestsForSigning(memberPubKey, communityID, addressesToReveal, false)
 }
 
-func (m *Messenger) GenerateEditCommunityRequestsForSigning(memberPubKey string, communityID types3.HexBytes, addressesToReveal []string) ([]personal.SignParams, error) {
+func (m *Messenger) GenerateEditCommunityRequestsForSigning(memberPubKey string, communityID types.HexBytes, addressesToReveal []string) ([]personal.SignParams, error) {
 	return m.generateCommunityRequestsForSigning(memberPubKey, communityID, addressesToReveal, true)
 }
 
@@ -1365,7 +1365,7 @@ func (m *Messenger) SignData(signParams []personal.SignParams) ([]string, error)
 			return nil, err
 		}
 
-		account, err := m.settings.GetAccountByAddress(types3.HexToAddress(param.Address))
+		account, err := m.settings.GetAccountByAddress(types.HexToAddress(param.Address))
 		if err != nil {
 			return nil, err
 		}
@@ -1383,7 +1383,7 @@ func (m *Messenger) SignData(signParams []personal.SignParams) ([]string, error)
 			return nil, errors.New(ErrSigningJoinRequestForColdWalletAccounts)
 		}
 
-		verifiedAccount, err := m.accountsManager.GetVerifiedWalletAccount(types3.HexToAddress(param.Address), param.Password)
+		verifiedAccount, err := m.accountsManager.GetVerifiedWalletAccount(types.HexToAddress(param.Address), param.Password)
 		if err != nil {
 			return nil, err
 		}
@@ -1393,7 +1393,7 @@ func (m *Messenger) SignData(signParams []personal.SignParams) ([]string, error)
 			return nil, err
 		}
 
-		signatures[i] = types3.EncodeHex(signature)
+		signatures[i] = types.EncodeHex(signature)
 	}
 
 	return signatures, nil
@@ -1565,7 +1565,7 @@ func (m *Messenger) RequestToJoinCommunity(request *requests.RequestToJoinCommun
 
 	// Activity center notification
 	notification := &ActivityCenterNotification{
-		ID:               types3.FromHex(requestToJoin.ID.String()),
+		ID:               types.FromHex(requestToJoin.ID.String()),
 		Type:             ActivityCenterNotificationTypeCommunityRequest,
 		Timestamp:        m.getTimesource().GetCurrentTime(),
 		CommunityID:      community.IDString(),
@@ -1582,7 +1582,7 @@ func (m *Messenger) RequestToJoinCommunity(request *requests.RequestToJoinCommun
 	}
 
 	for _, account := range requestToJoin.RevealedAccounts {
-		err := m.settings.AddressWasShown(types3.HexToAddress(account.Address))
+		err := m.settings.AddressWasShown(types.HexToAddress(account.Address))
 		if err != nil {
 			return nil, err
 		}
@@ -1632,7 +1632,7 @@ func (m *Messenger) EditSharedAddressesForCommunity(request *requests.EditShared
 	for i := range request.AddressesToReveal {
 		revealedAcc := &protobuf.RevealedAccount{
 			Address:          request.AddressesToReveal[i],
-			IsAirdropAddress: types3.HexToAddress(request.AddressesToReveal[i]) == types3.HexToAddress(request.AirdropAddress),
+			IsAirdropAddress: types.HexToAddress(request.AddressesToReveal[i]) == types.HexToAddress(request.AirdropAddress),
 			Signature:        request.Signatures[i],
 		}
 
@@ -1736,11 +1736,11 @@ func (m *Messenger) PublishTokenActionToPrivilegedMembers(communityID []byte, ch
 	return nil
 }
 
-func (m *Messenger) GetRevealedAccounts(communityID types3.HexBytes, memberPk string) ([]*protobuf.RevealedAccount, error) {
+func (m *Messenger) GetRevealedAccounts(communityID types.HexBytes, memberPk string) ([]*protobuf.RevealedAccount, error) {
 	return m.communitiesManager.GetRevealedAddresses(communityID, memberPk)
 }
 
-func (m *Messenger) GetRevealedAccountsForAllMembers(communityID types3.HexBytes) (map[string][]*protobuf.RevealedAccount, error) {
+func (m *Messenger) GetRevealedAccountsForAllMembers(communityID types.HexBytes) (map[string][]*protobuf.RevealedAccount, error) {
 	community, err := m.communitiesManager.GetByID(communityID)
 	if err != nil {
 		return nil, err
@@ -1942,7 +1942,7 @@ func (m *Messenger) CancelRequestToJoinCommunity(ctx context.Context, request *r
 
 	if notification != nil {
 		notification.IncrementUpdatedAt(m.getTimesource())
-		err = m.persistence.DeleteActivityCenterNotificationByID(types3.FromHex(requestToJoin.ID.String()), notification.UpdatedAt)
+		err = m.persistence.DeleteActivityCenterNotificationByID(types.FromHex(requestToJoin.ID.String()), notification.UpdatedAt)
 		if err != nil {
 			m.logger.Error("failed to delete notification from Activity Center", zap.Error(err))
 			return nil, err
@@ -1950,7 +1950,7 @@ func (m *Messenger) CancelRequestToJoinCommunity(ctx context.Context, request *r
 
 		// set notification as deleted, so that the client will remove the activity center notification from UI
 		notification.Deleted = true
-		err = m.syncActivityCenterDeletedByIDs(ctx, []types3.HexBytes{notification.ID}, notification.UpdatedAt)
+		err = m.syncActivityCenterDeletedByIDs(ctx, []types.HexBytes{notification.ID}, notification.UpdatedAt)
 		if err != nil {
 			m.logger.Error("CancelRequestToJoinCommunity, failed to sync activity center notification as deleted", zap.Error(err))
 			return nil, err
@@ -2188,7 +2188,7 @@ func (m *Messenger) DeclineRequestToJoinCommunity(request *requests.DeclineReque
 	return m.declineRequestToJoinCommunity(requestToJoin)
 }
 
-func (m *Messenger) LeaveCommunity(communityID types3.HexBytes) (*MessengerResponse, error) {
+func (m *Messenger) LeaveCommunity(communityID types.HexBytes) (*MessengerResponse, error) {
 	ctx, span := m.tracer.Start(context.Background(), "Messenger.LeaveCommunity")
 	defer span.End()
 
@@ -2258,7 +2258,7 @@ func (m *Messenger) LeaveCommunity(communityID types3.HexBytes) (*MessengerRespo
 	return mr, nil
 }
 
-func (m *Messenger) leaveCommunity(communityID types3.HexBytes) (*MessengerResponse, error) {
+func (m *Messenger) leaveCommunity(communityID types.HexBytes) (*MessengerResponse, error) {
 	response := &MessengerResponse{}
 
 	community, err := m.communitiesManager.LeaveCommunity(communityID)
@@ -2295,7 +2295,7 @@ func (m *Messenger) leaveCommunity(communityID types3.HexBytes) (*MessengerRespo
 	return response, nil
 }
 
-func (m *Messenger) kickedOutOfCommunity(communityID types3.HexBytes, spectateMode bool) (*MessengerResponse, error) {
+func (m *Messenger) kickedOutOfCommunity(communityID types.HexBytes, spectateMode bool) (*MessengerResponse, error) {
 	response := &MessengerResponse{}
 
 	community, err := m.communitiesManager.KickedOutOfCommunity(communityID, spectateMode)
@@ -2355,7 +2355,7 @@ func (m *Messenger) CheckAndDeletePendingRequestToJoinCommunity(ctx context.Cont
 			if notification != nil {
 				// Delete activity centre notification for community admin
 				if notification.Type == ActivityCenterNotificationTypeCommunityMembershipRequest {
-					response2, err := m.MarkActivityCenterNotificationsDeleted(ctx, []types3.HexBytes{notification.ID}, m.GetCurrentTimeInMillis(), true)
+					response2, err := m.MarkActivityCenterNotificationsDeleted(ctx, []types.HexBytes{notification.ID}, m.GetCurrentTimeInMillis(), true)
 					if err != nil {
 						m.logger.Error("[CheckAndDeletePendingRequestToJoinCommunity] failed to mark notification as deleted", zap.Error(err))
 						return nil, err
@@ -2392,7 +2392,7 @@ func (m *Messenger) CheckAndDeletePendingRequestToJoinCommunity(ctx context.Cont
 	return nil, nil
 }
 
-func (m *Messenger) CreateCommunityChat(communityID types3.HexBytes, c *protobuf.CommunityChat) (*MessengerResponse, error) {
+func (m *Messenger) CreateCommunityChat(communityID types.HexBytes, c *protobuf.CommunityChat) (*MessengerResponse, error) {
 	var response MessengerResponse
 
 	c.Identity.FirstMessageTimestamp = FirstMessageTimestampNoMessage
@@ -2423,7 +2423,7 @@ func (m *Messenger) CreateCommunityChat(communityID types3.HexBytes, c *protobuf
 	return &response, nil
 }
 
-func (m *Messenger) EditCommunityChat(communityID types3.HexBytes, chatID string, c *protobuf.CommunityChat) (*MessengerResponse, error) {
+func (m *Messenger) EditCommunityChat(communityID types.HexBytes, chatID string, c *protobuf.CommunityChat) (*MessengerResponse, error) {
 	var response MessengerResponse
 	community, changes, err := m.communitiesManager.EditChat(communityID, chatID, c)
 	if err != nil {
@@ -2442,7 +2442,7 @@ func (m *Messenger) EditCommunityChat(communityID types3.HexBytes, chatID string
 	return &response, m.saveChats(chats)
 }
 
-func (m *Messenger) DeleteCommunityChat(communityID types3.HexBytes, chatID string) (*MessengerResponse, error) {
+func (m *Messenger) DeleteCommunityChat(communityID types.HexBytes, chatID string) (*MessengerResponse, error) {
 	response := &MessengerResponse{}
 
 	community, _, err := m.communitiesManager.DeleteChat(communityID, chatID)
@@ -2773,7 +2773,7 @@ func (m *Messenger) EditCommunity(request *requests.EditCommunity) (*MessengerRe
 	return response, nil
 }
 
-func (m *Messenger) RemovePrivateKey(id types3.HexBytes) (*MessengerResponse, error) {
+func (m *Messenger) RemovePrivateKey(id types.HexBytes) (*MessengerResponse, error) {
 	community, err := m.communitiesManager.RemovePrivateKey(id)
 	if err != nil {
 		return nil, err
@@ -2785,7 +2785,7 @@ func (m *Messenger) RemovePrivateKey(id types3.HexBytes) (*MessengerResponse, er
 	return response, nil
 }
 
-func (m *Messenger) ExportCommunity(id types3.HexBytes) (*ecdsa.PrivateKey, error) {
+func (m *Messenger) ExportCommunity(id types.HexBytes) (*ecdsa.PrivateKey, error) {
 	return m.communitiesManager.ExportCommunity(id)
 }
 
@@ -2840,7 +2840,7 @@ func (m *Messenger) ImportCommunity(ctx context.Context, key *ecdsa.PrivateKey) 
 	return response, nil
 }
 
-func (m *Messenger) GetCommunityByID(communityID types3.HexBytes) (*communities.Community, error) {
+func (m *Messenger) GetCommunityByID(communityID types.HexBytes) (*communities.Community, error) {
 	return m.communitiesManager.GetByID(communityID)
 }
 
@@ -2908,31 +2908,31 @@ func (m *Messenger) MyPendingRequestsToJoin() ([]*communities.RequestToJoin, err
 	return m.communitiesManager.PendingRequestsToJoinForUser(&m.identity.PublicKey)
 }
 
-func (m *Messenger) LatestRequestToJoinForCommunity(communityID types3.HexBytes) (*communities.RequestToJoin, error) {
+func (m *Messenger) LatestRequestToJoinForCommunity(communityID types.HexBytes) (*communities.RequestToJoin, error) {
 	return m.communitiesManager.GetCommunityRequestToJoinWithRevealedAddresses(m.myHexIdentity(), communityID)
 }
 
-func (m *Messenger) PendingRequestsToJoinForCommunity(id types3.HexBytes) ([]*communities.RequestToJoin, error) {
+func (m *Messenger) PendingRequestsToJoinForCommunity(id types.HexBytes) ([]*communities.RequestToJoin, error) {
 	return m.communitiesManager.PendingRequestsToJoinForCommunity(id)
 }
 
-func (m *Messenger) DeclinedRequestsToJoinForCommunity(id types3.HexBytes) ([]*communities.RequestToJoin, error) {
+func (m *Messenger) DeclinedRequestsToJoinForCommunity(id types.HexBytes) ([]*communities.RequestToJoin, error) {
 	return m.communitiesManager.DeclinedRequestsToJoinForCommunity(id)
 }
 
-func (m *Messenger) CanceledRequestsToJoinForCommunity(id types3.HexBytes) ([]*communities.RequestToJoin, error) {
+func (m *Messenger) CanceledRequestsToJoinForCommunity(id types.HexBytes) ([]*communities.RequestToJoin, error) {
 	return m.communitiesManager.CanceledRequestsToJoinForCommunity(id)
 }
 
-func (m *Messenger) AcceptedRequestsToJoinForCommunity(id types3.HexBytes) ([]*communities.RequestToJoin, error) {
+func (m *Messenger) AcceptedRequestsToJoinForCommunity(id types.HexBytes) ([]*communities.RequestToJoin, error) {
 	return m.communitiesManager.AcceptedRequestsToJoinForCommunity(id)
 }
 
-func (m *Messenger) AcceptedPendingRequestsToJoinForCommunity(id types3.HexBytes) ([]*communities.RequestToJoin, error) {
+func (m *Messenger) AcceptedPendingRequestsToJoinForCommunity(id types.HexBytes) ([]*communities.RequestToJoin, error) {
 	return m.communitiesManager.AcceptedPendingRequestsToJoinForCommunity(id)
 }
 
-func (m *Messenger) DeclinedPendingRequestsToJoinForCommunity(id types3.HexBytes) ([]*communities.RequestToJoin, error) {
+func (m *Messenger) DeclinedPendingRequestsToJoinForCommunity(id types.HexBytes) ([]*communities.RequestToJoin, error) {
 	return m.communitiesManager.DeclinedPendingRequestsToJoinForCommunity(id)
 }
 
@@ -2940,7 +2940,7 @@ func (m *Messenger) AllNonApprovedCommunitiesRequestsToJoin() ([]*communities.Re
 	return m.communitiesManager.AllNonApprovedCommunitiesRequestsToJoin()
 }
 
-func (m *Messenger) RemoveUserFromCommunity(id types3.HexBytes, pkString string) (*MessengerResponse, error) {
+func (m *Messenger) RemoveUserFromCommunity(id types.HexBytes, pkString string) (*MessengerResponse, error) {
 	publicKey, err := crypto.HexToPubkey(pkString)
 	if err != nil {
 		return nil, err
@@ -3103,7 +3103,7 @@ func (m *Messenger) handleCommunityDescription(state *ReceivedMessageState, sign
 		for _, r := range communityResponse.FailedToDecrypt {
 			if state.CurrentMessageState != nil && state.CurrentMessageState.StatusMessage != nil {
 				err := m.messaging.SaveHashRatchetMessage(r.GroupID, r.KeyID, state.CurrentMessageState.StatusMessage.TransportLayer.Message)
-				m.logger.Info("saving failed to decrypt community description", zap.String("hash", types3.Bytes2Hex(state.CurrentMessageState.StatusMessage.TransportLayer.Message.Hash)))
+				m.logger.Info("saving failed to decrypt community description", zap.String("hash", types.Bytes2Hex(state.CurrentMessageState.StatusMessage.TransportLayer.Message.Hash)))
 				if err != nil {
 					m.logger.Warn("failed to save waku message")
 				}
@@ -3771,7 +3771,7 @@ func (m *Messenger) enableHistoryArchivesImportAfterDelay() {
 	}()
 }
 
-func (m *Messenger) checkIfIMemberOfCommunity(communityID types3.HexBytes) error {
+func (m *Messenger) checkIfIMemberOfCommunity(communityID types.HexBytes) error {
 	community, err := m.communitiesManager.GetByID(communityID)
 	if err != nil {
 		m.logger.Error("couldn't get community to import archives", zap.Error(err))
@@ -3786,7 +3786,7 @@ func (m *Messenger) checkIfIMemberOfCommunity(communityID types3.HexBytes) error
 	return nil
 }
 
-func (m *Messenger) resumeHistoryArchivesImport(communityID types3.HexBytes) error {
+func (m *Messenger) resumeHistoryArchivesImport(communityID types.HexBytes) error {
 	archiveIDsToImport, err := m.archiveManager.GetMessageArchiveIDsToImport(communityID)
 	if err != nil {
 		return err
@@ -3832,7 +3832,7 @@ func (m *Messenger) resumeHistoryArchivesImport(communityID types3.HexBytes) err
 		if err != nil {
 			m.logger.Error("failed to import history archives", zap.Error(err))
 		}
-		m.config.messengerSignalsHandler.DownloadingHistoryArchivesFinished(types3.EncodeHex(communityID))
+		m.config.messengerSignalsHandler.DownloadingHistoryArchivesFinished(types.EncodeHex(communityID))
 	}()
 	return nil
 }
@@ -3845,7 +3845,7 @@ func (m *Messenger) SlowdownArchivesImport() {
 	m.importRateLimiter.SetLimit(rate.Every(importSlowRate))
 }
 
-func (m *Messenger) importHistoryArchives(communityID types3.HexBytes, cancel chan struct{}, archiveLink string) error {
+func (m *Messenger) importHistoryArchives(communityID types.HexBytes, cancel chan struct{}, archiveLink string) error {
 	importTicker := time.NewTicker(100 * time.Millisecond)
 	defer importTicker.Stop()
 
@@ -3916,7 +3916,7 @@ importMessageArchivesLoop:
 				continue
 			}
 
-			m.config.messengerSignalsHandler.ImportingHistoryArchiveMessages(types3.EncodeHex(communityID))
+			m.config.messengerSignalsHandler.ImportingHistoryArchiveMessages(types.EncodeHex(communityID))
 
 			for _, messagesChunk := range chunkSlice(archiveMessages, importMessagesChunkSize) {
 				if err := m.importRateLimiter.Wait(ctx); err != nil {
@@ -4375,7 +4375,7 @@ func (m *Messenger) CheckPermissionsToJoinCommunity(request *requests.CheckPermi
 	return m.communitiesManager.CheckPermissionToJoin(request.CommunityID, addresses)
 }
 
-func (m *Messenger) getSharedAddresses(communityID types3.HexBytes, requestAddresses []string) ([]gethcommon.Address, error) {
+func (m *Messenger) getSharedAddresses(communityID types.HexBytes, requestAddresses []string) ([]gethcommon.Address, error) {
 	addressesMap := make(map[string]struct{})
 
 	for _, v := range requestAddresses {
@@ -4438,7 +4438,7 @@ func (m *Messenger) CheckAllCommunityChannelsPermissions(request *requests.Check
 	return m.communitiesManager.CheckAllChannelsPermissions(request.CommunityID, addresses)
 }
 
-func (m *Messenger) GetCommunityCheckChannelPermissionResponses(communityID types3.HexBytes) (*communities.CheckAllChannelsPermissionsResponse, error) {
+func (m *Messenger) GetCommunityCheckChannelPermissionResponses(communityID types.HexBytes) (*communities.CheckAllChannelsPermissionsResponse, error) {
 	return m.communitiesManager.GetCheckChannelPermissionResponses(communityID)
 }
 
@@ -4572,7 +4572,7 @@ func (m *Messenger) rekeyCommunities(logger *zap.Logger) {
 	}
 }
 
-func (m *Messenger) GetCommunityMembersForWalletAddresses(communityID types3.HexBytes, chainID uint64) (map[string]*contacts.Contact, error) {
+func (m *Messenger) GetCommunityMembersForWalletAddresses(communityID types.HexBytes, chainID uint64) (map[string]*contacts.Contact, error) {
 	community, err := m.communitiesManager.GetByID(communityID)
 	if err != nil {
 		return nil, err
@@ -4636,11 +4636,11 @@ func (m *Messenger) processCommunityChanges(messageState *ReceivedMessageState) 
 	messageState.Response.CommunityChanges = nil
 }
 
-func (m *Messenger) PromoteSelfToControlNode(communityID types3.HexBytes) (*MessengerResponse, error) {
+func (m *Messenger) PromoteSelfToControlNode(communityID types.HexBytes) (*MessengerResponse, error) {
 	clock, _ := m.getLastClockWithRelatedChat()
 
 	community, err := m.FetchCommunity(&FetchCommunityRequest{
-		CommunityKey:    types3.EncodeHex(communityID),
+		CommunityKey:    types.EncodeHex(communityID),
 		TryDatabase:     true,
 		WaitForResponse: true,
 	})
@@ -4694,7 +4694,7 @@ func (m *Messenger) CreateResponseWithACNotification(communityID string, acType 
 	}
 	// Activity center notification
 	notification := &ActivityCenterNotification{
-		ID:          types3.FromHex(uuid.New().String()),
+		ID:          types.FromHex(uuid.New().String()),
 		Type:        acType,
 		Timestamp:   m.getTimesource().GetCurrentTime(),
 		CommunityID: communityID,
@@ -4746,7 +4746,7 @@ func (m *Messenger) SendMessageToControlNode(ctx context.Context, community *com
 func (m *Messenger) AddActivityCenterNotificationToResponse(communityID string, acType ActivityCenterType, response *MessengerResponse) {
 	// Activity Center notification
 	notification := &ActivityCenterNotification{
-		ID:          types3.FromHex(uuid.New().String()),
+		ID:          types.FromHex(uuid.New().String()),
 		Type:        acType,
 		Timestamp:   m.getTimesource().GetCurrentTime(),
 		CommunityID: communityID,
@@ -4770,7 +4770,7 @@ func (m *Messenger) leaveCommunityDueToKickOrBan(changes *communities.CommunityC
 
 	// Activity Center notification
 	notification := &ActivityCenterNotification{
-		ID:          types3.FromHex(uuid.New().String()),
+		ID:          types.FromHex(uuid.New().String()),
 		Type:        acType,
 		Timestamp:   m.getTimesource().GetCurrentTime(),
 		CommunityID: changes.Community.IDString(),
@@ -4897,18 +4897,18 @@ func (m *Messenger) HandleDeleteCommunityMemberMessages(ctx context.Context, sta
 func (m *Messenger) leaveCommunityOnSoftKick(community *communities.Community, messengerResponse *MessengerResponse) {
 	response, err := m.kickedOutOfCommunity(community.ID(), true)
 	if err != nil {
-		m.logger.Error("member soft kick error", zap.String("communityID", gocommon.TruncateWithDot(types3.EncodeHex(community.ID()))), zap.Error(err))
+		m.logger.Error("member soft kick error", zap.String("communityID", gocommon.TruncateWithDot(types.EncodeHex(community.ID()))), zap.Error(err))
 	}
 
 	if err := messengerResponse.Merge(response); err != nil {
-		m.logger.Error("cannot merge leaveCommunityOnSoftKick response", zap.String("communityID", gocommon.TruncateWithDot(types3.EncodeHex(community.ID()))), zap.Error(err))
+		m.logger.Error("cannot merge leaveCommunityOnSoftKick response", zap.String("communityID", gocommon.TruncateWithDot(types.EncodeHex(community.ID()))), zap.Error(err))
 	}
 }
 
 func (m *Messenger) shareRevealedAccountsOnSoftKick(community *communities.Community, messengerResponse *MessengerResponse) {
 	requestToJoin, err := m.sendSharedAddressToControlNode(community.ControlNode(), community)
 	if err != nil {
-		m.logger.Error("share address to control node failed", zap.String("id", gocommon.TruncateWithDot(types3.EncodeHex(community.ID()))), zap.Error(err))
+		m.logger.Error("share address to control node failed", zap.String("id", gocommon.TruncateWithDot(types.EncodeHex(community.ID()))), zap.Error(err))
 
 		if err == communities.ErrRevealedAccountsAbsent || err == communities.ErrNoRevealedAccountsSignature {
 			m.AddActivityCenterNotificationToResponse(community.IDString(), ActivityCenterNotificationTypeShareAccounts, messengerResponse)
@@ -4993,7 +4993,7 @@ func (m *Messenger) startRequestMissingCommunityChannelsHRKeysLoop() {
 	}()
 }
 
-func (m *Messenger) IsSeedingHistoryArchive(communityID types3.HexBytes) bool {
+func (m *Messenger) IsSeedingHistoryArchive(communityID types.HexBytes) bool {
 	lastSeenArchiveLink, err := m.communitiesManager.GetLastSeenArchiveLink(communityID)
 	if err != nil {
 		return false

--- a/protocol/messenger_communities_import_discord.go
+++ b/protocol/messenger_communities_import_discord.go
@@ -15,7 +15,7 @@ import (
 
 	gocommon "github.com/status-im/status-go/common"
 	"github.com/status-im/status-go/internal/crypto"
-	types3 "github.com/status-im/status-go/internal/crypto/types"
+	"github.com/status-im/status-go/internal/crypto/types"
 	"github.com/status-im/status-go/internal/images"
 	types2 "github.com/status-im/status-go/pkg/messaging/types"
 	"github.com/status-im/status-go/protocol/common"
@@ -190,7 +190,7 @@ func (m *Messenger) createPinMessageFromDiscordMessage(message *common.Message, 
 	}
 
 	pinMessageToSave := &common.PinMessage{
-		ID:               types3.EncodeHex(types2.MessageID(&community.PrivateKey().PublicKey, wrappedPayload)),
+		ID:               types.EncodeHex(types2.MessageID(&community.PrivateKey().PublicKey, wrappedPayload)),
 		PinMessage:       &pinMessage,
 		LocalChatID:      channelID,
 		From:             message.From,
@@ -289,7 +289,7 @@ func (m *Messenger) processDiscordMessages(discordChannel *discord.ExportedData,
 		messageToSave := &common.Message{
 			ID:               community.IDString() + discordMessage.Id,
 			WhisperTimestamp: clockAndTimestamp,
-			From:             types3.EncodeHex(crypto.FromECDSAPub(&communityPubKey)),
+			From:             types.EncodeHex(crypto.FromECDSAPub(&communityPubKey)),
 			Seen:             true,
 			LocalChatID:      channel.ID,
 			SigPubKey:        &communityPubKey,
@@ -388,7 +388,7 @@ func (m *Messenger) cleanUpImport(communityID string) {
 }
 
 func (m *Messenger) cleanUpImportChannel(communityID string, channelID string) {
-	_, err := m.DeleteCommunityChat(types3.HexBytes(communityID), channelID)
+	_, err := m.DeleteCommunityChat(types.HexBytes(communityID), channelID)
 	if err != nil {
 		m.logger.Error("clean up failed, couldn't delete community chat", zap.Error(err))
 		return
@@ -1347,7 +1347,7 @@ func (m *Messenger) RequestImportDiscordCommunity(request *requests.ImportDiscor
 				messageToSave := &common.Message{
 					ID:               communityID + discordMessage.Id,
 					WhisperTimestamp: clockAndTimestamp,
-					From:             types3.EncodeHex(crypto.FromECDSAPub(&communityPubKey)),
+					From:             types.EncodeHex(crypto.FromECDSAPub(&communityPubKey)),
 					Seen:             true,
 					LocalChatID:      processedChannelIds[channel.Channel.ID],
 					SigPubKey:        &communityPubKey,
@@ -1394,7 +1394,7 @@ func (m *Messenger) RequestImportDiscordCommunity(request *requests.ImportDiscor
 						}
 
 						pinMessageToSave := common.PinMessage{
-							ID:               types3.EncodeHex(types2.MessageID(&communityPubKey, wrappedPayload)),
+							ID:               types.EncodeHex(types2.MessageID(&communityPubKey, wrappedPayload)),
 							PinMessage:       &pinMessage,
 							LocalChatID:      processedChannelIds[channel.Channel.ID],
 							From:             messageToSave.From,

--- a/protocol/messenger_communities_import_discord.go
+++ b/protocol/messenger_communities_import_discord.go
@@ -15,9 +15,9 @@ import (
 
 	gocommon "github.com/status-im/status-go/common"
 	"github.com/status-im/status-go/internal/crypto"
-	"github.com/status-im/status-go/internal/crypto/types"
+	cryptotypes "github.com/status-im/status-go/internal/crypto/types"
 	"github.com/status-im/status-go/internal/images"
-	types2 "github.com/status-im/status-go/pkg/messaging/types"
+	messagingtypes "github.com/status-im/status-go/pkg/messaging/types"
 	"github.com/status-im/status-go/protocol/common"
 	"github.com/status-im/status-go/protocol/communities"
 	"github.com/status-im/status-go/protocol/discord"
@@ -190,7 +190,7 @@ func (m *Messenger) createPinMessageFromDiscordMessage(message *common.Message, 
 	}
 
 	pinMessageToSave := &common.PinMessage{
-		ID:               types.EncodeHex(types2.MessageID(&community.PrivateKey().PublicKey, wrappedPayload)),
+		ID:               cryptotypes.EncodeHex(messagingtypes.MessageID(&community.PrivateKey().PublicKey, wrappedPayload)),
 		PinMessage:       &pinMessage,
 		LocalChatID:      channelID,
 		From:             message.From,
@@ -289,7 +289,7 @@ func (m *Messenger) processDiscordMessages(discordChannel *discord.ExportedData,
 		messageToSave := &common.Message{
 			ID:               community.IDString() + discordMessage.Id,
 			WhisperTimestamp: clockAndTimestamp,
-			From:             types.EncodeHex(crypto.FromECDSAPub(&communityPubKey)),
+			From:             cryptotypes.EncodeHex(crypto.FromECDSAPub(&communityPubKey)),
 			Seen:             true,
 			LocalChatID:      channel.ID,
 			SigPubKey:        &communityPubKey,
@@ -388,7 +388,7 @@ func (m *Messenger) cleanUpImport(communityID string) {
 }
 
 func (m *Messenger) cleanUpImportChannel(communityID string, channelID string) {
-	_, err := m.DeleteCommunityChat(types.HexBytes(communityID), channelID)
+	_, err := m.DeleteCommunityChat(cryptotypes.HexBytes(communityID), channelID)
 	if err != nil {
 		m.logger.Error("clean up failed, couldn't delete community chat", zap.Error(err))
 		return
@@ -1347,7 +1347,7 @@ func (m *Messenger) RequestImportDiscordCommunity(request *requests.ImportDiscor
 				messageToSave := &common.Message{
 					ID:               communityID + discordMessage.Id,
 					WhisperTimestamp: clockAndTimestamp,
-					From:             types.EncodeHex(crypto.FromECDSAPub(&communityPubKey)),
+					From:             cryptotypes.EncodeHex(crypto.FromECDSAPub(&communityPubKey)),
 					Seen:             true,
 					LocalChatID:      processedChannelIds[channel.Channel.ID],
 					SigPubKey:        &communityPubKey,
@@ -1394,7 +1394,7 @@ func (m *Messenger) RequestImportDiscordCommunity(request *requests.ImportDiscor
 						}
 
 						pinMessageToSave := common.PinMessage{
-							ID:               types.EncodeHex(types2.MessageID(&communityPubKey, wrappedPayload)),
+							ID:               cryptotypes.EncodeHex(messagingtypes.MessageID(&communityPubKey, wrappedPayload)),
 							PinMessage:       &pinMessage,
 							LocalChatID:      processedChannelIds[channel.Channel.ID],
 							From:             messageToSave.From,
@@ -1804,7 +1804,7 @@ func (m *Messenger) RequestImportDiscordCommunity(request *requests.ImportDiscor
 		}
 
 		// Init the community filter so we can receive messages on the community
-		_, err = m.InitCommunityFilters(types2.CommunitiesToInitialize{{
+		_, err = m.InitCommunityFilters(messagingtypes.CommunitiesToInitialize{{
 			PrivKey: discordCommunity.PrivateKey(),
 		}})
 		if err != nil {

--- a/protocol/messenger_contact_requests_test.go
+++ b/protocol/messenger_contact_requests_test.go
@@ -10,11 +10,11 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/status-im/status-go/internal/crypto"
-	"github.com/status-im/status-go/internal/crypto/types"
+	cryptotypes "github.com/status-im/status-go/internal/crypto/types"
 	multiaccountscommon "github.com/status-im/status-go/internal/db/multiaccounts/common"
 	"github.com/status-im/status-go/internal/db/multiaccounts/settings"
 	"github.com/status-im/status-go/pkg/messaging"
-	types2 "github.com/status-im/status-go/pkg/messaging/types"
+	messagingtypes "github.com/status-im/status-go/pkg/messaging/types"
 	"github.com/status-im/status-go/protocol/common"
 	contacts2 "github.com/status-im/status-go/protocol/contacts"
 	"github.com/status-im/status-go/protocol/protobuf"
@@ -216,7 +216,7 @@ func (s *MessengerContactRequestSuite) acceptContactRequest(contactRequest *comm
 		zap.String("receiver", receiver.IdentityPublicKeyString()))
 
 	// Accept contact request, receiver side
-	resp, err := receiver.AcceptContactRequest(context.Background(), &requests.AcceptContactRequest{ID: types.Hex2Bytes(contactRequest.ID), ContactID: contactRequest.From})
+	resp, err := receiver.AcceptContactRequest(context.Background(), &requests.AcceptContactRequest{ID: cryptotypes.Hex2Bytes(contactRequest.ID), ContactID: contactRequest.From})
 	s.Require().NoError(err)
 
 	// Check updated contact request message and mutual state update
@@ -323,7 +323,7 @@ func (s *MessengerContactRequestSuite) acceptContactRequest(contactRequest *comm
 	s.Require().True(chat.Active)
 
 	// Receiver's side chat should be also active after the accepting the CR
-	myID := types.EncodeHex(crypto.FromECDSAPub(&s.m.identity.PublicKey))
+	myID := cryptotypes.EncodeHex(crypto.FromECDSAPub(&s.m.identity.PublicKey))
 	chat, ok = receiver.allChats.Load(myID)
 	s.Require().True(ok)
 	s.Require().NotNil(chat)
@@ -347,7 +347,7 @@ func (s *MessengerContactRequestSuite) createContactRequest(contactPublicKey str
 
 func (s *MessengerContactRequestSuite) declineContactRequest(contactRequest *common.Message, theirMessenger *Messenger) {
 	// Dismiss contact request, receiver side
-	resp, err := theirMessenger.DeclineContactRequest(context.Background(), &requests.DeclineContactRequest{ID: types.Hex2Bytes(contactRequest.ID), ContactID: contactRequest.From})
+	resp, err := theirMessenger.DeclineContactRequest(context.Background(), &requests.DeclineContactRequest{ID: cryptotypes.Hex2Bytes(contactRequest.ID), ContactID: contactRequest.From})
 	s.Require().NoError(err)
 
 	// Check the contact state is correctly set
@@ -377,7 +377,7 @@ func (s *MessengerContactRequestSuite) declineContactRequest(contactRequest *com
 }
 
 func (s *MessengerContactRequestSuite) retractContactRequest(contactID string, theirMessenger *Messenger) {
-	resp, err := s.m.RetractContactRequest(&requests.RetractContactRequest{ID: types.Hex2Bytes(contactID)})
+	resp, err := s.m.RetractContactRequest(&requests.RetractContactRequest{ID: cryptotypes.Hex2Bytes(contactID)})
 	s.Require().NoError(err)
 	s.Require().NotNil(resp)
 	s.Require().Len(resp.Contacts, 1)
@@ -394,7 +394,7 @@ func (s *MessengerContactRequestSuite) retractContactRequest(contactID string, t
 	mutualStateUpdate := s.findFirstByContentType(resp.Messages(), protobuf.ChatMessage_SYSTEM_MESSAGE_MUTUAL_EVENT_REMOVED)
 	s.Require().NotNil(mutualStateUpdate)
 
-	myID := types.EncodeHex(crypto.FromECDSAPub(&s.m.identity.PublicKey))
+	myID := cryptotypes.EncodeHex(crypto.FromECDSAPub(&s.m.identity.PublicKey))
 	s.Require().Equal(mutualStateUpdate.From, myID)
 	s.Require().Equal(mutualStateUpdate.ChatId, contactID)
 	s.Require().Equal(mutualStateUpdate.Text, fmt.Sprintf(outgoingMutualStateEventRemovedDefaultText, contactID))
@@ -460,7 +460,7 @@ func (s *MessengerContactRequestSuite) TestReceiveAndAcceptContactRequest() { //
 
 	theirMessenger := s.newMessenger()
 
-	contactID := types.EncodeHex(crypto.FromECDSAPub(&theirMessenger.identity.PublicKey))
+	contactID := cryptotypes.EncodeHex(crypto.FromECDSAPub(&theirMessenger.identity.PublicKey))
 	request := &requests.SendContactRequest{
 		ID:      contactID,
 		Message: messageText,
@@ -475,7 +475,7 @@ func (s *MessengerContactRequestSuite) TestReceiveAndDismissContactRequest() {
 
 	theirMessenger := s.newMessenger()
 
-	contactID := types.EncodeHex(crypto.FromECDSAPub(&theirMessenger.identity.PublicKey))
+	contactID := cryptotypes.EncodeHex(crypto.FromECDSAPub(&theirMessenger.identity.PublicKey))
 	request := &requests.SendContactRequest{
 		ID:      contactID,
 		Message: messageText,
@@ -492,7 +492,7 @@ func (s *MessengerContactRequestSuite) TestReceiveAcceptAndRetractContactRequest
 
 	s.Require().NoError(theirMessenger.settings.SaveSettingField(settings.MutualContactEnabled, true))
 
-	contactID := types.EncodeHex(crypto.FromECDSAPub(&theirMessenger.identity.PublicKey))
+	contactID := cryptotypes.EncodeHex(crypto.FromECDSAPub(&theirMessenger.identity.PublicKey))
 	request := &requests.SendContactRequest{
 		ID:      contactID,
 		Message: messageText,
@@ -511,7 +511,7 @@ func (s *MessengerContactRequestSuite) TestReceiveAcceptAndRetractContactRequest
 func (s *MessengerContactRequestSuite) TestAcceptCRRemoveAndRepeat() {
 	theirMessenger := s.newMessenger()
 
-	contactID := types.EncodeHex(crypto.FromECDSAPub(&theirMessenger.identity.PublicKey))
+	contactID := cryptotypes.EncodeHex(crypto.FromECDSAPub(&theirMessenger.identity.PublicKey))
 
 	for i := 0; i < 5; i++ {
 		messageText := fmt.Sprintf("hello %d", i)
@@ -535,7 +535,7 @@ func (s *MessengerContactRequestSuite) TestAliceTriesToSpamBobWithContactRequest
 	alice := s.m
 
 	bob := s.newMessenger()
-	bobID := types.EncodeHex(crypto.FromECDSAPub(&bob.identity.PublicKey))
+	bobID := cryptotypes.EncodeHex(crypto.FromECDSAPub(&bob.identity.PublicKey))
 
 	// Alice sends a contact request to Bob
 	request := &requests.SendContactRequest{
@@ -656,7 +656,7 @@ func (s *MessengerContactRequestSuite) TestAliceSeesOnlyOneAcceptFromBob() {
 
 	bob := s.newMessenger()
 
-	bobID := types.EncodeHex(crypto.FromECDSAPub(&bob.identity.PublicKey))
+	bobID := cryptotypes.EncodeHex(crypto.FromECDSAPub(&bob.identity.PublicKey))
 
 	// Alice sends a contact request to Bob
 	request := &requests.SendContactRequest{
@@ -672,7 +672,7 @@ func (s *MessengerContactRequestSuite) TestAliceSeesOnlyOneAcceptFromBob() {
 	s.acceptContactRequest(contactRequest, alice, bob)
 
 	// Accept contact request again
-	secondAcceptResp, err := bob.AcceptContactRequest(context.Background(), &requests.AcceptContactRequest{ID: types.Hex2Bytes(contactRequest.ID), ContactID: contactRequest.From})
+	secondAcceptResp, err := bob.AcceptContactRequest(context.Background(), &requests.AcceptContactRequest{ID: cryptotypes.Hex2Bytes(contactRequest.ID), ContactID: contactRequest.From})
 	s.Require().NoError(err)
 	s.Require().NotNil(secondAcceptResp)
 
@@ -714,7 +714,7 @@ func (s *MessengerContactRequestSuite) TestReceiveAndAcceptContactRequestTwice()
 
 	theirMessenger := s.newMessenger()
 
-	contactID := types.EncodeHex(crypto.FromECDSAPub(&theirMessenger.identity.PublicKey))
+	contactID := cryptotypes.EncodeHex(crypto.FromECDSAPub(&theirMessenger.identity.PublicKey))
 	request := &requests.SendContactRequest{
 		ID:      contactID,
 		Message: messageText,
@@ -755,7 +755,7 @@ func (s *MessengerContactRequestSuite) TestAcceptLatestContactRequestForContact(
 
 	theirMessenger := s.newMessenger()
 
-	contactID := types.EncodeHex(crypto.FromECDSAPub(&theirMessenger.identity.PublicKey))
+	contactID := cryptotypes.EncodeHex(crypto.FromECDSAPub(&theirMessenger.identity.PublicKey))
 	request := &requests.SendContactRequest{
 		ID:      contactID,
 		Message: messageText,
@@ -764,8 +764,8 @@ func (s *MessengerContactRequestSuite) TestAcceptLatestContactRequestForContact(
 	contactRequest := s.receiveContactRequest(messageText, theirMessenger)
 
 	// Accept latest contact request, receiver side
-	myID := types.EncodeHex(crypto.FromECDSAPub(&s.m.identity.PublicKey))
-	resp, err := theirMessenger.AcceptLatestContactRequestForContact(context.Background(), &requests.AcceptLatestContactRequestForContact{ID: types.Hex2Bytes(myID)})
+	myID := cryptotypes.EncodeHex(crypto.FromECDSAPub(&s.m.identity.PublicKey))
+	resp, err := theirMessenger.AcceptLatestContactRequestForContact(context.Background(), &requests.AcceptLatestContactRequestForContact{ID: cryptotypes.Hex2Bytes(myID)})
 	s.Require().NoError(err)
 
 	// Make sure the message is updated
@@ -847,7 +847,7 @@ func (s *MessengerContactRequestSuite) TestAcceptLatestContactRequestForContactW
 
 	theirMessenger := s.newMessenger()
 
-	contactID := types.EncodeHex(crypto.FromECDSAPub(&theirMessenger.identity.PublicKey))
+	contactID := cryptotypes.EncodeHex(crypto.FromECDSAPub(&theirMessenger.identity.PublicKey))
 	request := &requests.SendContactRequest{
 		ID:      contactID,
 		Message: messageText,
@@ -858,8 +858,8 @@ func (s *MessengerContactRequestSuite) TestAcceptLatestContactRequestForContactW
 	err := theirMessenger.persistence.DeleteMessage(contactRequest.ID)
 	s.Require().NoError(err)
 
-	myID := types.EncodeHex(crypto.FromECDSAPub(&s.m.identity.PublicKey))
-	resp, err := theirMessenger.AcceptLatestContactRequestForContact(context.Background(), &requests.AcceptLatestContactRequestForContact{ID: types.Hex2Bytes(myID)})
+	myID := cryptotypes.EncodeHex(crypto.FromECDSAPub(&s.m.identity.PublicKey))
+	resp, err := theirMessenger.AcceptLatestContactRequestForContact(context.Background(), &requests.AcceptLatestContactRequestForContact{ID: cryptotypes.Hex2Bytes(myID)})
 	s.Require().NoError(err)
 	s.Require().NotNil(resp)
 
@@ -874,7 +874,7 @@ func (s *MessengerContactRequestSuite) TestDismissLatestContactRequestForContact
 
 	theirMessenger := s.newMessenger()
 
-	contactID := types.EncodeHex(crypto.FromECDSAPub(&theirMessenger.identity.PublicKey))
+	contactID := cryptotypes.EncodeHex(crypto.FromECDSAPub(&theirMessenger.identity.PublicKey))
 	request := &requests.SendContactRequest{
 		ID:      contactID,
 		Message: messageText,
@@ -883,8 +883,8 @@ func (s *MessengerContactRequestSuite) TestDismissLatestContactRequestForContact
 	contactRequest := s.receiveContactRequest(messageText, theirMessenger)
 
 	// Dismiss latest contact request, receiver side
-	myID := types.EncodeHex(crypto.FromECDSAPub(&s.m.identity.PublicKey))
-	resp, err := theirMessenger.DismissLatestContactRequestForContact(context.Background(), &requests.DismissLatestContactRequestForContact{ID: types.Hex2Bytes(myID)})
+	myID := cryptotypes.EncodeHex(crypto.FromECDSAPub(&s.m.identity.PublicKey))
+	resp, err := theirMessenger.DismissLatestContactRequestForContact(context.Background(), &requests.DismissLatestContactRequestForContact{ID: cryptotypes.Hex2Bytes(myID)})
 	s.Require().NoError(err)
 
 	// Make sure the message is updated
@@ -904,7 +904,7 @@ func (s *MessengerContactRequestSuite) TestDismissLatestContactRequestForContact
 
 	theirMessenger := s.newMessenger()
 
-	contactID := types.EncodeHex(crypto.FromECDSAPub(&theirMessenger.identity.PublicKey))
+	contactID := cryptotypes.EncodeHex(crypto.FromECDSAPub(&theirMessenger.identity.PublicKey))
 	request := &requests.SendContactRequest{
 		ID:      contactID,
 		Message: messageText,
@@ -915,8 +915,8 @@ func (s *MessengerContactRequestSuite) TestDismissLatestContactRequestForContact
 	err := theirMessenger.persistence.DeleteMessage(contactRequest.ID)
 	s.Require().NoError(err)
 
-	myID := types.EncodeHex(crypto.FromECDSAPub(&s.m.identity.PublicKey))
-	resp, err := theirMessenger.DismissLatestContactRequestForContact(context.Background(), &requests.DismissLatestContactRequestForContact{ID: types.Hex2Bytes(myID)})
+	myID := cryptotypes.EncodeHex(crypto.FromECDSAPub(&s.m.identity.PublicKey))
+	resp, err := theirMessenger.DismissLatestContactRequestForContact(context.Background(), &requests.DismissLatestContactRequestForContact{ID: cryptotypes.Hex2Bytes(myID)})
 	s.Require().NoError(err)
 	s.Require().NotNil(resp)
 
@@ -939,7 +939,7 @@ func (s *MessengerContactRequestSuite) TestPairedDevicesRemoveContact() {
 	bob := s.newMessenger()
 
 	// Alice sends a contact request to bob
-	contactID := types.EncodeHex(crypto.FromECDSAPub(&bob.identity.PublicKey))
+	contactID := cryptotypes.EncodeHex(crypto.FromECDSAPub(&bob.identity.PublicKey))
 	request := &requests.SendContactRequest{
 		ID:      contactID,
 		Message: messageText,
@@ -999,7 +999,7 @@ func (s *MessengerContactRequestSuite) TestAliceRecoverStateSendContactRequest()
 
 	bob := s.newMessenger()
 
-	bobID := types.EncodeHex(crypto.FromECDSAPub(&bob.identity.PublicKey))
+	bobID := cryptotypes.EncodeHex(crypto.FromECDSAPub(&bob.identity.PublicKey))
 
 	// Alice sends a contact request to bob
 	request := &requests.SendContactRequest{
@@ -1063,7 +1063,7 @@ func (s *MessengerContactRequestSuite) TestAliceRecoverStateReceiveContactReques
 
 	bob := s.newMessenger()
 
-	bobID := types.EncodeHex(crypto.FromECDSAPub(&bob.identity.PublicKey))
+	bobID := cryptotypes.EncodeHex(crypto.FromECDSAPub(&bob.identity.PublicKey))
 
 	// Alice sends a contact request to bob
 	request := &requests.SendContactRequest{
@@ -1131,7 +1131,7 @@ func (s *MessengerContactRequestSuite) TestAliceOfflineRetractsAndAddsCorrectOrd
 
 	bob := s.newMessenger()
 
-	bobID := types.EncodeHex(crypto.FromECDSAPub(&bob.identity.PublicKey))
+	bobID := cryptotypes.EncodeHex(crypto.FromECDSAPub(&bob.identity.PublicKey))
 
 	// Alice sends a contact request to bob
 	request := &requests.SendContactRequest{
@@ -1147,7 +1147,7 @@ func (s *MessengerContactRequestSuite) TestAliceOfflineRetractsAndAddsCorrectOrd
 	s.acceptContactRequest(contactRequest, alice1, bob)
 
 	// Alice removes Bob from contacts
-	_, err := alice1.RetractContactRequest(&requests.RetractContactRequest{ID: types.Hex2Bytes(bob.myHexIdentity())})
+	_, err := alice1.RetractContactRequest(&requests.RetractContactRequest{ID: cryptotypes.Hex2Bytes(bob.myHexIdentity())})
 	s.Require().NoError(err)
 
 	// Adds bob again to her device
@@ -1178,7 +1178,7 @@ func (s *MessengerContactRequestSuite) TestAliceOfflineRetractsAndAddsWrongOrder
 
 	bob := s.newMessenger()
 
-	bobID := types.EncodeHex(crypto.FromECDSAPub(&bob.identity.PublicKey))
+	bobID := cryptotypes.EncodeHex(crypto.FromECDSAPub(&bob.identity.PublicKey))
 
 	// Alice sends a contact request to bob
 	request := &requests.SendContactRequest{
@@ -1194,7 +1194,7 @@ func (s *MessengerContactRequestSuite) TestAliceOfflineRetractsAndAddsWrongOrder
 	s.acceptContactRequest(contactRequest, alice1, bob)
 
 	// Alice removes Bob from contacts
-	_, err := alice1.RetractContactRequest(&requests.RetractContactRequest{ID: types.Hex2Bytes(bob.myHexIdentity())})
+	_, err := alice1.RetractContactRequest(&requests.RetractContactRequest{ID: cryptotypes.Hex2Bytes(bob.myHexIdentity())})
 	s.Require().NoError(err)
 
 	// Adds bob again to her device
@@ -1227,7 +1227,7 @@ func (s *MessengerContactRequestSuite) TestAliceResendsContactRequestAfterRemovi
 
 	theirMessenger := s.newMessenger()
 
-	contactID := types.EncodeHex(crypto.FromECDSAPub(&theirMessenger.identity.PublicKey))
+	contactID := cryptotypes.EncodeHex(crypto.FromECDSAPub(&theirMessenger.identity.PublicKey))
 
 	// Alice sends a contact request to Bob
 	request := &requests.SendContactRequest{
@@ -1280,7 +1280,7 @@ func (s *MessengerContactRequestSuite) TestBobSendsContactRequestAfterDecliningO
 
 	bob := s.newMessenger()
 
-	bobID := types.EncodeHex(crypto.FromECDSAPub(&bob.identity.PublicKey))
+	bobID := cryptotypes.EncodeHex(crypto.FromECDSAPub(&bob.identity.PublicKey))
 
 	// Alice sends a contact request to bob
 	requestFromAlice := &requests.SendContactRequest{
@@ -1297,7 +1297,7 @@ func (s *MessengerContactRequestSuite) TestBobSendsContactRequestAfterDecliningO
 
 	messageTextBob := "hello, Alice!"
 
-	aliceID := types.EncodeHex(crypto.FromECDSAPub(&alice.identity.PublicKey))
+	aliceID := cryptotypes.EncodeHex(crypto.FromECDSAPub(&alice.identity.PublicKey))
 
 	// Bob sends a contact request to Alice
 	requestFromBob := &requests.SendContactRequest{
@@ -1356,7 +1356,7 @@ func (s *MessengerContactRequestSuite) TestBobSendsContactRequestAfterDecliningO
 func (s *MessengerContactRequestSuite) TestBuildContact() {
 	contactKey, err := crypto.GenerateKey()
 	s.Require().NoError(err)
-	contactID := types.EncodeHex(crypto.FromECDSAPub(&contactKey.PublicKey))
+	contactID := cryptotypes.EncodeHex(crypto.FromECDSAPub(&contactKey.PublicKey))
 
 	contact, err := s.m.BuildContact(&requests.BuildContact{PublicKey: contactID})
 	s.Require().NoError(err)
@@ -1393,11 +1393,11 @@ func (s *MessengerContactRequestSuite) TestReceiveAcceptAndRetractContactRequest
 		PublicKey: &contactKey.PublicKey,
 		MessageID: "0xa",
 		StatusMessage: &common.StatusMessage{
-			Message: types2.Message{
-				TransportLayer: types2.TransportLayer{
-					Message: &types2.ReceivedMessage{Timestamp: 1},
+			Message: messagingtypes.Message{
+				TransportLayer: messagingtypes.TransportLayer{
+					Message: &messagingtypes.ReceivedMessage{Timestamp: 1},
 				},
-				EncryptionLayer: types2.EncryptionLayer{},
+				EncryptionLayer: messagingtypes.EncryptionLayer{},
 			},
 			ApplicationLayer: common.ApplicationLayer{
 				ID: []byte("test-id"),
@@ -1442,8 +1442,8 @@ func (s *MessengerContactRequestSuite) TestBobRestoresIncomingContactRequestFrom
 
 	bob1 := s.newMessenger()
 
-	aliceID := types.EncodeHex(crypto.FromECDSAPub(&alice.identity.PublicKey))
-	bobID := types.EncodeHex(crypto.FromECDSAPub(&bob1.identity.PublicKey))
+	aliceID := cryptotypes.EncodeHex(crypto.FromECDSAPub(&alice.identity.PublicKey))
+	bobID := cryptotypes.EncodeHex(crypto.FromECDSAPub(&bob1.identity.PublicKey))
 
 	// Alice sends a contact request to bob
 	requestFromAlice := &requests.SendContactRequest{
@@ -1471,7 +1471,7 @@ func (s *MessengerContactRequestSuite) TestBobRestoresIncomingContactRequestFrom
 	s.Require().NoError(err)
 
 	// Accept latest CR for a contact
-	resp, err := bob2.AcceptLatestContactRequestForContact(context.Background(), &requests.AcceptLatestContactRequestForContact{ID: types.Hex2Bytes(aliceID)})
+	resp, err := bob2.AcceptLatestContactRequestForContact(context.Background(), &requests.AcceptLatestContactRequestForContact{ID: cryptotypes.Hex2Bytes(aliceID)})
 	s.Require().NoError(err)
 	s.Require().Len(resp.Contacts, 1)
 
@@ -1516,8 +1516,8 @@ func (s *MessengerContactRequestSuite) TestAliceRestoresOutgoingContactRequestFr
 	alice1 := s.m
 	bob := s.newMessenger()
 
-	aliceID := types.EncodeHex(crypto.FromECDSAPub(&alice1.identity.PublicKey))
-	bobID := types.EncodeHex(crypto.FromECDSAPub(&bob.identity.PublicKey))
+	aliceID := cryptotypes.EncodeHex(crypto.FromECDSAPub(&alice1.identity.PublicKey))
+	bobID := cryptotypes.EncodeHex(crypto.FromECDSAPub(&bob.identity.PublicKey))
 
 	// Alice sends a contact request to bob
 	requestFromAlice := &requests.SendContactRequest{
@@ -1543,7 +1543,7 @@ func (s *MessengerContactRequestSuite) TestAliceRestoresOutgoingContactRequestFr
 	s.Require().NoError(err)
 
 	// Accept latest CR for a contact
-	resp, err := bob.AcceptLatestContactRequestForContact(context.Background(), &requests.AcceptLatestContactRequestForContact{ID: types.Hex2Bytes(aliceID)})
+	resp, err := bob.AcceptLatestContactRequestForContact(context.Background(), &requests.AcceptLatestContactRequestForContact{ID: cryptotypes.Hex2Bytes(aliceID)})
 	s.Require().NoError(err)
 
 	// Make sure the message is updated
@@ -1737,7 +1737,7 @@ func (s *MessengerContactRequestSuite) TestAcceptContactWithoutRequest() { //nol
 
 	contactRequest, err := s.m.createDefaultContactRequest(s.m.selfContact, s.m.getTimesource().GetCurrentTime())
 	s.Require().NoError(err)
-	resp, err := theirMessenger.AcceptContactRequest(context.Background(), &requests.AcceptContactRequest{ID: types.Hex2Bytes(contactRequest.ID), ContactID: contactRequest.From})
+	resp, err := theirMessenger.AcceptContactRequest(context.Background(), &requests.AcceptContactRequest{ID: cryptotypes.Hex2Bytes(contactRequest.ID), ContactID: contactRequest.From})
 	s.Require().NoError(err)
 	// Check updated contact request message and mutual state update
 	s.Require().NotNil(resp)

--- a/protocol/messenger_contact_requests_test.go
+++ b/protocol/messenger_contact_requests_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/status-im/status-go/pkg/messaging"
 	messagingtypes "github.com/status-im/status-go/pkg/messaging/types"
 	"github.com/status-im/status-go/protocol/common"
-	contacts2 "github.com/status-im/status-go/protocol/contacts"
+	"github.com/status-im/status-go/protocol/contacts"
 	"github.com/status-im/status-go/protocol/protobuf"
 	"github.com/status-im/status-go/protocol/requests"
 )
@@ -78,13 +78,13 @@ func (s *MessengerContactRequestSuite) sendContactRequestWithState(request *requ
 	}
 
 	// Make sure contact is added on the sender side
-	contacts := messenger.AddedContacts()
-	s.Require().Len(contacts, 1)
-	s.Require().Equal(contacts2.ContactRequestStateSent, contacts[0].ContactRequestLocalState)
-	s.Require().NotNil(contacts[0].DisplayName)
+	addedContacts := messenger.AddedContacts()
+	s.Require().Len(addedContacts, 1)
+	s.Require().Equal(contacts.ContactRequestStateSent, addedContacts[0].ContactRequestLocalState)
+	s.Require().NotNil(addedContacts[0].DisplayName)
 
 	// Check contact's primary name matches notification's name
-	s.Require().Equal(resp.ActivityCenterNotifications()[0].Name, contacts[0].PrimaryName())
+	s.Require().Equal(resp.ActivityCenterNotifications()[0].Name, addedContacts[0].PrimaryName())
 
 	return resp
 }
@@ -149,7 +149,7 @@ func (s *MessengerContactRequestSuite) receiveContactRequest(messageText string,
 	// Check the contact state is correctly set
 	s.Require().Len(resp.Contacts, 1)
 	contact := resp.Contacts[0]
-	s.Require().Equal(contacts2.ContactRequestStateReceived, contact.ContactRequestRemoteState)
+	s.Require().Equal(contacts.ContactRequestStateReceived, contact.ContactRequestRemoteState)
 
 	// Check contact's primary name matches notification's name
 	s.Require().Equal(resp.ActivityCenterNotifications()[0].Name, contact.PrimaryName())
@@ -253,8 +253,8 @@ func (s *MessengerContactRequestSuite) acceptContactRequest(contactRequest *comm
 	s.Require().True(resp.Chats()[0].Active)
 
 	// Make sure the sender is added to our contacts
-	contacts := receiver.AddedContacts()
-	s.Require().Len(contacts, 1)
+	addedContacts := receiver.AddedContacts()
+	s.Require().Len(addedContacts, 1)
 
 	// Make sure we consider them a mutual contact, receiver side
 	mutualContacts := receiver.MutualContacts()
@@ -331,9 +331,9 @@ func (s *MessengerContactRequestSuite) acceptContactRequest(contactRequest *comm
 }
 
 func (s *MessengerContactRequestSuite) checkMutualContact(messenger *Messenger, contactPublicKey string) {
-	contacts := messenger.AddedContacts()
-	s.Require().Len(contacts, 1)
-	contact := contacts[0]
+	addedContacts := messenger.AddedContacts()
+	s.Require().Len(addedContacts, 1)
+	contact := addedContacts[0]
 	s.Require().Equal(contactPublicKey, contact.ID)
 	s.Require().True(contact.Mutual())
 }
@@ -352,7 +352,7 @@ func (s *MessengerContactRequestSuite) declineContactRequest(contactRequest *com
 
 	// Check the contact state is correctly set
 	s.Require().Len(resp.Contacts, 1)
-	s.Require().Equal(contacts2.ContactRequestStateDismissed, resp.Contacts[0].ContactRequestLocalState)
+	s.Require().Equal(contacts.ContactRequestStateDismissed, resp.Contacts[0].ContactRequestLocalState)
 
 	// Make sure the message is updated
 	s.Require().NotNil(resp)
@@ -372,8 +372,8 @@ func (s *MessengerContactRequestSuite) declineContactRequest(contactRequest *com
 	s.Require().Equal(resp.ActivityCenterNotifications()[0].Name, resp.Contacts[0].PrimaryName())
 
 	// Make sure the sender is not added to our contacts
-	contacts := theirMessenger.AddedContacts()
-	s.Require().Len(contacts, 0)
+	addedContacts := theirMessenger.AddedContacts()
+	s.Require().Len(addedContacts, 0)
 }
 
 func (s *MessengerContactRequestSuite) retractContactRequest(contactID string, theirMessenger *Messenger) {
@@ -386,8 +386,8 @@ func (s *MessengerContactRequestSuite) retractContactRequest(contactID string, t
 
 	// Check the contact state is correctly set
 	s.Require().Len(resp.Contacts, 1)
-	s.Require().Equal(contacts2.ContactRequestStateNone, resp.Contacts[0].ContactRequestLocalState)
-	s.Require().Equal(contacts2.ContactRequestStateNone, resp.Contacts[0].ContactRequestRemoteState)
+	s.Require().Equal(contacts.ContactRequestStateNone, resp.Contacts[0].ContactRequestLocalState)
+	s.Require().Equal(contacts.ContactRequestStateNone, resp.Contacts[0].ContactRequestRemoteState)
 
 	// Check outgoing mutual state message
 	s.Require().Len(resp.Messages(), 1)
@@ -415,8 +415,8 @@ func (s *MessengerContactRequestSuite) retractContactRequest(contactID string, t
 
 	s.Require().False(resp.Contacts[0].Added())
 	s.Require().False(resp.Contacts[0].HasAddedUs())
-	s.Require().Equal(contacts2.ContactRequestStateNone, resp.Contacts[0].ContactRequestLocalState)
-	s.Require().Equal(contacts2.ContactRequestStateNone, resp.Contacts[0].ContactRequestRemoteState)
+	s.Require().Equal(contacts.ContactRequestStateNone, resp.Contacts[0].ContactRequestLocalState)
+	s.Require().Equal(contacts.ContactRequestStateNone, resp.Contacts[0].ContactRequestRemoteState)
 
 	// Check pending notification
 	s.Require().Len(resp.ActivityCenterNotifications(), 1)
@@ -433,7 +433,7 @@ func (s *MessengerContactRequestSuite) retractContactRequest(contactID string, t
 	s.Require().Equal(mutualStateUpdate.Text, fmt.Sprintf(incomingMutualStateEventRemovedDefaultText, myID))
 }
 
-func (s *MessengerContactRequestSuite) syncInstallationContactV2FromContact(contact *contacts2.Contact) protobuf.SyncInstallationContactV2 {
+func (s *MessengerContactRequestSuite) syncInstallationContactV2FromContact(contact *contacts.Contact) protobuf.SyncInstallationContactV2 {
 	return protobuf.SyncInstallationContactV2{
 		LastUpdatedLocally:        contact.LastUpdatedLocally,
 		LastUpdated:               contact.LastUpdated,
@@ -794,8 +794,8 @@ func (s *MessengerContactRequestSuite) TestAcceptLatestContactRequestForContact(
 	s.Require().True(resp.Contacts[0].Mutual())
 
 	// Make sure the sender is added to our contacts
-	contacts := theirMessenger.AddedContacts()
-	s.Require().Len(contacts, 1)
+	addedContacts := theirMessenger.AddedContacts()
+	s.Require().Len(addedContacts, 1)
 
 	// Make sure we consider them a mutual contact, receiver side
 	mutualContacts := theirMessenger.MutualContacts()
@@ -981,8 +981,8 @@ func (s *MessengerContactRequestSuite) TestPairedDevicesRemoveContact() {
 	s.Require().Len(resp.Contacts, 1)
 
 	// Check the contact state is correctly set
-	s.Require().Equal(contacts2.ContactRequestStateNone, resp.Contacts[0].ContactRequestLocalState)
-	s.Require().Equal(contacts2.ContactRequestStateNone, resp.Contacts[0].ContactRequestRemoteState)
+	s.Require().Equal(contacts.ContactRequestStateNone, resp.Contacts[0].ContactRequestLocalState)
+	s.Require().Equal(contacts.ContactRequestStateNone, resp.Contacts[0].ContactRequestRemoteState)
 }
 
 // The scenario tested is as follow:
@@ -1113,8 +1113,8 @@ func (s *MessengerContactRequestSuite) TestAliceRecoverStateReceiveContactReques
 	s.Require().Len(resp.Contacts, 1)
 
 	// Check the contact state is correctly set
-	s.Require().Equal(contacts2.ContactRequestStateNone, resp.Contacts[0].ContactRequestLocalState)
-	s.Require().Equal(contacts2.ContactRequestStateReceived, resp.Contacts[0].ContactRequestRemoteState)
+	s.Require().Equal(contacts.ContactRequestStateNone, resp.Contacts[0].ContactRequestLocalState)
+	s.Require().Equal(contacts.ContactRequestStateReceived, resp.Contacts[0].ContactRequestRemoteState)
 }
 
 // The scenario tested is as follow:
@@ -1384,7 +1384,7 @@ func (s *MessengerContactRequestSuite) TestReceiveAcceptAndRetractContactRequest
 	contactKey, err := crypto.GenerateKey()
 	s.Require().NoError(err)
 
-	contact, err := contacts2.BuildContactFromPublicKey(&contactKey.PublicKey)
+	contact, err := contacts.BuildContactFromPublicKey(&contactKey.PublicKey)
 	s.Require().NoError(err)
 
 	state := s.m.buildMessageState()
@@ -1411,9 +1411,9 @@ func (s *MessengerContactRequestSuite) TestReceiveAcceptAndRetractContactRequest
 	err = s.m.HandleChatMessage(context.Background(), state, &message, nil, false)
 	s.Require().NoError(err)
 	s.Require().Len(response.ActivityCenterNotifications(), 1)
-	contacts := s.m.Contacts()
-	s.Require().Len(contacts, 1)
-	s.Require().Equal(contacts2.ContactRequestStateReceived, contacts[0].ContactRequestRemoteState)
+	allContacts := s.m.Contacts()
+	s.Require().Len(allContacts, 1)
+	s.Require().Equal(contacts.ContactRequestStateReceived, allContacts[0].ContactRequestRemoteState)
 
 	retract := protobuf.RetractContactRequest{
 		Clock: 2,
@@ -1422,9 +1422,9 @@ func (s *MessengerContactRequestSuite) TestReceiveAcceptAndRetractContactRequest
 	s.Require().NoError(err)
 
 	// Nothing should have changed
-	contacts = s.m.Contacts()
-	s.Require().Len(contacts, 1)
-	s.Require().Equal(contacts2.ContactRequestStateReceived, contacts[0].ContactRequestRemoteState)
+	allContacts = s.m.Contacts()
+	s.Require().Len(allContacts, 1)
+	s.Require().Equal(contacts.ContactRequestStateReceived, allContacts[0].ContactRequestRemoteState)
 }
 
 // The scenario tested is as follow:
@@ -1495,8 +1495,8 @@ func (s *MessengerContactRequestSuite) TestBobRestoresIncomingContactRequestFrom
 	s.Require().True(resp.Contacts[0].Mutual())
 
 	// Make sure the sender is added to our contacts
-	contacts := bob2.AddedContacts()
-	s.Require().Len(contacts, 1)
+	addedContacts := bob2.AddedContacts()
+	s.Require().Len(addedContacts, 1)
 
 	// Make sure we consider them a mutual contact, receiver side
 	mutualContacts := bob2.MutualContacts()
@@ -1566,8 +1566,8 @@ func (s *MessengerContactRequestSuite) TestAliceRestoresOutgoingContactRequestFr
 	s.Require().True(resp.Contacts[0].Mutual())
 
 	// Make sure the sender is added to our contacts
-	contacts := bob.AddedContacts()
-	s.Require().Len(contacts, 1)
+	addedContacts := bob.AddedContacts()
+	s.Require().Len(addedContacts, 1)
 
 	// Make sure we consider them a mutual contact, receiver side
 	mutualContacts := bob.MutualContacts()
@@ -1630,8 +1630,8 @@ func (s *MessengerContactRequestSuite) blockContactAndSync(alice1 *Messenger, al
 	s.Require().Len(resp.Contacts, 1)
 	respContact := resp.Contacts[0]
 	s.Require().Equal(respContact.ID, alice1.IdentityPublicKeyString())
-	s.Require().Equal(contacts2.ContactRequestStateNone, respContact.ContactRequestLocalState)
-	s.Require().Equal(contacts2.ContactRequestStateNone, respContact.ContactRequestRemoteState)
+	s.Require().Equal(contacts.ContactRequestStateNone, respContact.ContactRequestLocalState)
+	s.Require().Equal(contacts.ContactRequestStateNone, respContact.ContactRequestRemoteState)
 
 	// Check response messages
 	s.Require().Len(resp.Messages(), 1)
@@ -1657,8 +1657,8 @@ func (s *MessengerContactRequestSuite) blockContactAndSync(alice1 *Messenger, al
 	s.Require().True(respContact.Removed)
 	s.Require().Equal(bobPublicKey, respContact.ID)
 	s.Require().Equal(bobDisplayName, respContact.DisplayName)
-	s.Require().Equal(contacts2.ContactRequestStateDismissed, respContact.ContactRequestLocalState)
-	s.Require().Equal(contacts2.ContactRequestStateReceived, respContact.ContactRequestRemoteState)
+	s.Require().Equal(contacts.ContactRequestStateDismissed, respContact.ContactRequestLocalState)
+	s.Require().Equal(contacts.ContactRequestStateReceived, respContact.ContactRequestRemoteState)
 
 	// Check chats list
 	s.Require().Len(alice2.Chats(), 2)
@@ -1688,8 +1688,8 @@ func (s *MessengerContactRequestSuite) unblockContactAndSync(alice1 *Messenger, 
 	s.Require().Equal(bobPublicKey, respContact.ID)
 	s.Require().False(respContact.Blocked)
 	s.Require().True(respContact.Removed)
-	s.Require().Equal(respContact.ContactRequestLocalState, contacts2.ContactRequestStateNone)
-	s.Require().Equal(respContact.ContactRequestRemoteState, contacts2.ContactRequestStateNone)
+	s.Require().Equal(respContact.ContactRequestLocalState, contacts.ContactRequestStateNone)
+	s.Require().Equal(respContact.ContactRequestRemoteState, contacts.ContactRequestStateNone)
 
 	// Check chats list
 	s.Require().Len(alice2.Chats(), 2)
@@ -1783,9 +1783,9 @@ func (s *MessengerContactRequestSuite) TestSyncInstallationContactV2_IgnoresNonC
 	sync := &protobuf.SyncInstallationContactV2{
 		Id:                        nonCanonicalSelfID,
 		Added:                     true,
-		ContactRequestLocalState:  int64(contacts2.ContactRequestStateSent),
+		ContactRequestLocalState:  int64(contacts.ContactRequestStateSent),
 		ContactRequestLocalClock:  1,
-		ContactRequestRemoteState: int64(contacts2.ContactRequestStateNone),
+		ContactRequestRemoteState: int64(contacts.ContactRequestStateNone),
 		ContactRequestRemoteClock: 0,
 		LastUpdated:               1,
 		LastUpdatedLocally:        1,

--- a/protocol/messenger_contact_verification_test.go
+++ b/protocol/messenger_contact_verification_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/status-im/status-go/internal/crypto"
 	"github.com/status-im/status-go/internal/crypto/types"
 	"github.com/status-im/status-go/protocol/common"
-	contacts2 "github.com/status-im/status-go/protocol/contacts"
+	"github.com/status-im/status-go/protocol/contacts"
 	"github.com/status-im/status-go/protocol/requests"
 	"github.com/status-im/status-go/protocol/verification"
 
@@ -44,9 +44,9 @@ func (s *MessengerVerificationRequests) mutualContact(theirMessenger *Messenger)
 	s.Require().Len(contactRequests, 0)
 
 	// Make sure contact is added on the sender side
-	contacts := s.m.AddedContacts()
-	s.Require().Len(contacts, 1)
-	s.Require().Equal(contacts2.ContactRequestStateSent, contacts[0].ContactRequestLocalState)
+	addedContacts := s.m.AddedContacts()
+	s.Require().Len(addedContacts, 1)
+	s.Require().Equal(contacts.ContactRequestStateSent, addedContacts[0].ContactRequestLocalState)
 
 	// Wait for the message to reach its destination
 	resp, err = WaitOnMessengerResponse(
@@ -68,7 +68,7 @@ func (s *MessengerVerificationRequests) mutualContact(theirMessenger *Messenger)
 
 	// Check the contact state is correctly set
 	s.Require().Len(resp.Contacts, 1)
-	s.Require().Equal(contacts2.ContactRequestStateReceived, resp.Contacts[0].ContactRequestRemoteState)
+	s.Require().Equal(contacts.ContactRequestStateReceived, resp.Contacts[0].ContactRequestRemoteState)
 
 	// Make sure it's the pending contact requests
 	contactRequests, _, err = theirMessenger.PendingContactRequests("", 10)
@@ -94,8 +94,8 @@ func (s *MessengerVerificationRequests) mutualContact(theirMessenger *Messenger)
 	s.Require().True(resp.Contacts[0].Mutual())
 
 	// Make sure the sender is added to our contacts
-	contacts = theirMessenger.AddedContacts()
-	s.Require().Len(contacts, 1)
+	addedContacts = theirMessenger.AddedContacts()
+	s.Require().Len(addedContacts, 1)
 
 	// Make sure we consider them a mutual contact, receiver side
 	mutualContacts := theirMessenger.MutualContacts()
@@ -253,7 +253,7 @@ func (s *MessengerVerificationRequests) TestAcceptVerificationRequests() {
 
 	s.Require().Len(resp.Contacts, 1)
 	s.Require().Equal(resp.Contacts[0].ID, theirPk)
-	s.Require().Equal(resp.Contacts[0].VerificationStatus, contacts2.VerificationStatusVERIFIED)
+	s.Require().Equal(resp.Contacts[0].VerificationStatus, contacts.VerificationStatusVERIFIED)
 }
 
 func (s *MessengerVerificationRequests) TestTrustedVerificationRequests() {
@@ -545,7 +545,7 @@ func (s *MessengerVerificationRequests) TestRemoveTrustVerificationStatus() {
 
 	contact, _ := s.m.allContacts.Load(theirPk)
 	s.Require().NotNil(contact)
-	s.Require().Equal(contacts2.VerificationStatusUNVERIFIED, contact.VerificationStatus)
+	s.Require().Equal(contacts.VerificationStatusUNVERIFIED, contact.VerificationStatus)
 	s.Require().Equal(verification.TrustStatusUNKNOWN, contact.TrustStatus)
 }
 
@@ -651,7 +651,7 @@ func (s *MessengerVerificationRequests) TestDeclineVerificationRequests() {
 
 	s.Require().Len(resp.Contacts, 1)
 	s.Require().Equal(resp.Contacts[0].ID, theirPk)
-	s.Require().Equal(resp.Contacts[0].VerificationStatus, contacts2.VerificationStatusUNVERIFIED)
+	s.Require().Equal(resp.Contacts[0].VerificationStatus, contacts.VerificationStatusUNVERIFIED)
 
 	s.Require().Len(resp.ActivityCenterNotifications(), 1)
 	s.Require().Equal(resp.ActivityCenterNotifications()[0].ID.String(), verificationRequestID)
@@ -729,7 +729,7 @@ func (s *MessengerVerificationRequests) TestCancelVerificationRequest() {
 
 	s.Require().Len(resp.Contacts, 1)
 	s.Require().Equal(resp.Contacts[0].ID, theirPk)
-	s.Require().Equal(resp.Contacts[0].VerificationStatus, contacts2.VerificationStatusUNVERIFIED)
+	s.Require().Equal(resp.Contacts[0].VerificationStatus, contacts.VerificationStatusUNVERIFIED)
 
 	// Check canceled state on the receiver's side
 	resp, err = WaitOnMessengerResponse(

--- a/protocol/messenger_contact_verification_test.go
+++ b/protocol/messenger_contact_verification_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/status-im/status-go/internal/crypto"
-	types2 "github.com/status-im/status-go/internal/crypto/types"
+	"github.com/status-im/status-go/internal/crypto/types"
 	"github.com/status-im/status-go/protocol/common"
 	contacts2 "github.com/status-im/status-go/protocol/contacts"
 	"github.com/status-im/status-go/protocol/requests"
@@ -25,7 +25,7 @@ type MessengerVerificationRequests struct {
 func (s *MessengerVerificationRequests) mutualContact(theirMessenger *Messenger) {
 	messageText := "hello!"
 
-	contactID := types2.EncodeHex(crypto.FromECDSAPub(&theirMessenger.identity.PublicKey))
+	contactID := types.EncodeHex(crypto.FromECDSAPub(&theirMessenger.identity.PublicKey))
 	request := &requests.SendContactRequest{
 		ID:      contactID,
 		Message: messageText,
@@ -77,7 +77,7 @@ func (s *MessengerVerificationRequests) mutualContact(theirMessenger *Messenger)
 	s.Require().Equal(contactRequests[0].ContactRequestState, common.ContactRequestStatePending)
 
 	// Accept contact request, receiver side
-	resp, err = theirMessenger.AcceptContactRequest(context.Background(), &requests.AcceptContactRequest{ID: types2.Hex2Bytes(contactRequests[0].ID), ContactID: contactRequests[0].From})
+	resp, err = theirMessenger.AcceptContactRequest(context.Background(), &requests.AcceptContactRequest{ID: types.Hex2Bytes(contactRequests[0].ID), ContactID: contactRequests[0].From})
 	s.Require().NoError(err)
 
 	// Make sure the message is updated
@@ -134,7 +134,7 @@ func (s *MessengerVerificationRequests) TestAcceptVerificationRequests() {
 
 	s.mutualContact(theirMessenger)
 
-	theirPk := types2.EncodeHex(crypto.FromECDSAPub(&theirMessenger.identity.PublicKey))
+	theirPk := types.EncodeHex(crypto.FromECDSAPub(&theirMessenger.identity.PublicKey))
 	challenge := "challenge"
 
 	resp, err := s.m.SendContactVerificationRequest(context.Background(), theirPk, challenge)
@@ -239,7 +239,7 @@ func (s *MessengerVerificationRequests) TestAcceptVerificationRequests() {
 	s.Require().Equal(resp.ActivityCenterNotifications()[0].Dismissed, false)
 
 	// Mark as tusted
-	resp, err = s.m.VerifiedTrusted(context.Background(), &requests.VerifiedTrusted{ID: types2.FromHex(verificationRequestID)})
+	resp, err = s.m.VerifiedTrusted(context.Background(), &requests.VerifiedTrusted{ID: types.FromHex(verificationRequestID)})
 	s.Require().NoError(err)
 	s.Require().NotNil(resp)
 
@@ -261,7 +261,7 @@ func (s *MessengerVerificationRequests) TestTrustedVerificationRequests() {
 
 	s.mutualContact(theirMessenger)
 
-	theirPk := types2.EncodeHex(crypto.FromECDSAPub(&theirMessenger.identity.PublicKey))
+	theirPk := types.EncodeHex(crypto.FromECDSAPub(&theirMessenger.identity.PublicKey))
 	challenge := "challenge"
 
 	resp, err := s.m.SendContactVerificationRequest(context.Background(), theirPk, challenge)
@@ -350,7 +350,7 @@ func (s *MessengerVerificationRequests) TestTrustedVerificationRequests() {
 	s.Require().Empty(resp.ActivityCenterNotifications()[0].ReplyMessage.OutgoingStatus)
 	s.Require().Equal("hello back", resp.ActivityCenterNotifications()[0].ReplyMessage.Text)
 
-	resp, err = s.m.VerifiedTrusted(context.Background(), &requests.VerifiedTrusted{ID: types2.FromHex(verificationRequestID)})
+	resp, err = s.m.VerifiedTrusted(context.Background(), &requests.VerifiedTrusted{ID: types.FromHex(verificationRequestID)})
 	s.Require().NoError(err)
 	s.Require().NotNil(resp)
 
@@ -371,7 +371,7 @@ func (s *MessengerVerificationRequests) TestUnthrustworthyVerificationRequests()
 
 	s.mutualContact(theirMessenger)
 
-	theirPk := types2.EncodeHex(crypto.FromECDSAPub(&theirMessenger.identity.PublicKey))
+	theirPk := types.EncodeHex(crypto.FromECDSAPub(&theirMessenger.identity.PublicKey))
 	challenge := "challenge"
 
 	resp, err := s.m.SendContactVerificationRequest(context.Background(), theirPk, challenge)
@@ -475,7 +475,7 @@ func (s *MessengerVerificationRequests) TestUnthrustworthyVerificationRequests()
 	s.Require().Empty(resp.ActivityCenterNotifications()[0].ReplyMessage.OutgoingStatus)
 	s.Require().Equal("hello back", resp.ActivityCenterNotifications()[0].ReplyMessage.Text)
 
-	resp, err = s.m.VerifiedUntrustworthy(context.Background(), &requests.VerifiedUntrustworthy{ID: types2.FromHex(verificationRequestID)})
+	resp, err = s.m.VerifiedUntrustworthy(context.Background(), &requests.VerifiedUntrustworthy{ID: types.FromHex(verificationRequestID)})
 	s.Require().NoError(err)
 	s.Require().NotNil(resp)
 
@@ -497,7 +497,7 @@ func (s *MessengerVerificationRequests) TestRemoveTrustVerificationStatus() {
 
 	s.mutualContact(theirMessenger)
 
-	theirPk := types2.EncodeHex(crypto.FromECDSAPub(&theirMessenger.identity.PublicKey))
+	theirPk := types.EncodeHex(crypto.FromECDSAPub(&theirMessenger.identity.PublicKey))
 	challenge := "challenge"
 
 	resp, err := s.m.SendContactVerificationRequest(context.Background(), theirPk, challenge)
@@ -531,7 +531,7 @@ func (s *MessengerVerificationRequests) TestRemoveTrustVerificationStatus() {
 	s.Require().NoError(err)
 
 	// Mark as trusted
-	_, err = s.m.VerifiedTrusted(context.Background(), &requests.VerifiedTrusted{ID: types2.FromHex(verificationRequestID)})
+	_, err = s.m.VerifiedTrusted(context.Background(), &requests.VerifiedTrusted{ID: types.FromHex(verificationRequestID)})
 	s.Require().NoError(err)
 
 	// WHEN
@@ -554,7 +554,7 @@ func (s *MessengerVerificationRequests) TestDeclineVerificationRequests() {
 
 	s.mutualContact(theirMessenger)
 
-	theirPk := types2.EncodeHex(crypto.FromECDSAPub(&theirMessenger.identity.PublicKey))
+	theirPk := types.EncodeHex(crypto.FromECDSAPub(&theirMessenger.identity.PublicKey))
 	challenge := "challenge"
 
 	resp, err := s.m.SendContactVerificationRequest(context.Background(), theirPk, challenge)
@@ -591,7 +591,7 @@ func (s *MessengerVerificationRequests) TestDeclineVerificationRequests() {
 	s.Require().Equal(resp.Messages()[0].ContactVerificationState, common.ContactVerificationStatePending)
 
 	// Make sure it's stored and retrieved correctly
-	notification, err := theirMessenger.ActivityCenterNotification(types2.FromHex(verificationRequestID))
+	notification, err := theirMessenger.ActivityCenterNotification(types.FromHex(verificationRequestID))
 
 	s.Require().NoError(err)
 	s.Require().NotNil(notification)
@@ -624,7 +624,7 @@ func (s *MessengerVerificationRequests) TestDeclineVerificationRequests() {
 	s.Require().Equal(resp.Messages()[0].ContactVerificationState, common.ContactVerificationStateDeclined)
 
 	// Make sure it's stored and retrieved correctly
-	notification, err = theirMessenger.ActivityCenterNotification(types2.FromHex(verificationRequestID))
+	notification, err = theirMessenger.ActivityCenterNotification(types.FromHex(verificationRequestID))
 
 	s.Require().NoError(err)
 	s.Require().NotNil(notification)
@@ -667,7 +667,7 @@ func (s *MessengerVerificationRequests) TestCancelVerificationRequest() {
 
 	s.mutualContact(theirMessenger)
 
-	theirPk := types2.EncodeHex(crypto.FromECDSAPub(&theirMessenger.identity.PublicKey))
+	theirPk := types.EncodeHex(crypto.FromECDSAPub(&theirMessenger.identity.PublicKey))
 	challenge := "challenge"
 
 	resp, err := s.m.SendContactVerificationRequest(context.Background(), theirPk, challenge)
@@ -761,7 +761,7 @@ func (s *MessengerVerificationRequests) TestTrustStatus() {
 
 	s.mutualContact(theirMessenger)
 
-	theirPk := types2.EncodeHex(crypto.FromECDSAPub(&theirMessenger.identity.PublicKey))
+	theirPk := types.EncodeHex(crypto.FromECDSAPub(&theirMessenger.identity.PublicKey))
 
 	// Test Mark as Trusted
 	err := s.m.MarkAsTrusted(context.Background(), theirPk)

--- a/protocol/messenger_contacts.go
+++ b/protocol/messenger_contacts.go
@@ -11,7 +11,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/status-im/status-go/internal/crypto"
-	types2 "github.com/status-im/status-go/internal/crypto/types"
+	"github.com/status-im/status-go/internal/crypto/types"
 	multiaccountscommon "github.com/status-im/status-go/internal/db/multiaccounts/common"
 	"github.com/status-im/status-go/internal/logutils"
 	"github.com/status-im/status-go/pkg/messaging"
@@ -94,7 +94,7 @@ func (m *Messenger) prepareMutualStateUpdateMessage(contactID string, updateType
 		WhisperTimestamp: timestamp,
 		LocalChatID:      contactID,
 		Seen:             true,
-		ID:               types2.EncodeHex(crypto.Keccak256([]byte(fmt.Sprintf("%s%s%d%d", from, to, updateType, clock)))),
+		ID:               types.EncodeHex(crypto.Keccak256([]byte(fmt.Sprintf("%s%s%d%d", from, to, updateType, clock)))),
 	}
 
 	return message, nil
@@ -228,7 +228,7 @@ func (m *Messenger) declineContactRequest(requestID, contactID string) (*Messeng
 	response.AddContact(contact)
 
 	// update notification with the correct status
-	notification, err := m.persistence.GetActivityCenterNotificationByID(types2.FromHex(contactRequest.ID))
+	notification, err := m.persistence.GetActivityCenterNotificationByID(types.FromHex(contactRequest.ID))
 	if err != nil {
 		return nil, err
 	}
@@ -339,7 +339,7 @@ func (m *Messenger) updateAcceptedContactRequest(response *MessengerResponse, co
 		return nil, errors.New("no chat found for accepted contact request")
 	}
 
-	notification, err := m.persistence.GetActivityCenterNotificationByID(types2.FromHex(contactRequest.ID))
+	notification, err := m.persistence.GetActivityCenterNotificationByID(types.FromHex(contactRequest.ID))
 	if err != nil {
 		return nil, err
 	}
@@ -624,7 +624,7 @@ func (m *Messenger) generateContactRequest(clock uint64, timestamp uint64, conta
 
 func (m *Messenger) generateOutgoingContactRequestNotification(contact *contacts.Contact, contactRequest *common.Message) *ActivityCenterNotification {
 	return &ActivityCenterNotification{
-		ID:        types2.FromHex(contactRequest.ID),
+		ID:        types.FromHex(contactRequest.ID),
 		Type:      ActivityCenterNotificationTypeContactRequest,
 		Name:      contact.PrimaryName(),
 		Author:    m.myHexIdentity(),
@@ -1219,7 +1219,7 @@ func (m *Messenger) AcceptLatestContactRequestForContact(ctx context.Context, re
 		return nil, err
 	}
 
-	return m.AcceptContactRequest(ctx, &requests.AcceptContactRequest{ID: types2.Hex2Bytes(contactRequestID), ContactID: request.ID.String()})
+	return m.AcceptContactRequest(ctx, &requests.AcceptContactRequest{ID: types.Hex2Bytes(contactRequestID), ContactID: request.ID.String()})
 }
 
 func (m *Messenger) DismissLatestContactRequestForContact(ctx context.Context, request *requests.DismissLatestContactRequestForContact) (*MessengerResponse, error) {
@@ -1232,7 +1232,7 @@ func (m *Messenger) DismissLatestContactRequestForContact(ctx context.Context, r
 		return nil, err
 	}
 
-	return m.DeclineContactRequest(ctx, &requests.DeclineContactRequest{ID: types2.Hex2Bytes(contactRequestID), ContactID: request.ID.String()})
+	return m.DeclineContactRequest(ctx, &requests.DeclineContactRequest{ID: types.Hex2Bytes(contactRequestID), ContactID: request.ID.String()})
 }
 
 func (m *Messenger) PendingContactRequests(cursor string, limit int) ([]*common.Message, string, error) {
@@ -1240,7 +1240,7 @@ func (m *Messenger) PendingContactRequests(cursor string, limit int) ([]*common.
 }
 
 func defaultContactRequestID(contactID string) string {
-	return "0x" + types2.Bytes2Hex(append(types2.Hex2Bytes(contactID), 0x20))
+	return "0x" + types.Bytes2Hex(append(types.Hex2Bytes(contactID), 0x20))
 }
 
 func defaultContactRequestText() string {

--- a/protocol/messenger_handler.go
+++ b/protocol/messenger_handler.go
@@ -14,10 +14,10 @@ import (
 	gocommon "github.com/status-im/status-go/common"
 	accsmanagementtypes "github.com/status-im/status-go/internal/accounts-management/types"
 	"github.com/status-im/status-go/internal/crypto"
-	types3 "github.com/status-im/status-go/internal/crypto/types"
+	"github.com/status-im/status-go/internal/crypto/types"
 	"github.com/status-im/status-go/internal/db/multiaccounts/accounts"
 	multiaccountscommon "github.com/status-im/status-go/internal/db/multiaccounts/common"
-	settings2 "github.com/status-im/status-go/internal/db/multiaccounts/settings"
+	"github.com/status-im/status-go/internal/db/multiaccounts/settings"
 	walletsettings "github.com/status-im/status-go/internal/db/multiaccounts/settings_wallet"
 	types2 "github.com/status-im/status-go/pkg/messaging/types"
 	"github.com/status-im/status-go/pkg/pubsub"
@@ -121,7 +121,7 @@ func (m *Messenger) HandleMembershipUpdate(ctx context.Context, messageState *Re
 				GroupChatInvitation: &protobuf.GroupChatInvitation{
 					ChatId: message.ChatID,
 				},
-				From: types3.EncodeHex(crypto.FromECDSAPub(&m.identity.PublicKey)),
+				From: types.EncodeHex(crypto.FromECDSAPub(&m.identity.PublicKey)),
 			}
 
 			groupChatInvitation, err = m.persistence.InvitationByID(groupChatInvitation.ID())
@@ -294,7 +294,7 @@ func (m *Messenger) createMessageNotification(chat *Chat, messageState *Received
 		notificationType = ActivityCenterNotificationTypeNewPrivateGroupChat
 	}
 	notification := &ActivityCenterNotification{
-		ID:          types3.FromHex(chat.ID),
+		ID:          types.FromHex(chat.ID),
 		Name:        chat.Name,
 		Message:     message,
 		Type:        notificationType,
@@ -352,7 +352,7 @@ func (m *Messenger) createContactRequestForContactUpdate(contact *contacts.Conta
 func (m *Messenger) createIncomingContactRequestNotification(contact *contacts.Contact, messageState *ReceivedMessageState, contactRequest *common.Message, createNewNotification bool) error {
 	if contactRequest.ContactRequestState == common.ContactRequestStateAccepted {
 		// Pull one from the db if there
-		notification, err := m.persistence.GetActivityCenterNotificationByID(types3.FromHex(contactRequest.ID))
+		notification, err := m.persistence.GetActivityCenterNotificationByID(types.FromHex(contactRequest.ID))
 		if err != nil {
 			return err
 		}
@@ -379,7 +379,7 @@ func (m *Messenger) createIncomingContactRequestNotification(contact *contacts.C
 	}
 
 	notification := &ActivityCenterNotification{
-		ID:        types3.FromHex(contactRequest.ID),
+		ID:        types.FromHex(contactRequest.ID),
 		Name:      contact.PrimaryName(),
 		Message:   contactRequest,
 		Type:      ActivityCenterNotificationTypeContactRequest,
@@ -1032,7 +1032,7 @@ func (m *Messenger) handleAcceptContactRequestMessage(state *ReceivedMessageStat
 			// Device 1 processes this, but device 2 doesn't due to an error `ErrRecordNotFound` from `m.persistence.MessageByID(contactRequestID)`.
 			// The correct notification ID on device 2 should be defaultContactRequestID(contact.ID).
 			// Thus, we must sync the accepted decision to device 2.
-			err = m.syncActivityCenterAcceptedByIDs(context.TODO(), []types3.HexBytes{types3.FromHex(defaultContactRequestID(contact.ID))}, m.GetCurrentTimeInMillis())
+			err = m.syncActivityCenterAcceptedByIDs(context.TODO(), []types.HexBytes{types.FromHex(defaultContactRequestID(contact.ID))}, m.GetCurrentTimeInMillis())
 			if err != nil {
 				m.logger.Warn("could not sync activity center notification as accepted", zap.Error(err))
 			}
@@ -1109,7 +1109,7 @@ func (m *Messenger) handleRetractContactRequest(state *ReceivedMessageState, con
 	state.Response.AddChat(chat)
 
 	notification := &ActivityCenterNotification{
-		ID:        types3.FromHex(uuid.New().String()),
+		ID:        types.FromHex(uuid.New().String()),
 		Type:      ActivityCenterNotificationTypeContactRemoved,
 		Name:      contact.PrimaryName(),
 		Author:    contact.ID,
@@ -1270,7 +1270,7 @@ func (m *Messenger) HandleSyncPairInstallation(ctx context.Context, state *Recei
 
 func (m *Messenger) HandleHistoryArchiveLinkMessage(state *ReceivedMessageState, communityPubKey *ecdsa.PublicKey, archiveLink string, clock uint64) error {
 	m.logger.Debug("[LogosStorage][HandleHistoryArchiveLinkMessage] Handling history archive link message", zap.String("archiveLink", archiveLink))
-	id := types3.HexBytes(crypto.CompressPubkey(communityPubKey))
+	id := types.HexBytes(crypto.CompressPubkey(communityPubKey))
 
 	community, err := m.communitiesManager.GetByID(id)
 	if err != nil && err != communities.ErrOrgNotFound {
@@ -1319,7 +1319,7 @@ func (m *Messenger) HandleHistoryArchiveLinkMessage(state *ReceivedMessageState,
 			m.archiveManager.UnseedHistoryArchive(id, lastSeenArchiveLink)
 			currentTask := m.archiveManager.GetHistoryArchiveDownloadTask(id.String())
 
-			go func(currentTask *archivetypes.HistoryArchiveDownloadTask, communityID types3.HexBytes) {
+			go func(currentTask *archivetypes.HistoryArchiveDownloadTask, communityID types.HexBytes) {
 				defer gocommon.LogOnPanic()
 				// Cancel ongoing download/import task
 				if currentTask != nil && !currentTask.IsCancelled() {
@@ -1357,7 +1357,7 @@ func (m *Messenger) HandleHistoryArchiveLinkMessage(state *ReceivedMessageState,
 	return nil
 }
 
-func (m *Messenger) downloadAndImportHistoryArchives(id types3.HexBytes, archiveLink string, cancel chan struct{}) {
+func (m *Messenger) downloadAndImportHistoryArchives(id types.HexBytes, archiveLink string, cancel chan struct{}) {
 	downloadTaskInfo, err := m.archiveManager.DownloadHistoryArchives(id, archiveLink, cancel)
 	if err != nil {
 		logMsg := "failed to download history archive data"
@@ -1402,11 +1402,11 @@ func (m *Messenger) downloadAndImportHistoryArchives(id types3.HexBytes, archive
 	err = m.importHistoryArchives(id, cancel, archiveLink)
 	if err != nil {
 		m.logger.Error("failed to import history archives", zap.Error(err))
-		m.config.messengerSignalsHandler.DownloadingHistoryArchivesFinished(types3.EncodeHex(id))
+		m.config.messengerSignalsHandler.DownloadingHistoryArchivesFinished(types.EncodeHex(id))
 		return
 	}
 
-	m.config.messengerSignalsHandler.DownloadingHistoryArchivesFinished(types3.EncodeHex(id))
+	m.config.messengerSignalsHandler.DownloadingHistoryArchivesFinished(types.EncodeHex(id))
 }
 
 func (m *Messenger) handleArchiveMessages(archiveMessages []*protobuf.WakuMessage) (*MessengerResponse, error) {
@@ -1481,7 +1481,7 @@ func (m *Messenger) HandleCommunityCancelRequestToJoin(ctx context.Context, stat
 		notification.UpdatedAt = updatedAt
 		// we shouldn't sync deleted notification here,
 		// as the same user on different devices will receive the same message(CommunityCancelRequestToJoin) ?
-		err = m.persistence.DeleteActivityCenterNotificationByID(types3.FromHex(requestToJoin.ID.String()), updatedAt)
+		err = m.persistence.DeleteActivityCenterNotificationByID(types.FromHex(requestToJoin.ID.String()), updatedAt)
 		if err != nil {
 			m.logger.Error("failed to delete notification from Activity Center", zap.Error(err))
 			return err
@@ -1526,7 +1526,7 @@ func (m *Messenger) HandleCommunityRequestToJoin(ctx context.Context, state *Rec
 
 		// Activity Center notification, new for pending state
 		notification := &ActivityCenterNotification{
-			ID:               types3.FromHex(requestToJoin.ID.String()),
+			ID:               types.FromHex(requestToJoin.ID.String()),
 			Type:             ActivityCenterNotificationTypeCommunityMembershipRequest,
 			Timestamp:        m.getTimesource().GetCurrentTime(),
 			Author:           contact.ID,
@@ -1952,7 +1952,7 @@ func (m *Messenger) handleDeleteMessage(ctx context.Context, state *ReceivedMess
 		state.Response.AddRemovedMessage(&RemovedMessage{MessageID: messageToDelete.ID, ChatID: chat.ID, DeletedBy: deleteMessage.DeleteMessage.DeletedBy})
 		state.Response.AddNotification(DeletedMessageNotification(messageToDelete.ID, chat))
 		state.Response.AddActivityCenterNotification(&ActivityCenterNotification{
-			ID:      types3.FromHex(messageToDelete.ID),
+			ID:      types.FromHex(messageToDelete.ID),
 			Deleted: true,
 		})
 
@@ -2147,7 +2147,7 @@ func (m *Messenger) handleChatMessage(ctx context.Context, state *ReceivedMessag
 
 	var communityChatAccessible = true
 	if chat.ChatType == ChatTypeCommunityChat {
-		communityID, err := types3.DecodeHex(chat.CommunityID)
+		communityID, err := types.DecodeHex(chat.CommunityID)
 		if err != nil {
 			return err
 		}
@@ -2333,7 +2333,7 @@ func (m *Messenger) handleChatMessage(ctx context.Context, state *ReceivedMessag
 			receivedMessage.CommunityID = description.ID
 		} else {
 			// Backward compatibility
-			receivedMessage.CommunityID = types3.EncodeHex(crypto.CompressPubkey(signer))
+			receivedMessage.CommunityID = types.EncodeHex(crypto.CompressPubkey(signer))
 		}
 	}
 
@@ -2468,7 +2468,7 @@ func (m *Messenger) HandleSyncSetting(ctx context.Context, messageState *Receive
 			if err := m.settings.DeleteMnemonic(); err != nil {
 				return err
 			}
-			messageState.Response.AddSetting(&settings2.SyncSettingField{SettingField: settings2.Mnemonic})
+			messageState.Response.AddSetting(&settings.SyncSettingField{SettingField: settings.Mnemonic})
 		}
 		return nil
 	}
@@ -2712,7 +2712,7 @@ func (m *Messenger) HandleGroupChatInvitation(ctx context.Context, state *Receiv
 	//From is the PK of author of invitation request
 	if groupChatInvitation.State == protobuf.GroupChatInvitation_REJECTED {
 		//rejected so From is the current user who received this rejection
-		groupChatInvitation.From = types3.EncodeHex(crypto.FromECDSAPub(&m.identity.PublicKey))
+		groupChatInvitation.From = types.EncodeHex(crypto.FromECDSAPub(&m.identity.PublicKey))
 	} else {
 		//invitation request, so From is the author of message
 		groupChatInvitation.From = state.CurrentMessageState.Contact.ID
@@ -2763,8 +2763,8 @@ func (m *Messenger) HandleChatIdentity(ctx context.Context, state *ReceivedMessa
 	}
 
 	contact := state.CurrentMessageState.Contact
-	viewFromContacts := s.ProfilePicturesVisibility == settings2.ProfilePicturesVisibilityContactsOnly
-	viewFromNoOne := s.ProfilePicturesVisibility == settings2.ProfilePicturesVisibilityNone
+	viewFromContacts := s.ProfilePicturesVisibility == settings.ProfilePicturesVisibilityContactsOnly
+	viewFromNoOne := s.ProfilePicturesVisibility == settings.ProfilePicturesVisibilityNone
 
 	m.logger.Debug("settings found",
 		zap.Bool("viewFromContacts", viewFromContacts),
@@ -3047,7 +3047,7 @@ func (m *Messenger) resolveAccountOperability(syncAcc *protobuf.SyncAccount,
 	}
 
 	accountsOperability := accsmanagementtypes.AccountNonOperable
-	dbAccount, err := m.settings.GetAccountByAddress(types3.BytesToAddress(syncAcc.Address))
+	dbAccount, err := m.settings.GetAccountByAddress(types.BytesToAddress(syncAcc.Address))
 	if err != nil && err != accounts.ErrDbAccountNotFound {
 		return accountsOperability, err
 	}
@@ -3186,7 +3186,7 @@ func (m *Messenger) handleSyncAccountsPositions(message *protobuf.SyncAccountsPo
 	var accs []*accsmanagementtypes.Account
 	for _, sAcc := range message.Accounts {
 		acc := &accsmanagementtypes.Account{
-			Address:  types3.BytesToAddress(sAcc.Address),
+			Address:  types.BytesToAddress(sAcc.Address),
 			KeyUID:   sAcc.KeyUid,
 			Position: sAcc.Position,
 		}
@@ -3227,12 +3227,12 @@ func (m *Messenger) handleProfileKeypairMigration(state *ReceivedMessageState, f
 
 	migrationNeeded = dbKeypair.MigratedToColdWallet() && message.ColdWallet == "" || // `true` if profile keypair cold wallet was removed on one of paired devices
 		!dbKeypair.MigratedToColdWallet() && message.ColdWallet != "" // `true` if profile keypair was migrated to a cold wallet on one of paired devices
-	err = m.settings.SaveSettingField(settings2.ProfileMigrationNeeded, migrationNeeded)
+	err = m.settings.SaveSettingField(settings.ProfileMigrationNeeded, migrationNeeded)
 	if err != nil {
 		return
 	}
 
-	state.Response.AddSetting(&settings2.SyncSettingField{SettingField: settings2.ProfileMigrationNeeded, Value: migrationNeeded})
+	state.Response.AddSetting(&settings.SyncSettingField{SettingField: settings.ProfileMigrationNeeded, Value: migrationNeeded})
 	return
 }
 
@@ -3258,7 +3258,7 @@ func (m *Messenger) handleSyncKeypair(message *protobuf.SyncKeypair, fromLocalPa
 		ColdWallet:              accsmanagementtypes.ColdWalletType(message.ColdWallet),
 	}
 
-	oldAddresses := make(map[types3.Address]bool)
+	oldAddresses := make(map[types.Address]bool)
 
 	if dbKeypair != nil {
 		if dbKeypair.Clock >= kp.Clock {
@@ -3672,7 +3672,7 @@ func (m *Messenger) addNewKeypairAddedOnPairedDeviceACNotification(keyUID string
 	}
 
 	notification := &ActivityCenterNotification{
-		ID:        types3.FromHex(uuid.New().String()),
+		ID:        types.FromHex(uuid.New().String()),
 		Type:      ActivityCenterNotificationTypeNewKeypairAddedToPairedDevice,
 		Timestamp: m.getTimesource().GetCurrentTime(),
 		Read:      false,

--- a/protocol/messenger_handler.go
+++ b/protocol/messenger_handler.go
@@ -14,12 +14,12 @@ import (
 	gocommon "github.com/status-im/status-go/common"
 	accsmanagementtypes "github.com/status-im/status-go/internal/accounts-management/types"
 	"github.com/status-im/status-go/internal/crypto"
-	"github.com/status-im/status-go/internal/crypto/types"
+	cryptotypes "github.com/status-im/status-go/internal/crypto/types"
 	"github.com/status-im/status-go/internal/db/multiaccounts/accounts"
 	multiaccountscommon "github.com/status-im/status-go/internal/db/multiaccounts/common"
 	"github.com/status-im/status-go/internal/db/multiaccounts/settings"
 	walletsettings "github.com/status-im/status-go/internal/db/multiaccounts/settings_wallet"
-	types2 "github.com/status-im/status-go/pkg/messaging/types"
+	messagingtypes "github.com/status-im/status-go/pkg/messaging/types"
 	"github.com/status-im/status-go/pkg/pubsub"
 	"github.com/status-im/status-go/protocol/contacts"
 	"github.com/status-im/status-go/services/accounts/accountsevent"
@@ -121,7 +121,7 @@ func (m *Messenger) HandleMembershipUpdate(ctx context.Context, messageState *Re
 				GroupChatInvitation: &protobuf.GroupChatInvitation{
 					ChatId: message.ChatID,
 				},
-				From: types.EncodeHex(crypto.FromECDSAPub(&m.identity.PublicKey)),
+				From: cryptotypes.EncodeHex(crypto.FromECDSAPub(&m.identity.PublicKey)),
 			}
 
 			groupChatInvitation, err = m.persistence.InvitationByID(groupChatInvitation.ID())
@@ -294,7 +294,7 @@ func (m *Messenger) createMessageNotification(chat *Chat, messageState *Received
 		notificationType = ActivityCenterNotificationTypeNewPrivateGroupChat
 	}
 	notification := &ActivityCenterNotification{
-		ID:          types.FromHex(chat.ID),
+		ID:          cryptotypes.FromHex(chat.ID),
 		Name:        chat.Name,
 		Message:     message,
 		Type:        notificationType,
@@ -352,7 +352,7 @@ func (m *Messenger) createContactRequestForContactUpdate(contact *contacts.Conta
 func (m *Messenger) createIncomingContactRequestNotification(contact *contacts.Contact, messageState *ReceivedMessageState, contactRequest *common.Message, createNewNotification bool) error {
 	if contactRequest.ContactRequestState == common.ContactRequestStateAccepted {
 		// Pull one from the db if there
-		notification, err := m.persistence.GetActivityCenterNotificationByID(types.FromHex(contactRequest.ID))
+		notification, err := m.persistence.GetActivityCenterNotificationByID(cryptotypes.FromHex(contactRequest.ID))
 		if err != nil {
 			return err
 		}
@@ -379,7 +379,7 @@ func (m *Messenger) createIncomingContactRequestNotification(contact *contacts.C
 	}
 
 	notification := &ActivityCenterNotification{
-		ID:        types.FromHex(contactRequest.ID),
+		ID:        cryptotypes.FromHex(contactRequest.ID),
 		Name:      contact.PrimaryName(),
 		Message:   contactRequest,
 		Type:      ActivityCenterNotificationTypeContactRequest,
@@ -1032,7 +1032,7 @@ func (m *Messenger) handleAcceptContactRequestMessage(state *ReceivedMessageStat
 			// Device 1 processes this, but device 2 doesn't due to an error `ErrRecordNotFound` from `m.persistence.MessageByID(contactRequestID)`.
 			// The correct notification ID on device 2 should be defaultContactRequestID(contact.ID).
 			// Thus, we must sync the accepted decision to device 2.
-			err = m.syncActivityCenterAcceptedByIDs(context.TODO(), []types.HexBytes{types.FromHex(defaultContactRequestID(contact.ID))}, m.GetCurrentTimeInMillis())
+			err = m.syncActivityCenterAcceptedByIDs(context.TODO(), []cryptotypes.HexBytes{cryptotypes.FromHex(defaultContactRequestID(contact.ID))}, m.GetCurrentTimeInMillis())
 			if err != nil {
 				m.logger.Warn("could not sync activity center notification as accepted", zap.Error(err))
 			}
@@ -1109,7 +1109,7 @@ func (m *Messenger) handleRetractContactRequest(state *ReceivedMessageState, con
 	state.Response.AddChat(chat)
 
 	notification := &ActivityCenterNotification{
-		ID:        types.FromHex(uuid.New().String()),
+		ID:        cryptotypes.FromHex(uuid.New().String()),
 		Type:      ActivityCenterNotificationTypeContactRemoved,
 		Name:      contact.PrimaryName(),
 		Author:    contact.ID,
@@ -1253,7 +1253,7 @@ func (m *Messenger) HandleSyncPairInstallation(ctx context.Context, state *Recei
 		return errors.New("installation not found")
 	}
 
-	metadata := &types2.InstallationMetadata{
+	metadata := &messagingtypes.InstallationMetadata{
 		Name:       message.Name,
 		DeviceType: message.DeviceType,
 	}
@@ -1270,7 +1270,7 @@ func (m *Messenger) HandleSyncPairInstallation(ctx context.Context, state *Recei
 
 func (m *Messenger) HandleHistoryArchiveLinkMessage(state *ReceivedMessageState, communityPubKey *ecdsa.PublicKey, archiveLink string, clock uint64) error {
 	m.logger.Debug("[LogosStorage][HandleHistoryArchiveLinkMessage] Handling history archive link message", zap.String("archiveLink", archiveLink))
-	id := types.HexBytes(crypto.CompressPubkey(communityPubKey))
+	id := cryptotypes.HexBytes(crypto.CompressPubkey(communityPubKey))
 
 	community, err := m.communitiesManager.GetByID(id)
 	if err != nil && err != communities.ErrOrgNotFound {
@@ -1319,7 +1319,7 @@ func (m *Messenger) HandleHistoryArchiveLinkMessage(state *ReceivedMessageState,
 			m.archiveManager.UnseedHistoryArchive(id, lastSeenArchiveLink)
 			currentTask := m.archiveManager.GetHistoryArchiveDownloadTask(id.String())
 
-			go func(currentTask *archivetypes.HistoryArchiveDownloadTask, communityID types.HexBytes) {
+			go func(currentTask *archivetypes.HistoryArchiveDownloadTask, communityID cryptotypes.HexBytes) {
 				defer gocommon.LogOnPanic()
 				// Cancel ongoing download/import task
 				if currentTask != nil && !currentTask.IsCancelled() {
@@ -1357,7 +1357,7 @@ func (m *Messenger) HandleHistoryArchiveLinkMessage(state *ReceivedMessageState,
 	return nil
 }
 
-func (m *Messenger) downloadAndImportHistoryArchives(id types.HexBytes, archiveLink string, cancel chan struct{}) {
+func (m *Messenger) downloadAndImportHistoryArchives(id cryptotypes.HexBytes, archiveLink string, cancel chan struct{}) {
 	downloadTaskInfo, err := m.archiveManager.DownloadHistoryArchives(id, archiveLink, cancel)
 	if err != nil {
 		logMsg := "failed to download history archive data"
@@ -1402,24 +1402,24 @@ func (m *Messenger) downloadAndImportHistoryArchives(id types.HexBytes, archiveL
 	err = m.importHistoryArchives(id, cancel, archiveLink)
 	if err != nil {
 		m.logger.Error("failed to import history archives", zap.Error(err))
-		m.config.messengerSignalsHandler.DownloadingHistoryArchivesFinished(types.EncodeHex(id))
+		m.config.messengerSignalsHandler.DownloadingHistoryArchivesFinished(cryptotypes.EncodeHex(id))
 		return
 	}
 
-	m.config.messengerSignalsHandler.DownloadingHistoryArchivesFinished(types.EncodeHex(id))
+	m.config.messengerSignalsHandler.DownloadingHistoryArchivesFinished(cryptotypes.EncodeHex(id))
 }
 
 func (m *Messenger) handleArchiveMessages(archiveMessages []*protobuf.WakuMessage) (*MessengerResponse, error) {
 
-	messagesToHandle := make(map[types2.ChatFilter][]*types2.ReceivedMessage)
+	messagesToHandle := make(map[messagingtypes.ChatFilter][]*messagingtypes.ReceivedMessage)
 
 	for _, message := range archiveMessages {
 		filter := m.messaging.ChatFilterByTopic(message.Topic)
 		if filter != nil {
-			shhMessage := &types2.ReceivedMessage{
+			shhMessage := &messagingtypes.ReceivedMessage{
 				Sig:          message.Sig,
 				Timestamp:    uint32(message.Timestamp),
-				Topic:        types2.BytesToContentTopic(message.Topic),
+				Topic:        messagingtypes.BytesToContentTopic(message.Topic),
 				Payload:      message.Payload,
 				Padding:      message.Padding,
 				Hash:         message.Hash,
@@ -1429,8 +1429,8 @@ func (m *Messenger) handleArchiveMessages(archiveMessages []*protobuf.WakuMessag
 		}
 	}
 
-	importedMessages := make(map[types2.ChatFilter][]*types2.ReceivedMessage, 0)
-	otherMessages := make(map[types2.ChatFilter][]*types2.ReceivedMessage, 0)
+	importedMessages := make(map[messagingtypes.ChatFilter][]*messagingtypes.ReceivedMessage, 0)
+	otherMessages := make(map[messagingtypes.ChatFilter][]*messagingtypes.ReceivedMessage, 0)
 
 	for filter, messages := range messagesToHandle {
 		for _, message := range messages {
@@ -1481,7 +1481,7 @@ func (m *Messenger) HandleCommunityCancelRequestToJoin(ctx context.Context, stat
 		notification.UpdatedAt = updatedAt
 		// we shouldn't sync deleted notification here,
 		// as the same user on different devices will receive the same message(CommunityCancelRequestToJoin) ?
-		err = m.persistence.DeleteActivityCenterNotificationByID(types.FromHex(requestToJoin.ID.String()), updatedAt)
+		err = m.persistence.DeleteActivityCenterNotificationByID(cryptotypes.FromHex(requestToJoin.ID.String()), updatedAt)
 		if err != nil {
 			m.logger.Error("failed to delete notification from Activity Center", zap.Error(err))
 			return err
@@ -1526,7 +1526,7 @@ func (m *Messenger) HandleCommunityRequestToJoin(ctx context.Context, state *Rec
 
 		// Activity Center notification, new for pending state
 		notification := &ActivityCenterNotification{
-			ID:               types.FromHex(requestToJoin.ID.String()),
+			ID:               cryptotypes.FromHex(requestToJoin.ID.String()),
 			Type:             ActivityCenterNotificationTypeCommunityMembershipRequest,
 			Timestamp:        m.getTimesource().GetCurrentTime(),
 			Author:           contact.ID,
@@ -1952,7 +1952,7 @@ func (m *Messenger) handleDeleteMessage(ctx context.Context, state *ReceivedMess
 		state.Response.AddRemovedMessage(&RemovedMessage{MessageID: messageToDelete.ID, ChatID: chat.ID, DeletedBy: deleteMessage.DeleteMessage.DeletedBy})
 		state.Response.AddNotification(DeletedMessageNotification(messageToDelete.ID, chat))
 		state.Response.AddActivityCenterNotification(&ActivityCenterNotification{
-			ID:      types.FromHex(messageToDelete.ID),
+			ID:      cryptotypes.FromHex(messageToDelete.ID),
 			Deleted: true,
 		})
 
@@ -2147,7 +2147,7 @@ func (m *Messenger) handleChatMessage(ctx context.Context, state *ReceivedMessag
 
 	var communityChatAccessible = true
 	if chat.ChatType == ChatTypeCommunityChat {
-		communityID, err := types.DecodeHex(chat.CommunityID)
+		communityID, err := cryptotypes.DecodeHex(chat.CommunityID)
 		if err != nil {
 			return err
 		}
@@ -2333,7 +2333,7 @@ func (m *Messenger) handleChatMessage(ctx context.Context, state *ReceivedMessag
 			receivedMessage.CommunityID = description.ID
 		} else {
 			// Backward compatibility
-			receivedMessage.CommunityID = types.EncodeHex(crypto.CompressPubkey(signer))
+			receivedMessage.CommunityID = cryptotypes.EncodeHex(crypto.CompressPubkey(signer))
 		}
 	}
 
@@ -2712,7 +2712,7 @@ func (m *Messenger) HandleGroupChatInvitation(ctx context.Context, state *Receiv
 	//From is the PK of author of invitation request
 	if groupChatInvitation.State == protobuf.GroupChatInvitation_REJECTED {
 		//rejected so From is the current user who received this rejection
-		groupChatInvitation.From = types.EncodeHex(crypto.FromECDSAPub(&m.identity.PublicKey))
+		groupChatInvitation.From = cryptotypes.EncodeHex(crypto.FromECDSAPub(&m.identity.PublicKey))
 	} else {
 		//invitation request, so From is the author of message
 		groupChatInvitation.From = state.CurrentMessageState.Contact.ID
@@ -3047,7 +3047,7 @@ func (m *Messenger) resolveAccountOperability(syncAcc *protobuf.SyncAccount,
 	}
 
 	accountsOperability := accsmanagementtypes.AccountNonOperable
-	dbAccount, err := m.settings.GetAccountByAddress(types.BytesToAddress(syncAcc.Address))
+	dbAccount, err := m.settings.GetAccountByAddress(cryptotypes.BytesToAddress(syncAcc.Address))
 	if err != nil && err != accounts.ErrDbAccountNotFound {
 		return accountsOperability, err
 	}
@@ -3186,7 +3186,7 @@ func (m *Messenger) handleSyncAccountsPositions(message *protobuf.SyncAccountsPo
 	var accs []*accsmanagementtypes.Account
 	for _, sAcc := range message.Accounts {
 		acc := &accsmanagementtypes.Account{
-			Address:  types.BytesToAddress(sAcc.Address),
+			Address:  cryptotypes.BytesToAddress(sAcc.Address),
 			KeyUID:   sAcc.KeyUid,
 			Position: sAcc.Position,
 		}
@@ -3258,7 +3258,7 @@ func (m *Messenger) handleSyncKeypair(message *protobuf.SyncKeypair, fromLocalPa
 		ColdWallet:              accsmanagementtypes.ColdWalletType(message.ColdWallet),
 	}
 
-	oldAddresses := make(map[types.Address]bool)
+	oldAddresses := make(map[cryptotypes.Address]bool)
 
 	if dbKeypair != nil {
 		if dbKeypair.Clock >= kp.Clock {
@@ -3672,7 +3672,7 @@ func (m *Messenger) addNewKeypairAddedOnPairedDeviceACNotification(keyUID string
 	}
 
 	notification := &ActivityCenterNotification{
-		ID:        types.FromHex(uuid.New().String()),
+		ID:        cryptotypes.FromHex(uuid.New().String()),
 		Type:      ActivityCenterNotificationTypeNewKeypairAddedToPairedDevice,
 		Timestamp: m.getTimesource().GetCurrentTime(),
 		Read:      false,

--- a/protocol/messenger_identity_image_test.go
+++ b/protocol/messenger_identity_image_test.go
@@ -15,9 +15,9 @@ import (
 
 	"github.com/status-im/status-go/internal/crypto"
 	"github.com/status-im/status-go/internal/db/multiaccounts"
-	settings2 "github.com/status-im/status-go/internal/db/multiaccounts/settings"
+	"github.com/status-im/status-go/internal/db/multiaccounts/settings"
 	"github.com/status-im/status-go/internal/images"
-	testutils2 "github.com/status-im/status-go/internal/testutils"
+	"github.com/status-im/status-go/internal/testutils"
 	"github.com/status-im/status-go/internal/testutils/fake"
 	"github.com/status-im/status-go/protocol/contacts"
 	"github.com/status-im/status-go/protocol/protobuf"
@@ -166,10 +166,10 @@ func (s *MessengerProfilePictureHandlerSuite) TestEncryptDecryptIdentityImagesWi
 }
 
 func (s *MessengerProfilePictureHandlerSuite) TestPictureInPrivateChatOneSided() {
-	err := s.bob.settings.SaveSettingField(settings2.ProfilePicturesVisibility, settings2.ProfilePicturesShowToEveryone)
+	err := s.bob.settings.SaveSettingField(settings.ProfilePicturesVisibility, settings.ProfilePicturesShowToEveryone)
 	s.Require().NoError(err)
 
-	err = s.alice.settings.SaveSettingField(settings2.ProfilePicturesVisibility, settings2.ProfilePicturesShowToEveryone)
+	err = s.alice.settings.SaveSettingField(settings.ProfilePicturesVisibility, settings.ProfilePicturesShowToEveryone)
 	s.Require().NoError(err)
 
 	bChat := CreateOneToOneChat(s.alice.IdentityPublicKeyString(), s.alice.IdentityPublicKey(), s.alice.getTimesource())
@@ -189,7 +189,7 @@ func (s *MessengerProfilePictureHandlerSuite) TestPictureInPrivateChatOneSided()
 		b.MaxElapsedTime = 2 * time.Second
 	}
 
-	err = testutils2.RetryWithBackOff(func() error {
+	err = testutils.RetryWithBackOff(func() error {
 
 		response, err = s.alice.RetrieveAll()
 		if err != nil {
@@ -210,16 +210,16 @@ func (s *MessengerProfilePictureHandlerSuite) TestPictureInPrivateChatOneSided()
 }
 
 func (s *MessengerProfilePictureHandlerSuite) TestE2eSendingReceivingProfilePicture() {
-	profilePicShowSettings := []settings2.ProfilePicturesShowToType{
-		settings2.ProfilePicturesShowToContactsOnly,
-		settings2.ProfilePicturesShowToEveryone,
-		settings2.ProfilePicturesShowToNone,
+	profilePicShowSettings := []settings.ProfilePicturesShowToType{
+		settings.ProfilePicturesShowToContactsOnly,
+		settings.ProfilePicturesShowToEveryone,
+		settings.ProfilePicturesShowToNone,
 	}
 
-	profilePicViewSettings := []settings2.ProfilePicturesVisibilityType{
-		settings2.ProfilePicturesVisibilityContactsOnly,
-		settings2.ProfilePicturesVisibilityEveryone,
-		settings2.ProfilePicturesVisibilityNone,
+	profilePicViewSettings := []settings.ProfilePicturesVisibilityType{
+		settings.ProfilePicturesVisibilityContactsOnly,
+		settings.ProfilePicturesVisibilityEveryone,
+		settings.ProfilePicturesVisibilityNone,
 	}
 
 	isContactFor := map[string][]bool{
@@ -274,7 +274,7 @@ func (s *MessengerProfilePictureHandlerSuite) testE2eSendingReceivingProfilePict
 		zap.Error(err))
 
 	// Setting up Bob
-	err = bob.settings.SaveSettingField(settings2.ProfilePicturesVisibility, args.visibilityType)
+	err = bob.settings.SaveSettingField(settings.ProfilePicturesVisibility, args.visibilityType)
 	s.Require().NoError(err)
 
 	if args.bobContact {
@@ -304,7 +304,7 @@ func (s *MessengerProfilePictureHandlerSuite) testE2eSendingReceivingProfilePict
 	}
 
 	// Setting up Alice
-	err = alice.settings.SaveSettingField(settings2.ProfilePicturesShowTo, args.showToType)
+	err = alice.settings.SaveSettingField(settings.ProfilePicturesShowTo, args.showToType)
 	s.Require().NoError(err)
 
 	if args.aliceContact {
@@ -353,7 +353,7 @@ func (s *MessengerProfilePictureHandlerSuite) testE2eSendingReceivingProfilePict
 		b.MaxElapsedTime = 2 * time.Second
 	}
 
-	err = testutils2.RetryWithBackOff(func() error {
+	err = testutils.RetryWithBackOff(func() error {
 		response, err := bob.RetrieveAll()
 		if err != nil {
 			return err
@@ -403,8 +403,8 @@ func (s *MessengerProfilePictureHandlerSuite) testE2eSendingReceivingProfilePict
 
 type e2eArgs struct {
 	chatContext    ChatContext
-	showToType     settings2.ProfilePicturesShowToType
-	visibilityType settings2.ProfilePicturesVisibilityType
+	showToType     settings.ProfilePicturesShowToType
+	visibilityType settings.ProfilePicturesVisibilityType
 	aliceContact   bool
 	bobContact     bool
 }
@@ -435,14 +435,14 @@ func (args *e2eArgs) TestCaseName(t *testing.T) string {
 
 func (args *e2eArgs) resultExpected() (bool, error) {
 	switch args.showToType {
-	case settings2.ProfilePicturesShowToContactsOnly:
+	case settings.ProfilePicturesShowToContactsOnly:
 		if args.aliceContact {
 			return args.resultExpectedVS()
 		}
 		return false, nil
-	case settings2.ProfilePicturesShowToEveryone:
+	case settings.ProfilePicturesShowToEveryone:
 		return args.resultExpectedVS()
-	case settings2.ProfilePicturesShowToNone:
+	case settings.ProfilePicturesShowToNone:
 		return false, nil
 	default:
 		return false, errors.New("unknown ProfilePicturesShowToType")
@@ -451,11 +451,11 @@ func (args *e2eArgs) resultExpected() (bool, error) {
 
 func (args *e2eArgs) resultExpectedVS() (bool, error) {
 	switch args.visibilityType {
-	case settings2.ProfilePicturesVisibilityContactsOnly:
+	case settings.ProfilePicturesVisibilityContactsOnly:
 		return true, nil
-	case settings2.ProfilePicturesVisibilityEveryone:
+	case settings.ProfilePicturesVisibilityEveryone:
 		return true, nil
-	case settings2.ProfilePicturesVisibilityNone:
+	case settings.ProfilePicturesVisibilityNone:
 		// If we are contacts, we save the image regardless
 		return args.bobContact, nil
 	default:
@@ -463,14 +463,14 @@ func (args *e2eArgs) resultExpectedVS() (bool, error) {
 	}
 }
 
-var profilePicShowSettingsMap = map[settings2.ProfilePicturesShowToType]string{
-	settings2.ProfilePicturesShowToContactsOnly: "ShowToContactsOnly",
-	settings2.ProfilePicturesShowToEveryone:     "ShowToEveryone",
-	settings2.ProfilePicturesShowToNone:         "ShowToNone",
+var profilePicShowSettingsMap = map[settings.ProfilePicturesShowToType]string{
+	settings.ProfilePicturesShowToContactsOnly: "ShowToContactsOnly",
+	settings.ProfilePicturesShowToEveryone:     "ShowToEveryone",
+	settings.ProfilePicturesShowToNone:         "ShowToNone",
 }
 
-var profilePicViewSettingsMap = map[settings2.ProfilePicturesVisibilityType]string{
-	settings2.ProfilePicturesVisibilityContactsOnly: "ViewFromContactsOnly",
-	settings2.ProfilePicturesVisibilityEveryone:     "ViewFromEveryone",
-	settings2.ProfilePicturesVisibilityNone:         "ViewFromNone",
+var profilePicViewSettingsMap = map[settings.ProfilePicturesVisibilityType]string{
+	settings.ProfilePicturesVisibilityContactsOnly: "ViewFromContactsOnly",
+	settings.ProfilePicturesVisibilityEveryone:     "ViewFromEveryone",
+	settings.ProfilePicturesVisibilityNone:         "ViewFromNone",
 }

--- a/protocol/messenger_local_backup.go
+++ b/protocol/messenger_local_backup.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/status-im/status-go/internal/db/multiaccounts/settings"
 	"github.com/status-im/status-go/protocol/communities"
-	contacts2 "github.com/status-im/status-go/protocol/contacts"
+	"github.com/status-im/status-go/protocol/contacts"
 	"github.com/status-im/status-go/protocol/protobuf"
 	"github.com/status-im/status-go/signal"
 )
@@ -25,9 +25,9 @@ type CommunitySet struct {
 }
 
 func (m *Messenger) backupContacts() []*protobuf.Backup {
-	var contacts []*protobuf.SyncInstallationContactV2
-	myID := contacts2.ContactIDFromPublicKey(&m.identity.PublicKey)
-	m.allContacts.Range(func(contactID string, contact *contacts2.Contact) (shouldContinue bool) {
+	var syncContacts []*protobuf.SyncInstallationContactV2
+	myID := contacts.ContactIDFromPublicKey(&m.identity.PublicKey)
+	m.allContacts.Range(func(contactID string, contact *contacts.Contact) (shouldContinue bool) {
 		syncContact := m.buildSyncContactMessage(contact)
 		if syncContact == nil {
 			return true
@@ -37,21 +37,21 @@ func (m *Messenger) backupContacts() []*protobuf.Backup {
 		if contact.ID == myID {
 			return true
 		}
-		canonicalID, err := contacts2.ContactIDFromPublicKeyString(contact.ID)
+		canonicalID, err := contacts.ContactIDFromPublicKeyString(contact.ID)
 		if err == nil && canonicalID == myID {
 			return true
 		}
 
-		contacts = append(contacts, syncContact)
+		syncContacts = append(syncContacts, syncContact)
 
 		return true
 	})
 
 	var backupMessages []*protobuf.Backup
-	for i := 0; i < len(contacts); i += BackupContactsPerBatch {
-		j := min(i+BackupContactsPerBatch, len(contacts))
+	for i := 0; i < len(syncContacts); i += BackupContactsPerBatch {
+		j := min(i+BackupContactsPerBatch, len(syncContacts))
 
-		contactsToAdd := contacts[i:j]
+		contactsToAdd := syncContacts[i:j]
 
 		backupMessage := &protobuf.Backup{
 			Contacts: contactsToAdd,

--- a/protocol/messenger_mailserver.go
+++ b/protocol/messenger_mailserver.go
@@ -12,8 +12,8 @@ import (
 	gocommon "github.com/status-im/status-go/common"
 	"github.com/status-im/status-go/internal/connection"
 	"github.com/status-im/status-go/internal/crypto"
-	"github.com/status-im/status-go/internal/crypto/types"
-	types2 "github.com/status-im/status-go/pkg/messaging/types"
+	cryptotypes "github.com/status-im/status-go/internal/crypto/types"
+	messagingtypes "github.com/status-im/status-go/pkg/messaging/types"
 	"github.com/status-im/status-go/protocol/common"
 	"github.com/status-im/status-go/protocol/protobuf"
 	"github.com/status-im/status-go/services/mailservers"
@@ -89,7 +89,7 @@ func (m *Messenger) scheduleSyncChat(chat *Chat) (bool, error) {
 	return true, nil
 }
 
-func (m *Messenger) scheduleSyncFilters(filters types2.ChatFilters) (bool, error) {
+func (m *Messenger) scheduleSyncFilters(filters messagingtypes.ChatFilters) (bool, error) {
 	shouldSync, err := m.shouldSync()
 	if err != nil {
 		m.logger.Error("failed to get shouldSync", zap.Error(err))
@@ -126,12 +126,12 @@ func (m *Messenger) calculateMailserverTimeBounds(duration time.Duration) (time.
 	return from, to
 }
 
-func (m *Messenger) filtersForChat(chatID string) (types2.ChatFilters, error) {
+func (m *Messenger) filtersForChat(chatID string) (messagingtypes.ChatFilters, error) {
 	chat, ok := m.allChats.Load(chatID)
 	if !ok {
 		return nil, ErrChatNotFound
 	}
-	var filters []*types2.ChatFilter
+	var filters []*messagingtypes.ChatFilter
 
 	if chat.OneToOne() {
 		// We sync our own topic and any eventual negotiated
@@ -152,19 +152,19 @@ func (m *Messenger) filtersForChat(chatID string) (types2.ChatFilters, error) {
 		if filter == nil {
 			return nil, ErrNoFiltersForChat
 		}
-		filters = []*types2.ChatFilter{filter}
+		filters = []*messagingtypes.ChatFilter{filter}
 	}
 
 	return filters, nil
 }
 
-func (m *Messenger) topicsForChat(chatID string) (string, []types2.ContentTopic, error) {
+func (m *Messenger) topicsForChat(chatID string) (string, []messagingtypes.ContentTopic, error) {
 	filters, err := m.filtersForChat(chatID)
 	if err != nil {
 		return "", nil, err
 	}
 
-	var contentTopics []types2.ContentTopic
+	var contentTopics []messagingtypes.ContentTopic
 
 	for _, filter := range filters {
 		contentTopics = append(contentTopics, filter.ContentTopic())
@@ -202,7 +202,7 @@ func (m *Messenger) capToDefaultSyncPeriod(period uint32) (uint32, error) {
 	return period - tolerance, nil
 }
 
-func (m *Messenger) updateFiltersPriority(filters types2.ChatFilters) error {
+func (m *Messenger) updateFiltersPriority(filters messagingtypes.ChatFilters) error {
 	for _, filter := range filters {
 		chatID := filter.ChatID()
 		chat := m.Chat(chatID)
@@ -217,7 +217,7 @@ func (m *Messenger) updateFiltersPriority(filters types2.ChatFilters) error {
 	return nil
 }
 
-func (m *Messenger) resetFiltersPriority(filters types2.ChatFilters) error {
+func (m *Messenger) resetFiltersPriority(filters messagingtypes.ChatFilters) error {
 	for _, filter := range filters {
 		err := m.messaging.UpdateFilterPriority(filter.ChatID(), 0)
 		if err != nil {
@@ -244,7 +244,7 @@ func (m *Messenger) runAutomaticHistoricSync(request historicSyncRequest) (bool,
 		return false, nil
 	}
 	_, executed, err := m.requestAllHistoricMessagesWithOptions(false, syncFiltersOptions{
-		Window: &types2.HistoryReconcileWindow{From: request.From, To: request.To},
+		Window: &messagingtypes.HistoryReconcileWindow{From: request.From, To: request.To},
 	})
 	return executed, err
 }
@@ -333,10 +333,10 @@ type syncFiltersOptions struct {
 	ExactFrom uint32
 	// Window bounds automatic reconciliation. A zero From means cursor-based
 	// catch-up with only a fixed upper bound (used at startup).
-	Window *types2.HistoryReconcileWindow
+	Window *messagingtypes.HistoryReconcileWindow
 }
 
-func applyHistoryWindowFloor(from uint32, initialized bool, window *types2.HistoryReconcileWindow) uint32 {
+func applyHistoryWindowFloor(from uint32, initialized bool, window *messagingtypes.HistoryReconcileWindow) uint32 {
 	if !initialized || window == nil || window.From.IsZero() {
 		return from
 	}
@@ -354,11 +354,11 @@ func getPrioritizedBatches() []int {
 	return []int{1, 5, 10}
 }
 
-func (m *Messenger) syncFiltersFrom(filters types2.ChatFilters, lastRequest uint32) (*MessengerResponse, error) {
+func (m *Messenger) syncFiltersFrom(filters messagingtypes.ChatFilters, lastRequest uint32) (*MessengerResponse, error) {
 	return m.syncFiltersWithOptions(filters, syncFiltersOptions{ExactFrom: lastRequest})
 }
 
-func (m *Messenger) syncFiltersWithOptions(filters types2.ChatFilters, options syncFiltersOptions) (*MessengerResponse, error) {
+func (m *Messenger) syncFiltersWithOptions(filters messagingtypes.ChatFilters, options syncFiltersOptions) (*MessengerResponse, error) {
 	canSync, err := m.canSyncWithStoreNodes()
 	if err != nil {
 		return nil, err
@@ -378,7 +378,7 @@ func (m *Messenger) syncFiltersWithOptions(filters types2.ChatFilters, options s
 		topicsData[fmt.Sprintf("%s-%s", topic.PubsubTopic, topic.ContentTopic)] = topic
 	}
 
-	batches := make(map[string]map[int]types2.StoreNodeBatch)
+	batches := make(map[string]map[int]messagingtypes.StoreNodeBatch)
 
 	to := m.calculateMailserverTo()
 	if options.Window != nil && !options.Window.To.IsZero() {
@@ -409,7 +409,7 @@ func (m *Messenger) syncFiltersWithOptions(filters types2.ChatFilters, options s
 		return nil, err
 	}
 
-	contentTopicsPerPubsubTopic := make(map[string]map[string]*types2.ChatFilter, len(filters))
+	contentTopicsPerPubsubTopic := make(map[string]map[string]*messagingtypes.ChatFilter, len(filters))
 	for _, filter := range filters {
 		if !filter.IsListening() || filter.IsEphemeral() {
 			continue
@@ -417,7 +417,7 @@ func (m *Messenger) syncFiltersWithOptions(filters types2.ChatFilters, options s
 
 		contentTopics, ok := contentTopicsPerPubsubTopic[filter.PubsubTopic()]
 		if !ok {
-			contentTopics = make(map[string]*types2.ChatFilter)
+			contentTopics = make(map[string]*messagingtypes.ChatFilter)
 		}
 		contentTopics[filter.ContentTopic().String()] = filter
 		contentTopicsPerPubsubTopic[filter.PubsubTopic()] = contentTopics
@@ -427,11 +427,11 @@ func (m *Messenger) syncFiltersWithOptions(filters types2.ChatFilters, options s
 	if err != nil {
 		return nil, err
 	}
-	var communityDescriptionFilters []*types2.ChatFilter
+	var communityDescriptionFilters []*messagingtypes.ChatFilter
 
 	for pubsubTopic, contentTopics := range contentTopicsPerPubsubTopic {
 		if _, ok := batches[pubsubTopic]; !ok {
-			batches[pubsubTopic] = make(map[int]types2.StoreNodeBatch)
+			batches[pubsubTopic] = make(map[int]messagingtypes.StoreNodeBatch)
 		}
 
 		for _, filter := range contentTopics {
@@ -510,7 +510,7 @@ func (m *Messenger) syncFiltersWithOptions(filters types2.ChatFilters, options s
 				if int64(from) >= to.Unix() {
 					continue
 				}
-				batch = types2.StoreNodeBatch{From: time.Unix(int64(from), 0), To: to}
+				batch = messagingtypes.StoreNodeBatch{From: time.Unix(int64(from), 0), To: to}
 			}
 
 			batch.ChatIDs = append(batch.ChatIDs, chatID)
@@ -604,7 +604,7 @@ func (m *Messenger) syncFiltersWithOptions(filters types2.ChatFilters, options s
 	return response, nil
 }
 
-func (m *Messenger) syncFilters(filters types2.ChatFilters) (*MessengerResponse, error) {
+func (m *Messenger) syncFilters(filters messagingtypes.ChatFilters) (*MessengerResponse, error) {
 	return m.syncFiltersWithOptions(filters, syncFiltersOptions{})
 }
 
@@ -625,7 +625,7 @@ func (m *Messenger) communityDescriptionChatIDs() (map[string]struct{}, error) {
 // fetchLatestCommunityDescriptions gets the latest description for each
 // community filter and stops after the first page of results.
 // This avoids downloading many older copies.
-func (m *Messenger) fetchLatestCommunityDescriptions(filters []*types2.ChatFilter) {
+func (m *Messenger) fetchLatestCommunityDescriptions(filters []*messagingtypes.ChatFilter) {
 	if len(filters) == 0 {
 		return
 	}
@@ -639,11 +639,11 @@ func (m *Messenger) fetchLatestCommunityDescriptions(filters []*types2.ChatFilte
 	}
 
 	for _, filter := range filters {
-		batch := types2.StoreNodeBatch{
+		batch := messagingtypes.StoreNodeBatch{
 			From:        from,
 			To:          to,
 			PubsubTopic: filter.PubsubTopic(),
-			Topics:      []types2.ContentTopic{filter.ContentTopic()},
+			Topics:      []messagingtypes.ContentTopic{filter.ContentTopic()},
 			ChatIDs:     []string{filter.ChatID()},
 		}
 		err := m.processMailserverBatchWithOptions(batch, 1, stopAfterFirstPage, false)
@@ -685,7 +685,7 @@ func (m *Messenger) calculateGapForChat(chat *Chat, from uint32) (*common.Messag
 		WhisperTimestamp: timestamp,
 		LocalChatID:      chat.ID,
 		Seen:             true,
-		ID:               types.EncodeHex(crypto.Keccak256([]byte(fmt.Sprintf("%s-%d-%d", chat.ID, chat.SyncedTo, from)))),
+		ID:               cryptotypes.EncodeHex(crypto.Keccak256([]byte(fmt.Sprintf("%s-%d-%d", chat.ID, chat.SyncedTo, from)))),
 	}
 
 	return message, m.persistence.SaveMessages([]*common.Message{message})
@@ -706,7 +706,7 @@ func (m *Messenger) ConnectionChanged(state connection.State) {
 // processMailserverBatch queries the store for a single batch, applying the
 // mobile-network gate. The store node is selected internally by the StoreClient
 // (no peer argument).
-func (m *Messenger) processMailserverBatch(batch types2.StoreNodeBatch) error {
+func (m *Messenger) processMailserverBatch(batch messagingtypes.StoreNodeBatch) error {
 	canSync, err := m.canSyncWithStoreNodes()
 	if err != nil {
 		return err
@@ -718,7 +718,7 @@ func (m *Messenger) processMailserverBatch(batch types2.StoreNodeBatch) error {
 	return m.messaging.Query(m.ctx, batch, defaultStoreNodeRequestPageSize, nil, false)
 }
 
-func (m *Messenger) processMailserverBatchWithOptions(batch types2.StoreNodeBatch, pageLimit uint64, shouldProcessNextPage func(int) (bool, uint64), processEnvelopes bool) error {
+func (m *Messenger) processMailserverBatchWithOptions(batch messagingtypes.StoreNodeBatch, pageLimit uint64, shouldProcessNextPage func(int) (bool, uint64), processEnvelopes bool) error {
 	canSync, err := m.canSyncWithStoreNodes()
 	if err != nil {
 		return err
@@ -754,7 +754,7 @@ func (m *Messenger) SyncChatFromSyncedFrom(chatID string) (uint32, error) {
 		return 0, err
 	}
 
-	batch := types2.StoreNodeBatch{
+	batch := messagingtypes.StoreNodeBatch{
 		ChatIDs:     []string{chatID},
 		To:          time.Unix(int64(chat.SyncedFrom), 0),
 		From:        time.Unix(int64(chat.SyncedFrom-defaultSyncPeriod), 0),
@@ -819,7 +819,7 @@ func (m *Messenger) FillGaps(chatID string, messageIDs []string) error {
 		}
 	}
 
-	batch := types2.StoreNodeBatch{
+	batch := messagingtypes.StoreNodeBatch{
 		ChatIDs:     []string{chatID},
 		To:          time.Unix(int64(highestTo), 0),
 		From:        time.Unix(int64(lowestFrom), 0),
@@ -852,7 +852,7 @@ func (m *Messenger) ToggleUseMailservers(value bool) error {
 	return nil
 }
 
-func (m *Messenger) RemoveFilters(filters []*types2.ChatFilter) error {
+func (m *Messenger) RemoveFilters(filters []*messagingtypes.ChatFilter) error {
 	return m.messaging.RemoveFilters(filters)
 }
 
@@ -878,7 +878,7 @@ func (m *Messenger) fetchMessages(chatID string, duration time.Duration) (uint32
 		return uint32(from.Unix()), nil
 	}
 
-	batch := types2.StoreNodeBatch{
+	batch := messagingtypes.StoreNodeBatch{
 		ChatIDs:     []string{chatID},
 		From:        from,
 		To:          to,

--- a/protocol/messenger_mailserver_test.go
+++ b/protocol/messenger_mailserver_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	"github.com/status-im/status-go/pkg/messaging"
-	types2 "github.com/status-im/status-go/pkg/messaging/types"
+	"github.com/status-im/status-go/pkg/messaging/types"
 	wakutypes "github.com/status-im/status-go/pkg/messaging/waku/types"
 	"github.com/status-im/status-go/protocol/communities"
 	"github.com/status-im/status-go/protocol/protobuf"
@@ -73,11 +73,11 @@ func (s *MessengerFetchLatestCommunityDescriptionsSuite) recordMailserverBatches
 	return recorded
 }
 
-func descriptionFilter(chatID, pubsubTopic, contentTopic string) *types2.ChatFilter {
-	return types2.NewChatFilter(&types2.ChatFilterConfig{
+func descriptionFilter(chatID, pubsubTopic, contentTopic string) *types.ChatFilter {
+	return types.NewChatFilter(&types.ChatFilterConfig{
 		ChatID:       chatID,
 		PubsubTopic:  pubsubTopic,
-		ContentTopic: types2.StringToContentTopic(contentTopic),
+		ContentTopic: types.StringToContentTopic(contentTopic),
 		Listen:       true,
 	})
 }
@@ -88,7 +88,7 @@ func descriptionFilter(chatID, pubsubTopic, contentTopic string) *types2.ChatFil
 func (s *MessengerFetchLatestCommunityDescriptionsSuite) TestFetchesOnlyNewestPagePerFilter() {
 	recorded := s.recordMailserverBatches()
 
-	filters := []*types2.ChatFilter{
+	filters := []*types.ChatFilter{
 		descriptionFilter("0xcommunity1", "/waku/2/pubsub-a", "0xcontenttopic1"),
 		descriptionFilter("0xcommunity2", "/waku/2/pubsub-b", "0xcontenttopic2"),
 	}
@@ -131,7 +131,7 @@ func (s *MessengerFetchLatestCommunityDescriptionsSuite) TestLatestDescriptionUs
 	filter := descriptionFilter("0xcommunity1", "/waku/2/pubsub-a", "0xcontenttopic1")
 	from, to := s.m.calculateMailserverTimeBounds(oneMonthDuration)
 
-	s.m.fetchLatestCommunityDescriptions([]*types2.ChatFilter{filter})
+	s.m.fetchLatestCommunityDescriptions([]*types.ChatFilter{filter})
 
 	s.Require().Len(*recorded, 1)
 	s.Require().Equal(from, (*recorded)[0].batch.From)

--- a/protocol/messenger_profile_showcase_test.go
+++ b/protocol/messenger_profile_showcase_test.go
@@ -11,7 +11,7 @@ import (
 
 	accsmanagementtypes "github.com/status-im/status-go/internal/accounts-management/types"
 	"github.com/status-im/status-go/internal/crypto"
-	types2 "github.com/status-im/status-go/internal/crypto/types"
+	"github.com/status-im/status-go/internal/crypto/types"
 	"github.com/status-im/status-go/internal/db/multiaccounts/accounts"
 	"github.com/status-im/status-go/internal/testutils"
 	"github.com/status-im/status-go/protocol/common"
@@ -41,7 +41,7 @@ func (s *TestMessengerProfileShowcase) SetupTest() {
 func (s *TestMessengerProfileShowcase) mutualContact(theirMessenger *Messenger) {
 	messageText := "hello!"
 
-	contactID := types2.EncodeHex(crypto.FromECDSAPub(&theirMessenger.identity.PublicKey))
+	contactID := types.EncodeHex(crypto.FromECDSAPub(&theirMessenger.identity.PublicKey))
 	request := &requests.SendContactRequest{
 		ID:      contactID,
 		Message: messageText,
@@ -68,7 +68,7 @@ func (s *TestMessengerProfileShowcase) mutualContact(theirMessenger *Messenger) 
 	s.Require().Equal(contactRequests[0].ContactRequestState, common.ContactRequestStatePending)
 
 	// Accept contact request, receiver side
-	_, err = theirMessenger.AcceptContactRequest(context.Background(), &requests.AcceptContactRequest{ID: types2.Hex2Bytes(contactRequests[0].ID), ContactID: contactRequests[0].From})
+	_, err = theirMessenger.AcceptContactRequest(context.Background(), &requests.AcceptContactRequest{ID: types.Hex2Bytes(contactRequests[0].ID), ContactID: contactRequests[0].From})
 	s.Require().NoError(err)
 
 	// Wait for the message to reach its destination
@@ -87,7 +87,7 @@ func (s *TestMessengerProfileShowcase) mutualContact(theirMessenger *Messenger) 
 }
 
 func (s *TestMessengerProfileShowcase) verifiedContact(theirMessenger *Messenger) {
-	theirPk := types2.EncodeHex(crypto.FromECDSAPub(&theirMessenger.identity.PublicKey))
+	theirPk := types.EncodeHex(crypto.FromECDSAPub(&theirMessenger.identity.PublicKey))
 	challenge := "Want to see what I'm hiding in my profile showcase?"
 
 	_, err := s.m.SendContactVerificationRequest(context.Background(), theirPk, challenge)
@@ -120,7 +120,7 @@ func (s *TestMessengerProfileShowcase) verifiedContact(theirMessenger *Messenger
 	)
 	s.Require().NoError(err)
 
-	resp, err = s.m.VerifiedTrusted(context.Background(), &requests.VerifiedTrusted{ID: types2.FromHex(verificationRequestID)})
+	resp, err = s.m.VerifiedTrusted(context.Background(), &requests.VerifiedTrusted{ID: types.FromHex(verificationRequestID)})
 	s.Require().NoError(err)
 
 	s.Require().Len(resp.Messages(), 1)
@@ -368,14 +368,14 @@ func (s *TestMessengerProfileShowcase) TestShareShowcasePreferences() {
 
 	// Save wallet accounts to pass the validation
 	acc1 := &accsmanagementtypes.Account{
-		Address: types2.HexToAddress(request.Accounts[0].Address),
+		Address: types.HexToAddress(request.Accounts[0].Address),
 		Type:    accsmanagementtypes.AccountTypeGenerated,
 		Name:    "Test Account 1",
 		ColorID: "",
 		Emoji:   "emoji",
 	}
 	acc2 := &accsmanagementtypes.Account{
-		Address: types2.HexToAddress(request.Accounts[1].Address),
+		Address: types.HexToAddress(request.Accounts[1].Address),
 		Type:    accsmanagementtypes.AccountTypeSeed,
 		Name:    "Test Account 2",
 		ColorID: "",
@@ -421,7 +421,7 @@ func (s *TestMessengerProfileShowcase) TestShareShowcasePreferences() {
 	s.mutualContact(verifiedContact)
 	s.verifiedContact(verifiedContact)
 
-	contactID := types2.EncodeHex(crypto.FromECDSAPub(&s.m.identity.PublicKey))
+	contactID := types.EncodeHex(crypto.FromECDSAPub(&s.m.identity.PublicKey))
 	// Get summarised profile data for mutual contact
 	_, err = WaitOnMessengerResponse(
 		mutualContact,
@@ -568,7 +568,7 @@ func (s *TestMessengerProfileShowcase) TestProfileShowcaseProofOfMembershipUnenc
 	}, false)
 	s.Require().NoError(err)
 
-	contactID := types2.EncodeHex(crypto.FromECDSAPub(&alice.identity.PublicKey))
+	contactID := types.EncodeHex(crypto.FromECDSAPub(&alice.identity.PublicKey))
 	_, err = WaitOnMessengerResponse(
 		bob,
 		func(r *MessengerResponse) bool {
@@ -636,7 +636,7 @@ func (s *TestMessengerProfileShowcase) TestProfileShowcaseProofOfMembershipEncry
 	}, false)
 	s.Require().NoError(err)
 
-	contactID := types2.EncodeHex(crypto.FromECDSAPub(&alice.identity.PublicKey))
+	contactID := types.EncodeHex(crypto.FromECDSAPub(&alice.identity.PublicKey))
 	// The showcased communities are validated and populated asynchronously: the
 	// first profile-showcase update can arrive before bob has validated alice's
 	// membership in the encrypted community, so the entry may not be present yet.
@@ -713,7 +713,7 @@ func (s *TestMessengerProfileShowcase) TestProfileShowcaseCommuniesGrantExpires(
 	s.Require().NoError(err)
 
 	// 5) Bob gets the community from Alice's profile showcase and tries to validate community's membership with expired grant
-	contactID := types2.EncodeHex(crypto.FromECDSAPub(&alice.identity.PublicKey))
+	contactID := types.EncodeHex(crypto.FromECDSAPub(&alice.identity.PublicKey))
 	_, err = WaitOnMessengerResponse(
 		bob,
 		func(r *MessengerResponse) bool {
@@ -803,7 +803,7 @@ func (s *TestMessengerProfileShowcase) TestProfileShowcaseCommuniesDispatchOnGra
 	s.Require().NoError(err)
 
 	// 5) Bob gets the community from Alice's profile showcase and validates community's membership with grant
-	contactID := types2.EncodeHex(crypto.FromECDSAPub(&alice.identity.PublicKey))
+	contactID := types.EncodeHex(crypto.FromECDSAPub(&alice.identity.PublicKey))
 	_, err = WaitOnMessengerResponse(
 		bob,
 		func(r *MessengerResponse) bool {

--- a/protocol/messenger_store_node_request_manager.go
+++ b/protocol/messenger_store_node_request_manager.go
@@ -9,8 +9,8 @@ import (
 
 	gocommon "github.com/status-im/status-go/common"
 	"github.com/status-im/status-go/internal/crypto"
-	"github.com/status-im/status-go/internal/crypto/types"
-	types2 "github.com/status-im/status-go/pkg/messaging/types"
+	cryptotypes "github.com/status-im/status-go/internal/crypto/types"
+	messagingtypes "github.com/status-im/status-go/pkg/messaging/types"
 	"github.com/status-im/status-go/protocol/contacts"
 
 	"github.com/status-im/status-go/protocol/communities"
@@ -48,7 +48,7 @@ type StoreNodeRequestManager struct {
 	// activeRequestsLock should be locked each time activeRequests is being accessed or changed.
 	activeRequestsLock sync.RWMutex
 
-	onPerformingBatch func(types2.StoreNodeBatch)
+	onPerformingBatch func(messagingtypes.StoreNodeBatch)
 }
 
 func NewStoreNodeRequestManager(m *Messenger) *StoreNodeRequestManager {
@@ -74,7 +74,7 @@ func (m *StoreNodeRequestManager) FetchCommunity(ctx context.Context, communityI
 		zap.Any("config", cfg))
 
 	fetch := func() (*communities.Community, StoreNodeRequestStats, error) {
-		sub, err := m.subscribeToRequest(ctx, storeNodeCommunityRequest, communityID, types2.DefaultShard(), cfg)
+		sub, err := m.subscribeToRequest(ctx, storeNodeCommunityRequest, communityID, messagingtypes.DefaultShard(), cfg)
 		if err != nil {
 			return nil, StoreNodeRequestStats{}, fmt.Errorf("failed to create a shard info request: %w", err)
 		}
@@ -125,7 +125,7 @@ func (m *StoreNodeRequestManager) FetchContact(ctx context.Context, contactID st
 // subscribeToRequest checks if a request for given community/contact is already in progress, creates and installs
 // a new one if not found, and returns a subscription to the result of the found/started request.
 // The subscription can then be used to get the result of the request, this could be either a community/contact or an error.
-func (m *StoreNodeRequestManager) subscribeToRequest(ctx context.Context, requestType storeNodeRequestType, dataID string, shard *types2.Shard, cfg StoreNodeRequestConfig) (storeNodeResponseSubscription, error) {
+func (m *StoreNodeRequestManager) subscribeToRequest(ctx context.Context, requestType storeNodeRequestType, dataID string, shard *messagingtypes.Shard, cfg StoreNodeRequestConfig) (storeNodeResponseSubscription, error) {
 	// It's important to unlock only after getting the subscription channel.
 	// We also lock `activeRequestsLock` during finalizing the requests. This ensures that the subscription
 	// created in this function will get the result even if the requests proceeds faster than this function ends.
@@ -142,7 +142,7 @@ func (m *StoreNodeRequestManager) subscribeToRequest(ctx context.Context, reques
 	if !requestFound {
 		// Create corresponding filter
 		var err error
-		var filter *types2.ChatFilter
+		var filter *messagingtypes.ChatFilter
 		filterShouldForget := false
 
 		filter, filterShouldForget, err = m.getFilter(requestType, dataID, shard)
@@ -184,7 +184,7 @@ func (m *StoreNodeRequestManager) newStoreNodeRequest(ctx context.Context) *stor
 // always temporary. A reused filter is kept only for joined/spectated
 // communities (they keep a live description subscription); for any other
 // community it is a snapshot and must not outlive the request.
-func (m *StoreNodeRequestManager) getFilter(requestType storeNodeRequestType, dataID string, shard *types2.Shard) (*types2.ChatFilter, bool, error) {
+func (m *StoreNodeRequestManager) getFilter(requestType storeNodeRequestType, dataID string, shard *messagingtypes.Shard) (*messagingtypes.ChatFilter, bool, error) {
 	// First check if such filter already exists.
 	filter := m.messenger.messaging.ChatFilterByChatID(dataID)
 	if filter != nil {
@@ -195,7 +195,7 @@ func (m *StoreNodeRequestManager) getFilter(requestType storeNodeRequestType, da
 	case storeNodeCommunityRequest:
 		// If filter wasn't installed we create it and
 		// remember for uninstalling after response is received
-		filters, err := m.messenger.messaging.InitPublicChats(types2.ChatsToInitialize{{
+		filters, err := m.messenger.messaging.InitPublicChats(messagingtypes.ChatsToInitialize{{
 			ChatID:      dataID,
 			PubsubTopic: shard.PubsubTopic(),
 		}})
@@ -212,7 +212,7 @@ func (m *StoreNodeRequestManager) getFilter(requestType storeNodeRequestType, da
 
 		filter = filters[0]
 	case storeNodeContactRequest:
-		publicKeyBytes, err := types.DecodeHex(dataID)
+		publicKeyBytes, err := cryptotypes.DecodeHex(dataID)
 		if err != nil {
 			return nil, false, fmt.Errorf("failed to decode contact id: %w", err)
 		}
@@ -247,7 +247,7 @@ func (m *StoreNodeRequestManager) reusedFilterShouldForget(requestType storeNode
 	if requestType != storeNodeCommunityRequest {
 		return false
 	}
-	communityID, err := types.DecodeHex(dataID)
+	communityID, err := cryptotypes.DecodeHex(dataID)
 	if err != nil {
 		return false
 	}
@@ -262,8 +262,8 @@ func (m *StoreNodeRequestManager) reusedFilterShouldForget(requestType storeNode
 }
 
 // forgetFilter uninstalls the given filter
-func (m *StoreNodeRequestManager) forgetFilter(filter *types2.ChatFilter) {
-	err := m.messenger.messaging.RemoveFilters(types2.ChatFilters{filter})
+func (m *StoreNodeRequestManager) forgetFilter(filter *messagingtypes.ChatFilter) {
+	err := m.messenger.messaging.RemoveFilters(messagingtypes.ChatFilters{filter})
 	if err != nil {
 		m.logger.Warn("failed to remove filter", zap.Error(err))
 	}
@@ -284,12 +284,12 @@ type storeNodeRequest struct {
 
 	// request parameters
 	pubsubTopic      string
-	contentTopic     types2.ContentTopic
+	contentTopic     messagingtypes.ContentTopic
 	minimumDataClock uint64
 	config           StoreNodeRequestConfig
 
 	// request corresponding metadata to be used in finalize
-	filterToForget *types2.ChatFilter
+	filterToForget *messagingtypes.ChatFilter
 
 	// internal fields
 	manager       *StoreNodeRequestManager
@@ -365,7 +365,7 @@ func (r *storeNodeRequest) shouldFetchNextPage(envelopesCount int) (bool, uint64
 	// Try to get community from database
 	switch r.requestID.RequestType {
 	case storeNodeCommunityRequest:
-		communityID, err := types.DecodeHex(r.requestID.DataID)
+		communityID, err := cryptotypes.DecodeHex(r.requestID.DataID)
 		if err != nil {
 			logger.Error("failed to decode community ID",
 				zap.String("communityID", r.requestID.DataID),
@@ -480,11 +480,11 @@ func (r *storeNodeRequest) routine() {
 	// Start store node request
 	from, to := r.manager.messenger.calculateMailserverTimeBounds(oneMonthDuration)
 
-	batch := types2.StoreNodeBatch{
+	batch := messagingtypes.StoreNodeBatch{
 		From:        from,
 		To:          to,
 		PubsubTopic: r.pubsubTopic,
-		Topics:      []types2.ContentTopic{r.contentTopic},
+		Topics:      []messagingtypes.ContentTopic{r.contentTopic},
 	}
 	r.manager.logger.Info("perform store node request", zap.Any("batch", batch))
 	if r.manager.onPerformingBatch != nil {

--- a/protocol/messenger_sync_profile_picture_test.go
+++ b/protocol/messenger_sync_profile_picture_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/stretchr/testify/suite"
 
-	testutils2 "github.com/status-im/status-go/internal/testutils"
+	"github.com/status-im/status-go/internal/testutils"
 	"github.com/status-im/status-go/internal/testutils/fake"
 	messagingtypes "github.com/status-im/status-go/pkg/messaging/types"
 )
@@ -70,7 +70,7 @@ func (s *MessengerSyncProfilePictureSuite) TestSyncProfilePicture() {
 	s.Require().NoError(s.m.multiAccounts.StoreIdentityImages(keyUID, iis, true))
 
 	// Wait for the message to reach its destination
-	err = testutils2.RetryWithBackOff(func() error {
+	err = testutils.RetryWithBackOff(func() error {
 		response, err = theirMessenger.RetrieveAll()
 		if err != nil {
 			return err
@@ -108,7 +108,7 @@ func (s *MessengerSyncProfilePictureSuite) TestSyncProfilePicture() {
 	iis = append(iis, iis2...)
 	s.Require().NoError(s.m.multiAccounts.StoreIdentityImages(keyUID, iis, true))
 
-	err = testutils2.RetryWithBackOff(func() error {
+	err = testutils.RetryWithBackOff(func() error {
 		response, err = theirMessenger.RetrieveAll()
 		if err != nil {
 			return err

--- a/protocol/messenger_sync_settings.go
+++ b/protocol/messenger_sync_settings.go
@@ -7,7 +7,7 @@ import (
 	"go.uber.org/zap"
 
 	gocommon "github.com/status-im/status-go/common"
-	settings2 "github.com/status-im/status-go/internal/db/multiaccounts/settings"
+	"github.com/status-im/status-go/internal/db/multiaccounts/settings"
 	"github.com/status-im/status-go/protocol/common"
 	"github.com/status-im/status-go/protocol/protobuf"
 )
@@ -25,8 +25,8 @@ func (m *Messenger) prepareSyncSettingsMessages(currentClock uint64, prepareForB
 	// Do not use the network clock, use the db value
 	_, chat := m.getLastClockWithRelatedChat()
 
-	for _, sf := range settings2.SettingFieldRegister {
-		if sf.CanSync(settings2.FromStruct) {
+	for _, sf := range settings.SettingFieldRegister {
+		if sf.CanSync(settings.FromStruct) {
 			// DisplayName is backed up via `protobuf.BackedUpProfile` message.
 			if prepareForBackup && sf.SyncProtobufFactory().SyncSettingProtobufType() == protobuf.SyncSetting_DISPLAY_NAME {
 				continue
@@ -90,7 +90,7 @@ func (m *Messenger) startSyncSettingsLoop() {
 		for {
 			select {
 			case s := <-m.settings.GetSyncQueue():
-				if s.CanSync(settings2.FromInterface) {
+				if s.CanSync(settings.FromInterface) {
 					logger.Debug("setting for sync received from settings.SyncQueue")
 
 					clock, chat := m.getLastClockWithRelatedChat()
@@ -130,13 +130,13 @@ func (m *Messenger) startSettingsChangesLoop() {
 			select {
 			case s := <-channel:
 				switch s.GetReactName() {
-				case settings2.DisplayName.GetReactName():
+				case settings.DisplayName.GetReactName():
 					m.selfContact.DisplayName = s.Value.(string)
 					m.publishSelfContactSubscriptions(&SelfContactChangeEvent{DisplayNameChanged: true})
-				case settings2.PreferredName.GetReactName():
+				case settings.PreferredName.GetReactName():
 					m.selfContact.EnsName = s.Value.(string)
 					m.publishSelfContactSubscriptions(&SelfContactChangeEvent{PreferredNameChanged: true})
-				case settings2.Bio.GetReactName():
+				case settings.Bio.GetReactName():
 					m.selfContact.Bio = s.Value.(string)
 					m.publishSelfContactSubscriptions(&SelfContactChangeEvent{BioChanged: true})
 				}

--- a/protocol/messenger_sync_settings_test.go
+++ b/protocol/messenger_sync_settings_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	"github.com/status-im/status-go/internal/crypto/types"
-	settings2 "github.com/status-im/status-go/internal/db/multiaccounts/settings"
+	"github.com/status-im/status-go/internal/db/multiaccounts/settings"
 	"github.com/status-im/status-go/internal/testutils"
 	messagingtypes "github.com/status-im/status-go/pkg/messaging/types"
 	"github.com/status-im/status-go/services/stickers"
@@ -66,7 +66,7 @@ func (s *MessengerSyncSettingsSuite) SetupTest() {
 	s.MessengerBaseTestSuite.setupMessaging()
 
 	networks := json.RawMessage("{}")
-	settings := settings2.Settings{
+	settings := settings.Settings{
 		Address:                   types.HexToAddress("0x1122334455667788990011223344556677889900"),
 		CurrentNetwork:            "mainnet_rpc",
 		DappsAddress:              types.HexToAddress("0x1122334455667788990011223344556677889900"),
@@ -87,7 +87,7 @@ func (s *MessengerSyncSettingsSuite) SetupTest() {
 		LinkPreviewRequestEnabled: true,
 		SendStatusUpdates:         true,
 		WalletRootAddress:         types.HexToAddress("0x1122334455667788990011223344556677889900"),
-		URLUnfurlingMode:          settings2.URLUnfurlingAlwaysAsk,
+		URLUnfurlingMode:          settings.URLUnfurlingAlwaysAsk,
 		PreferredName:             &pf,
 		Currency:                  "eth",
 	}
@@ -121,7 +121,7 @@ func prepAliceMessengersForPairing(s *suite.Suite, alice1, alice2 *Messenger) {
 	s.Require().NoError(err)
 }
 
-func (s *MessengerSyncSettingsSuite) syncSettingAndCheck(m1 *Messenger, m2 *Messenger, settingField settings2.SettingField, settingValue interface{}) settings2.Settings {
+func (s *MessengerSyncSettingsSuite) syncSettingAndCheck(m1 *Messenger, m2 *Messenger, settingField settings.SettingField, settingValue interface{}) settings.Settings {
 	err := m1.settings.SaveSettingField(settingField, settingValue)
 	s.Require().NoError(err)
 
@@ -152,25 +152,25 @@ func (s *MessengerSyncSettingsSuite) TestSyncSettings() {
 	// Check alice 1 settings values
 	as, err := s.alice.settings.GetSettings()
 	s.Require().NoError(err)
-	s.Require().Exactly(settings2.ProfilePicturesShowToContactsOnly, as.ProfilePicturesShowTo)
-	s.Require().Exactly(settings2.ProfilePicturesVisibilityContactsOnly, as.ProfilePicturesVisibility)
-	s.Require().Exactly(settings2.URLUnfurlingAlwaysAsk, as.URLUnfurlingMode)
+	s.Require().Exactly(settings.ProfilePicturesShowToContactsOnly, as.ProfilePicturesShowTo)
+	s.Require().Exactly(settings.ProfilePicturesVisibilityContactsOnly, as.ProfilePicturesVisibility)
+	s.Require().Exactly(settings.URLUnfurlingAlwaysAsk, as.URLUnfurlingMode)
 
 	// Check alice 2 settings values
 	aos, err := s.alice2.settings.GetSettings()
 	s.Require().NoError(err)
-	s.Require().Exactly(settings2.ProfilePicturesShowToContactsOnly, aos.ProfilePicturesShowTo)
-	s.Require().Exactly(settings2.ProfilePicturesVisibilityContactsOnly, aos.ProfilePicturesVisibility)
-	s.Require().Exactly(settings2.URLUnfurlingAlwaysAsk, as.URLUnfurlingMode)
+	s.Require().Exactly(settings.ProfilePicturesShowToContactsOnly, aos.ProfilePicturesShowTo)
+	s.Require().Exactly(settings.ProfilePicturesVisibilityContactsOnly, aos.ProfilePicturesVisibility)
+	s.Require().Exactly(settings.URLUnfurlingAlwaysAsk, as.URLUnfurlingMode)
 
-	aos = s.syncSettingAndCheck(s.alice, s.alice2, settings2.ProfilePicturesVisibility, settings2.ProfilePicturesVisibilityEveryone)
-	s.Require().Equal(settings2.ProfilePicturesVisibilityEveryone, aos.ProfilePicturesVisibility)
+	aos = s.syncSettingAndCheck(s.alice, s.alice2, settings.ProfilePicturesVisibility, settings.ProfilePicturesVisibilityEveryone)
+	s.Require().Equal(settings.ProfilePicturesVisibilityEveryone, aos.ProfilePicturesVisibility)
 
-	as = s.syncSettingAndCheck(s.alice2, s.alice, settings2.ProfilePicturesShowTo, settings2.ProfilePicturesShowToEveryone)
-	s.Require().Exactly(settings2.ProfilePicturesShowToEveryone, as.ProfilePicturesShowTo)
+	as = s.syncSettingAndCheck(s.alice2, s.alice, settings.ProfilePicturesShowTo, settings.ProfilePicturesShowToEveryone)
+	s.Require().Exactly(settings.ProfilePicturesShowToEveryone, as.ProfilePicturesShowTo)
 
-	aos = s.syncSettingAndCheck(s.alice, s.alice2, settings2.URLUnfurlingMode, settings2.URLUnfurlingDisableAll)
-	s.Require().Exactly(settings2.URLUnfurlingDisableAll, aos.URLUnfurlingMode)
+	aos = s.syncSettingAndCheck(s.alice, s.alice2, settings.URLUnfurlingMode, settings.URLUnfurlingDisableAll)
+	s.Require().Exactly(settings.URLUnfurlingDisableAll, aos.URLUnfurlingMode)
 }
 
 func (s *MessengerSyncSettingsSuite) TestSyncSettings_StickerPacks() {
@@ -198,7 +198,7 @@ func (s *MessengerSyncSettingsSuite) TestSyncSettings_StickerPacks() {
 	err = json.Unmarshal(rawSticker, &stickerPacks)
 	s.Require().NoError(err)
 
-	err = s.alice.settings.SaveSettingField(settings2.StickersPacksInstalled, stickerPacks)
+	err = s.alice.settings.SaveSettingField(settings.StickersPacksInstalled, stickerPacks)
 	s.Require().NoError(err)
 
 	as, err = s.alice.settings.GetSettings()
@@ -244,7 +244,7 @@ func (s *MessengerSyncSettingsSuite) TestSyncSettings_PreferredName() {
 	PairDevices(&s.Suite, s.alice2, s.alice)
 
 	// Update Alice's PreferredName
-	err = s.alice.settings.SaveSettingField(settings2.PreferredName, pf2)
+	err = s.alice.settings.SaveSettingField(settings.PreferredName, pf2)
 	s.Require().NoError(err)
 
 	apn, err := s.alice.settings.GetPreferredUsername()

--- a/protocol/persistence_test.go
+++ b/protocol/persistence_test.go
@@ -18,7 +18,7 @@ import (
 	"github.com/status-im/status-go/internal/db/appdatabase"
 	"github.com/status-im/status-go/internal/testutils"
 	"github.com/status-im/status-go/protocol/common"
-	contacts2 "github.com/status-im/status-go/protocol/contacts"
+	"github.com/status-im/status-go/protocol/contacts"
 	"github.com/status-im/status-go/protocol/protobuf"
 	"github.com/status-im/status-go/protocol/sqlite"
 )
@@ -1190,7 +1190,7 @@ func TestContactBioPersistence(t *testing.T) {
 	contactID := types.EncodeHex(crypto.FromECDSAPub(&key.PublicKey))
 	contactBio := "A contact bio description"
 
-	err = p.SaveContact(&contacts2.Contact{ID: contactID, Bio: contactBio}, nil)
+	err = p.SaveContact(&contacts.Contact{ID: contactID, Bio: contactBio}, nil)
 	require.NoError(t, err)
 
 	contacts, err := p.Contacts()
@@ -1209,7 +1209,7 @@ func TestContactBioPersistenceDefaults(t *testing.T) {
 
 	contactID := types.EncodeHex(crypto.FromECDSAPub(&key.PublicKey))
 
-	err = p.SaveContact(&contacts2.Contact{ID: contactID}, nil)
+	err = p.SaveContact(&contacts.Contact{ID: contactID}, nil)
 	require.NoError(t, err)
 
 	contacts, err := p.Contacts()
@@ -1228,7 +1228,7 @@ func TestUpdateContactChatIdentity(t *testing.T) {
 
 	contactID := types.EncodeHex(crypto.FromECDSAPub(&key.PublicKey))
 
-	err = p.SaveContact(&contacts2.Contact{ID: contactID}, nil)
+	err = p.SaveContact(&contacts.Contact{ID: contactID}, nil)
 	require.NoError(t, err)
 
 	jpegType := []byte{0xff, 0xd8, 0xff, 0x1}
@@ -1304,7 +1304,7 @@ func TestRemovedProfileImage(t *testing.T) {
 
 	contactID := types.EncodeHex(crypto.FromECDSAPub(&key.PublicKey))
 
-	err = p.SaveContact(&contacts2.Contact{ID: contactID}, nil)
+	err = p.SaveContact(&contacts.Contact{ID: contactID}, nil)
 	require.NoError(t, err)
 
 	jpegType := []byte{0xff, 0xd8, 0xff, 0x1}

--- a/protocol/push_notification_test.go
+++ b/protocol/push_notification_test.go
@@ -14,7 +14,7 @@ import (
 
 	"github.com/status-im/status-go/internal/crypto"
 	"github.com/status-im/status-go/internal/crypto/types"
-	testutils2 "github.com/status-im/status-go/internal/testutils"
+	"github.com/status-im/status-go/internal/testutils"
 	"github.com/status-im/status-go/protocol/common"
 	"github.com/status-im/status-go/protocol/communities"
 	"github.com/status-im/status-go/protocol/contacts"
@@ -93,7 +93,7 @@ func (s *MessengerPushNotificationSuite) newPushNotificationServer() (*Messenger
 
 	serverConfig := &pushnotificationserver.Config{
 		Enabled:   true,
-		Logger:    testutils2.MustCreateTestLogger(),
+		Logger:    testutils.MustCreateTestLogger(),
 		Identity:  privateKey,
 		GorushURL: s.gorushMockURL,
 	}
@@ -132,7 +132,7 @@ func (s *MessengerPushNotificationSuite) TestReceivePushNotification() {
 	err = bob1.RegisterForPushNotifications(context.Background(), bob1DeviceToken, testAPNTopic, protobuf.PushNotificationRegistration_APN_TOKEN)
 
 	// Pull servers  and check we registered
-	err = testutils2.RetryWithBackOff(func() error {
+	err = testutils.RetryWithBackOff(func() error {
 		_, err = messenger.RetrieveAll()
 		if err != nil {
 			return err
@@ -171,7 +171,7 @@ func (s *MessengerPushNotificationSuite) TestReceivePushNotification() {
 	err = bob2.RegisterForPushNotifications(context.Background(), bob2DeviceToken, testAPNTopic, protobuf.PushNotificationRegistration_APN_TOKEN)
 	s.Require().NoError(err)
 
-	err = testutils2.RetryWithBackOff(func() error {
+	err = testutils.RetryWithBackOff(func() error {
 		_, err = messenger.RetrieveAll()
 		if err != nil {
 			return err
@@ -225,7 +225,7 @@ func (s *MessengerPushNotificationSuite) TestReceivePushNotification() {
 	s.Require().NoError(bob2.PublishIdentityImage())
 
 	infoMap := make(map[string]*pushnotificationclient.PushNotificationInfo)
-	err = testutils2.RetryWithBackOff(func() error {
+	err = testutils.RetryWithBackOff(func() error {
 		_, err = messenger.RetrieveAll()
 		if err != nil {
 			return err
@@ -276,7 +276,7 @@ func (s *MessengerPushNotificationSuite) TestReceivePushNotification() {
 	s.Require().Len(retrievedNotificationInfo, 2)
 
 	var sentNotification *pushnotificationclient.SentNotification
-	err = testutils2.RetryWithBackOff(func() error {
+	err = testutils.RetryWithBackOff(func() error {
 		_, err = messenger.RetrieveAll()
 		if err != nil {
 			return err
@@ -330,7 +330,7 @@ func (s *MessengerPushNotificationSuite) TestReceivePushNotificationFromContactO
 	s.Require().NoError(err)
 
 	// Pull servers  and check we registered
-	err = testutils2.RetryWithBackOff(func() error {
+	err = testutils.RetryWithBackOff(func() error {
 		_, err = messenger.RetrieveAll()
 		if err != nil {
 			return err
@@ -374,7 +374,7 @@ func (s *MessengerPushNotificationSuite) TestReceivePushNotificationFromContactO
 	s.Require().NoError(err)
 
 	var info []*pushnotificationclient.PushNotificationInfo
-	err = testutils2.RetryWithBackOff(func() error {
+	err = testutils.RetryWithBackOff(func() error {
 		_, err = messenger.RetrieveAll()
 		if err != nil {
 			return err
@@ -408,7 +408,7 @@ func (s *MessengerPushNotificationSuite) TestReceivePushNotificationFromContactO
 	s.Require().Len(retrievedNotificationInfo, 1)
 
 	var sentNotification *pushnotificationclient.SentNotification
-	err = testutils2.RetryWithBackOff(func() error {
+	err = testutils.RetryWithBackOff(func() error {
 		_, err = messenger.RetrieveAll()
 		if err != nil {
 			return err
@@ -475,7 +475,7 @@ func (s *MessengerPushNotificationSuite) TestReceivePushNotificationRetries() {
 	s.Require().NoError(err)
 
 	// Pull servers  and check we registered
-	err = testutils2.RetryWithBackOff(func() error {
+	err = testutils.RetryWithBackOff(func() error {
 		_, err = messenger.RetrieveAll()
 		if err != nil {
 			return err
@@ -517,7 +517,7 @@ func (s *MessengerPushNotificationSuite) TestReceivePushNotificationRetries() {
 
 	// We check that alice retrieves the info from the messenger
 	var info []*pushnotificationclient.PushNotificationInfo
-	err = testutils2.RetryWithBackOff(func() error {
+	err = testutils.RetryWithBackOff(func() error {
 		_, err = messenger.RetrieveAll()
 		if err != nil {
 			return err
@@ -555,7 +555,7 @@ func (s *MessengerPushNotificationSuite) TestReceivePushNotificationRetries() {
 
 	// Re-registration should be triggered, pull from messenger and bob to check we are correctly registered
 	// Pull servers  and check we registered
-	err = testutils2.RetryWithBackOff(func() error {
+	err = testutils.RetryWithBackOff(func() error {
 		_, err = messenger.RetrieveAll()
 		if err != nil {
 			return err
@@ -587,7 +587,7 @@ func (s *MessengerPushNotificationSuite) TestReceivePushNotificationRetries() {
 	messageID, err := hex.DecodeString(messageIDString[2:])
 	s.Require().NoError(err)
 
-	err = testutils2.RetryWithBackOff(func() error {
+	err = testutils.RetryWithBackOff(func() error {
 		_, err = messenger.RetrieveAll()
 		if err != nil {
 			return err
@@ -624,7 +624,7 @@ func (s *MessengerPushNotificationSuite) TestReceivePushNotificationRetries() {
 	s.Require().Len(retrievedNotificationInfo, 1)
 
 	var sentNotification *pushnotificationclient.SentNotification
-	err = testutils2.RetryWithBackOff(func() error {
+	err = testutils.RetryWithBackOff(func() error {
 		_, err = messenger.RetrieveAll()
 		if err != nil {
 			return err
@@ -663,7 +663,7 @@ func (s *MessengerPushNotificationSuite) TestContactCode() {
 	err = bob1.RegisterForPushNotifications(context.Background(), bob1DeviceToken, testAPNTopic, protobuf.PushNotificationRegistration_APN_TOKEN)
 
 	// Pull servers  and check we registered
-	err = testutils2.RetryWithBackOff(func() error {
+	err = testutils.RetryWithBackOff(func() error {
 		_, err = messenger.RetrieveAll()
 		if err != nil {
 			return err
@@ -723,7 +723,7 @@ func (s *MessengerPushNotificationSuite) TestContactCodeAdvertisementStoresPushI
 	err = bob1.RegisterForPushNotifications(context.Background(), bob1DeviceToken, testAPNTopic, protobuf.PushNotificationRegistration_APN_TOKEN)
 	s.Require().NoError(err)
 
-	err = testutils2.RetryWithBackOff(func() error {
+	err = testutils.RetryWithBackOff(func() error {
 		if _, err := messenger.RetrieveAll(); err != nil {
 			return err
 		}
@@ -798,7 +798,7 @@ func (s *MessengerPushNotificationSuite) TestReceivePushNotificationMention() {
 	err = bob.RegisterForPushNotifications(context.Background(), bob1DeviceToken, testAPNTopic, protobuf.PushNotificationRegistration_APN_TOKEN)
 
 	// Pull servers  and check we registered
-	err = testutils2.RetryWithBackOff(func() error {
+	err = testutils.RetryWithBackOff(func() error {
 		_, err = messenger.RetrieveAll()
 		if err != nil {
 			return err
@@ -841,7 +841,7 @@ func (s *MessengerPushNotificationSuite) TestReceivePushNotificationMention() {
 	s.Require().NoError(err)
 
 	var bobInfo []*pushnotificationclient.PushNotificationInfo
-	err = testutils2.RetryWithBackOff(func() error {
+	err = testutils.RetryWithBackOff(func() error {
 		_, err = messenger.RetrieveAll()
 		if err != nil {
 			return err
@@ -877,7 +877,7 @@ func (s *MessengerPushNotificationSuite) TestReceivePushNotificationMention() {
 	s.Require().Len(retrievedNotificationInfo, 1)
 
 	var sentNotification *pushnotificationclient.SentNotification
-	err = testutils2.RetryWithBackOff(func() error {
+	err = testutils.RetryWithBackOff(func() error {
 		_, err = messenger.RetrieveAll()
 		if err != nil {
 			return err
@@ -915,7 +915,7 @@ func (s *MessengerPushNotificationSuite) TestReceivePushNotificationCommunityReq
 	err = bob.RegisterForPushNotifications(context.Background(), bob1DeviceToken, testAPNTopic, protobuf.PushNotificationRegistration_APN_TOKEN)
 
 	// Pull servers  and check we registered
-	err = testutils2.RetryWithBackOff(func() error {
+	err = testutils.RetryWithBackOff(func() error {
 		_, err = messenger.RetrieveAll()
 		if err != nil {
 			return err
@@ -975,7 +975,7 @@ func (s *MessengerPushNotificationSuite) TestReceivePushNotificationCommunityReq
 	s.NoError(err)
 
 	// Pull message and make sure org is received
-	err = testutils2.RetryWithBackOff(func() error {
+	err = testutils.RetryWithBackOff(func() error {
 		response, err = alice.RetrieveAll()
 		if err != nil {
 			return err
@@ -1003,7 +1003,7 @@ func (s *MessengerPushNotificationSuite) TestReceivePushNotificationCommunityReq
 	s.Require().Equal(requestToJoin1.PublicKey, crypto.PubkeyToHex(&alice.identity.PublicKey))
 	s.Require().Equal(communities.RequestToJoinStatePending, requestToJoin1.State)
 
-	err = testutils2.RetryWithBackOff(func() error {
+	err = testutils.RetryWithBackOff(func() error {
 		_, err = messenger.RetrieveAll()
 		if err != nil {
 			return err
@@ -1044,7 +1044,7 @@ func (s *MessengerPushNotificationSuite) TestReceivePushNotificationPairedDevice
 	err = bob1.RegisterForPushNotifications(context.Background(), bob1DeviceToken, testAPNTopic, protobuf.PushNotificationRegistration_APN_TOKEN)
 
 	// Pull servers  and check we registered
-	err = testutils2.RetryWithBackOff(func() error {
+	err = testutils.RetryWithBackOff(func() error {
 		_, err = messenger.RetrieveAll()
 		if err != nil {
 			return err
@@ -1083,7 +1083,7 @@ func (s *MessengerPushNotificationSuite) TestReceivePushNotificationPairedDevice
 	err = bob2.RegisterForPushNotifications(context.Background(), bob2DeviceToken, testAPNTopic, protobuf.PushNotificationRegistration_APN_TOKEN)
 	s.Require().NoError(err)
 
-	err = testutils2.RetryWithBackOff(func() error {
+	err = testutils.RetryWithBackOff(func() error {
 		_, err = messenger.RetrieveAll()
 		if err != nil {
 			return err
@@ -1137,7 +1137,7 @@ func (s *MessengerPushNotificationSuite) TestReceivePushNotificationPairedDevice
 	s.Require().NoError(bob2.PublishIdentityImage())
 
 	infoMap := make(map[string]*pushnotificationclient.PushNotificationInfo)
-	err = testutils2.RetryWithBackOff(func() error {
+	err = testutils.RetryWithBackOff(func() error {
 		_, err = messenger.RetrieveAll()
 		if err != nil {
 			return err
@@ -1188,7 +1188,7 @@ func (s *MessengerPushNotificationSuite) TestReceivePushNotificationPairedDevice
 	s.Require().Len(retrievedNotificationInfo, 2)
 
 	var sentNotification *pushnotificationclient.SentNotification
-	err = testutils2.RetryWithBackOff(func() error {
+	err = testutils.RetryWithBackOff(func() error {
 		_, err = messenger.RetrieveAll()
 		if err != nil {
 			return err
@@ -1241,7 +1241,7 @@ func (s *MessengerPushNotificationSuite) TestReceivePushNotificationReply() {
 	err = bob.RegisterForPushNotifications(context.Background(), bob1DeviceToken, testAPNTopic, protobuf.PushNotificationRegistration_APN_TOKEN)
 
 	// Pull servers  and check we registered
-	err = testutils2.RetryWithBackOff(func() error {
+	err = testutils.RetryWithBackOff(func() error {
 		_, err = messenger.RetrieveAll()
 		if err != nil {
 			return err
@@ -1304,7 +1304,7 @@ func (s *MessengerPushNotificationSuite) TestReceivePushNotificationReply() {
 	s.Require().NoError(err)
 
 	var bobInfo []*pushnotificationclient.PushNotificationInfo
-	err = testutils2.RetryWithBackOff(func() error {
+	err = testutils.RetryWithBackOff(func() error {
 		_, err = messenger.RetrieveAll()
 		if err != nil {
 			return err
@@ -1340,7 +1340,7 @@ func (s *MessengerPushNotificationSuite) TestReceivePushNotificationReply() {
 	s.Require().Len(retrievedNotificationInfo, 1)
 
 	var sentNotification *pushnotificationclient.SentNotification
-	err = testutils2.RetryWithBackOff(func() error {
+	err = testutils.RetryWithBackOff(func() error {
 		_, err = messenger.RetrieveAll()
 		if err != nil {
 			return err

--- a/protocol/syncing/syncing.go
+++ b/protocol/syncing/syncing.go
@@ -9,11 +9,11 @@ import (
 	gethcommon "github.com/ethereum/go-ethereum/common"
 
 	accsmanagementtypes "github.com/status-im/status-go/internal/accounts-management/types"
-	types2 "github.com/status-im/status-go/internal/crypto/types"
+	"github.com/status-im/status-go/internal/crypto/types"
 	"github.com/status-im/status-go/internal/db/multiaccounts/accounts"
 	multiaccountscommon "github.com/status-im/status-go/internal/db/multiaccounts/common"
 	maErrors "github.com/status-im/status-go/internal/db/multiaccounts/errors"
-	settings2 "github.com/status-im/status-go/internal/db/multiaccounts/settings"
+	"github.com/status-im/status-go/internal/db/multiaccounts/settings"
 	"github.com/status-im/status-go/pkg/pubsub"
 	"github.com/status-im/status-go/protocol/protobuf"
 	"github.com/status-im/status-go/services/accounts/accountsevent"
@@ -30,9 +30,9 @@ var (
 func MapSyncAccountToAccount(message *protobuf.SyncAccount, accountOperability accsmanagementtypes.AccountOperable,
 	accType accsmanagementtypes.AccountType) *accsmanagementtypes.Account {
 	return &accsmanagementtypes.Account{
-		Address:               types2.BytesToAddress(message.Address),
+		Address:               types.BytesToAddress(message.Address),
 		KeyUID:                message.KeyUid,
-		PublicKey:             types2.HexBytes(message.PublicKey),
+		PublicKey:             types.HexBytes(message.PublicKey),
 		Type:                  accType,
 		Path:                  message.Path,
 		Name:                  message.Name,
@@ -57,7 +57,7 @@ func HandleSyncWatchOnlyAccount(accountsDB *accounts.Database, message *protobuf
 
 	accountOperability := accsmanagementtypes.AccountFullyOperable
 
-	accAddress := types2.BytesToAddress(message.Address)
+	accAddress := types.BytesToAddress(message.Address)
 	dbAccount, err := accountsDB.GetAccountByAddress(accAddress)
 	if err != nil && err != accounts.ErrDbAccountNotFound {
 		return nil, err
@@ -106,8 +106,8 @@ func HandleSyncWatchOnlyAccount(accountsDB *accounts.Database, message *protobuf
 }
 
 // extractSyncSetting parses incoming *protobuf.SyncSetting and stores the setting data if needed
-func ExtractAndSaveSyncSetting(accountsDB *accounts.Database, logger *zap.Logger, syncSetting *protobuf.SyncSetting) (*settings2.SyncSettingField, error) {
-	sf, err := settings2.GetFieldFromProtobufType(syncSetting.Type)
+func ExtractAndSaveSyncSetting(accountsDB *accounts.Database, logger *zap.Logger, syncSetting *protobuf.SyncSetting) (*settings.SyncSettingField, error) {
+	sf, err := settings.GetFieldFromProtobufType(syncSetting.Type)
 	if err != nil {
 		logger.Error(
 			"extractSyncSetting - settings.GetFieldFromProtobufType",
@@ -142,5 +142,5 @@ func ExtractAndSaveSyncSetting(accountsDB *accounts.Database, logger *zap.Logger
 		value = json.RawMessage(v)
 	}
 
-	return &settings2.SyncSettingField{SettingField: sf, Value: value}, nil
+	return &settings.SyncSettingField{SettingField: sf, Value: value}, nil
 }

--- a/services/accounts/service.go
+++ b/services/accounts/service.go
@@ -16,7 +16,7 @@ import (
 	"github.com/status-im/status-go/internal/crypto/types"
 	"github.com/status-im/status-go/internal/db/multiaccounts"
 	"github.com/status-im/status-go/internal/db/multiaccounts/accounts"
-	settings2 "github.com/status-im/status-go/internal/db/multiaccounts/settings"
+	"github.com/status-im/status-go/internal/db/multiaccounts/settings"
 	"github.com/status-im/status-go/params"
 	"github.com/status-im/status-go/pkg/pubsub"
 	"github.com/status-im/status-go/protocol"
@@ -44,9 +44,9 @@ func NewService(
 		publisher:   publisher,
 		logger:      logger,
 	}
-	db.SetSettingsNotifier(func(setting settings2.SettingField, val interface{}) {
+	db.SetSettingsNotifier(func(setting settings.SettingField, val interface{}) {
 		if s.publisher != nil {
-			pubsub.Publish(s.publisher, settings2.EventSettingChanged{
+			pubsub.Publish(s.publisher, settings.EventSettingChanged{
 				Setting: setting,
 				Value:   val,
 			})
@@ -112,7 +112,7 @@ func (s *Service) GetKeypairByKeyUID(keyUID string) (*accsmanagementtypes.Keypai
 	return s.db.GetKeypairByKeyUID(keyUID)
 }
 
-func (s *Service) GetSettings() (settings2.Settings, error) {
+func (s *Service) GetSettings() (settings.Settings, error) {
 	return s.db.GetSettings()
 }
 
@@ -121,7 +121,7 @@ func (s *Service) GetBackupPath() (string, error) {
 }
 
 func (s *Service) SetBackupPath(path string) error {
-	return s.db.SaveSettingField(settings2.BackupPath, path)
+	return s.db.SaveSettingField(settings.BackupPath, path)
 }
 
 func (s *Service) GetMessenger() *protocol.Messenger {
@@ -144,8 +144,8 @@ func (s *Service) prepareSyncSettingsMessages(currentClock uint64, prepareForBac
 		return
 	}
 
-	for _, sf := range settings2.SettingFieldRegister {
-		if !sf.CanSync(settings2.FromStruct) {
+	for _, sf := range settings.SettingFieldRegister {
+		if !sf.CanSync(settings.FromStruct) {
 			continue
 		}
 
@@ -207,7 +207,7 @@ func (s *Service) handleBackedUpSettings(message *protobuf.SyncSetting) error {
 
 	if settingField != nil && s.account != nil {
 		if message.GetType() == protobuf.SyncSetting_PREFERRED_NAME && message.GetValueString() != "" {
-			displayNameClock, err := s.db.GetSettingLastSynced(settings2.DisplayName)
+			displayNameClock, err := s.db.GetSettingLastSynced(settings.DisplayName)
 			if err != nil {
 				s.logger.Warn("failed to get last synced clock for display name", zap.Error(err))
 				return nil

--- a/services/chat/api_group_chats.go
+++ b/services/chat/api_group_chats.go
@@ -4,7 +4,7 @@ import (
 	"context"
 
 	"github.com/status-im/status-go/internal/crypto"
-	types2 "github.com/status-im/status-go/internal/crypto/types"
+	"github.com/status-im/status-go/internal/crypto/types"
 	"github.com/status-im/status-go/protocol"
 	"github.com/status-im/status-go/protocol/common"
 	"github.com/status-im/status-go/protocol/contacts"
@@ -33,7 +33,7 @@ type StartGroupChatResponse struct {
 	Messages []*common.Message   `json:"messages,omitempty"`
 }
 
-func (api *API) CreateOneToOneChat(ctx context.Context, communityID types2.HexBytes, ID types2.HexBytes, ensName string) (*CreateOneToOneChatResponse, error) {
+func (api *API) CreateOneToOneChat(ctx context.Context, communityID types.HexBytes, ID types.HexBytes, ensName string) (*CreateOneToOneChatResponse, error) {
 	if len(communityID) != 0 {
 		return nil, ErrCommunitiesNotSupported
 	}
@@ -56,7 +56,7 @@ func (api *API) CreateOneToOneChat(ctx context.Context, communityID types2.HexBy
 	}, nil
 }
 
-func (api *API) CreateGroupChat(ctx context.Context, communityID types2.HexBytes, name string, members []string) (*GroupChatResponse, error) {
+func (api *API) CreateGroupChat(ctx context.Context, communityID types.HexBytes, name string, members []string) (*GroupChatResponse, error) {
 	if len(communityID) != 0 {
 		return nil, ErrCommunitiesNotSupported
 	}
@@ -66,7 +66,7 @@ func (api *API) CreateGroupChat(ctx context.Context, communityID types2.HexBytes
 	})
 }
 
-func (api *API) CreateGroupChatFromInvitation(communityID types2.HexBytes, name string, chatID string, adminPK string) (*GroupChatResponse, error) {
+func (api *API) CreateGroupChatFromInvitation(communityID types.HexBytes, name string, chatID string, adminPK string) (*GroupChatResponse, error) {
 	if len(communityID) != 0 {
 		return nil, ErrCommunitiesNotSupported
 	}
@@ -76,7 +76,7 @@ func (api *API) CreateGroupChatFromInvitation(communityID types2.HexBytes, name 
 	})
 }
 
-func (api *API) LeaveChat(ctx context.Context, communityID types2.HexBytes, chatID string, remove bool) (*GroupChatResponse, error) {
+func (api *API) LeaveChat(ctx context.Context, communityID types.HexBytes, chatID string, remove bool) (*GroupChatResponse, error) {
 	if len(communityID) != 0 {
 		return nil, ErrCommunitiesNotSupported
 	}
@@ -86,7 +86,7 @@ func (api *API) LeaveChat(ctx context.Context, communityID types2.HexBytes, chat
 	})
 }
 
-func (api *API) AddMembers(ctx context.Context, communityID types2.HexBytes, chatID string, members []string) (*GroupChatResponseWithInvitations, error) {
+func (api *API) AddMembers(ctx context.Context, communityID types.HexBytes, chatID string, members []string) (*GroupChatResponseWithInvitations, error) {
 	if len(communityID) != 0 {
 		return nil, ErrCommunitiesNotSupported
 	}
@@ -96,7 +96,7 @@ func (api *API) AddMembers(ctx context.Context, communityID types2.HexBytes, cha
 	})
 }
 
-func (api *API) RemoveMember(ctx context.Context, communityID types2.HexBytes, chatID string, member string) (*GroupChatResponse, error) {
+func (api *API) RemoveMember(ctx context.Context, communityID types.HexBytes, chatID string, member string) (*GroupChatResponse, error) {
 	if len(communityID) != 0 {
 		return nil, ErrCommunitiesNotSupported
 	}
@@ -106,7 +106,7 @@ func (api *API) RemoveMember(ctx context.Context, communityID types2.HexBytes, c
 	})
 }
 
-func (api *API) MakeAdmin(ctx context.Context, communityID types2.HexBytes, chatID string, member string) (*GroupChatResponse, error) {
+func (api *API) MakeAdmin(ctx context.Context, communityID types.HexBytes, chatID string, member string) (*GroupChatResponse, error) {
 	if len(communityID) != 0 {
 		return nil, ErrCommunitiesNotSupported
 	}
@@ -116,7 +116,7 @@ func (api *API) MakeAdmin(ctx context.Context, communityID types2.HexBytes, chat
 	})
 }
 
-func (api *API) RenameChat(ctx context.Context, communityID types2.HexBytes, chatID string, name string) (*GroupChatResponse, error) {
+func (api *API) RenameChat(ctx context.Context, communityID types.HexBytes, chatID string, name string) (*GroupChatResponse, error) {
 	if len(communityID) != 0 {
 		return nil, ErrCommunitiesNotSupported
 	}
@@ -126,7 +126,7 @@ func (api *API) RenameChat(ctx context.Context, communityID types2.HexBytes, cha
 	})
 }
 
-func (api *API) SendGroupChatInvitationRequest(ctx context.Context, communityID types2.HexBytes, chatID string, adminPK string, message string) (*GroupChatResponseWithInvitations, error) {
+func (api *API) SendGroupChatInvitationRequest(ctx context.Context, communityID types.HexBytes, chatID string, adminPK string, message string) (*GroupChatResponseWithInvitations, error) {
 	if len(communityID) != 0 {
 		return nil, ErrCommunitiesNotSupported
 	}
@@ -148,7 +148,7 @@ func (api *API) SendGroupChatInvitationRejection(ctx context.Context, invitation
 	return response.Invitations, nil
 }
 
-func (api *API) StartGroupChat(ctx context.Context, communityID types2.HexBytes, name string, members []string) (*StartGroupChatResponse, error) {
+func (api *API) StartGroupChat(ctx context.Context, communityID types.HexBytes, name string, members []string) (*StartGroupChatResponse, error) {
 	if len(communityID) != 0 {
 		return nil, ErrCommunitiesNotSupported
 	}
@@ -161,7 +161,7 @@ func (api *API) StartGroupChat(ctx context.Context, communityID types2.HexBytes,
 			return nil, err
 		}
 		response, err = api.s.messenger.CreateOneToOneChat(&requests.CreateOneToOneChat{
-			ID: types2.HexBytes(crypto.FromECDSAPub(memberPk)),
+			ID: types.HexBytes(crypto.FromECDSAPub(memberPk)),
 		})
 		if err != nil {
 			return nil, err
@@ -205,7 +205,7 @@ func (api *API) toGroupChatResponseWithInvitations(pubKey string, response *prot
 }
 
 func (api *API) execAndGetGroupChatResponse(fn func() (*protocol.MessengerResponse, error)) (*GroupChatResponse, error) {
-	pubKey := types2.EncodeHex(crypto.FromECDSAPub(api.s.messenger.IdentityPublicKey()))
+	pubKey := types.EncodeHex(crypto.FromECDSAPub(api.s.messenger.IdentityPublicKey()))
 	response, err := fn()
 	if err != nil {
 		return nil, err
@@ -214,7 +214,7 @@ func (api *API) execAndGetGroupChatResponse(fn func() (*protocol.MessengerRespon
 }
 
 func (api *API) execAndGetGroupChatResponseWithInvitations(fn func() (*protocol.MessengerResponse, error)) (*GroupChatResponseWithInvitations, error) {
-	pubKey := types2.EncodeHex(crypto.FromECDSAPub(api.s.messenger.IdentityPublicKey()))
+	pubKey := types.EncodeHex(crypto.FromECDSAPub(api.s.messenger.IdentityPublicKey()))
 
 	response, err := fn()
 	if err != nil {

--- a/services/communitytokens/manager.go
+++ b/services/communitytokens/manager.go
@@ -16,10 +16,9 @@ import (
 	"github.com/status-im/status-go/internal/contracts/community-tokens/ownertoken"
 	communityownertokenregistry "github.com/status-im/status-go/internal/contracts/community-tokens/registry"
 	"github.com/status-im/status-go/internal/crypto"
-	types2 "github.com/status-im/status-go/internal/crypto/types"
+	"github.com/status-im/status-go/internal/crypto/types"
 	"github.com/status-im/status-go/internal/rpc"
 
-	communitytokendeployer2 "github.com/status-im/status-go/internal/contracts/community-tokens/deployer"
 	"github.com/status-im/status-go/protocol/communities"
 	"github.com/status-im/status-go/services/wallet/bigint"
 	"github.com/status-im/status-go/services/wallet/requests"
@@ -45,7 +44,7 @@ func (m *Manager) NewCollectiblesInstance(chainID uint64, contractAddress common
 	return m.contractMaker.NewCollectiblesInstance(chainID, contractAddress)
 }
 
-func (m *Manager) NewCommunityTokenDeployerInstance(chainID uint64) (*communitytokendeployer2.CommunityTokenDeployer, error) {
+func (m *Manager) NewCommunityTokenDeployerInstance(chainID uint64) (*communitytokendeployer.CommunityTokenDeployer, error) {
 	deployerAddr, err := m.DeployerContractAddress(chainID)
 	if err != nil {
 		return nil, err
@@ -111,7 +110,7 @@ func (m *Manager) GetAssetContractData(chainID uint64, contractAddress string) (
 }
 
 func convert33BytesPubKeyToEthAddress(pubKey string) (common.Address, error) {
-	decoded, err := types2.DecodeHex(pubKey)
+	decoded, err := types.DecodeHex(pubKey)
 	if err != nil {
 		return common.Address{}, err
 	}
@@ -123,7 +122,7 @@ func convert33BytesPubKeyToEthAddress(pubKey string) (common.Address, error) {
 }
 
 // Simpler version of hashing typed structured data alternative to typedStructuredDataHash. Keeping this for reference.
-func customTypedStructuredDataHash(domainSeparator []byte, signatureTypedHash []byte, signer string, deployer string) types2.Hash {
+func customTypedStructuredDataHash(domainSeparator []byte, signatureTypedHash []byte, signer string, deployer string) types.Hash {
 	// every field should be 32 bytes, eth address is 20 bytes so padding should be added
 	emptyOffset := [12]byte{}
 	hashedEncoded := crypto.Keccak256Hash(signatureTypedHash, emptyOffset[:], common.HexToAddress(signer).Bytes(),
@@ -134,7 +133,7 @@ func customTypedStructuredDataHash(domainSeparator []byte, signatureTypedHash []
 
 // Returns a typed structured hash according to https://eips.ethereum.org/EIPS/eip-712
 // Domain separator from smart contract is used.
-func typedStructuredDataHash(domainSeparator []byte, signer string, addressFrom string, deployerContractAddress string, chainID uint64) (types2.Hash, error) {
+func typedStructuredDataHash(domainSeparator []byte, signer string, addressFrom string, deployerContractAddress string, chainID uint64) (types.Hash, error) {
 	myTypedData := apitypes.TypedData{
 		Types: apitypes.Types{
 			"Deploy": []apitypes.Type{
@@ -165,7 +164,7 @@ func typedStructuredDataHash(domainSeparator []byte, signer string, addressFrom 
 
 	typedDataHash, err := myTypedData.HashStruct(myTypedData.PrimaryType, myTypedData.Message)
 	if err != nil {
-		return types2.Hash{}, err
+		return types.Hash{}, err
 	}
 	rawData := []byte(fmt.Sprintf("\x19\x01%s%s", domainSeparator, string(typedDataHash)))
 	return crypto.Keccak256Hash(rawData), nil

--- a/services/communitytokens/service.go
+++ b/services/communitytokens/service.go
@@ -18,7 +18,7 @@ import (
 	gocommon "github.com/status-im/status-go/common"
 	accsmanagement "github.com/status-im/status-go/internal/accounts-management"
 	"github.com/status-im/status-go/internal/crypto"
-	types2 "github.com/status-im/status-go/internal/crypto/types"
+	"github.com/status-im/status-go/internal/crypto/types"
 	"github.com/status-im/status-go/internal/logutils"
 	"github.com/status-im/status-go/internal/rpc"
 	"github.com/status-im/status-go/internal/transactions"
@@ -278,7 +278,7 @@ func (s *Service) handleSetSignerPubKey(status string, toAddress common.Address,
 	}
 
 	if status == ac.Success {
-		_, err := s.Messenger.PromoteSelfToControlNode(types2.FromHex(communityToken.CommunityID))
+		_, err := s.Messenger.PromoteSelfToControlNode(types.FromHex(communityToken.CommunityID))
 		if err != nil {
 			return nil, err
 		}
@@ -375,7 +375,7 @@ func (s *Service) GetSignerPubKey(ctx context.Context, chainID uint64, contractA
 		return "", err
 	}
 
-	return types2.ToHex(signerPubKey), nil
+	return types.ToHex(signerPubKey), nil
 }
 
 func (s *Service) SafeGetSignerPubKey(ctx context.Context, chainID uint64, communityID string) (string, error) {
@@ -637,7 +637,7 @@ func (s *Service) GetOwnerTokenContractAddressFromHash(ctx context.Context, chai
 }
 
 func (s *Service) publishTokenActionToPrivilegedMembers(communityID string, chainID uint64, contractAddress string, actionType protobuf.CommunityTokenAction_ActionType) error {
-	decodedCommunityID, err := types2.DecodeHex(communityID)
+	decodedCommunityID, err := types.DecodeHex(communityID)
 	if err != nil {
 		return err
 	}

--- a/services/connector/api_test.go
+++ b/services/connector/api_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 
-	types2 "github.com/status-im/status-go/internal/crypto/types"
+	"github.com/status-im/status-go/internal/crypto/types"
 	"github.com/status-im/status-go/internal/rpc/network"
 	"github.com/status-im/status-go/services/connector/commands"
 	persistence "github.com/status-im/status-go/services/connector/database"
@@ -203,7 +203,7 @@ func TestDeleteEphemeralDApps(t *testing.T) {
 		Name:          "Normal",
 		IconURL:       "",
 		ClientID:      "status-desktop/dapp-browser",
-		SharedAccount: types2.HexToAddress("0x1111"),
+		SharedAccount: types.HexToAddress("0x1111"),
 		ChainID:       0x1,
 	}
 	ephemeral := persistence.DApp{
@@ -211,7 +211,7 @@ func TestDeleteEphemeralDApps(t *testing.T) {
 		Name:          "Ephemeral",
 		IconURL:       "",
 		ClientID:      "status-desktop/dapp-browser" + persistence.EphemeralClientIDSuffix,
-		SharedAccount: types2.HexToAddress("0x2222"),
+		SharedAccount: types.HexToAddress("0x2222"),
 		ChainID:       0x1,
 	}
 	require.NoError(t, persistence.UpsertDApp(state.walletDb, &normal))
@@ -250,7 +250,7 @@ func TestGetWCActiveSessions(t *testing.T) {
 	dappURL := "https://wc-test-dapp.com"
 	require.NoError(t, persistence.UpsertDApp(state.walletDb, &persistence.DApp{
 		URL: dappURL, Name: "WC Test", IconURL: "", ClientID: persistence.WCClientID,
-		SharedAccount: types2.Address{}, ChainID: 0x1,
+		SharedAccount: types.Address{}, ChainID: 0x1,
 	}))
 	require.NoError(t, persistence.UpsertWCSession(state.walletDb, "topic1", `{"session":"data"}`, 9999999999, "pairing1", dappURL, "symkey", 100))
 
@@ -272,7 +272,7 @@ func TestDisconnectWCSession(t *testing.T) {
 	dappURL := "https://wc-disconnect-test.com"
 	require.NoError(t, persistence.UpsertDApp(state.walletDb, &persistence.DApp{
 		URL: dappURL, Name: "WC Disconnect Test", IconURL: "", ClientID: persistence.WCClientID,
-		SharedAccount: types2.Address{}, ChainID: 0x1,
+		SharedAccount: types.Address{}, ChainID: 0x1,
 	}))
 	require.NoError(t, persistence.UpsertWCSession(state.walletDb, "topic-disconnect", `{"session":"data"}`, 9999999999, "pairing1", dappURL, "symkey", 100))
 
@@ -310,7 +310,7 @@ func TestUpdateWCSessionChains_InvalidSessionJSON(t *testing.T) {
 	dappURL := "https://wc-update-test.com"
 	require.NoError(t, persistence.UpsertDApp(state.walletDb, &persistence.DApp{
 		URL: dappURL, Name: "WC Update Test", IconURL: "", ClientID: persistence.WCClientID,
-		SharedAccount: types2.Address{}, ChainID: 0x1,
+		SharedAccount: types.Address{}, ChainID: 0x1,
 	}))
 	// Store invalid JSON as session data
 	require.NoError(t, persistence.UpsertWCSession(state.walletDb, "topic-update-invalid", `not-valid-json`, 9999999999, "pairing1", dappURL, "symkey", 100))
@@ -444,7 +444,7 @@ func TestNewAPI_WithRestoredSessions(t *testing.T) {
 	dappURL := "https://wc-restore-test.com"
 	require.NoError(t, persistence.UpsertDApp(walletDb, &persistence.DApp{
 		URL: dappURL, Name: "WC Restore Test", IconURL: "", ClientID: persistence.WCClientID,
-		SharedAccount: types2.Address{}, ChainID: 0x1,
+		SharedAccount: types.Address{}, ChainID: 0x1,
 	}))
 	require.NoError(t, persistence.UpsertWCSession(walletDb, "restore-topic-1", `{"session":"data"}`, 9999999999, "pairing1", dappURL, "symkey1", 100))
 

--- a/services/connector/commands/client_handler.go
+++ b/services/connector/commands/client_handler.go
@@ -11,7 +11,7 @@ import (
 	"sync/atomic"
 	"time"
 
-	types2 "github.com/status-im/status-go/internal/crypto/types"
+	"github.com/status-im/status-go/internal/crypto/types"
 	persistence "github.com/status-im/status-go/services/connector/database"
 	"github.com/status-im/status-go/services/wallet/wallettypes"
 	"github.com/status-im/status-go/signal"
@@ -140,9 +140,9 @@ func (c *ClientSideHandler) clearRequestRunning() {
 	atomic.StoreInt32(&c.isRequestRunning, 0)
 }
 
-func (c *ClientSideHandler) RequestShareAccountForDApp(dApp signal.ConnectorDApp) (types2.Address, uint64, error) {
+func (c *ClientSideHandler) RequestShareAccountForDApp(dApp signal.ConnectorDApp) (types.Address, uint64, error) {
 	if !c.setRequestRunning() {
-		return types2.Address{}, 0, ErrAnotherConnectorOperationIsAwaitingFor
+		return types.Address{}, 0, ErrAnotherConnectorOperationIsAwaitingFor
 	}
 	defer c.clearRequestRunning()
 
@@ -163,11 +163,11 @@ func (c *ClientSideHandler) RequestShareAccountForDApp(dApp signal.ConnectorDApp
 			case Rejected:
 				response := msg.Data.(RejectedArgs)
 				if response.RequestID == requestID {
-					return types2.Address{}, 0, ErrRequestAccountsRejectedByUser
+					return types.Address{}, 0, ErrRequestAccountsRejectedByUser
 				}
 			}
 		case <-timeout:
-			return types2.Address{}, 0, ErrWalletResponseTimeout
+			return types.Address{}, 0, ErrWalletResponseTimeout
 		}
 	}
 }
@@ -228,15 +228,15 @@ func (c *ClientSideHandler) RecallDAppPermissions(args RecallDAppPermissionsArgs
 	return nil
 }
 
-func (c *ClientSideHandler) RequestSendTransaction(dApp signal.ConnectorDApp, chainID uint64, txArgs *wallettypes.SendTxArgs) (types2.Hash, error) {
+func (c *ClientSideHandler) RequestSendTransaction(dApp signal.ConnectorDApp, chainID uint64, txArgs *wallettypes.SendTxArgs) (types.Hash, error) {
 	if !c.setRequestRunning() {
-		return types2.Hash{}, ErrAnotherConnectorOperationIsAwaitingFor
+		return types.Hash{}, ErrAnotherConnectorOperationIsAwaitingFor
 	}
 	defer c.clearRequestRunning()
 
 	txArgsJson, err := json.Marshal(txArgs)
 	if err != nil {
-		return types2.Hash{}, fmt.Errorf("failed to marshal txArgs: %v", err)
+		return types.Hash{}, fmt.Errorf("failed to marshal txArgs: %v", err)
 	}
 
 	requestID := c.generateRequestID(dApp)
@@ -256,11 +256,11 @@ func (c *ClientSideHandler) RequestSendTransaction(dApp signal.ConnectorDApp, ch
 			case Rejected:
 				response := msg.Data.(RejectedArgs)
 				if response.RequestID == requestID {
-					return types2.Hash{}, ErrSendTransactionRejectedByUser
+					return types.Hash{}, ErrSendTransactionRejectedByUser
 				}
 			}
 		case <-timeout:
-			return types2.Hash{}, ErrWalletResponseTimeout
+			return types.Hash{}, ErrWalletResponseTimeout
 		}
 	}
 }

--- a/services/connector/commands/disconnect_wc_session_test.go
+++ b/services/connector/commands/disconnect_wc_session_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	types2 "github.com/status-im/status-go/internal/crypto/types"
+	"github.com/status-im/status-go/internal/crypto/types"
 	persistence "github.com/status-im/status-go/services/connector/database"
 	"github.com/status-im/status-go/signal"
 )
@@ -15,7 +15,7 @@ func TestDisconnectWCSessionDeletesDApp(t *testing.T) {
 	db, close := createWalletDB(t)
 	t.Cleanup(close)
 
-	sharedAccount := types2.BytesToAddress(types2.FromHex("0x6d0aa2a774b74bb1d36f97700315adf962c69fcg"))
+	sharedAccount := types.BytesToAddress(types.FromHex("0x6d0aa2a774b74bb1d36f97700315adf962c69fcg"))
 	wcDAppData := signal.ConnectorDApp{
 		URL:      "https://wc-test-dapp.com",
 		Name:     "WC Test DApp",
@@ -73,7 +73,7 @@ func TestDisconnectWCSessionWithMultipleSessions(t *testing.T) {
 	db, close := createWalletDB(t)
 	t.Cleanup(close)
 
-	sharedAccount := types2.BytesToAddress(types2.FromHex("0x6d0aa2a774b74bb1d36f97700315adf962c69fcg"))
+	sharedAccount := types.BytesToAddress(types.FromHex("0x6d0aa2a774b74bb1d36f97700315adf962c69fcg"))
 	wcDAppData := signal.ConnectorDApp{
 		URL:      "https://wc-test-dapp.com",
 		Name:     "WC Test DApp",
@@ -131,7 +131,7 @@ func TestDisconnectWCSessionHandlesNonWCDApp(t *testing.T) {
 	t.Cleanup(close)
 
 	// Create a non-WC DApp (browser connector)
-	sharedAccount := types2.BytesToAddress(types2.FromHex("0x6d0aa2a774b74bb1d36f97700315adf962c69fcg"))
+	sharedAccount := types.BytesToAddress(types.FromHex("0x6d0aa2a774b74bb1d36f97700315adf962c69fcg"))
 	bcDAppData := signal.ConnectorDApp{
 		URL:      "https://bc-test-dapp.com",
 		Name:     "BC Test DApp",

--- a/services/connector/commands/request_permissions_autoshare_test.go
+++ b/services/connector/commands/request_permissions_autoshare_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	types2 "github.com/status-im/status-go/internal/crypto/types"
+	"github.com/status-im/status-go/internal/crypto/types"
 	persistence "github.com/status-im/status-go/services/connector/database"
 	walletCommon "github.com/status-im/status-go/services/wallet/common"
 	"github.com/status-im/status-go/signal"
@@ -16,10 +16,10 @@ import (
 
 type overrideRequestShareHandler struct {
 	*ClientSideHandler
-	shareFn func(dApp signal.ConnectorDApp) (types2.Address, uint64, error)
+	shareFn func(dApp signal.ConnectorDApp) (types.Address, uint64, error)
 }
 
-func (o *overrideRequestShareHandler) RequestShareAccountForDApp(dApp signal.ConnectorDApp) (types2.Address, uint64, error) {
+func (o *overrideRequestShareHandler) RequestShareAccountForDApp(dApp signal.ConnectorDApp) (types.Address, uint64, error) {
 	if o.shareFn != nil {
 		return o.shareFn(dApp)
 	}
@@ -28,13 +28,13 @@ func (o *overrideRequestShareHandler) RequestShareAccountForDApp(dApp signal.Con
 
 func TestRequestPermissions_AutoShareWhenNoDApp(t *testing.T) {
 	rejectErr := errors.New("user dismissed share")
-	acc := types2.BytesToAddress(types2.FromHex("0x00000000000000000000000000000000000000a1"))
+	acc := types.BytesToAddress(types.FromHex("0x00000000000000000000000000000000000000a1"))
 
 	tests := []struct {
 		name             string
 		autoURL          string
 		clientID         string
-		shareFn          func(dApp signal.ConnectorDApp) (types2.Address, uint64, error)
+		shareFn          func(dApp signal.ConnectorDApp) (types.Address, uint64, error)
 		wantGrantSignals int
 		wantDApp         bool
 		wantErr          error
@@ -43,7 +43,7 @@ func TestRequestPermissions_AutoShareWhenNoDApp(t *testing.T) {
 			name:     "accept creates dapp and emits one grant",
 			autoURL:  "https://perm-autoshare-no-pending.test",
 			clientID: "status-desktop/dapp-browser",
-			shareFn: func(dApp signal.ConnectorDApp) (types2.Address, uint64, error) {
+			shareFn: func(dApp signal.ConnectorDApp) (types.Address, uint64, error) {
 				require.Equal(t, "https://perm-autoshare-no-pending.test", dApp.URL)
 				return acc, walletCommon.EthereumMainnet, nil
 			},
@@ -54,8 +54,8 @@ func TestRequestPermissions_AutoShareWhenNoDApp(t *testing.T) {
 			name:     "reject propagates error and leaves no dapp",
 			autoURL:  "https://perm-autoshare-reject.test",
 			clientID: "c1",
-			shareFn: func(dApp signal.ConnectorDApp) (types2.Address, uint64, error) {
-				return types2.Address{}, 0, rejectErr
+			shareFn: func(dApp signal.ConnectorDApp) (types.Address, uint64, error) {
+				return types.Address{}, 0, rejectErr
 			},
 			wantGrantSignals: 0,
 			wantDApp:         false,

--- a/services/connector/commands/revoke_permissions_test.go
+++ b/services/connector/commands/revoke_permissions_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	types2 "github.com/status-im/status-go/internal/crypto/types"
+	"github.com/status-im/status-go/internal/crypto/types"
 	persistence "github.com/status-im/status-go/services/connector/database"
 	"github.com/status-im/status-go/signal"
 )
@@ -56,7 +56,7 @@ func TestRevokePermissionsSucceeded(t *testing.T) {
 	state, close := setupCommand(t, Method_RevokePermissions)
 	t.Cleanup(close)
 
-	sharedAccount := types2.BytesToAddress(types2.FromHex("0x6d0aa2a774b74bb1d36f97700315adf962c69fcf"))
+	sharedAccount := types.BytesToAddress(types.FromHex("0x6d0aa2a774b74bb1d36f97700315adf962c69fcf"))
 	dAppPermissionRevoked := false
 
 	signal.SetHandler(signal.Handler(func(s []byte) {
@@ -92,7 +92,7 @@ func TestRevokePermissionsDeletesWCSessions(t *testing.T) {
 	state, close := setupCommand(t, Method_RevokePermissions)
 	t.Cleanup(close)
 
-	sharedAccount := types2.BytesToAddress(types2.FromHex("0x6d0aa2a774b74bb1d36f97700315adf962c69fcf"))
+	sharedAccount := types.BytesToAddress(types.FromHex("0x6d0aa2a774b74bb1d36f97700315adf962c69fcf"))
 	wcDAppData := signal.ConnectorDApp{
 		URL:      "https://wc-test-dapp.com",
 		Name:     "WC Test DApp",
@@ -166,7 +166,7 @@ func TestRevokePermissions_TargetedEthAccounts_KeepsDApp_NoRevokedSignal(t *test
 			state, close := setupCommand(t, Method_RevokePermissions)
 			t.Cleanup(close)
 
-			sharedAccount := types2.BytesToAddress(types2.FromHex("0x6d0aa2a774b74bb1d36f97700315adf962c69fcf"))
+			sharedAccount := types.BytesToAddress(types.FromHex("0x6d0aa2a774b74bb1d36f97700315adf962c69fcf"))
 			revoked := trackRevokedSignal(t)
 
 			err := PersistDAppData(state.walletDb, testDAppData, sharedAccount, 0x123)
@@ -208,7 +208,7 @@ func TestRevokePermissions_MultiElementParams_RemovesAllCapabilities(t *testing.
 	state, close := setupCommand(t, Method_RevokePermissions)
 	t.Cleanup(close)
 
-	sharedAccount := types2.BytesToAddress(types2.FromHex("0x6d0aa2a774b74bb1d36f97700315adf962c69fcf"))
+	sharedAccount := types.BytesToAddress(types.FromHex("0x6d0aa2a774b74bb1d36f97700315adf962c69fcf"))
 	revoked := trackRevokedSignal(t)
 
 	err := PersistDAppData(state.walletDb, testDAppData, sharedAccount, 0x123)
@@ -242,7 +242,7 @@ func TestRevokePermissions_InvalidParamsType(t *testing.T) {
 	state, close := setupCommand(t, Method_RevokePermissions)
 	t.Cleanup(close)
 
-	sharedAccount := types2.BytesToAddress(types2.FromHex("0x6d0aa2a774b74bb1d36f97700315adf962c69fcf"))
+	sharedAccount := types.BytesToAddress(types.FromHex("0x6d0aa2a774b74bb1d36f97700315adf962c69fcf"))
 	err := PersistDAppData(state.walletDb, testDAppData, sharedAccount, 0x123)
 	assert.NoError(t, err)
 	err = persistence.InsertPermission(state.walletDb, testDAppData.URL, testDAppData.ClientID, "eth_accounts", []persistence.Caveat{}, time.Now().Unix())

--- a/services/connector/commands/rpc_traits.go
+++ b/services/connector/commands/rpc_traits.go
@@ -6,7 +6,7 @@ import (
 	"errors"
 	"fmt"
 
-	types2 "github.com/status-im/status-go/internal/crypto/types"
+	"github.com/status-im/status-go/internal/crypto/types"
 	"github.com/status-im/status-go/params"
 	"github.com/status-im/status-go/services/wallet/wallettypes"
 	"github.com/status-im/status-go/signal"
@@ -48,14 +48,14 @@ type RPCCommand interface {
 }
 
 type RequestAccountsAcceptedArgs struct {
-	RequestID string         `json:"requestId"`
-	Account   types2.Address `json:"account"`
-	ChainID   uint64         `json:"chainId"`
+	RequestID string        `json:"requestId"`
+	Account   types.Address `json:"account"`
+	ChainID   uint64        `json:"chainId"`
 }
 
 type SendTransactionAcceptedArgs struct {
-	RequestID string      `json:"requestId"`
-	Hash      types2.Hash `json:"hash"`
+	RequestID string     `json:"requestId"`
+	Hash      types.Hash `json:"hash"`
 }
 
 type SignAcceptedArgs struct {
@@ -73,18 +73,18 @@ type RecallDAppPermissionsArgs struct {
 }
 
 type ChangeAccountArgs struct {
-	URL      string         `json:"url"`
-	Account  types2.Address `json:"account"`
-	ClientID string         `json:"clientId"`
+	URL      string        `json:"url"`
+	Account  types.Address `json:"account"`
+	ClientID string        `json:"clientId"`
 }
 
 type ClientSideHandlerInterface interface {
-	RequestShareAccountForDApp(dApp signal.ConnectorDApp) (types2.Address, uint64, error)
+	RequestShareAccountForDApp(dApp signal.ConnectorDApp) (types.Address, uint64, error)
 	RequestAccountsAccepted(args RequestAccountsAcceptedArgs) error
 	RequestAccountsRejected(args RejectedArgs) error
 	RecallDAppPermissions(args RecallDAppPermissionsArgs) error
 
-	RequestSendTransaction(dApp signal.ConnectorDApp, chainID uint64, txArgs *wallettypes.SendTxArgs) (types2.Hash, error)
+	RequestSendTransaction(dApp signal.ConnectorDApp, chainID uint64, txArgs *wallettypes.SendTxArgs) (types.Hash, error)
 	SendTransactionAccepted(args SendTransactionAcceptedArgs) error
 	SendTransactionRejected(args RejectedArgs) error
 
@@ -128,7 +128,7 @@ func (c *ChangeAccountArgs) Validate() error {
 	if c.ClientID == "" || c.URL == "" {
 		return ErrEmptyRPCParams
 	}
-	if c.Account == types2.ZeroAddress() {
+	if c.Account == types.ZeroAddress() {
 		return ErrEmptyRPCParams
 	}
 	return nil

--- a/services/connector/commands/send_transaction_test.go
+++ b/services/connector/commands/send_transaction_test.go
@@ -13,19 +13,19 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 
-	types2 "github.com/status-im/status-go/internal/crypto/types"
+	"github.com/status-im/status-go/internal/crypto/types"
 	mock_client "github.com/status-im/status-go/internal/rpc/chain/mock/client"
 	"github.com/status-im/status-go/services/wallet/router/fees"
 	"github.com/status-im/status-go/services/wallet/wallettypes"
 	"github.com/status-im/status-go/signal"
 )
 
-func prepareSendTransactionRequest(dApp signal.ConnectorDApp, from types2.Address) (RPCRequest, error) {
+func prepareSendTransactionRequest(dApp signal.ConnectorDApp, from types.Address) (RPCRequest, error) {
 	sendArgs := wallettypes.SendTxArgs{
 		From:  from,
-		To:    &types2.Address{0x02},
+		To:    &types.Address{0x02},
 		Value: &hexutil.Big{},
-		Data:  types2.HexBytes("0x0"),
+		Data:  types.HexBytes("0x0"),
 	}
 
 	sendArgsJSON, err := json.Marshal(sendArgs)
@@ -49,7 +49,7 @@ func TestFailToSendTransactionWithoutPermittedDApp(t *testing.T) {
 	t.Cleanup(close)
 
 	// Don't save dApp in the database
-	request, err := prepareSendTransactionRequest(testDAppData, types2.Address{0x1})
+	request, err := prepareSendTransactionRequest(testDAppData, types.Address{0x1})
 	assert.NoError(t, err)
 
 	_, err = state.cmd.Execute(state.ctx, request)
@@ -60,10 +60,10 @@ func TestFailToSendTransactionWithWrongAddress(t *testing.T) {
 	state, close := setupCommand(t, Method_EthSendTransaction)
 	t.Cleanup(close)
 
-	err := PersistDAppData(state.walletDb, testDAppData, types2.Address{0x01}, uint64(0x1))
+	err := PersistDAppData(state.walletDb, testDAppData, types.Address{0x01}, uint64(0x1))
 	assert.NoError(t, err)
 
-	request, err := prepareSendTransactionRequest(testDAppData, types2.Address{0x02})
+	request, err := prepareSendTransactionRequest(testDAppData, types.Address{0x02})
 	assert.NoError(t, err)
 
 	_, err = state.cmd.Execute(state.ctx, request)
@@ -74,7 +74,7 @@ func TestSendTransactionWithSignalTimout(t *testing.T) {
 	state, close := setupCommand(t, Method_EthSendTransaction)
 	t.Cleanup(close)
 
-	accountAddress := types2.Address{0x01}
+	accountAddress := types.Address{0x01}
 	err := PersistDAppData(state.walletDb, testDAppData, accountAddress, uint64(0x1))
 	assert.NoError(t, err)
 
@@ -115,9 +115,9 @@ func TestSendTransactionWithSignalAccepted(t *testing.T) {
 	state, close := setupCommand(t, Method_EthSendTransaction)
 	t.Cleanup(close)
 
-	fakedTransactionHash := types2.Hash{0x051}
+	fakedTransactionHash := types.Hash{0x051}
 
-	accountAddress := types2.Address{0x01}
+	accountAddress := types.Address{0x01}
 	err := PersistDAppData(state.walletDb, testDAppData, accountAddress, uint64(0x1))
 	assert.NoError(t, err)
 
@@ -175,7 +175,7 @@ func TestSendTransactionWithSignalRejected(t *testing.T) {
 	state, close := setupCommand(t, Method_EthSendTransaction)
 	t.Cleanup(close)
 
-	accountAddress := types2.Address{0x01}
+	accountAddress := types.Address{0x01}
 	err := PersistDAppData(state.walletDb, testDAppData, accountAddress, uint64(0x1))
 	assert.NoError(t, err)
 

--- a/services/connector/connector_flows_test.go
+++ b/services/connector/connector_flows_test.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 
-	types2 "github.com/status-im/status-go/internal/crypto/types"
+	"github.com/status-im/status-go/internal/crypto/types"
 	mock_client "github.com/status-im/status-go/internal/rpc/chain/mock/client"
 	"github.com/status-im/status-go/services/connector/chainutils"
 	"github.com/status-im/status-go/services/connector/commands"
@@ -26,8 +26,8 @@ func TestRequestAccountsSwitchChainAndSendTransactionFlow(t *testing.T) {
 	t.Skip("Broken by PR-6882, must fix")
 	state := setupTests(t)
 
-	accountAddress := types2.BytesToAddress(types2.FromHex("0x6d0aa2a774b74bb1d36f97700315adf962c69fcg"))
-	expectedHash := types2.BytesToHash(types2.FromHex("0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"))
+	accountAddress := types.BytesToAddress(types.FromHex("0x6d0aa2a774b74bb1d36f97700315adf962c69fcg"))
+	expectedHash := types.BytesToHash(types.FromHex("0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"))
 	expectedSignature := "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"
 
 	dAppPermissionRevoked := false
@@ -147,7 +147,7 @@ func TestForwardedRPCs(t *testing.T) {
 
 	ethClientMock := mock_client.NewMockClientInterface(state.mockCtrl)
 
-	sharedAccount := types2.BytesToAddress(types2.FromHex("0x3d0ab2a774b74bb1d36f97700315adf962c69fct"))
+	sharedAccount := types.BytesToAddress(types.FromHex("0x3d0ab2a774b74bb1d36f97700315adf962c69fct"))
 
 	testDAppData := signal.ConnectorDApp{
 		URL:     "https://app.test.org",
@@ -191,7 +191,7 @@ func TestForwardedRPCs(t *testing.T) {
 func TestRequestAccountsAfterPermissionsRevokeTest(t *testing.T) {
 	state := setupTests(t)
 
-	accountAddress := types2.BytesToAddress(types2.FromHex("0x6d0aa2a774b74bb1d36f97700315adf962c69fcg"))
+	accountAddress := types.BytesToAddress(types.FromHex("0x6d0aa2a774b74bb1d36f97700315adf962c69fcg"))
 	dAppPermissionRevoked := false
 	dAppPermissionGranted := false
 

--- a/services/connector/request_permissions_concurrency_test.go
+++ b/services/connector/request_permissions_concurrency_test.go
@@ -8,13 +8,13 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	types2 "github.com/status-im/status-go/internal/crypto/types"
+	"github.com/status-im/status-go/internal/crypto/types"
 	"github.com/status-im/status-go/services/connector/commands"
 	persistence "github.com/status-im/status-go/services/connector/database"
 	"github.com/status-im/status-go/signal"
 )
 
-var concurrencyTestAccountAddress = types2.BytesToAddress(types2.FromHex("0x0000000000000000000000000000000000000001"))
+var concurrencyTestAccountAddress = types.BytesToAddress(types.FromHex("0x0000000000000000000000000000000000000001"))
 
 func recvRequestIDOrFatal(t *testing.T, ch <-chan string) string {
 	t.Helper()

--- a/services/connector/service_test.go
+++ b/services/connector/service_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	types2 "github.com/status-im/status-go/internal/crypto/types"
+	"github.com/status-im/status-go/internal/crypto/types"
 	persistence "github.com/status-im/status-go/services/connector/database"
 )
 
@@ -23,7 +23,7 @@ func TestService_StartPurgesStaleEphemeralDAppsOnce(t *testing.T) {
 	require.NoError(t, persistence.UpsertDApp(state.walletDb, &persistence.DApp{
 		URL: "https://stale.com", Name: "Stale", IconURL: "",
 		ClientID:      ephemeralBrowserClientID(),
-		SharedAccount: types2.Address{}, ChainID: 0x1,
+		SharedAccount: types.Address{}, ChainID: 0x1,
 	}))
 
 	require.NoError(t, state.service.Start())
@@ -43,7 +43,7 @@ func TestService_StopPurgesEphemeralDApps(t *testing.T) {
 	require.NoError(t, persistence.UpsertDApp(state.walletDb, &persistence.DApp{
 		URL: "https://incognito-dapp2.com", Name: "Incognito DApp 2", IconURL: "",
 		ClientID:      ephemeralBrowserClientID(),
-		SharedAccount: types2.Address{}, ChainID: 0x1,
+		SharedAccount: types.Address{}, ChainID: 0x1,
 	}))
 
 	require.NoError(t, state.service.Stop())
@@ -171,7 +171,7 @@ func TestService_PauseResumePreservesEphemeralDApps(t *testing.T) {
 	require.NoError(t, persistence.UpsertDApp(state.walletDb, &persistence.DApp{
 		URL: "https://pause-incognito.com", Name: "Pause Test", IconURL: "",
 		ClientID:      ephemeralBrowserClientID(),
-		SharedAccount: types2.Address{}, ChainID: 0x1,
+		SharedAccount: types.Address{}, ChainID: 0x1,
 	}))
 
 	require.NoError(t, state.service.Pause())

--- a/services/connector/test_helpers_test.go
+++ b/services/connector/test_helpers_test.go
@@ -11,7 +11,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/status-im/status-go/internal/db/appdatabase"
-	settings2 "github.com/status-im/status-go/internal/db/multiaccounts/settings"
+	"github.com/status-im/status-go/internal/db/multiaccounts/settings"
 	"github.com/status-im/status-go/internal/db/walletdatabase"
 	"github.com/status-im/status-go/internal/rpc/network"
 	network_testutil "github.com/status-im/status-go/internal/rpc/network/testutil"
@@ -61,11 +61,11 @@ func setupTests(t *testing.T) (state testState) {
 		NetworkID: 10,
 	}
 	networks := json.RawMessage("{}")
-	settingsObj := settings2.Settings{
+	settingsObj := settings.Settings{
 		Networks: &networks,
 	}
 
-	settDb, err := settings2.MakeNewDB(state.db)
+	settDb, err := settings.MakeNewDB(state.db)
 	require.NoError(t, err)
 	err = settDb.CreateSettings(settingsObj, config)
 	require.NoError(t, err)

--- a/services/ext/api.go
+++ b/services/ext/api.go
@@ -10,7 +10,7 @@ import (
 	"github.com/status-im/status-go/internal/crypto"
 	"github.com/status-im/status-go/internal/crypto/types"
 	multiaccountscommon "github.com/status-im/status-go/internal/db/multiaccounts/common"
-	settings2 "github.com/status-im/status-go/internal/db/multiaccounts/settings"
+	"github.com/status-im/status-go/internal/db/multiaccounts/settings"
 	"github.com/status-im/status-go/internal/logutils"
 	types2 "github.com/status-im/status-go/pkg/messaging/types"
 	"github.com/status-im/status-go/protocol/contacts"
@@ -903,7 +903,7 @@ func (api *PublicAPI) UnregisterFromPushNotifications(ctx context.Context) error
 }
 
 func (api *PublicAPI) DisableSendingNotifications(ctx context.Context) error {
-	err := api.service.accountsDB.SaveSettingField(settings2.SendPushNotifications, false)
+	err := api.service.accountsDB.SaveSettingField(settings.SendPushNotifications, false)
 	if err != nil {
 		return err
 	}
@@ -912,7 +912,7 @@ func (api *PublicAPI) DisableSendingNotifications(ctx context.Context) error {
 }
 
 func (api *PublicAPI) EnableSendingNotifications(ctx context.Context) error {
-	err := api.service.accountsDB.SaveSettingField(settings2.SendPushNotifications, true)
+	err := api.service.accountsDB.SaveSettingField(settings.SendPushNotifications, true)
 	if err != nil {
 		return err
 	}
@@ -920,7 +920,7 @@ func (api *PublicAPI) EnableSendingNotifications(ctx context.Context) error {
 }
 
 func (api *PublicAPI) EnablePushNotificationsFromContactsOnly(ctx context.Context) error {
-	err := api.service.accountsDB.SaveSettingField(settings2.PushNotificationsFromContactsOnly, true)
+	err := api.service.accountsDB.SaveSettingField(settings.PushNotificationsFromContactsOnly, true)
 	if err != nil {
 		return err
 	}
@@ -928,7 +928,7 @@ func (api *PublicAPI) EnablePushNotificationsFromContactsOnly(ctx context.Contex
 }
 
 func (api *PublicAPI) DisablePushNotificationsFromContactsOnly(ctx context.Context) error {
-	err := api.service.accountsDB.SaveSettingField(settings2.PushNotificationsFromContactsOnly, false)
+	err := api.service.accountsDB.SaveSettingField(settings.PushNotificationsFromContactsOnly, false)
 	if err != nil {
 		return err
 	}
@@ -936,7 +936,7 @@ func (api *PublicAPI) DisablePushNotificationsFromContactsOnly(ctx context.Conte
 }
 
 func (api *PublicAPI) EnablePushNotificationsBlockMentions(ctx context.Context) error {
-	err := api.service.accountsDB.SaveSettingField(settings2.PushNotificationsBlockMentions, true)
+	err := api.service.accountsDB.SaveSettingField(settings.PushNotificationsBlockMentions, true)
 	if err != nil {
 		return err
 	}
@@ -944,7 +944,7 @@ func (api *PublicAPI) EnablePushNotificationsBlockMentions(ctx context.Context) 
 }
 
 func (api *PublicAPI) DisablePushNotificationsBlockMentions(ctx context.Context) error {
-	err := api.service.accountsDB.SaveSettingField(settings2.PushNotificationsBlockMentions, false)
+	err := api.service.accountsDB.SaveSettingField(settings.PushNotificationsBlockMentions, false)
 	if err != nil {
 		return err
 	}
@@ -1102,8 +1102,8 @@ func (api *PublicAPI) PeerID() string {
 	return api.service.messaging.PeerID().String()
 }
 
-func (api *PublicAPI) ChangeIdentityImageShowTo(showTo settings2.ProfilePicturesShowToType) error {
-	err := api.service.accountsDB.SaveSettingField(settings2.ProfilePicturesShowTo, showTo)
+func (api *PublicAPI) ChangeIdentityImageShowTo(showTo settings.ProfilePicturesShowToType) error {
+	err := api.service.accountsDB.SaveSettingField(settings.ProfilePicturesShowTo, showTo)
 	if err != nil {
 		return err
 	}

--- a/services/ext/api.go
+++ b/services/ext/api.go
@@ -8,11 +8,11 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/status-im/status-go/internal/crypto"
-	"github.com/status-im/status-go/internal/crypto/types"
+	cryptotypes "github.com/status-im/status-go/internal/crypto/types"
 	multiaccountscommon "github.com/status-im/status-go/internal/db/multiaccounts/common"
 	"github.com/status-im/status-go/internal/db/multiaccounts/settings"
 	"github.com/status-im/status-go/internal/logutils"
-	types2 "github.com/status-im/status-go/pkg/messaging/types"
+	messagingtypes "github.com/status-im/status-go/pkg/messaging/types"
 	"github.com/status-im/status-go/protocol/contacts"
 	"github.com/status-im/status-go/services/browsers"
 	"github.com/status-im/status-go/services/personal"
@@ -179,7 +179,7 @@ func (api *PublicAPI) RequestContactInfoFromMailserver(pubkey string) (*contacts
 	return api.service.messenger.FetchContact(pubkey, true)
 }
 
-func (api *PublicAPI) RemoveFilters(parent context.Context, chats types2.ChatFilters) error {
+func (api *PublicAPI) RemoveFilters(parent context.Context, chats messagingtypes.ChatFilters) error {
 	return api.service.messenger.RemoveFilters(chats)
 }
 
@@ -199,12 +199,12 @@ func (api *PublicAPI) DeleteInstallation(installationID string) error {
 }
 
 // GetOurInstallations returns all the installations available given an identity
-func (api *PublicAPI) GetOurInstallations() []*types2.Installation {
+func (api *PublicAPI) GetOurInstallations() []*messagingtypes.Installation {
 	return api.service.messenger.Installations()
 }
 
 // SetInstallationMetadata sets the metadata for our own installation
-func (api *PublicAPI) SetInstallationMetadata(installationID string, data *types2.InstallationMetadata) error {
+func (api *PublicAPI) SetInstallationMetadata(installationID string, data *messagingtypes.InstallationMetadata) error {
 	return api.service.messenger.SetInstallationMetadata(installationID, data)
 }
 
@@ -247,17 +247,17 @@ func (api *PublicAPI) CuratedCommunities(parent context.Context) (*communities.K
 
 // SpectateCommunity spectates community with the given ID
 // Meaning user is only a spectator, not a member
-func (api *PublicAPI) SpectateCommunity(parent context.Context, communityID types.HexBytes) (*protocol.MessengerResponse, error) {
+func (api *PublicAPI) SpectateCommunity(parent context.Context, communityID cryptotypes.HexBytes) (*protocol.MessengerResponse, error) {
 	return api.service.messenger.SpectateCommunity(communityID)
 }
 
 // JoinCommunity joins a community with the given ID
-func (api *PublicAPI) JoinCommunity(parent context.Context, communityID types.HexBytes) (*protocol.MessengerResponse, error) {
+func (api *PublicAPI) JoinCommunity(parent context.Context, communityID cryptotypes.HexBytes) (*protocol.MessengerResponse, error) {
 	return api.service.messenger.JoinCommunity(parent, communityID, false)
 }
 
 // LeaveCommunity leaves a commuity with the given ID
-func (api *PublicAPI) LeaveCommunity(ctx context.Context, communityID types.HexBytes) (*protocol.MessengerResponse, error) {
+func (api *PublicAPI) LeaveCommunity(ctx context.Context, communityID cryptotypes.HexBytes) (*protocol.MessengerResponse, error) {
 	return api.service.messenger.LeaveCommunity(communityID)
 }
 
@@ -272,12 +272,12 @@ func (api *PublicAPI) EditCommunity(request *requests.EditCommunity) (*protocol.
 }
 
 // RemovePrivateKey removes the private key of the community with given ID
-func (api *PublicAPI) RemovePrivateKey(id types.HexBytes) (*protocol.MessengerResponse, error) {
+func (api *PublicAPI) RemovePrivateKey(id cryptotypes.HexBytes) (*protocol.MessengerResponse, error) {
 	return api.service.messenger.RemovePrivateKey(id)
 }
 
 // ExportCommunity exports the private key of the community with given ID
-func (api *PublicAPI) ExportCommunity(id types.HexBytes) (types.HexBytes, error) {
+func (api *PublicAPI) ExportCommunity(id cryptotypes.HexBytes) (cryptotypes.HexBytes, error) {
 	key, err := api.service.messenger.ExportCommunity(id)
 	if err != nil {
 		return nil, err
@@ -302,7 +302,7 @@ func (api *PublicAPI) GetCommunityPublicKeyFromPrivateKey(ctx context.Context, h
 }
 
 // Get community members contact list for provided wallet addresses
-func (api *PublicAPI) GetCommunityMembersForWalletAddresses(communityID types.HexBytes, chainID uint64) (map[string]*contacts.Contact, error) {
+func (api *PublicAPI) GetCommunityMembersForWalletAddresses(communityID cryptotypes.HexBytes, chainID uint64) (map[string]*contacts.Contact, error) {
 	return api.service.messenger.GetCommunityMembersForWalletAddresses(communityID, chainID)
 }
 
@@ -317,17 +317,17 @@ func (api *PublicAPI) SlowdownArchivesImport(ctx context.Context) {
 }
 
 // CreateCommunityChat creates a community chat in the given community
-func (api *PublicAPI) CreateCommunityChat(communityID types.HexBytes, c *protobuf.CommunityChat) (*protocol.MessengerResponse, error) {
+func (api *PublicAPI) CreateCommunityChat(communityID cryptotypes.HexBytes, c *protobuf.CommunityChat) (*protocol.MessengerResponse, error) {
 	return api.service.messenger.CreateCommunityChat(communityID, c)
 }
 
 // EditCommunityChat edits a community chat in the given community
-func (api *PublicAPI) EditCommunityChat(communityID types.HexBytes, chatID string, c *protobuf.CommunityChat) (*protocol.MessengerResponse, error) {
+func (api *PublicAPI) EditCommunityChat(communityID cryptotypes.HexBytes, chatID string, c *protobuf.CommunityChat) (*protocol.MessengerResponse, error) {
 	return api.service.messenger.EditCommunityChat(communityID, chatID, c)
 }
 
 // DeleteCommunityChat deletes a community chat in the given community
-func (api *PublicAPI) DeleteCommunityChat(communityID types.HexBytes, chatID string) (*protocol.MessengerResponse, error) {
+func (api *PublicAPI) DeleteCommunityChat(communityID cryptotypes.HexBytes, chatID string) (*protocol.MessengerResponse, error) {
 	return api.service.messenger.DeleteCommunityChat(communityID, chatID)
 }
 
@@ -342,7 +342,7 @@ func (api *PublicAPI) ShareImageMessage(request *requests.ShareImageMessage) (*p
 }
 
 // RemoveUserFromCommunity removes the user with pk from the community with ID
-func (api *PublicAPI) RemoveUserFromCommunity(communityID types.HexBytes, userPublicKey string) (*protocol.MessengerResponse, error) {
+func (api *PublicAPI) RemoveUserFromCommunity(communityID cryptotypes.HexBytes, userPublicKey string) (*protocol.MessengerResponse, error) {
 	return api.service.messenger.RemoveUserFromCommunity(communityID, userPublicKey)
 }
 
@@ -386,7 +386,7 @@ func (api *PublicAPI) EditCommunityTokenPermission(request *requests.EditCommuni
 	return api.service.messenger.EditCommunityTokenPermission(request)
 }
 
-func (api *PublicAPI) LatestRequestToJoinForCommunity(id types.HexBytes) (*communities.RequestToJoin, error) {
+func (api *PublicAPI) LatestRequestToJoinForCommunity(id cryptotypes.HexBytes) (*communities.RequestToJoin, error) {
 	return api.service.messenger.LatestRequestToJoinForCommunity(id)
 }
 
@@ -401,17 +401,17 @@ func (api *PublicAPI) MyCanceledRequestsToJoin() ([]*communities.RequestToJoin, 
 }
 
 // PendingRequestsToJoinForCommunity returns the pending requests to join for a given community
-func (api *PublicAPI) PendingRequestsToJoinForCommunity(id types.HexBytes) ([]*communities.RequestToJoin, error) {
+func (api *PublicAPI) PendingRequestsToJoinForCommunity(id cryptotypes.HexBytes) ([]*communities.RequestToJoin, error) {
 	return api.service.messenger.PendingRequestsToJoinForCommunity(id)
 }
 
 // DeclinedRequestsToJoinForCommunity returns the declined requests to join for a given community
-func (api *PublicAPI) DeclinedRequestsToJoinForCommunity(id types.HexBytes) ([]*communities.RequestToJoin, error) {
+func (api *PublicAPI) DeclinedRequestsToJoinForCommunity(id cryptotypes.HexBytes) ([]*communities.RequestToJoin, error) {
 	return api.service.messenger.DeclinedRequestsToJoinForCommunity(id)
 }
 
 // CanceledRequestsToJoinForCommunity returns the declined requests to join for a given community
-func (api *PublicAPI) CanceledRequestsToJoinForCommunity(id types.HexBytes) ([]*communities.RequestToJoin, error) {
+func (api *PublicAPI) CanceledRequestsToJoinForCommunity(id cryptotypes.HexBytes) ([]*communities.RequestToJoin, error) {
 	return api.service.messenger.CanceledRequestsToJoinForCommunity(id)
 }
 
@@ -423,14 +423,14 @@ func (api *PublicAPI) AllNonApprovedCommunitiesRequestsToJoin() ([]*communities.
 // Generates a single hash for each address that needs to be revealed to a community.
 // Each hash needs to be signed.
 // The order of retuned hashes corresponds to the order of addresses in addressesToReveal.
-func (api *PublicAPI) GenerateJoiningCommunityRequestsForSigning(memberPubKey string, communityID types.HexBytes, addressesToReveal []string) ([]personal.SignParams, error) {
+func (api *PublicAPI) GenerateJoiningCommunityRequestsForSigning(memberPubKey string, communityID cryptotypes.HexBytes, addressesToReveal []string) ([]personal.SignParams, error) {
 	return api.service.messenger.GenerateJoiningCommunityRequestsForSigning(memberPubKey, communityID, addressesToReveal)
 }
 
 // Generates a single hash for each address that needs to be revealed to a community.
 // Each hash needs to be signed.
 // The order of retuned hashes corresponds to the order of addresses in addressesToReveal.
-func (api *PublicAPI) GenerateEditCommunityRequestsForSigning(memberPubKey string, communityID types.HexBytes, addressesToReveal []string) ([]personal.SignParams, error) {
+func (api *PublicAPI) GenerateEditCommunityRequestsForSigning(memberPubKey string, communityID cryptotypes.HexBytes, addressesToReveal []string) ([]personal.SignParams, error) {
 	return api.service.messenger.GenerateEditCommunityRequestsForSigning(memberPubKey, communityID, addressesToReveal)
 }
 
@@ -467,12 +467,12 @@ func (api *PublicAPI) EditSharedAddressesForCommunity(request *requests.EditShar
 }
 
 // GetRevealedAccounts gets the revealed addresses for a member in a community
-func (api *PublicAPI) GetRevealedAccounts(communityID types.HexBytes, memberPk string) ([]*protobuf.RevealedAccount, error) {
+func (api *PublicAPI) GetRevealedAccounts(communityID cryptotypes.HexBytes, memberPk string) ([]*protobuf.RevealedAccount, error) {
 	return api.service.messenger.GetRevealedAccounts(communityID, memberPk)
 }
 
 // GetRevealedAccountsForAllMembers gets the revealed addresses for all the members of a community
-func (api *PublicAPI) GetRevealedAccountsForAllMembers(communityID types.HexBytes) (map[string][]*protobuf.RevealedAccount, error) {
+func (api *PublicAPI) GetRevealedAccountsForAllMembers(communityID cryptotypes.HexBytes) (map[string][]*protobuf.RevealedAccount, error) {
 	return api.service.messenger.GetRevealedAccountsForAllMembers(communityID)
 }
 
@@ -506,7 +506,7 @@ func (api *PublicAPI) DeleteCommunityCategory(request *requests.DeleteCommunityC
 	return api.service.messenger.DeleteCommunityCategory(request)
 }
 
-func (api *PublicAPI) PromoteSelfToControlNode(communityID types.HexBytes) (*protocol.MessengerResponse, error) {
+func (api *PublicAPI) PromoteSelfToControlNode(communityID cryptotypes.HexBytes) (*protocol.MessengerResponse, error) {
 	return api.service.messenger.PromoteSelfToControlNode(communityID)
 }
 
@@ -599,11 +599,11 @@ func (api *PublicAPI) StartMessenger() (*protocol.MessengerResponse, error) {
 	return api.service.StartMessenger()
 }
 
-func (api *PublicAPI) ConnectionStatus() types2.ConnectionStatus {
+func (api *PublicAPI) ConnectionStatus() messagingtypes.ConnectionStatus {
 	if api.service == nil || api.service.messaging == nil {
-		return types2.ConnectionStatus{
+		return messagingtypes.ConnectionStatus{
 			IsOnline: false,
-			State:    types2.ConnectionStateDisconnected,
+			State:    messagingtypes.ConnectionStateDisconnected,
 		}
 	}
 
@@ -862,11 +862,11 @@ func (api *PublicAPI) UpdateBookmark(ctx context.Context, oldURL string, bookmar
 	return api.service.messenger.UpdateBookmark(ctx, oldURL, bookmark)
 }
 
-func (api *PublicAPI) SignMessageWithChatKey(ctx context.Context, message string) (types.HexBytes, error) {
+func (api *PublicAPI) SignMessageWithChatKey(ctx context.Context, message string) (cryptotypes.HexBytes, error) {
 	return api.service.messenger.SignMessage(message)
 }
 
-func (api *PublicAPI) CreateCommunityTokenDeploymentSignature(ctx context.Context, chainID uint64, addressFrom string, communityID string) (types.HexBytes, error) {
+func (api *PublicAPI) CreateCommunityTokenDeploymentSignature(ctx context.Context, chainID uint64, addressFrom string, communityID string) (cryptotypes.HexBytes, error) {
 	return api.service.messenger.CreateCommunityTokenDeploymentSignature(ctx, chainID, addressFrom, communityID)
 }
 
@@ -951,7 +951,7 @@ func (api *PublicAPI) DisablePushNotificationsBlockMentions(ctx context.Context)
 	return api.service.messenger.DisablePushNotificationsBlockMentions()
 }
 
-func (api *PublicAPI) AddPushNotificationsServer(ctx context.Context, publicKeyBytes types.HexBytes) error {
+func (api *PublicAPI) AddPushNotificationsServer(ctx context.Context, publicKeyBytes cryptotypes.HexBytes) error {
 	publicKey, err := crypto.UnmarshalPubkey(publicKeyBytes)
 	if err != nil {
 		return err
@@ -961,7 +961,7 @@ func (api *PublicAPI) AddPushNotificationsServer(ctx context.Context, publicKeyB
 	return api.service.messenger.AddPushNotificationsServer(ctx, publicKey, pushnotificationclient.ServerTypeCustom)
 }
 
-func (api *PublicAPI) RemovePushNotificationServer(ctx context.Context, publicKeyBytes types.HexBytes) error {
+func (api *PublicAPI) RemovePushNotificationServer(ctx context.Context, publicKeyBytes cryptotypes.HexBytes) error {
 	publicKey, err := crypto.UnmarshalPubkey(publicKeyBytes)
 	if err != nil {
 		return err
@@ -1027,28 +1027,28 @@ func (api *PublicAPI) MarkAllActivityCenterNotificationsRead(ctx context.Context
 	return api.service.messenger.MarkAllActivityCenterNotificationsRead(ctx)
 }
 
-func (api *PublicAPI) MarkActivityCenterNotificationsRead(ctx context.Context, ids []types.HexBytes) (*protocol.MessengerResponse, error) {
+func (api *PublicAPI) MarkActivityCenterNotificationsRead(ctx context.Context, ids []cryptotypes.HexBytes) (*protocol.MessengerResponse, error) {
 	return api.service.messenger.MarkActivityCenterNotificationsRead(ctx, ids, 0, true)
 }
 
-func (api *PublicAPI) MarkActivityCenterNotificationsUnread(ctx context.Context, ids []types.HexBytes) (*protocol.MessengerResponse, error) {
+func (api *PublicAPI) MarkActivityCenterNotificationsUnread(ctx context.Context, ids []cryptotypes.HexBytes) (*protocol.MessengerResponse, error) {
 	m := api.service.messenger
 	updatedAt := m.GetCurrentTimeInMillis()
 	return m.MarkActivityCenterNotificationsUnread(ctx, ids, updatedAt, true)
 }
 
-func (api *PublicAPI) AcceptActivityCenterNotifications(ctx context.Context, ids []types.HexBytes) (*protocol.MessengerResponse, error) {
+func (api *PublicAPI) AcceptActivityCenterNotifications(ctx context.Context, ids []cryptotypes.HexBytes) (*protocol.MessengerResponse, error) {
 	m := api.service.messenger
 	updatedAt := m.GetCurrentTimeInMillis()
 	return api.service.messenger.AcceptActivityCenterNotifications(ctx, ids, updatedAt, true)
 }
 
-func (api *PublicAPI) DismissActivityCenterNotifications(ctx context.Context, ids []types.HexBytes) error {
+func (api *PublicAPI) DismissActivityCenterNotifications(ctx context.Context, ids []cryptotypes.HexBytes) error {
 	_, err := api.service.messenger.DismissActivityCenterNotifications(ctx, ids, 0, true)
 	return err
 }
 
-func (api *PublicAPI) DeleteActivityCenterNotifications(ctx context.Context, ids []types.HexBytes) error {
+func (api *PublicAPI) DeleteActivityCenterNotifications(ctx context.Context, ids []cryptotypes.HexBytes) error {
 	m := api.service.messenger
 	updatedAt := m.GetCurrentTimeInMillis()
 	_, err := m.MarkActivityCenterNotificationsDeleted(ctx, ids, updatedAt, true)
@@ -1094,7 +1094,7 @@ func (api *PublicAPI) DisableCommunityHistoryArchiveProtocol() error {
 	return api.service.messenger.DisableCommunityHistoryArchiveProtocol()
 }
 
-func (api *PublicAPI) Peers() types2.PeerStats {
+func (api *PublicAPI) Peers() messagingtypes.PeerStats {
 	return api.service.messenger.Peers()
 }
 
@@ -1251,7 +1251,7 @@ func (api *PublicAPI) ChatMentionToInputField(chatID, text string) (*protocol.Ch
 	return api.service.messenger.GetMentionsManager().ToInputField(chatID, text)
 }
 
-func (api *PublicAPI) GetCheckChannelPermissionResponses(parent context.Context, communityID types.HexBytes) (*communities.CheckAllChannelsPermissionsResponse, error) {
+func (api *PublicAPI) GetCheckChannelPermissionResponses(parent context.Context, communityID cryptotypes.HexBytes) (*communities.CheckAllChannelsPermissionsResponse, error) {
 	return api.service.messenger.GetCommunityCheckChannelPermissionResponses(communityID)
 }
 
@@ -1401,15 +1401,15 @@ func (api *PublicAPI) Debug() (logosstorage.LogosStorageDebugInfo, error) {
 	return api.service.messenger.Debug()
 }
 
-func (api *PublicAPI) HasCommunityArchive(communityID types.HexBytes) bool {
+func (api *PublicAPI) HasCommunityArchive(communityID cryptotypes.HexBytes) bool {
 	return api.service.messenger.IsSeedingHistoryArchive(communityID)
 }
 
-func (api *PublicAPI) GetDownloadedMessageArchiveIDs(communityID types.HexBytes) ([]string, error) {
+func (api *PublicAPI) GetDownloadedMessageArchiveIDs(communityID cryptotypes.HexBytes) ([]string, error) {
 	return api.service.messenger.GetDownloadedMessageArchiveIDs(communityID)
 }
 
-func (api *PublicAPI) GetMessageArchiveIDsToImport(communityID types.HexBytes) ([]string, error) {
+func (api *PublicAPI) GetMessageArchiveIDsToImport(communityID cryptotypes.HexBytes) ([]string, error) {
 	return api.service.messenger.GetMessageArchiveIDsToImport(communityID)
 }
 

--- a/services/ext/service.go
+++ b/services/ext/service.go
@@ -23,7 +23,7 @@ import (
 	accsmanagement "github.com/status-im/status-go/internal/accounts-management"
 	"github.com/status-im/status-go/internal/connection"
 	"github.com/status-im/status-go/internal/crypto"
-	types2 "github.com/status-im/status-go/internal/crypto/types"
+	"github.com/status-im/status-go/internal/crypto/types"
 	"github.com/status-im/status-go/internal/db/multiaccounts"
 	"github.com/status-im/status-go/internal/db/multiaccounts/accounts"
 	"github.com/status-im/status-go/internal/images"
@@ -31,7 +31,7 @@ import (
 	"github.com/status-im/status-go/internal/rpc"
 	"github.com/status-im/status-go/internal/timesource"
 	"github.com/status-im/status-go/params"
-	messaging2 "github.com/status-im/status-go/pkg/messaging"
+	"github.com/status-im/status-go/pkg/messaging"
 	messagingtypes "github.com/status-im/status-go/pkg/messaging/types"
 	"github.com/status-im/status-go/pkg/multiformat"
 	"github.com/status-im/status-go/pkg/pubsub"
@@ -69,14 +69,14 @@ func isPinnedBootstrapDisabledByEnv() bool {
 type EnvelopeEventsHandler interface {
 	EnvelopeSent([][]byte)
 	EnvelopeExpired([][]byte, error)
-	MailServerRequestCompleted(types2.Hash, types2.Hash, []byte, error)
-	MailServerRequestExpired(types2.Hash)
+	MailServerRequestCompleted(types.Hash, types.Hash, []byte, error)
+	MailServerRequestExpired(types.Hash)
 }
 
 // Service is a service that provides some additional API to whisper-based protocols like Whisper or Waku.
 type Service struct {
 	gocommon.PauseBroadcaster
-	messaging       *messaging2.API
+	messaging       *messaging.API
 	messenger       *protocol.Messenger
 	cancelMessenger chan struct{}
 	rpcClient       *rpc.Client
@@ -185,21 +185,21 @@ func (s *Service) InitProtocol(params InitProtocolParams) error {
 		tracer = trace.NewTracer(otel.Tracer(name))
 	}
 
-	messaging, err := messaging2.NewCore(
-		messaging2.CoreParams{
+	messaging, err := messaging.NewCore(
+		messaging.CoreParams{
 			Identity:       params.Identity,
 			NodeKey:        nodeKey,
 			WakuConfig:     s.config.WakuV2Config,
 			Fleet:          s.config.ClusterConfig.Fleet,
-			Mode:           messaging2.ModeFromLightClient(s.config.WakuV2Config.LightClient),
+			Mode:           messaging.ModeFromLightClient(s.config.WakuV2Config.LightClient),
 			InstallationID: s.config.ShhextConfig.InstallationID,
 			TimeSource:     params.TimeSource,
 		},
-		messaging2.WithSQLitePersistence(params.AppDB),
-		messaging2.WithLogger(s.logger),
-		messaging2.WithEnvelopeEventsConfig(envelopeEventsConfig),
-		messaging2.WithMetrics(params.MetricsEnabled),
-		messaging2.WithTracer(tracer),
+		messaging.WithSQLitePersistence(params.AppDB),
+		messaging.WithLogger(s.logger),
+		messaging.WithEnvelopeEventsConfig(envelopeEventsConfig),
+		messaging.WithMetrics(params.MetricsEnabled),
+		messaging.WithTracer(tracer),
 	)
 	if err != nil {
 		return err
@@ -432,7 +432,7 @@ func tokenURIToCommunityID(tokenURI string) string {
 		return ""
 	}
 
-	communityID := types2.EncodeHex(crypto.CompressPubkey(pubKey))
+	communityID := types.EncodeHex(crypto.CompressPubkey(pubKey))
 
 	return communityID
 }

--- a/services/personal/api.go
+++ b/services/personal/api.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 
 	"github.com/status-im/status-go/internal/accounts-management/generator"
-	types2 "github.com/status-im/status-go/internal/crypto/types"
+	"github.com/status-im/status-go/internal/crypto/types"
 )
 
 var (
@@ -23,16 +23,16 @@ func NewAPI(s *Service) *PublicAPI {
 }
 
 // Recover is an implementation of `personal_ecRecover` or `web3.personal.ecRecover` API
-func (api *PublicAPI) Recover(rpcParams RecoverParams) (addr types2.Address, err error) {
+func (api *PublicAPI) Recover(rpcParams RecoverParams) (addr types.Address, err error) {
 	return api.s.Recover(rpcParams)
 }
 
 // CanRecover is an implementation of `personal_ecRecover` or `web3.personal.ecRecover` API
-func (api *PublicAPI) CanRecover(rpcParams RecoverParams, revealedAddress types2.Address) (bool, error) {
+func (api *PublicAPI) CanRecover(rpcParams RecoverParams, revealedAddress types.Address) (bool, error) {
 	return api.s.CanRecover(rpcParams, revealedAddress)
 }
 
 // Sign is an implementation of `personal_sign` or `web3.personal.sign` API
-func (api *PublicAPI) Sign(rpcParams SignParams, verifiedAccount *generator.Account) (result types2.HexBytes, err error) {
+func (api *PublicAPI) Sign(rpcParams SignParams, verifiedAccount *generator.Account) (result types.HexBytes, err error) {
 	return api.s.Sign(rpcParams, verifiedAccount)
 }

--- a/services/personal/service.go
+++ b/services/personal/service.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/status-im/status-go/internal/accounts-management/generator"
 	"github.com/status-im/status-go/internal/crypto"
-	types2 "github.com/status-im/status-go/internal/crypto/types"
+	"github.com/status-im/status-go/internal/crypto/types"
 )
 
 // Make sure that Service implements node.Service interface.
@@ -47,33 +47,33 @@ func (s *Service) Stop() error {
 }
 
 // Recover is an implementation of `personal_ecRecover` or `web3.personal.ecRecover` API
-func (s *Service) Recover(rpcParams RecoverParams) (addr types2.Address, err error) {
+func (s *Service) Recover(rpcParams RecoverParams) (addr types.Address, err error) {
 	message, err := hexutil.Decode(rpcParams.Message)
 	if err != nil {
-		return types2.Address{}, err
+		return types.Address{}, err
 	}
 	sig, err := hexutil.Decode(rpcParams.Signature)
 	if err != nil {
-		return types2.Address{}, err
+		return types.Address{}, err
 	}
 
 	if len(sig) != 65 {
-		return types2.Address{}, ErrInvalidSignatureLength
+		return types.Address{}, ErrInvalidSignatureLength
 	}
 	if sig[64] != 27 && sig[64] != 28 {
-		return types2.Address{}, ErrInvalidSignatureV
+		return types.Address{}, ErrInvalidSignatureV
 	}
 	sig[64] -= 27 // Transform yellow paper V from 27/28 to 0/1
 	hash := crypto.TextHash(message)
 	rpk, err := crypto.SigToPub(hash, sig)
 	if err != nil {
-		return types2.Address{}, err
+		return types.Address{}, err
 	}
 	return crypto.PubkeyToAddress(*rpk), nil
 }
 
 // CanRecover is an implementation of `personal_ecRecover` or `web3.personal.ecRecover` API
-func (s *Service) CanRecover(rpcParams RecoverParams, revealedAddress types2.Address) (bool, error) {
+func (s *Service) CanRecover(rpcParams RecoverParams, revealedAddress types.Address) (bool, error) {
 	recovered, err := s.Recover(rpcParams)
 	if err != nil {
 		return false, err
@@ -82,13 +82,13 @@ func (s *Service) CanRecover(rpcParams RecoverParams, revealedAddress types2.Add
 }
 
 // Sign is an implementation of `personal_sign` or `web3.personal.sign` API
-func (s *Service) Sign(rpcParams SignParams, verifiedAccount *generator.Account) (result types2.HexBytes, err error) {
+func (s *Service) Sign(rpcParams SignParams, verifiedAccount *generator.Account) (result types.HexBytes, err error) {
 	var dBytes []byte
 	switch d := rpcParams.Data.(type) {
 	case string:
 		dBytes, err = hexutil.Decode(rpcParams.Data.(string))
 		if err != nil {
-			return types2.HexBytes{}, err
+			return types.HexBytes{}, err
 		}
 	case []byte:
 		dBytes = d
@@ -100,9 +100,9 @@ func (s *Service) Sign(rpcParams SignParams, verifiedAccount *generator.Account)
 
 	sig, err := crypto.Sign(hash, verifiedAccount.PrivateKey())
 	if err != nil {
-		return types2.HexBytes{}, err
+		return types.HexBytes{}, err
 	}
 	sig[64] += 27 // Transform V from 0/1 to 27/28 according to the yellow paper
 
-	return types2.HexBytes(sig), err
+	return types.HexBytes(sig), err
 }

--- a/services/preferences/rpc_test.go
+++ b/services/preferences/rpc_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/ethereum/go-ethereum/rpc"
 	"github.com/stretchr/testify/require"
 
-	rpc2 "github.com/status-im/status-go/pkg/backend/node/rpc"
+	noderpc "github.com/status-im/status-go/pkg/backend/node/rpc"
 )
 
 func TestPreferencesRPCMethods(t *testing.T) {
@@ -21,7 +21,7 @@ func TestPreferencesRPCMethods(t *testing.T) {
 	call := func(method string, params string) string {
 		t.Helper()
 		input := `{"jsonrpc":"2.0","id":1,"method":"` + method + `","params":` + params + `}`
-		codec := rpc2.NewSingleRequestCodec(input)
+		codec := noderpc.NewSingleRequestCodec(input)
 		server.ServeCodec(codec.GethCodec(), 0)
 		return codec.Output()
 	}
@@ -47,7 +47,7 @@ func TestPreferencesListCategoriesRPC(t *testing.T) {
 	call := func(method string, params string) string {
 		t.Helper()
 		input := `{"jsonrpc":"2.0","id":1,"method":"` + method + `","params":` + params + `}`
-		codec := rpc2.NewSingleRequestCodec(input)
+		codec := noderpc.NewSingleRequestCodec(input)
 		server.ServeCodec(codec.GethCodec(), 0)
 		return codec.Output()
 	}

--- a/services/sharedurls/service.go
+++ b/services/sharedurls/service.go
@@ -11,7 +11,7 @@ import (
 
 	gocommon "github.com/status-im/status-go/common"
 	"github.com/status-im/status-go/internal/crypto"
-	types2 "github.com/status-im/status-go/internal/crypto/types"
+	"github.com/status-im/status-go/internal/crypto/types"
 	"github.com/status-im/status-go/pkg/multiformat"
 	"github.com/status-im/status-go/protocol/communities"
 	"github.com/status-im/status-go/protocol/contacts"
@@ -98,18 +98,18 @@ func decodeCommunityID(serialisedPublicKey string) (string, error) {
 		return "", err
 	}
 
-	return types2.EncodeHex(crypto.CompressPubkey(communityID)), nil
+	return types.EncodeHex(crypto.CompressPubkey(communityID)), nil
 }
 
-func serializePublicKey(compressedKey types2.HexBytes) (string, error) {
+func serializePublicKey(compressedKey types.HexBytes) (string, error) {
 	return utils.SerializePublicKey(compressedKey)
 }
 
-func deserializePublicKey(compressedKey string) (types2.HexBytes, error) {
+func deserializePublicKey(compressedKey string) (types.HexBytes, error) {
 	return utils.DeserializePublicKey(compressedKey)
 }
 
-func (s *Service) ShareCommunityURLWithChatKey(communityID types2.HexBytes) (string, error) {
+func (s *Service) ShareCommunityURLWithChatKey(communityID types.HexBytes) (string, error) {
 	shortKey, err := serializePublicKey(communityID)
 	if err != nil {
 		return "", err
@@ -167,7 +167,7 @@ func prepareEncodedCommunityData(community *communities.Community) (string, stri
 	return encodedData, shortKey, nil
 }
 
-func (s *Service) ShareCommunityURLWithData(communityID types2.HexBytes) (string, error) {
+func (s *Service) ShareCommunityURLWithData(communityID types.HexBytes) (string, error) {
 	community, err := s.provider.GetCommunityByID(communityID)
 	if err != nil {
 		return "", errors.Wrap(err, "failed to get community")
@@ -226,12 +226,12 @@ func parseCommunityURLWithData(data string, chatKey string) (*URLDataResponse, e
 			MembersCount: communityProto.MembersCount,
 			Color:        communityProto.Color,
 			TagIndices:   tagIndices,
-			CommunityID:  types2.EncodeHex(communityID),
+			CommunityID:  types.EncodeHex(communityID),
 		},
 	}, nil
 }
 
-func (s *Service) ShareCommunityChannelURLWithChatKey(communityID types2.HexBytes, channelID string) (string, error) {
+func (s *Service) ShareCommunityChannelURLWithChatKey(communityID types.HexBytes, channelID string) (string, error) {
 	if len(communityID) == 0 {
 		return "", errInvalidCommunityID
 	}
@@ -323,7 +323,7 @@ func (s *Service) prepareEncodedCommunityChannelData(community *communities.Comm
 	return encodedData, shortKey, nil
 }
 
-func (s *Service) ShareCommunityChannelURLWithData(communityID types2.HexBytes, channelID string) (string, error) {
+func (s *Service) ShareCommunityChannelURLWithData(communityID types.HexBytes, channelID string) (string, error) {
 	if len(communityID) == 0 {
 		return "", errInvalidCommunityID
 	}
@@ -392,7 +392,7 @@ func parseCommunityChannelURLWithData(data string, chatKey string) (*URLDataResp
 			MembersCount: channelProto.Community.MembersCount,
 			Color:        channelProto.Community.Color,
 			TagIndices:   tagIndices,
-			CommunityID:  types2.EncodeHex(communityID),
+			CommunityID:  types.EncodeHex(communityID),
 		},
 		Channel: &CommunityChannelURLData{
 			Emoji:       channelProto.Emoji,

--- a/services/utils/utils.go
+++ b/services/utils/utils.go
@@ -4,11 +4,11 @@ import (
 	"strings"
 
 	"github.com/status-im/status-go/internal/crypto"
-	types2 "github.com/status-im/status-go/internal/crypto/types"
+	"github.com/status-im/status-go/internal/crypto/types"
 	"github.com/status-im/status-go/pkg/multiformat"
 )
 
-func DeserializePublicKey(compressedKey string) (types2.HexBytes, error) {
+func DeserializePublicKey(compressedKey string) (types.HexBytes, error) {
 	rawKey, err := multiformat.DeserializePublicKey(compressedKey, "f")
 	if err != nil {
 		return nil, err
@@ -25,12 +25,12 @@ func DeserializePublicKey(compressedKey string) (types2.HexBytes, error) {
 	return crypto.CompressPubkey(pubKey), nil
 }
 
-func SerializePublicKey(compressedKey types2.HexBytes) (string, error) {
+func SerializePublicKey(compressedKey types.HexBytes) (string, error) {
 	rawKey, err := crypto.DecompressPubkey(compressedKey)
 	if err != nil {
 		return "", err
 	}
-	pubKey := types2.EncodeHex(crypto.FromECDSAPub(rawKey))
+	pubKey := types.EncodeHex(crypto.FromECDSAPub(rawKey))
 
 	secp256k1Code := "0xe701"
 	base58btc := "z"

--- a/services/wallet/activity/activity_v2_test.go
+++ b/services/wallet/activity/activity_v2_test.go
@@ -18,7 +18,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/common/hexutil"
 
-	types2 "github.com/status-im/status-go/internal/crypto/types"
+	"github.com/status-im/status-go/internal/crypto/types"
 	"github.com/status-im/status-go/internal/db/walletdatabase"
 	"github.com/status-im/status-go/internal/testutils"
 	"github.com/status-im/status-go/params"
@@ -100,17 +100,17 @@ func createEthereumTransaction(toAddr eth.Address, value *big.Int) *ethTypes.Tra
 
 // createTransactionData creates wallet transaction data for testing
 func createTransactionData(fromAddr eth.Address, toAddr eth.Address, value *big.Int, txHash eth.Hash, tx *ethTypes.Transaction) *wallettypes.TransactionData {
-	toAddress := types2.Address(toAddr)
+	toAddress := types.Address(toAddr)
 	return &wallettypes.TransactionData{
 		TxArgs: &wallettypes.SendTxArgs{
-			From:  types2.Address(fromAddr),
+			From:  types.Address(fromAddr),
 			To:    &toAddress,
 			Value: (*hexutil.Big)(value),
 		},
 		Tx:         tx,
-		HashToSign: types2.Hash(txHash),
+		HashToSign: types.Hash(txHash),
 		Signature:  []byte("test_signature"),
-		SentHash:   types2.Hash(txHash),
+		SentHash:   types.Hash(txHash),
 	}
 }
 

--- a/services/wallet/activityfetcher/service.go
+++ b/services/wallet/activityfetcher/service.go
@@ -15,7 +15,7 @@ import (
 	"github.com/status-im/status-go/internal/db/multiaccounts/accounts"
 	"github.com/status-im/status-go/internal/logutils"
 	"github.com/status-im/status-go/internal/rpc"
-	network2 "github.com/status-im/status-go/internal/rpc/network"
+	"github.com/status-im/status-go/internal/rpc/network"
 	"github.com/status-im/status-go/pkg/pubsub"
 	"github.com/status-im/status-go/services/accounts/accountsevent"
 	ac "github.com/status-im/status-go/services/wallet/activity/common"
@@ -41,7 +41,7 @@ type fetcherID struct {
 
 type Service struct {
 	activityFetcherManager ManagerIface
-	networksGetter         network2.GetterInterface
+	networksGetter         network.GetterInterface
 	accountsGetter         accounts.AccountsStorage
 	ethClientGetter        rpc.EthClientGetter
 
@@ -63,7 +63,7 @@ type Service struct {
 
 func NewService(
 	activityFetcherManager ManagerIface,
-	networksGetter network2.GetterInterface,
+	networksGetter network.GetterInterface,
 	accountsGetter accounts.AccountsStorage,
 	accountsPublisher *pubsub.Publisher,
 	ethClientGetter rpc.EthClientGetter,
@@ -96,7 +96,7 @@ func (s *Service) startNetworkWatcher() {
 		return
 	}
 
-	chNetworkChange, unsubFnNetworkChange := pubsub.Subscribe[network2.EventActiveNetworksChanged](s.networksPublisher, 10)
+	chNetworkChange, unsubFnNetworkChange := pubsub.Subscribe[network.EventActiveNetworksChanged](s.networksPublisher, 10)
 	go func() {
 		defer gocommon.LogOnPanic()
 		defer unsubFnNetworkChange()

--- a/services/wallet/api.go
+++ b/services/wallet/api.go
@@ -21,7 +21,7 @@ import (
 	abi_spec "github.com/status-im/status-go/internal/abi-spec"
 	"github.com/status-im/status-go/internal/accounts-management/generator"
 	"github.com/status-im/status-go/internal/crypto"
-	types2 "github.com/status-im/status-go/internal/crypto/types"
+	"github.com/status-im/status-go/internal/crypto/types"
 	"github.com/status-im/status-go/internal/healthmanager"
 	"github.com/status-im/status-go/internal/logutils"
 	"github.com/status-im/status-go/internal/rpc/network"
@@ -129,11 +129,11 @@ func (api *API) FetchOrGetCachedWalletBalances(ctx context.Context, addresses []
 }
 
 type DerivedAddress struct {
-	Address        types2.Address  `json:"address"`
-	PublicKey      types2.HexBytes `json:"public-key,omitempty"`
-	Path           string          `json:"path"`
-	HasActivity    bool            `json:"hasActivity"`
-	AlreadyCreated bool            `json:"alreadyCreated"`
+	Address        types.Address  `json:"address"`
+	PublicKey      types.HexBytes `json:"public-key,omitempty"`
+	Path           string         `json:"path"`
+	HasActivity    bool           `json:"hasActivity"`
+	AlreadyCreated bool           `json:"alreadyCreated"`
 }
 
 func (api *API) FetchDecodedTxData(ctx context.Context, data string) (*thirdparty.DataParsed, error) {
@@ -475,7 +475,7 @@ func (api *API) SetCustomTxDetails(ctx context.Context, pathTxIdentity *requests
 
 // Generates addresses for the provided paths, response doesn't include `HasActivity` value (if you need it check `GetAddressDetails` function)
 func (api *API) GetDerivedAddresses(ctx context.Context, password string, derivedFrom string, paths []string) ([]*DerivedAddress, error) {
-	acc, err := api.s.gethManager.LoadAccount(types2.HexToAddress(derivedFrom), password)
+	acc, err := api.s.gethManager.LoadAccount(types.HexToAddress(derivedFrom), password)
 	if err != nil {
 		return nil, err
 	}
@@ -512,8 +512,8 @@ func (api *API) getDerivedAddresses(account *generator.Account, paths []string) 
 		accountInfo := childAccount.ToAccountInfo()
 
 		derivedAddress := &DerivedAddress{
-			Address:   types2.HexToAddress(accountInfo.Address),
-			PublicKey: types2.Hex2Bytes(accountInfo.PublicKey),
+			Address:   types.HexToAddress(accountInfo.Address),
+			PublicKey: types.Hex2Bytes(accountInfo.PublicKey),
 			Path:      accPath,
 		}
 
@@ -530,7 +530,7 @@ func (api *API) getDerivedAddresses(account *generator.Account, paths []string) 
 	return derivedAddresses, nil
 }
 
-func (api *API) AddressExists(ctx context.Context, address types2.Address) (bool, error) {
+func (api *API) AddressExists(ctx context.Context, address types.Address) (bool, error) {
 	return api.s.accountsDB.AddressExists(address)
 }
 
@@ -544,7 +544,7 @@ func (api *API) AddressDetails(ctx context.Context, addrDetails *requests.Addres
 	}
 
 	result := &DerivedAddress{
-		Address: types2.HexToAddress(addrDetails.Address),
+		Address: types.HexToAddress(addrDetails.Address),
 	}
 	addressExists, err := api.s.accountsDB.AddressExists(result.Address)
 	if err != nil {
@@ -591,7 +591,7 @@ func (api *API) AddressDetails(ctx context.Context, addrDetails *requests.Addres
 // GetAddressDetails returns details for the passed address (response doesn't include derivation path)
 func (api *API) GetAddressDetails(ctx context.Context, chainID uint64, address string) (*DerivedAddress, error) {
 	result := &DerivedAddress{
-		Address: types2.HexToAddress(address),
+		Address: types.HexToAddress(address),
 	}
 	addressExists, err := api.s.accountsDB.AddressExists(result.Address)
 	if err != nil {
@@ -609,7 +609,7 @@ func (api *API) GetAddressDetails(ctx context.Context, chainID uint64, address s
 	return result, nil
 }
 
-func (api *API) SignMessage(ctx context.Context, message types2.HexBytes, address types2.Address, password string) (string, error) {
+func (api *API) SignMessage(ctx context.Context, message types.HexBytes, address types.Address, password string) (string, error) {
 	logutils.ZapLogger().Debug("[WalletAPI::SignMessage]", zap.Stringer("message", message), zap.Stringer("address", address))
 
 	selectedAccount, err := api.s.gethManager.LoadAccount(address, password)
@@ -648,7 +648,7 @@ func (api *API) BuildRawTransaction(ctx context.Context, chainID uint64, sendTxA
 }
 
 func (api *API) SendTransactionWithSignature(ctx context.Context, chainID uint64, txType pendingtxtracker.PendingTrxType,
-	sendTxArgsJSON string, signature string) (hash types2.Hash, err error) {
+	sendTxArgsJSON string, signature string) (hash types.Hash, err error) {
 	logutils.ZapLogger().Debug("[WalletAPI::SendTransactionWithSignature]",
 		zap.Uint64("chainID", chainID),
 		zap.String("txType", string(txType)),
@@ -779,7 +779,7 @@ func (api *API) FetchChainIDForURL(ctx context.Context, rpcURL string) (*big.Int
 
 // HashMessageEIP191 is used for hashing dApps requests for "personal_sign" and "eth_sign"
 // in a safe manner following the EIP-191 version 0x45 for signing on the client side.
-func (api *API) HashMessageEIP191(ctx context.Context, message types2.HexBytes) types2.Hash {
+func (api *API) HashMessageEIP191(ctx context.Context, message types.HexBytes) types.Hash {
 	logutils.ZapLogger().Debug("wallet.api.HashMessageEIP191", zap.Int("len(data)", len(message)))
 	safeMsg := fmt.Sprintf("\x19Ethereum Signed Message:\n%d%s", len(message), string(message))
 	return crypto.Keccak256Hash([]byte(safeMsg))
@@ -788,30 +788,30 @@ func (api *API) HashMessageEIP191(ctx context.Context, message types2.HexBytes) 
 // SignTypedDataV4 dApps use it to execute "eth_signTypedData_v4" requests
 // the formatted typed data will be prefixed with \x19\x01 based on the EIP-712
 // @deprecated
-func (api *API) SignTypedDataV4(typedJson string, address string, password string) (types2.HexBytes, error) {
+func (api *API) SignTypedDataV4(typedJson string, address string, password string) (types.HexBytes, error) {
 	logutils.ZapLogger().Debug("wallet.api.SignTypedDataV4",
 		zap.Int("len(typedJson)", len(typedJson)),
 		zap.String("address", address),
 		zap.Int("len(password)", len(password)),
 	)
 
-	account, err := api.s.gethManager.GetVerifiedWalletAccount(types2.HexToAddress(address), password)
+	account, err := api.s.gethManager.GetVerifiedWalletAccount(types.HexToAddress(address), password)
 	if err != nil {
-		return types2.HexBytes{}, err
+		return types.HexBytes{}, err
 	}
 	var typed signercore.TypedData
 	err = json.Unmarshal([]byte(typedJson), &typed)
 	if err != nil {
-		return types2.HexBytes{}, err
+		return types.HexBytes{}, err
 	}
 
 	// This is not used down the line but required by the typeddata.SignTypedDataV4 function call
 	chain := new(big.Int).SetUint64(api.s.config.NetworkID)
 	sig, err := typeddata.SignTypedDataV4(typed, account.PrivateKey(), chain)
 	if err != nil {
-		return types2.HexBytes{}, err
+		return types.HexBytes{}, err
 	}
-	return types2.HexBytes(sig), err
+	return types.HexBytes(sig), err
 }
 
 func (api *API) RestartWalletReloadTimer(ctx context.Context) error {

--- a/services/wallet/responses/router_transactions.go
+++ b/services/wallet/responses/router_transactions.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/common/hexutil"
 
-	types2 "github.com/status-im/status-go/internal/crypto/types"
+	"github.com/status-im/status-go/internal/crypto/types"
 	"github.com/status-im/status-go/internal/errors"
 	"github.com/status-im/status-go/services/wallet/requests"
 	"github.com/status-im/status-go/services/wallet/wallettypes"
@@ -14,8 +14,8 @@ import (
 type SendDetails struct {
 	Uuid                string                `json:"uuid"`
 	SendType            int                   `json:"sendType"`
-	FromAddress         types2.Address        `json:"fromAddress"`
-	ToAddress           types2.Address        `json:"toAddress"`
+	FromAddress         types.Address         `json:"fromAddress"`
+	ToAddress           types.Address         `json:"toAddress"`
 	FromChain           uint64                `json:"fromChain"` // this chain should be used only if en error occurred while sending a transaction
 	ToChain             uint64                `json:"toChain"`   // this chain should be used only if en error occurred while sending a transaction
 	FromTokenKey        string                `json:"fromToken"`
@@ -34,11 +34,11 @@ type SendDetails struct {
 }
 
 type SigningDetails struct {
-	Address       types2.Address `json:"address"`
-	AddressPath   string         `json:"addressPath"`
-	KeyUid        string         `json:"keyUid"`
-	SignOnKeycard bool           `json:"signOnKeycard"`
-	Hashes        []types2.Hash  `json:"hashes"`
+	Address       types.Address `json:"address"`
+	AddressPath   string        `json:"addressPath"`
+	KeyUid        string        `json:"keyUid"`
+	SignOnKeycard bool          `json:"signOnKeycard"`
+	Hashes        []types.Hash  `json:"hashes"`
 }
 
 type RouterTransactionsForSigning struct {
@@ -47,17 +47,17 @@ type RouterTransactionsForSigning struct {
 }
 
 type RouterSentTransaction struct {
-	FromAddress  types2.Address `json:"fromAddress"`
-	ToAddress    types2.Address `json:"toAddress"`
-	FromChain    uint64         `json:"fromChain"`
-	ToChain      uint64         `json:"toChain"`
-	FromTokenKey string         `json:"fromTokenKey"`
-	ToTokenKey   string         `json:"toTokenKey"`
-	Amount       string         `json:"amount"`    // amount sent
-	AmountIn     string         `json:"amountIn"`  // amount that is "data" of tx (important for erc20 tokens)
-	AmountOut    string         `json:"amountOut"` // amount that will be received
-	Hash         types2.Hash    `json:"hash"`
-	ApprovalTx   bool           `json:"approvalTx"`
+	FromAddress  types.Address `json:"fromAddress"`
+	ToAddress    types.Address `json:"toAddress"`
+	FromChain    uint64        `json:"fromChain"`
+	ToChain      uint64        `json:"toChain"`
+	FromTokenKey string        `json:"fromTokenKey"`
+	ToTokenKey   string        `json:"toTokenKey"`
+	Amount       string        `json:"amount"`    // amount sent
+	AmountIn     string        `json:"amountIn"`  // amount that is "data" of tx (important for erc20 tokens)
+	AmountOut    string        `json:"amountOut"` // amount that will be received
+	Hash         types.Hash    `json:"hash"`
+	ApprovalTx   bool          `json:"approvalTx"`
 }
 
 type RouterSentTransactions struct {
@@ -65,8 +65,8 @@ type RouterSentTransactions struct {
 	SentTransactions []*RouterSentTransaction `json:"sentTransactions"`
 }
 
-func NewRouterSentTransaction(sendArgs *wallettypes.SendTxArgs, hash types2.Hash, approvalTx bool) *RouterSentTransaction {
-	addr := types2.Address{}
+func NewRouterSentTransaction(sendArgs *wallettypes.SendTxArgs, hash types.Hash, approvalTx bool) *RouterSentTransaction {
+	addr := types.Address{}
 	if sendArgs.To != nil {
 		addr = *sendArgs.To
 	}
@@ -104,8 +104,8 @@ func NewRouterSentTransaction(sendArgs *wallettypes.SendTxArgs, hash types2.Hash
 
 func (sd *SendDetails) UpdateFields(inputParams requests.RouteInputParams, fromChain uint64, toChain uint64) {
 	sd.SendType = int(inputParams.SendType)
-	sd.FromAddress = types2.Address(inputParams.AddrFrom)
-	sd.ToAddress = types2.Address(inputParams.AddrTo)
+	sd.FromAddress = types.Address(inputParams.AddrFrom)
+	sd.ToAddress = types.Address(inputParams.AddrTo)
 	sd.FromTokenKey = inputParams.TokenKey
 	sd.ToTokenKey = inputParams.ToTokenKey
 	if inputParams.AmountIn != nil {

--- a/services/wallet/routeexecution/storage/route_db.go
+++ b/services/wallet/routeexecution/storage/route_db.go
@@ -6,7 +6,7 @@ import (
 	sq "github.com/Masterminds/squirrel"
 
 	"github.com/status-im/status-go/internal/crypto/types"
-	sqlite2 "github.com/status-im/status-go/internal/db/sqlite"
+	"github.com/status-im/status-go/internal/db/sqlite"
 	"github.com/status-im/status-go/services/wallet/requests"
 	"github.com/status-im/status-go/services/wallet/router/routes"
 	"github.com/status-im/status-go/services/wallet/wallettypes"
@@ -59,9 +59,9 @@ func (db *DB) GetRouteDataByHash(chainID uint64, txHash types.Hash) (*wallettype
 	return db.GetRouteData(uuid)
 }
 
-func putRouteInputParams(creator sqlite2.StatementCreator, p *requests.RouteInputParams) error {
+func putRouteInputParams(creator sqlite.StatementCreator, p *requests.RouteInputParams) error {
 	q := sq.Replace("route_input_parameters").
-		SetMap(sq.Eq{"route_input_params_json": &sqlite2.JSONBlob{Data: p}})
+		SetMap(sq.Eq{"route_input_params_json": &sqlite.JSONBlob{Data: p}})
 
 	query, args, err := q.ToSql()
 	if err != nil {
@@ -79,7 +79,7 @@ func putRouteInputParams(creator sqlite2.StatementCreator, p *requests.RouteInpu
 	return err
 }
 
-func putPathsData(creator sqlite2.StatementCreator, uuid string, d []*wallettypes.RouterTransactionDetails) error {
+func putPathsData(creator sqlite.StatementCreator, uuid string, d []*wallettypes.RouterTransactionDetails) error {
 	for i, pathData := range d {
 		if err := putPathData(creator, uuid, i, pathData); err != nil {
 			return err
@@ -88,7 +88,7 @@ func putPathsData(creator sqlite2.StatementCreator, uuid string, d []*wallettype
 	return nil
 }
 
-func putPathData(creator sqlite2.StatementCreator, uuid string, pathIdx int, d *wallettypes.RouterTransactionDetails) (err error) {
+func putPathData(creator sqlite.StatementCreator, uuid string, pathIdx int, d *wallettypes.RouterTransactionDetails) (err error) {
 	err = putPath(creator, uuid, pathIdx, d.RouterPath)
 	if err != nil {
 		return
@@ -122,12 +122,12 @@ func putPathData(creator sqlite2.StatementCreator, uuid string, pathIdx int, d *
 }
 
 func putPath(
-	creator sqlite2.StatementCreator,
+	creator sqlite.StatementCreator,
 	uuid string,
 	pathIdx int,
 	p *routes.Path) error {
 	q := sq.Replace("route_paths").
-		SetMap(sq.Eq{"uuid": uuid, "path_idx": pathIdx, "path_json": &sqlite2.JSONBlob{Data: p}})
+		SetMap(sq.Eq{"uuid": uuid, "path_idx": pathIdx, "path_json": &sqlite.JSONBlob{Data: p}})
 
 	query, args, err := q.ToSql()
 	if err != nil {
@@ -146,7 +146,7 @@ func putPath(
 }
 
 func putPathTransaction(
-	creator sqlite2.StatementCreator,
+	creator sqlite.StatementCreator,
 	uuid string,
 	pathIdx int,
 	isApproval bool,
@@ -160,7 +160,7 @@ func putPathTransaction(
 			"is_approval":  isApproval,
 			"chain_id":     chainID,
 			"tx_hash":      txData.SentHash[:],
-			"tx_args_json": &sqlite2.JSONBlob{Data: txData.TxArgs},
+			"tx_args_json": &sqlite.JSONBlob{Data: txData.TxArgs},
 			"hash_to_sign": txData.HashToSign[:],
 			"sig":          txData.Signature,
 		})
@@ -182,7 +182,7 @@ func putPathTransaction(
 }
 
 func putSentTransaction(
-	creator sqlite2.StatementCreator,
+	creator sqlite.StatementCreator,
 	chainID uint64,
 	txHash types.Hash,
 	tx *ethTypes.Transaction,
@@ -191,7 +191,7 @@ func putSentTransaction(
 		SetMap(sq.Eq{
 			"chain_id": chainID,
 			"tx_hash":  txHash[:],
-			"tx_json":  &sqlite2.JSONBlob{Data: tx},
+			"tx_json":  &sqlite.JSONBlob{Data: tx},
 		})
 
 	query, args, err := q.ToSql()
@@ -210,7 +210,7 @@ func putSentTransaction(
 	return err
 }
 
-func getRouteData(creator sqlite2.StatementCreator, uuid string) (*wallettypes.RouteData, error) {
+func getRouteData(creator sqlite.StatementCreator, uuid string) (*wallettypes.RouteData, error) {
 	routeInputParams, err := getRouteInputParams(creator, uuid)
 	if err != nil {
 		return nil, err
@@ -227,7 +227,7 @@ func getRouteData(creator sqlite2.StatementCreator, uuid string) (*wallettypes.R
 	}, nil
 }
 
-func getRouteInputParams(creator sqlite2.StatementCreator, uuid string) (*requests.RouteInputParams, error) {
+func getRouteInputParams(creator sqlite.StatementCreator, uuid string) (*requests.RouteInputParams, error) {
 	var p requests.RouteInputParams
 	q := sq.Select("route_input_params_json").
 		From("route_input_parameters").
@@ -244,11 +244,11 @@ func getRouteInputParams(creator sqlite2.StatementCreator, uuid string) (*reques
 	}
 	defer stmt.Close()
 
-	err = stmt.QueryRow(args...).Scan(&sqlite2.JSONBlob{Data: &p})
+	err = stmt.QueryRow(args...).Scan(&sqlite.JSONBlob{Data: &p})
 	return &p, err
 }
 
-func getPathsData(creator sqlite2.StatementCreator, uuid string) ([]*wallettypes.RouterTransactionDetails, error) {
+func getPathsData(creator sqlite.StatementCreator, uuid string) ([]*wallettypes.RouterTransactionDetails, error) {
 	var pathsData []*wallettypes.RouterTransactionDetails
 
 	paths, err := getPaths(creator, uuid)
@@ -273,7 +273,7 @@ func getPathsData(creator sqlite2.StatementCreator, uuid string) ([]*wallettypes
 	return pathsData, nil
 }
 
-func getPaths(creator sqlite2.StatementCreator, uuid string) ([]*routes.Path, error) {
+func getPaths(creator sqlite.StatementCreator, uuid string) ([]*routes.Path, error) {
 	var paths []*routes.Path
 	q := sq.Select("path_json").
 		From("route_paths").
@@ -299,7 +299,7 @@ func getPaths(creator sqlite2.StatementCreator, uuid string) ([]*routes.Path, er
 
 	for rows.Next() {
 		var p routes.Path
-		err = rows.Scan(&sqlite2.JSONBlob{Data: &p})
+		err = rows.Scan(&sqlite.JSONBlob{Data: &p})
 		if err != nil {
 			return nil, err
 		}
@@ -309,7 +309,7 @@ func getPaths(creator sqlite2.StatementCreator, uuid string) ([]*routes.Path, er
 	return paths, nil
 }
 
-func getPathTransaction(creator sqlite2.StatementCreator, uuid string, pathIdx int, isApproval bool) (*wallettypes.TransactionData, error) {
+func getPathTransaction(creator sqlite.StatementCreator, uuid string, pathIdx int, isApproval bool) (*wallettypes.TransactionData, error) {
 	q := sq.Select("rpt.tx_args_json", "st.tx_json", "rpt.hash_to_sign", "rpt.sig", "rpt.tx_hash").
 		From("route_path_transactions rpt").
 		LeftJoin(`sent_transactions st ON
@@ -332,8 +332,8 @@ func getPathTransaction(creator sqlite2.StatementCreator, uuid string, pathIdx i
 	var hashToSign []byte
 	var sentHash []byte
 	err = stmt.QueryRow(args...).Scan(
-		&sqlite2.JSONBlob{Data: &tx.TxArgs},
-		&sqlite2.JSONBlob{Data: &tx.Tx},
+		&sqlite.JSONBlob{Data: &tx.TxArgs},
+		&sqlite.JSONBlob{Data: &tx.Tx},
 		&hashToSign,
 		&tx.Signature,
 		&sentHash,
@@ -352,7 +352,7 @@ func getPathTransaction(creator sqlite2.StatementCreator, uuid string, pathIdx i
 	return tx, nil
 }
 
-func getUuidForTxOnChain(creator sqlite2.StatementCreator, chainID uint64, txHash types.Hash) (string, error) {
+func getUuidForTxOnChain(creator sqlite.StatementCreator, chainID uint64, txHash types.Hash) (string, error) {
 	var uuid string
 	q := sq.Select("uuid").
 		From("route_path_transactions").

--- a/services/wallet/router/pathprocessor/nft_handler_cryptokitties_test.go
+++ b/services/wallet/router/pathprocessor/nft_handler_cryptokitties_test.go
@@ -14,10 +14,10 @@ import (
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	ethTypes "github.com/ethereum/go-ethereum/core/types"
 
-	"github.com/status-im/go-wallet-sdk/pkg/tokens/types"
+	wsdktypes "github.com/status-im/go-wallet-sdk/pkg/tokens/types"
 
 	"github.com/status-im/status-go/internal/contracts/cryptokitties"
-	types2 "github.com/status-im/status-go/internal/crypto/types"
+	cryptotypes "github.com/status-im/status-go/internal/crypto/types"
 	mock_rpcclient "github.com/status-im/status-go/internal/rpc/mock/client"
 	mock_transactor "github.com/status-im/status-go/internal/transactions/mock"
 	walletCommon "github.com/status-im/status-go/services/wallet/common"
@@ -62,7 +62,7 @@ func TestCryptoKittiesHandler_Comprehensive(t *testing.T) {
 
 		params := ProcessorInputParams{
 			FromToken: &tokentypes.Token{
-				Token:              &types.Token{Symbol: "CK"},
+				Token:              &wsdktypes.Token{Symbol: "CK"},
 				CollectibleTokenID: &hb,
 			},
 			ToAddr: toAddr,
@@ -85,7 +85,7 @@ func TestCryptoKittiesHandler_Comprehensive(t *testing.T) {
 	assert.ErrorIs(t, err, ErrNoTokenSet)
 
 	_, err = handler.PackTxInputData(ProcessorInputParams{
-		FromToken: &tokentypes.Token{Token: &types.Token{Symbol: "CK"}},
+		FromToken: &tokentypes.Token{Token: &wsdktypes.Token{Symbol: "CK"}},
 		ToAddr:    toAddr,
 	})
 	assert.ErrorIs(t, err, ErrNoTokenSet)
@@ -104,17 +104,17 @@ func TestCryptoKittiesHandler_WithMocks(t *testing.T) {
 	// Test BuildTransactionV2
 	buildArgs := &wallettypes.SendTxArgs{
 		FromChainID: walletCommon.EthereumMainnet,
-		From:        types2.HexToAddress("0x1234567890123456789012345678901234567890"),
-		To:          &types2.Address{},
+		From:        cryptotypes.HexToAddress("0x1234567890123456789012345678901234567890"),
+		To:          &cryptotypes.Address{},
 		Gas:         (*hexutil.Uint64)(new(uint64)),
 		GasPrice:    (*hexutil.Big)(big.NewInt(1000000000)),
 		Value:       (*hexutil.Big)(big.NewInt(0)),
-		Data:        types2.HexBytes("test_data"),
+		Data:        cryptotypes.HexBytes("test_data"),
 	}
 
 	mockTransactor.EXPECT().ValidateAndBuildTransaction(walletCommon.EthereumMainnet, gomock.Any(), int64(-1)).DoAndReturn(
 		func(chainID uint64, args wallettypes.SendTxArgs, lastUsedNonce int64) (*ethTypes.Transaction, uint64, error) {
-			expectedAddress := types2.Address(CryptoKittiesContractID.Address)
+			expectedAddress := cryptotypes.Address(CryptoKittiesContractID.Address)
 			assert.Equal(t, &expectedAddress, args.To)
 			return testTx, uint64(1), nil
 		})

--- a/services/wallet/router/pathprocessor/nft_handler_cryptopunks_test.go
+++ b/services/wallet/router/pathprocessor/nft_handler_cryptopunks_test.go
@@ -14,10 +14,10 @@ import (
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	ethTypes "github.com/ethereum/go-ethereum/core/types"
 
-	"github.com/status-im/go-wallet-sdk/pkg/tokens/types"
+	wsdktypes "github.com/status-im/go-wallet-sdk/pkg/tokens/types"
 
 	"github.com/status-im/status-go/internal/contracts/cryptopunks"
-	types2 "github.com/status-im/status-go/internal/crypto/types"
+	cryptotypes "github.com/status-im/status-go/internal/crypto/types"
 	mock_rpcclient "github.com/status-im/status-go/internal/rpc/mock/client"
 	mock_transactor "github.com/status-im/status-go/internal/transactions/mock"
 	walletCommon "github.com/status-im/status-go/services/wallet/common"
@@ -48,7 +48,7 @@ func TestCryptoPunksHandler_Comprehensive(t *testing.T) {
 	hb := hexutil.Big(*parsed)
 	validParams := ProcessorInputParams{
 		FromToken: &tokentypes.Token{
-			Token:              &types.Token{Symbol: "PUNK"},
+			Token:              &wsdktypes.Token{Symbol: "PUNK"},
 			CollectibleTokenID: &hb,
 		},
 		ToAddr: common.HexToAddress("0x5678901234567890123456789012345678901234"),
@@ -70,7 +70,7 @@ func TestCryptoPunksHandler_Comprehensive(t *testing.T) {
 	assert.ErrorIs(t, err, ErrNoTokenSet)
 
 	_, err = handler.PackTxInputData(ProcessorInputParams{
-		FromToken: &tokentypes.Token{Token: &types.Token{Symbol: "PUNK"}},
+		FromToken: &tokentypes.Token{Token: &wsdktypes.Token{Symbol: "PUNK"}},
 		ToAddr:    validParams.ToAddr,
 	})
 	assert.ErrorIs(t, err, ErrNoTokenSet)
@@ -89,17 +89,17 @@ func TestCryptoPunksHandler_WithMocks(t *testing.T) {
 	// Test BuildTransactionV2
 	buildArgs := &wallettypes.SendTxArgs{
 		FromChainID: walletCommon.EthereumMainnet,
-		From:        types2.HexToAddress("0x1234567890123456789012345678901234567890"),
-		To:          &types2.Address{},
+		From:        cryptotypes.HexToAddress("0x1234567890123456789012345678901234567890"),
+		To:          &cryptotypes.Address{},
 		Gas:         (*hexutil.Uint64)(new(uint64)),
 		GasPrice:    (*hexutil.Big)(big.NewInt(1000000000)),
 		Value:       (*hexutil.Big)(big.NewInt(0)),
-		Data:        types2.HexBytes("test_data"),
+		Data:        cryptotypes.HexBytes("test_data"),
 	}
 
 	mockTransactor.EXPECT().ValidateAndBuildTransaction(walletCommon.EthereumMainnet, gomock.Any(), int64(-1)).DoAndReturn(
 		func(chainID uint64, args wallettypes.SendTxArgs, lastUsedNonce int64) (*ethTypes.Transaction, uint64, error) {
-			expectedAddress := types2.Address(CryptoPunksContractID.Address)
+			expectedAddress := cryptotypes.Address(CryptoPunksContractID.Address)
 			assert.Equal(t, &expectedAddress, args.To)
 			return testTx, uint64(1), nil
 		})

--- a/services/wallet/router/pathprocessor/nft_handler_erc721_test.go
+++ b/services/wallet/router/pathprocessor/nft_handler_erc721_test.go
@@ -14,10 +14,10 @@ import (
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	ethTypes "github.com/ethereum/go-ethereum/core/types"
 
-	"github.com/status-im/go-wallet-sdk/pkg/tokens/types"
+	wsdktypes "github.com/status-im/go-wallet-sdk/pkg/tokens/types"
 
 	"github.com/status-im/status-go/internal/contracts/erc721"
-	types2 "github.com/status-im/status-go/internal/crypto/types"
+	cryptotypes "github.com/status-im/status-go/internal/crypto/types"
 	mock_transactor "github.com/status-im/status-go/internal/transactions/mock"
 	"github.com/status-im/status-go/params"
 	walletCommon "github.com/status-im/status-go/services/wallet/common"
@@ -42,7 +42,7 @@ func TestERC721Handler_Comprehensive(t *testing.T) {
 	// Test GetContractAddress
 	contractAddr := common.HexToAddress("0xabcdefabcdefabcdefabcdefabcdefabcdefabcd")
 	params := ProcessorInputParams{
-		FromToken: &tokentypes.Token{Token: &types.Token{Address: contractAddr}},
+		FromToken: &tokentypes.Token{Token: &wsdktypes.Token{Address: contractAddr}},
 	}
 	address, err := handler.GetContractAddress(params)
 	require.NoError(t, err)
@@ -60,17 +60,17 @@ func TestERC721Handler_WithMocks(t *testing.T) {
 	handler := NewERC721Handler(nil, mockTransactor)
 
 	testTx := ethTypes.NewTransaction(1, common.HexToAddress("0xabcd"), big.NewInt(0), 21000, big.NewInt(1000000000), []byte{})
-	contractAddress := types2.Address(common.HexToAddress("0xabcdefabcdefabcdefabcdefabcdefabcdefabcd"))
+	contractAddress := cryptotypes.Address(common.HexToAddress("0xabcdefabcdefabcdefabcdefabcdefabcdefabcd"))
 
 	// Test BuildTransactionV2
 	buildArgs := &wallettypes.SendTxArgs{
 		FromChainID: walletCommon.EthereumMainnet,
-		From:        types2.HexToAddress("0x1234567890123456789012345678901234567890"),
+		From:        cryptotypes.HexToAddress("0x1234567890123456789012345678901234567890"),
 		To:          &contractAddress,
 		Gas:         (*hexutil.Uint64)(new(uint64)),
 		GasPrice:    (*hexutil.Big)(big.NewInt(1000000000)),
 		Value:       (*hexutil.Big)(big.NewInt(0)),
-		Data:        types2.HexBytes("test_data"),
+		Data:        cryptotypes.HexBytes("test_data"),
 	}
 
 	mockTransactor.EXPECT().ValidateAndBuildTransaction(walletCommon.EthereumMainnet, *buildArgs, int64(-1)).Return(testTx, uint64(1), nil)
@@ -108,7 +108,7 @@ func TestERC721Handler_PackTxInputDataInternally(t *testing.T) {
 
 			params := ProcessorInputParams{
 				FromToken: &tokentypes.Token{
-					Token:              &types.Token{Address: contractAddr},
+					Token:              &wsdktypes.Token{Address: contractAddr},
 					CollectibleTokenID: &collectibleTokenID,
 				},
 				FromAddr: fromAddr,
@@ -148,7 +148,7 @@ func TestERC721Handler_PackTxInputDataInternally(t *testing.T) {
 	assert.ErrorIs(t, err, ErrNoTokenSet)
 
 	_, err = handler.packTxInputDataInternally(ProcessorInputParams{
-		FromToken: &tokentypes.Token{Token: &types.Token{Address: contractAddr}},
+		FromToken: &tokentypes.Token{Token: &wsdktypes.Token{Address: contractAddr}},
 		FromAddr:  fromAddr,
 		ToAddr:    toAddr,
 	}, erc721FunctionNameSafeTransferFrom)
@@ -160,7 +160,7 @@ func TestERC721Handler_PackTxInputDataInternally(t *testing.T) {
 	collectibleTokenID := hexutil.Big(*parsed)
 	validParams := ProcessorInputParams{
 		FromToken: &tokentypes.Token{
-			Token:              &types.Token{Address: contractAddr},
+			Token:              &wsdktypes.Token{Address: contractAddr},
 			CollectibleTokenID: &collectibleTokenID,
 		},
 		FromAddr: fromAddr,
@@ -180,7 +180,7 @@ func TestERC721Handler_Integration(t *testing.T) {
 	collectibleTokenID := hexutil.Big(*parsed)
 	params := ProcessorInputParams{
 		FromChain: &params.Network{ChainID: walletCommon.EthereumMainnet},
-		FromToken: &tokentypes.Token{Token: &types.Token{
+		FromToken: &tokentypes.Token{Token: &wsdktypes.Token{
 			Address: contractAddr,
 		}},
 		ToToken: nil,

--- a/services/wallet/router/pathprocessor/nft_handler_test.go
+++ b/services/wallet/router/pathprocessor/nft_handler_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	ethTypes "github.com/ethereum/go-ethereum/core/types"
 
-	types2 "github.com/status-im/status-go/internal/crypto/types"
+	"github.com/status-im/status-go/internal/crypto/types"
 	mock_rpcclient "github.com/status-im/status-go/internal/rpc/mock/client"
 	mock_transactor "github.com/status-im/status-go/internal/transactions/mock"
 	walletCommon "github.com/status-im/status-go/services/wallet/common"
@@ -63,9 +63,9 @@ func TestSpecificHandlers_BuildTransactionV2(t *testing.T) {
 	testTx := ethTypes.NewTransaction(1, common.HexToAddress("0x1234"), big.NewInt(0), 21000, big.NewInt(1000000000), []byte{})
 
 	sendArgs := &wallettypes.SendTxArgs{
-		FromChainID: walletCommon.EthereumMainnet, From: types2.HexToAddress("0x1234567890123456789012345678901234567890"),
-		To: &types2.Address{}, Gas: (*hexutil.Uint64)(new(uint64)), GasPrice: (*hexutil.Big)(big.NewInt(1000000000)),
-		Value: (*hexutil.Big)(big.NewInt(0)), Data: types2.HexBytes("test_data"),
+		FromChainID: walletCommon.EthereumMainnet, From: types.HexToAddress("0x1234567890123456789012345678901234567890"),
+		To: &types.Address{}, Gas: (*hexutil.Uint64)(new(uint64)), GasPrice: (*hexutil.Big)(big.NewInt(1000000000)),
+		Value: (*hexutil.Big)(big.NewInt(0)), Data: types.HexBytes("test_data"),
 	}
 
 	// Test CryptoKitties handler

--- a/services/wallet/router/pathprocessor/processor_community_deploy_owner_token.go
+++ b/services/wallet/router/pathprocessor/processor_community_deploy_owner_token.go
@@ -15,13 +15,12 @@ import (
 
 	communitytokens "github.com/status-im/status-go/internal/contracts/community-tokens"
 	communitytokendeployer "github.com/status-im/status-go/internal/contracts/community-tokens/deployer"
-	crypto2 "github.com/status-im/status-go/internal/crypto"
+	"github.com/status-im/status-go/internal/crypto"
 	"github.com/status-im/status-go/internal/crypto/types"
 	"github.com/status-im/status-go/internal/logutils"
 	"github.com/status-im/status-go/internal/rpc"
 	"github.com/status-im/status-go/internal/transactions"
 
-	communitytokendeployer2 "github.com/status-im/status-go/internal/contracts/community-tokens/deployer"
 	"github.com/status-im/status-go/internal/errors"
 	walletCommon "github.com/status-im/status-go/services/wallet/common"
 	pathProcessorCommon "github.com/status-im/status-go/services/wallet/router/pathprocessor/common"
@@ -61,10 +60,10 @@ func (s *CommunityDeployOwnerTokenProcessor) CalculateFees(params ProcessorInput
 }
 
 func decodeSignature(sig []byte) (r [32]byte, s [32]byte, v uint8, err error) {
-	if len(sig) != crypto2.SignatureLength {
+	if len(sig) != crypto.SignatureLength {
 		err = &errors.ErrorResponse{
 			Code:    ErrIncorrectSignatureFormat.Code,
-			Details: fmt.Sprintf(ErrIncorrectSignatureFormat.Details, len(sig), crypto2.SignatureLength),
+			Details: fmt.Sprintf(ErrIncorrectSignatureFormat.Details, len(sig), crypto.SignatureLength),
 		}
 		return [32]byte{}, [32]byte{}, 0, err
 	}
@@ -79,23 +78,23 @@ func convert33BytesPubKeyToEthAddress(pubKey string) (common.Address, error) {
 	if err != nil {
 		return common.Address{}, err
 	}
-	communityPubKey, err := crypto2.DecompressPubkey(decoded)
+	communityPubKey, err := crypto.DecompressPubkey(decoded)
 	if err != nil {
 		return common.Address{}, err
 	}
-	return common.Address(crypto2.PubkeyToAddress(*communityPubKey)), nil
+	return common.Address(crypto.PubkeyToAddress(*communityPubKey)), nil
 }
 
-func prepareDeploymentSignatureStruct(signature string, communityID string, addressFrom common.Address) (communitytokendeployer2.CommunityTokenDeployerDeploymentSignature, error) {
+func prepareDeploymentSignatureStruct(signature string, communityID string, addressFrom common.Address) (communitytokendeployer.CommunityTokenDeployerDeploymentSignature, error) {
 	r, s, v, err := decodeSignature(common.FromHex(signature))
 	if err != nil {
-		return communitytokendeployer2.CommunityTokenDeployerDeploymentSignature{}, err
+		return communitytokendeployer.CommunityTokenDeployerDeploymentSignature{}, err
 	}
 	communityEthAddress, err := convert33BytesPubKeyToEthAddress(communityID)
 	if err != nil {
-		return communitytokendeployer2.CommunityTokenDeployerDeploymentSignature{}, err
+		return communitytokendeployer.CommunityTokenDeployerDeploymentSignature{}, err
 	}
-	communitySignature := communitytokendeployer2.CommunityTokenDeployerDeploymentSignature{
+	communitySignature := communitytokendeployer.CommunityTokenDeployerDeploymentSignature{
 		V:        v,
 		R:        r,
 		S:        s,
@@ -106,18 +105,18 @@ func prepareDeploymentSignatureStruct(signature string, communityID string, addr
 }
 
 func (s *CommunityDeployOwnerTokenProcessor) PackTxInputData(params ProcessorInputParams) ([]byte, error) {
-	deployerABI, err := abi.JSON(strings.NewReader(communitytokendeployer2.CommunityTokenDeployerABI))
+	deployerABI, err := abi.JSON(strings.NewReader(communitytokendeployer.CommunityTokenDeployerABI))
 	if err != nil {
 		return []byte{}, err
 	}
 
-	ownerTokenConfig := communitytokendeployer2.CommunityTokenDeployerTokenConfig{
+	ownerTokenConfig := communitytokendeployer.CommunityTokenDeployerTokenConfig{
 		Name:    params.CommunityParams.OwnerTokenParameters.Name,
 		Symbol:  params.CommunityParams.OwnerTokenParameters.Symbol,
 		BaseURI: params.CommunityParams.OwnerTokenParameters.TokenURI,
 	}
 
-	masterTokenConfig := communitytokendeployer2.CommunityTokenDeployerTokenConfig{
+	masterTokenConfig := communitytokendeployer.CommunityTokenDeployerTokenConfig{
 		Name:    params.CommunityParams.MasterTokenParameters.Name,
 		Symbol:  params.CommunityParams.MasterTokenParameters.Symbol,
 		BaseURI: params.CommunityParams.MasterTokenParameters.TokenURI,

--- a/services/wallet/router/pathprocessor/processor_lifi.go
+++ b/services/wallet/router/pathprocessor/processor_lifi.go
@@ -11,7 +11,7 @@ import (
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	ethTypes "github.com/ethereum/go-ethereum/core/types"
 
-	types2 "github.com/status-im/status-go/internal/crypto/types"
+	"github.com/status-im/status-go/internal/crypto/types"
 	"github.com/status-im/status-go/internal/rpc"
 	"github.com/status-im/status-go/internal/transactions"
 	walletCommon "github.com/status-im/status-go/services/wallet/common"
@@ -181,7 +181,7 @@ func (s *LiFiProcessor) PackTxInputData(params ProcessorInputParams) ([]byte, er
 	if err != nil {
 		return []byte{}, err
 	}
-	return types2.Hex2Bytes(quote.TransactionRequest.Data), nil
+	return types.Hex2Bytes(quote.TransactionRequest.Data), nil
 }
 
 func (s *LiFiProcessor) EstimateGas(params ProcessorInputParams, input []byte) (uint64, error) {
@@ -280,13 +280,13 @@ func (s *LiFiProcessor) BuildTransactionV2(sendArgs *wallettypes.SendTxArgs, las
 	}
 
 	sendArgs.FromChainID = txReq.ChainID
-	toAddr := types2.HexToAddress(txReq.To)
-	sendArgs.From = types2.HexToAddress(txReq.From)
+	toAddr := types.HexToAddress(txReq.To)
+	sendArgs.From = types.HexToAddress(txReq.From)
 	sendArgs.To = &toAddr
 	sendArgs.Value = (*hexutil.Big)(value)
 	sendArgs.Gas = (*hexutil.Uint64)(&gas)
 	sendArgs.GasPrice = (*hexutil.Big)(gasPrice)
-	sendArgs.Data = types2.Hex2Bytes(txReq.Data)
+	sendArgs.Data = types.Hex2Bytes(txReq.Data)
 
 	return s.transactor.ValidateAndBuildTransaction(sendArgs.FromChainID, *sendArgs, lastUsedNonce)
 }

--- a/services/wallet/router/pathprocessor/processor_swap_paraswap.go
+++ b/services/wallet/router/pathprocessor/processor_swap_paraswap.go
@@ -12,7 +12,7 @@ import (
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	ethTypes "github.com/ethereum/go-ethereum/core/types"
 
-	types2 "github.com/status-im/status-go/internal/crypto/types"
+	"github.com/status-im/status-go/internal/crypto/types"
 	"github.com/status-im/status-go/internal/rpc"
 	"github.com/status-im/status-go/internal/transactions"
 	walletCommon "github.com/status-im/status-go/services/wallet/common"
@@ -253,7 +253,7 @@ func (s *SwapParaswapProcessor) PackTxInputData(params ProcessorInputParams) ([]
 	if err != nil {
 		return []byte{}, createSwapParaswapErrorResponse(err)
 	}
-	return types2.Hex2Bytes(tx.Data), nil
+	return types.Hex2Bytes(tx.Data), nil
 }
 
 func (s *SwapParaswapProcessor) EstimateGas(params ProcessorInputParams, input []byte) (uint64, error) {
@@ -323,13 +323,13 @@ func (s *SwapParaswapProcessor) BuildTransactionV2(sendArgs *wallettypes.SendTxA
 	}
 
 	sendArgs.FromChainID = tx.ChainID
-	toAddr := types2.HexToAddress(tx.To)
-	sendArgs.From = types2.HexToAddress(tx.From)
+	toAddr := types.HexToAddress(tx.To)
+	sendArgs.From = types.HexToAddress(tx.From)
 	sendArgs.To = &toAddr
 	sendArgs.Value = (*hexutil.Big)(value)
 	sendArgs.Gas = (*hexutil.Uint64)(&gas)
 	sendArgs.GasPrice = (*hexutil.Big)(gasPrice)
-	sendArgs.Data = types2.Hex2Bytes(tx.Data)
+	sendArgs.Data = types.Hex2Bytes(tx.Data)
 
 	return s.transactor.ValidateAndBuildTransaction(sendArgs.FromChainID, *sendArgs, lastUsedNonce)
 }

--- a/services/wallet/service.go
+++ b/services/wallet/service.go
@@ -15,7 +15,7 @@ import (
 	accsmanagementtypes "github.com/status-im/status-go/internal/accounts-management/types"
 	"github.com/status-im/status-go/internal/db/multiaccounts/accounts"
 	"github.com/status-im/status-go/internal/logutils"
-	rpc2 "github.com/status-im/status-go/internal/rpc"
+	"github.com/status-im/status-go/internal/rpc"
 	"github.com/status-im/status-go/internal/transactions"
 	"github.com/status-im/status-go/services/wallet/common"
 	"github.com/status-im/status-go/services/wallet/multistandardbalance"
@@ -119,7 +119,7 @@ func NewService(
 	db *sql.DB,
 	accountsDB *accounts.Database,
 	appDB *sql.DB,
-	rpcClient *rpc2.Client,
+	rpcClient *rpc.Client,
 	accountsPublisher *pubsub.Publisher,
 	gethManager *accsmanagement.AccountsManager,
 	transactor *transactions.Transactor,
@@ -310,7 +310,7 @@ func NewService(
 
 	leaderboardService := leaderboard.NewMarketDataService(leaderboardConfig, db, feed)
 
-	alchemyEthClientGetter := rpc2.NewProviderChainClientGetter(common.SmartProxyAlchemy, rpcClient)
+	alchemyEthClientGetter := rpc.NewProviderChainClientGetter(common.SmartProxyAlchemy, rpcClient)
 	alchemyFetcherDb := activityfetcher_alchemy.NewPersistence(db)
 	alchemyFetcherClient := activityfetcher_alchemy.NewClient(alchemyEthClientGetter)
 	alchemyFetcherManager := alchemymanager.NewManager(alchemyFetcherClient, alchemyFetcherDb)
@@ -356,7 +356,7 @@ func NewService(
 }
 
 func buildPathProcessors(
-	rpcClient *rpc2.Client,
+	rpcClient *rpc.Client,
 	transactor *transactions.Transactor,
 	tokenManager *token.Manager,
 	ensResolver *ensresolver.EnsResolver,
@@ -424,7 +424,7 @@ func buildPathProcessors(
 type Service struct {
 	db                             *sql.DB
 	accountsDB                     *accounts.Database
-	rpcClient                      *rpc2.Client
+	rpcClient                      *rpc.Client
 	tokenManager                   *token.Manager
 	communityManager               *community.Manager
 	savedAddressesManager          *SavedAddressesManager
@@ -576,7 +576,7 @@ func (s *Service) FeatureFlags() *protocolCommon.FeatureFlags {
 	return s.featureFlags
 }
 
-func (s *Service) GetRPCClient() *rpc2.Client {
+func (s *Service) GetRPCClient() *rpc.Client {
 	return s.rpcClient
 }
 

--- a/services/wallet/thirdparty/activity/alchemy/persistence.go
+++ b/services/wallet/thirdparty/activity/alchemy/persistence.go
@@ -14,7 +14,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/rpc"
 
-	sqlite2 "github.com/status-im/status-go/internal/db/sqlite"
+	"github.com/status-im/status-go/internal/db/sqlite"
 )
 
 type Persistence struct {
@@ -42,7 +42,7 @@ func (p *Persistence) SaveTransfers(tt []Transfer, chainID uint64, address commo
 	return saveTransfers(tx, tt, chainID, address)
 }
 
-func saveTransfers(creator sqlite2.StatementCreator, transfers []Transfer, chainID uint64, address common.Address) error {
+func saveTransfers(creator sqlite.StatementCreator, transfers []Transfer, chainID uint64, address common.Address) error {
 	id := uuid.New().String()
 
 	for _, transfer := range transfers {
@@ -54,10 +54,10 @@ func saveTransfers(creator sqlite2.StatementCreator, transfers []Transfer, chain
 	return nil
 }
 
-func saveTransfer(creator sqlite2.StatementCreator, id string, transfer Transfer, chainID uint64, address common.Address) error {
+func saveTransfer(creator sqlite.StatementCreator, id string, transfer Transfer, chainID uint64, address common.Address) error {
 	q := sq.Insert("fetched_alchemy_transfers").
 		Columns("transfer", "chain_id", "address").
-		Values(sqlite2.ToJSONBlob(transfer), chainID, address)
+		Values(sqlite.ToJSONBlob(transfer), chainID, address)
 
 	query, args, err := q.ToSql()
 	if err != nil {
@@ -108,7 +108,7 @@ func rowsToTransfers(rows *sql.Rows) ([]Transfer, error) {
 	var transfers []Transfer
 	for rows.Next() {
 		var transfer Transfer
-		var transferJSON = sqlite2.ToJSONBlob(&transfer)
+		var transferJSON = sqlite.ToJSONBlob(&transfer)
 		err := rows.Scan(transferJSON)
 		fmt.Println("Scanned json:", transferJSON)
 		if err != nil {
@@ -143,7 +143,7 @@ func (p *Persistence) GetLastFetchedBlockAndTimestamp(ctx context.Context, chain
 
 	var lastFetchedTimestamp time.Time
 	var lastFetchedBlock rpc.BlockNumber
-	var lastFetchedBlockJSON = sqlite2.ToJSONBlob(&lastFetchedBlock)
+	var lastFetchedBlockJSON = sqlite.ToJSONBlob(&lastFetchedBlock)
 	err = stmt.QueryRow(args...).Scan(lastFetchedBlockJSON, &lastFetchedTimestamp)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {

--- a/services/wallet/token/token.go
+++ b/services/wallet/token/token.go
@@ -30,7 +30,7 @@ import (
 	"github.com/status-im/status-go/internal/contracts"
 	"github.com/status-im/status-go/internal/contracts/snt"
 	"github.com/status-im/status-go/internal/db/multiaccounts/accounts"
-	settings2 "github.com/status-im/status-go/internal/db/multiaccounts/settings"
+	"github.com/status-im/status-go/internal/db/multiaccounts/settings"
 	"github.com/status-im/status-go/internal/logutils"
 	"github.com/status-im/status-go/internal/rpc"
 	"github.com/status-im/status-go/internal/rpc/network"
@@ -78,7 +78,7 @@ type ManagerInterface interface {
 // Manager is used for accessing token store. It changes the token store based on overridden tokens
 type Manager struct {
 	walletDB                   *sql.DB
-	settings                   *settings2.Database
+	settings                   *settings.Database
 	ethClientGetter            rpc.EthClientGetter
 	ContractMaker              *contracts.ContractMaker
 	networkManager             network.ManagerInterface
@@ -111,7 +111,7 @@ func NewTokenManager(
 ) (*Manager, error) {
 	maker := contracts.NewContractMaker(ethClientGetter)
 
-	settings, err := settings2.MakeNewDB(appDB)
+	settings, err := settings.MakeNewDB(appDB)
 	if err != nil {
 		return nil, err
 	}
@@ -749,7 +749,7 @@ func (tm *Manager) CacheBalances(balances map[common.Address][]tokentypes.Storag
 }
 
 func (tm *Manager) setLastTokenListsRefreshTime(time time.Time) error {
-	return tm.settings.SaveSettingField(settings2.LastTokensUpdate, time)
+	return tm.settings.SaveSettingField(settings.LastTokensUpdate, time)
 }
 
 func (tm *Manager) FindOrCreateTokenByAddress(ctx context.Context, chainID uint64, address common.Address) (*tokentypes.Token, error) {

--- a/services/wallet/transfer/transaction_manager.go
+++ b/services/wallet/transfer/transaction_manager.go
@@ -13,7 +13,7 @@ import (
 
 	accsmanagement "github.com/status-im/status-go/internal/accounts-management"
 	"github.com/status-im/status-go/internal/crypto"
-	types2 "github.com/status-im/status-go/internal/crypto/types"
+	"github.com/status-im/status-go/internal/crypto/types"
 	"github.com/status-im/status-go/internal/db/multiaccounts/accounts"
 	"github.com/status-im/status-go/internal/transactions"
 	"github.com/status-im/status-go/params"
@@ -57,7 +57,7 @@ var (
 
 type TxResponse struct {
 	KeyUID        string                 `json:"keyUid,omitempty"`
-	Address       types2.Address         `json:"address,omitempty"`
+	Address       types.Address          `json:"address,omitempty"`
 	AddressPath   string                 `json:"addressPath,omitempty"`
 	SignOnKeycard bool                   `json:"signOnKeycard,omitempty"`
 	ChainID       uint64                 `json:"chainId,omitempty"`
@@ -67,14 +67,14 @@ type TxResponse struct {
 	TxHash        common.Hash            `json:"txHash,omitempty"`
 }
 
-func (tm *TransactionManager) SignMessage(message types2.HexBytes, privateKey *ecdsa.PrivateKey) (string, error) {
+func (tm *TransactionManager) SignMessage(message types.HexBytes, privateKey *ecdsa.PrivateKey) (string, error) {
 	if privateKey == nil {
 		return "", fmt.Errorf("account or private key is nil")
 	}
 
 	signature, err := crypto.Sign(message[:], privateKey)
 
-	return types2.EncodeHex(signature), err
+	return types.EncodeHex(signature), err
 }
 
 func (tm *TransactionManager) BuildTransaction(chainID uint64, sendArgs wallettypes.SendTxArgs) (response *TxResponse, err error) {
@@ -149,15 +149,15 @@ func (tm *TransactionManager) BuildRawTransaction(chainID uint64, sendArgs walle
 	return &TxResponse{
 		ChainID: chainID,
 		TxArgs:  sendArgs,
-		RawTx:   types2.EncodeHex(data),
+		RawTx:   types.EncodeHex(data),
 		TxHash:  tx.Hash(),
 	}, nil
 }
 
-func (tm *TransactionManager) SendTransactionWithSignature(chainID uint64, sendArgs wallettypes.SendTxArgs, signature []byte) (types2.Hash, error) {
+func (tm *TransactionManager) SendTransactionWithSignature(chainID uint64, sendArgs wallettypes.SendTxArgs, signature []byte) (types.Hash, error) {
 	txWithSignature, err := tm.transactor.BuildTransactionWithSignature(chainID, sendArgs, signature)
 	if err != nil {
-		return types2.Hash{}, err
+		return types.Hash{}, err
 	}
 
 	return tm.transactor.SendTransactionWithSignature(&sendArgs, txWithSignature)

--- a/services/wallet/transfer/transaction_manager_route.go
+++ b/services/wallet/transfer/transaction_manager_route.go
@@ -10,8 +10,8 @@ import (
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	ethTypes "github.com/ethereum/go-ethereum/core/types"
 
-	crypto2 "github.com/status-im/status-go/internal/crypto"
-	types2 "github.com/status-im/status-go/internal/crypto/types"
+	"github.com/status-im/status-go/internal/crypto"
+	"github.com/status-im/status-go/internal/crypto/types"
 	"github.com/status-im/status-go/internal/errors"
 	"github.com/status-im/status-go/internal/transactions"
 	walletCommon "github.com/status-im/status-go/services/wallet/common"
@@ -83,12 +83,12 @@ func buildApprovalTxForPath(transactor transactions.TransactorIface, path *route
 		lastUsedNonce = nonce
 	}
 
-	addrTo := types2.Address(path.FromToken.Address)
+	addrTo := types.Address(path.FromToken.Address)
 	approavalSendArgs := &wallettypes.SendTxArgs{
 		Version: wallettypes.SendTxArgsVersion1,
 
 		// tx fields
-		From:     types2.Address(addressFrom),
+		From:     types.Address(addressFrom),
 		To:       &addrTo,
 		Value:    (*hexutil.Big)(big.NewInt(0)),
 		Data:     path.ApprovalPackedData,
@@ -119,7 +119,7 @@ func buildApprovalTxForPath(transactor transactions.TransactorIface, path *route
 	return &wallettypes.TransactionData{
 		TxArgs:     approavalSendArgs,
 		Tx:         builtApprovalTx,
-		HashToSign: types2.Hash(approvalTxHash),
+		HashToSign: types.Hash(approvalTxHash),
 	}, nil
 }
 
@@ -135,7 +135,7 @@ func buildTxForPath(path *routes.Path, pathProcessors map[string]pathprocessor.P
 		Version: wallettypes.SendTxArgsVersion1,
 
 		// tx fields
-		From:  types2.Address(processorInputParams.FromAddr),
+		From:  types.Address(processorInputParams.FromAddr),
 		Value: path.AmountIn,
 		Data:  path.TxPackedData,
 		Nonce: path.TxNonce,
@@ -161,12 +161,12 @@ func buildTxForPath(path *routes.Path, pathProcessors map[string]pathprocessor.P
 	isContractDeployment := path.ProcessorName == pathProcessorCommon.ProcessorCommunityDeployCollectiblesName ||
 		path.ProcessorName == pathProcessorCommon.ProcessorCommunityDeployAssetsName
 	if !isContractDeployment {
-		addrTo := types2.Address(processorInputParams.ToAddr)
+		addrTo := types.Address(processorInputParams.ToAddr)
 		sendArgs.To = &addrTo
 	}
 
 	if path.FromToken != nil {
-		sendArgs.ToContractAddress = types2.Address(path.FromToken.Address)
+		sendArgs.ToContractAddress = types.Address(path.FromToken.Address)
 
 		// special handling for transfer tx if selected token is not ETH
 		// TODO: we should fix that in the trasactor, but till then, the best place to handle it is here
@@ -182,7 +182,7 @@ func buildTxForPath(path *routes.Path, pathProcessors map[string]pathprocessor.P
 				path.ProcessorName == pathProcessorCommon.ProcessorERC1155Name {
 				// TODO: update functions from `TransactorIface` to use `ToContractAddress` (as an address of the contract a transaction should be sent to)
 				// and `To` (as the destination address, recipient) of `SendTxArgs` struct appropriately
-				toContractAddr := types2.Address(path.FromToken.Address)
+				toContractAddr := types.Address(path.FromToken.Address)
 				sendArgs.To = &toContractAddr
 			}
 		} else if path.ProcessorName == pathProcessorCommon.ProcessorCommunityDeployOwnerTokenName || // special handling for community related txs, tokenID for those txs is ETH
@@ -190,7 +190,7 @@ func buildTxForPath(path *routes.Path, pathProcessors map[string]pathprocessor.P
 			path.ProcessorName == pathProcessorCommon.ProcessorCommunityRemoteBurnName ||
 			path.ProcessorName == pathProcessorCommon.ProcessorCommunityBurnName ||
 			path.ProcessorName == pathProcessorCommon.ProcessorCommunitySetSignerPubKeyName {
-			toContractAddr := types2.Address(*path.UsedContractAddress)
+			toContractAddr := types.Address(*path.UsedContractAddress)
 			sendArgs.To = &toContractAddr
 			sendArgs.ToContractAddress = toContractAddr
 		}
@@ -206,7 +206,7 @@ func buildTxForPath(path *routes.Path, pathProcessors map[string]pathprocessor.P
 	return &wallettypes.TransactionData{
 		TxArgs:     sendArgs,
 		Tx:         builtTx,
-		HashToSign: types2.Hash(txHash),
+		HashToSign: types.Hash(txHash),
 	}, nil
 }
 
@@ -216,7 +216,7 @@ func (tm *TransactionManager) BuildTransactionsFromRoute(route routes.Route, pat
 		return nil, 0, 0, ErrNoRoute
 	}
 
-	accFrom, err := tm.accountsDB.GetAccountByAddress(types2.Address(processorInputParams.FromAddr))
+	accFrom, err := tm.accountsDB.GetAccountByAddress(types.Address(processorInputParams.FromAddr))
 	if err != nil {
 		return nil, 0, 0, err
 	}
@@ -286,7 +286,7 @@ func getSignatureForTxHash(txHash string, signatures map[string]requests.Signatu
 		vByte = 1
 	}
 
-	signature := make([]byte, crypto2.SignatureLength)
+	signature := make([]byte, crypto.SignatureLength)
 	copy(signature[32-len(rBytes):32], rBytes)
 	copy(signature[64-len(rBytes):64], sBytes)
 	signature[64] = vByte
@@ -347,7 +347,7 @@ func addSignatureAndSendTransaction(
 	}
 
 	if txWithSignature.To() == nil {
-		toAddr := crypto2.CreateAddress(txData.TxArgs.From, txData.Tx.Nonce())
+		toAddr := crypto.CreateAddress(txData.TxArgs.From, txData.Tx.Nonce())
 		txData.TxArgs.To = &toAddr
 	}
 

--- a/services/wallet/transfer/transaction_manager_test.go
+++ b/services/wallet/transfer/transaction_manager_test.go
@@ -18,7 +18,7 @@ import (
 	"github.com/ethereum/go-ethereum/common/hexutil"
 
 	accsmanagementtypes "github.com/status-im/status-go/internal/accounts-management/types"
-	types2 "github.com/status-im/status-go/internal/crypto/types"
+	"github.com/status-im/status-go/internal/crypto/types"
 	mock_transactor "github.com/status-im/status-go/internal/transactions/mock"
 	"github.com/status-im/status-go/services/wallet/wallettypes"
 )
@@ -28,7 +28,7 @@ type dummyAccountsStorage struct {
 	account *accsmanagementtypes.Account
 }
 
-func (d *dummyAccountsStorage) GetAccountByAddress(address types2.Address) (*accsmanagementtypes.Account, error) {
+func (d *dummyAccountsStorage) GetAccountByAddress(address types.Address) (*accsmanagementtypes.Account, error) {
 	if address != d.account.Address {
 		return nil, fmt.Errorf("address not found")
 	}
@@ -42,12 +42,12 @@ func (d *dummyAccountsStorage) GetKeypairByKeyUID(keyUID string) (*accsmanagemen
 	return d.keypair, nil
 }
 
-func (d *dummyAccountsStorage) AddressExists(address types2.Address) (bool, error) {
+func (d *dummyAccountsStorage) AddressExists(address types.Address) (bool, error) {
 	return d.account.Address == address, nil
 }
 
-func (d *dummyAccountsStorage) GetWalletAddresses() ([]types2.Address, error) {
-	return []types2.Address{d.account.Address}, nil
+func (d *dummyAccountsStorage) GetWalletAddresses() ([]types.Address, error) {
+	return []types.Address{d.account.Address}, nil
 }
 
 type dummySigner struct{}
@@ -75,7 +75,7 @@ func setupAccountsStorage() *dummyAccountsStorage {
 		},
 		account: &accsmanagementtypes.Account{
 			KeyUID:  "keyUid",
-			Address: types2.Address{1},
+			Address: types.Address{1},
 		},
 	}
 }
@@ -83,7 +83,7 @@ func setupAccountsStorage() *dummyAccountsStorage {
 func TestSignMessage(t *testing.T) {
 	tm, _ := setupTestSuite(t)
 
-	message := (types2.HexBytes)(make([]byte, 32))
+	message := (types.HexBytes)(make([]byte, 32))
 	privateKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	require.NoError(t, err)
 
@@ -95,7 +95,7 @@ func TestSignMessage(t *testing.T) {
 func TestSignMessage_InvalidAccount(t *testing.T) {
 	tm, _ := setupTestSuite(t)
 
-	message := (types2.HexBytes)(make([]byte, 32))
+	message := (types.HexBytes)(make([]byte, 32))
 
 	signature, err := tm.SignMessage(message, nil)
 	require.Error(t, err)
@@ -105,7 +105,7 @@ func TestSignMessage_InvalidAccount(t *testing.T) {
 func TestSignMessage_InvalidMessage(t *testing.T) {
 	tm, _ := setupTestSuite(t)
 
-	message := types2.HexBytes{}
+	message := types.HexBytes{}
 	privateKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	require.NoError(t, err)
 
@@ -121,8 +121,8 @@ func TestBuildTransaction(t *testing.T) {
 	nonce := uint64(1)
 	gas := uint64(21000)
 	sendArgs := wallettypes.SendTxArgs{
-		From:                 types2.Address{1},
-		To:                   &types2.Address{2},
+		From:                 types.Address{1},
+		To:                   &types.Address{2},
 		Value:                (*hexutil.Big)(big.NewInt(123)),
 		Nonce:                (*hexutil.Uint64)(&nonce),
 		Gas:                  (*hexutil.Uint64)(&gas),
@@ -162,8 +162,8 @@ func TestBuildTransaction_AccountNotFound(t *testing.T) {
 	nonce := uint64(1)
 	gas := uint64(21000)
 	sendArgs := wallettypes.SendTxArgs{
-		From:                 types2.Address{2},
-		To:                   &types2.Address{2},
+		From:                 types.Address{2},
+		To:                   &types.Address{2},
 		Value:                (*hexutil.Big)(big.NewInt(123)),
 		Nonce:                (*hexutil.Uint64)(&nonce),
 		Gas:                  (*hexutil.Uint64)(&gas),
@@ -181,8 +181,8 @@ func TestBuildTransaction_InvalidSendTxArgs(t *testing.T) {
 
 	chainID := uint64(1)
 	sendArgs := wallettypes.SendTxArgs{
-		From: types2.Address{1},
-		To:   &types2.Address{2},
+		From: types.Address{1},
+		To:   &types.Address{2},
 	}
 
 	expectedErr := fmt.Errorf("invalid SendTxArgs")
@@ -199,8 +199,8 @@ func TestBuildRawTransaction(t *testing.T) {
 	nonce := uint64(1)
 	gas := uint64(21000)
 	sendArgs := wallettypes.SendTxArgs{
-		From:                 types2.Address{1},
-		To:                   &types2.Address{2},
+		From:                 types.Address{1},
+		To:                   &types.Address{2},
 		Value:                (*hexutil.Big)(big.NewInt(123)),
 		Nonce:                (*hexutil.Uint64)(&nonce),
 		Gas:                  (*hexutil.Uint64)(&gas),
@@ -222,6 +222,6 @@ func TestBuildRawTransaction(t *testing.T) {
 
 	require.Equal(t, chainID, response.ChainID)
 	require.Equal(t, sendArgs, response.TxArgs)
-	require.Equal(t, types2.EncodeHex(expectedData), response.RawTx)
+	require.Equal(t, types.EncodeHex(expectedData), response.RawTx)
 	require.Equal(t, expectedHash, response.TxHash)
 }

--- a/services/wallet/wallettypes/types.go
+++ b/services/wallet/wallettypes/types.go
@@ -12,7 +12,7 @@ import (
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	ethTypes "github.com/ethereum/go-ethereum/core/types"
 
-	types2 "github.com/status-im/status-go/internal/crypto/types"
+	"github.com/status-im/status-go/internal/crypto/types"
 	tokentypes "github.com/status-im/status-go/services/wallet/token/types"
 )
 
@@ -49,8 +49,8 @@ type GasCalculator interface {
 type SendTxArgs struct {
 	Version SendTxArgsVersion `json:"version"`
 
-	From                 types2.Address  `json:"from"`
-	To                   *types2.Address `json:"to"`
+	From                 types.Address   `json:"from"`
+	To                   *types.Address  `json:"to"`
 	Gas                  *hexutil.Uint64 `json:"gas"`
 	GasPrice             *hexutil.Big    `json:"gasPrice"`
 	Value                *hexutil.Big    `json:"value"`
@@ -60,8 +60,8 @@ type SendTxArgs struct {
 	// We keep both "input" and "data" for backward compatibility.
 	// "input" is a preferred field.
 	// see `vendor/github.com/ethereum/go-ethereum/internal/ethapi/api.go:1107`
-	Input types2.HexBytes `json:"input"`
-	Data  types2.HexBytes `json:"data"`
+	Input types.HexBytes `json:"input"`
+	Data  types.HexBytes `json:"data"`
 
 	// additional data - version SendTxArgsVersion1
 	FromChainID        uint64            `json:"fromChainID"`
@@ -70,7 +70,7 @@ type SendTxArgs struct {
 	ValueOut           *hexutil.Big      `json:"valueOut"`
 	FromToken          *tokentypes.Token `json:"fromToken"`
 	ToToken            *tokentypes.Token `json:"toToken"`
-	ToContractAddress  types2.Address    `json:"toContractAddress"` // represents address of the contract that needs to be used in order to send assets, like ERC721 or ERC1155 tx
+	ToContractAddress  types.Address     `json:"toContractAddress"` // represents address of the contract that needs to be used in order to send assets, like ERC721 or ERC1155 tx
 	SlippagePercentage float32           `json:"slippagePercentage"`
 }
 
@@ -91,7 +91,7 @@ func (args SendTxArgs) IsDynamicFeeTx() bool {
 }
 
 // GetInput returns either Input or Data field's value dependent on what is filled.
-func (args SendTxArgs) GetInput() types2.HexBytes {
+func (args SendTxArgs) GetInput() types.HexBytes {
 	if !isNilOrEmpty(args.Input) {
 		return args.Input
 	}
@@ -146,6 +146,6 @@ func (args SendTxArgs) ToTransactOpts(signerFn bind.SignerFn) *bind.TransactOpts
 	}
 }
 
-func isNilOrEmpty(bytes types2.HexBytes) bool {
+func isNilOrEmpty(bytes types.HexBytes) bool {
 	return len(bytes) == 0
 }

--- a/signal/events_shhext.go
+++ b/signal/events_shhext.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/ethereum/go-ethereum/common/hexutil"
 
-	"github.com/status-im/status-go/internal/crypto/types"
-	types2 "github.com/status-im/status-go/pkg/messaging/types"
+	cryptotypes "github.com/status-im/status-go/internal/crypto/types"
+	messagingtypes "github.com/status-im/status-go/pkg/messaging/types"
 )
 
 const (
@@ -45,17 +45,17 @@ const (
 
 // EnvelopeSignal includes hash of the envelope.
 type EnvelopeSignal struct {
-	IDs     []hexutil.Bytes `json:"ids"`
-	Hash    types.Hash      `json:"hash"`
-	Message string          `json:"message"`
+	IDs     []hexutil.Bytes  `json:"ids"`
+	Hash    cryptotypes.Hash `json:"hash"`
+	Message string           `json:"message"`
 }
 
 // MailServerResponseSignal holds the data received in the response from the mailserver.
 type MailServerResponseSignal struct {
-	RequestID        types.Hash `json:"requestID"`
-	LastEnvelopeHash types.Hash `json:"lastEnvelopeHash"`
-	Cursor           string     `json:"cursor"`
-	ErrorMsg         string     `json:"errorMessage"`
+	RequestID        cryptotypes.Hash `json:"requestID"`
+	LastEnvelopeHash cryptotypes.Hash `json:"lastEnvelopeHash"`
+	Cursor           string           `json:"cursor"`
+	ErrorMsg         string           `json:"errorMessage"`
 }
 
 type HistoryMessagesSignal struct {
@@ -84,7 +84,7 @@ type Filter struct {
 	// Identity is the public key of the other recipient for non-public chats
 	Identity string `json:"identity"`
 	// Topic is the whisper topic
-	Topic types2.ContentTopic `json:"topic"`
+	Topic messagingtypes.ContentTopic `json:"topic"`
 }
 
 // SendEnvelopeSent triggered when envelope delivered at least to 1 peer.
@@ -126,7 +126,7 @@ func SendUpdateAvailable(available bool, latestVersion string, url string) {
 }
 
 // SendMailServerRequestCompleted triggered when mail server response has been received
-func SendMailServerRequestCompleted(requestID types.Hash, lastEnvelopeHash types.Hash, cursor []byte, err error) {
+func SendMailServerRequestCompleted(requestID cryptotypes.Hash, lastEnvelopeHash cryptotypes.Hash, cursor []byte, err error) {
 	errorMsg := ""
 	if err != nil {
 		errorMsg = err.Error()
@@ -141,7 +141,7 @@ func SendMailServerRequestCompleted(requestID types.Hash, lastEnvelopeHash types
 }
 
 // SendMailServerRequestExpired triggered when mail server request expires
-func SendMailServerRequestExpired(hash types.Hash) {
+func SendMailServerRequestExpired(hash cryptotypes.Hash) {
 	send(EventMailServerRequestExpired, EnvelopeSignal{Hash: hash})
 }
 

--- a/tests-unit-network/alchemy-activity/alchemy_activity_test.go
+++ b/tests-unit-network/alchemy-activity/alchemy_activity_test.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/status-im/status-go/internal/db/appdatabase"
 	"github.com/status-im/status-go/internal/db/walletdatabase"
-	rpc2 "github.com/status-im/status-go/internal/rpc"
+	"github.com/status-im/status-go/internal/rpc"
 	"github.com/status-im/status-go/internal/rpc/network"
 	"github.com/status-im/status-go/internal/testutils"
 	"github.com/status-im/status-go/params/networkdefaults"
@@ -35,18 +35,18 @@ func setupAlchemyActivityManager(t *testing.T) *alchemymanager.Manager {
 	err = networkManager.InitEmbeddedNetworks(defaultNetworks)
 	require.NoError(t, err)
 
-	config := rpc2.ClientConfig{
+	config := rpc.ClientConfig{
 		Networks: defaultNetworks,
 		DB:       appDB,
 	}
-	rpcClient, err := rpc2.NewClient(config)
+	rpcClient, err := rpc.NewClient(config)
 	require.NoError(t, err)
 
 	ctx := context.Background()
 	rpcClient.Start(ctx)
 	t.Cleanup(func() { rpcClient.Stop() })
 
-	alchemyEthClientGetter := rpc2.NewProviderChainClientGetter(common.SmartProxyAlchemy, rpcClient)
+	alchemyEthClientGetter := rpc.NewProviderChainClientGetter(common.SmartProxyAlchemy, rpcClient)
 
 	alchemyClient := alchemy.NewClient(alchemyEthClientGetter)
 	alchemyPersistence := alchemy.NewPersistence(walletDB)


### PR DESCRIPTION
Clean up import aliases left behind by recent refactorings: `datasync2`, `types2`/`types3`, `stickers2`, `rpc2`, `wakuv3` and friends.

Pure rename/import churn — no behaviour change. Everything is compiler-verified (`go build ./...` + `go vet ./...`, which also type-checks test files), and `gofmt` / `goimports -local github.com/status-im/status-go` are clean.

Important changes:
- [x] **Commit 1 — drop redundant aliases (70 files).** 85 aliases whose base already equals the package name (`datasync2 ".../reliability/datasync"` → `".../reliability/datasync"`) are removed. Also drops 3 imports that imported the *same* path twice, once plain and once as `<pkg>2` (`internal/contracts/contracts.go`, `services/communitytokens/manager.go`, `services/wallet/router/pathprocessor/processor_community_deploy_owner_token.go`).
- [x] **Commit 2 — name the unavoidable ones (32 files).** Where two packages named `types` (or `rpc`) genuinely meet in one file, an alias has to stay, so it now uses the descriptive name already dominant in the tree instead of a digit: `cryptotypes` (34 existing uses), `messagingtypes` (57), `wakutypes` (16), `accsmanagementtypes` (29), `wsdktypes`, `noderpc`. Both sides of each collision are named, so files no longer mix a bare `types` with a `types2`. Also fixes the `cryptoypes` typo alias.
- [x] **Commit 3 — `pkg/messaging/waku` is imported as-is.** It was imported under three different spellings (`wakuv`, `wakuv2`, `wakuv3`) because the package still *declared* itself `wakuv2`, which forces an alias — `goimports` re-adds one whenever the package name differs from its directory. The package is now `package waku`, so all 9 import sites are plain `"github.com/status-im/status-go/pkg/messaging/waku"` with `waku.` qualifiers. The local `waku` variable in `transport_test.go` became `wakuNode` to free the name; the `wakuv2` RPC module string in `pkg/backend/default_test.go` is unrelated and untouched.
- [x] Deliberately untouched: mockgen-generated files (`Code generated ... DO NOT EDIT`) — mockgen emits `types0`/`common0`-style aliases itself and would reintroduce them; aliases that carry real information (`sqlite3`, `iso4217`, `bls12381`).
- [x] **Commit 4 — `protocol/contacts` imported as-is.** `contacts2` in three `protocol/` files existed only because local variables had taken the package name. They are renamed to what they actually hold: `syncContacts` (the `[]*protobuf.SyncInstallationContactV2` built in `backupContacts`), and `addedContacts` / `allContacts` in the contact-request and verification tests, depending on whether the value came from `AddedContacts()` or `Contacts()`.
