### PR TITLE
test(functional): drop stale strict xfail on post-reconnect delivery

### DIFF
--- a/tests-functional/tests/reliability/test_post_reconnect_delivery.py
+++ b/tests-functional/tests/reliability/test_post_reconnect_delivery.py
@@ -57,12 +57,6 @@ class TestPostReconnectDelivery:
                 last_exc = exc
         raise last_exc
 
-    @pytest.mark.xfail(
-        reason="https://github.com/status-im/status-go/issues/7688: after the first "
-        "offline->online change the SDS manager is not rebuilt, so community messages "
-        "sent after a reconnect cannot be decoded. Remove this marker when #7688 is fixed.",
-        strict=True,
-    )
     def test_community_message_after_reconnect(self, community_admin, community_member):
         community_id = messenger.create_community(community_admin)
         chat_id = messenger.join_community(member=community_member, admin=community_admin, community_id=community_id)


### PR DESCRIPTION
`test_community_message_after_reconnect` carries a `strict=True` xfail pointing at #7688.
That fix merged into `develop` on 2026-08-11, two days before the test itself landed via
#7693 — the marker was a forcing function that shipped already stale.

The SDS manager is now rebuilt correctly, so the test passes, and under `strict=True` an
unexpected pass is a failure. The nightly Test Reliability workflow has been red on this
alone since 2026-08-14 — three runs, both ipv4 and ipv6 legs, `1 failed, 56 passed` each,
no other failure.

It's a stale marker, not a masked bug. The fix (`b7b5f82`) is an ancestor of all three
failing head SHAs. The `empty reliability manager` signature appears zero times in the
uploaded status-backend container logs, which instead show the post-#7688 behaviour
directly — the datasync node stops on the offline transition while SDS survives and keeps
unwrapping (`reliability.mvds stopping node` at 02:38:45, `reliability.sds successfully
unwrapped message` at 02:38:48). And the rerun plugin retried the test twice per job, so
it passed 18 consecutive times rather than winning a coin flip.

This deletes the `@pytest.mark.xfail(...)` block and nothing else. The test remains a
regression guard for the offline->online SDS rebuild path, now as an ordinary passing test.