### PR TITLE
fix(logging): make session log archives removable and cap them by MaxBackups

### DIFF
--- a/internal/logutils/logrotation.go
+++ b/internal/logutils/logrotation.go
@@ -3,6 +3,7 @@ package logutils
 import (
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"time"
 
@@ -12,6 +13,12 @@ import (
 
 // processStartTime represents the start time of this process
 var processStartTime = time.Now()
+
+// sessionArchiveTimeFormat must equal lumberjack's backupTimeFormat, different naming conventions will be invisible to lumberjack's cleanup.
+const sessionArchiveTimeFormat = "2006-01-02T15-04-05.000"
+
+// legacySessionArchiveRegex matches legacy archives whose "Z" suffix lumberjack cannot parse.
+var legacySessionArchiveRegex = regexp.MustCompile(`^(.+)-(\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2})Z$`)
 
 // FileOptions are all options supported by internal rotation module.
 type FileOptions struct {
@@ -47,9 +54,44 @@ func rotateLogFileForNewSession(path string) error {
 	if !info.ModTime().Before(processStartTime) {
 		return nil
 	}
-	ts := info.ModTime().UTC().Format("2006-01-02T15-04-05Z")
+	ts := info.ModTime().UTC().Format(sessionArchiveTimeFormat)
 	ext := filepath.Ext(path)
 	base := strings.TrimSuffix(path, ext)
 	archived := base + "-" + ts + ext
 	return os.Rename(path, archived)
+}
+
+// renameLegacySessionArchives renames legacy session archives created with the "...Z" timestamp suffix to sessionArchiveTimeFormat
+// so lumberjack counts them against MaxBackups and eventually prunes them.
+func renameLegacySessionArchives(path string) error {
+	dir := filepath.Dir(path)
+	ext := filepath.Ext(path)
+	base := strings.TrimSuffix(filepath.Base(path), ext)
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+	var firstErr error
+	for _, entry := range entries {
+		if entry.IsDir() || filepath.Ext(entry.Name()) != ext {
+			continue
+		}
+		name := strings.TrimSuffix(entry.Name(), ext)
+		m := legacySessionArchiveRegex.FindStringSubmatch(name)
+		if m == nil || m[1] != base {
+			continue
+		}
+		newPath := filepath.Join(dir, m[1]+"-"+m[2]+".000"+ext)
+		if _, err := os.Stat(newPath); err == nil {
+			// Target exists (another legacy archive already claimed this second).
+			continue
+		}
+		if err := os.Rename(filepath.Join(dir, entry.Name()), newPath); err != nil && firstErr == nil {
+			firstErr = err
+		}
+	}
+	return firstErr
 }

--- a/internal/logutils/logrotation_test.go
+++ b/internal/logutils/logrotation_test.go
@@ -1,0 +1,110 @@
+package logutils
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+)
+
+func TestRotateLogFileForNewSessionProducesLumberjackParseableName(t *testing.T) {
+	dir := t.TempDir()
+	file := filepath.Join(dir, "test.log")
+	require.NoError(t, os.WriteFile(file, []byte("x"), 0600))
+	old := time.Now().Add(-time.Hour)
+	require.NoError(t, os.Chtimes(file, old, old))
+
+	require.NoError(t, rotateLogFileForNewSession(file))
+
+	_, err := os.Stat(file)
+	require.True(t, os.IsNotExist(err))
+
+	matches, err := filepath.Glob(filepath.Join(dir, "test-*.log"))
+	require.NoError(t, err)
+	require.Len(t, matches, 1)
+
+	// The archive suffix must parse with lumberjack's backupTimeFormat,
+	// otherwise MaxBackups never prunes session archives.
+	suffix := strings.TrimSuffix(strings.TrimPrefix(filepath.Base(matches[0]), "test-"), ".log")
+	_, err = time.Parse(sessionArchiveTimeFormat, suffix)
+	require.NoError(t, err)
+}
+
+func TestRotateLogFileForNewSessionKeepsActiveFile(t *testing.T) {
+	dir := t.TempDir()
+	file := filepath.Join(dir, "test.log")
+	// mtime is now, i.e. after processStartTime: the file belongs to this session.
+	require.NoError(t, os.WriteFile(file, []byte("x"), 0600))
+
+	require.NoError(t, rotateLogFileForNewSession(file))
+
+	_, err := os.Stat(file)
+	require.NoError(t, err)
+}
+
+func TestRenameLegacySessionArchives(t *testing.T) {
+	dir := t.TempDir()
+	file := filepath.Join(dir, "pre_login.log")
+	for _, name := range []string{
+		"pre_login-2026-08-14T11-08-48Z.log",    // legacy, to be renamed
+		"0x4d..2f40-2026-08-14T13-37-56Z.log",   // legacy, but different base: untouched
+		"pre_login-2026-08-14T12-00-00Z.log",    // legacy, collides with existing target
+		"pre_login-2026-08-14T12-00-00.000.log", // already in the new layout
+	} {
+		require.NoError(t, os.WriteFile(filepath.Join(dir, name), []byte("x"), 0600))
+	}
+
+	require.NoError(t, renameLegacySessionArchives(file))
+
+	for name, expectExists := range map[string]bool{
+		"pre_login-2026-08-14T11-08-48Z.log":    false,
+		"pre_login-2026-08-14T11-08-48.000.log": true,
+		"0x4d..2f40-2026-08-14T13-37-56Z.log":   true,
+		"pre_login-2026-08-14T12-00-00Z.log":    true, // left alone due to collision
+		"pre_login-2026-08-14T12-00-00.000.log": true,
+	} {
+		_, err := os.Stat(filepath.Join(dir, name))
+		if expectExists {
+			require.NoError(t, err, name)
+		} else {
+			require.True(t, os.IsNotExist(err), name)
+		}
+	}
+}
+
+func TestSessionArchivesPrunedToDefaultMaxBackups(t *testing.T) {
+	dir := t.TempDir()
+	file := filepath.Join(dir, "test.log")
+	base := time.Now().Add(-24 * time.Hour).UTC()
+	for i := range DefaultLogMaxBackups + 5 {
+		ts := base.Add(time.Duration(i) * time.Minute).Format(sessionArchiveTimeFormat)
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "test-"+ts+".log"), []byte("old"), 0600))
+	}
+
+	core := NewCore(
+		defaultEncoder(),
+		zapcore.AddSync(io.Discard),
+		zap.NewAtomicLevelAt(zap.InfoLevel),
+	)
+	filteringCore := newNamespaceFilteringCore(core)
+	// MaxBackups left at 0 => DefaultLogMaxBackups fallback.
+	require.NoError(t, overrideCoreWithConfig(filteringCore, LogSettings{
+		Enabled: true,
+		Level:   "info",
+		File:    file,
+	}))
+
+	// Lumberjack prunes asynchronously on write.
+	zap.New(filteringCore).Info("trigger mill")
+
+	require.Eventually(t, func() bool {
+		matches, err := filepath.Glob(filepath.Join(dir, "test-*.log"))
+		return err == nil && len(matches) <= DefaultLogMaxBackups
+	}, 5*time.Second, 100*time.Millisecond)
+}

--- a/internal/logutils/override.go
+++ b/internal/logutils/override.go
@@ -10,6 +10,8 @@ import (
 	"go.uber.org/zap/zapcore"
 )
 
+const DefaultLogMaxBackups = 10
+
 type LogSettings struct {
 	Enabled         bool   `json:"Enabled"`
 	Level           string `json:"Level"`
@@ -52,11 +54,17 @@ func overrideCoreWithConfig(filteringCore *namespaceFilteringCore, settings LogS
 		if settings.MaxBackups == 0 {
 			// Setting MaxBackups to 0 causes all log files to be kept. Even setting MaxAge to > 0 doesn't fix it
 			// Docs: https://pkg.go.dev/gopkg.in/natefinch/lumberjack.v2@v2.0.0#readme-cleaning-up-old-log-files
-			settings.MaxBackups = 1
+			settings.MaxBackups = DefaultLogMaxBackups
 		}
 
 		if err := rotateLogFileForNewSession(settings.File); err != nil {
 			ZapLogger().Warn("failed to rotate log file for new session",
+				zap.String("file", settings.File),
+				zap.Error(err))
+		}
+
+		if err := renameLegacySessionArchives(settings.File); err != nil {
+			ZapLogger().Warn("failed to rename legacy session log archives",
 				zap.String("file", settings.File),
 				zap.Error(err))
 		}

--- a/mobile/status.go
+++ b/mobile/status.go
@@ -1837,6 +1837,19 @@ func setProfileLogEnabled(requestJSON string) string {
 	return makeJSONResponse(statusBackend.SetProfileLogEnabled(request.Enabled))
 }
 
+func SetProfileLogMaxBackups(requestJSON string) string {
+	return callWithResponse(setProfileLogMaxBackups, requestJSON)
+}
+
+func setProfileLogMaxBackups(requestJSON string) string {
+	var request requests.SetMaxLogBackups
+	err := json.Unmarshal([]byte(requestJSON), &request)
+	if err != nil {
+		return makeJSONResponse(err)
+	}
+	return makeJSONResponse(statusBackend.SetProfileLogMaxBackups(request.MaxLogBackups))
+}
+
 func SetPreLoginLogEnabled(requestJSON string) string {
 	return callWithResponse(setPreLoginLogEnabled, requestJSON)
 }

--- a/mobile/status_test.go
+++ b/mobile/status_test.go
@@ -138,6 +138,11 @@ func TestRestoreAccountAndLoginMalformedJSONReturnsErrorEnvelope(t *testing.T) {
 	require.NotEmpty(t, response.Error, "malformed request JSON should surface an unmarshal error in the envelope, not start a restore")
 }
 
+func TestSetProfileLogMaxBackupsMalformedJSONReturnsErrorEnvelope(t *testing.T) {
+	response := parseAPIResponse(t, SetProfileLogMaxBackups(`{"maxLogBackups": not-json}`))
+	require.NotEmpty(t, response.Error, "malformed request JSON should surface an unmarshal error in the envelope, not touch the backend")
+}
+
 func TestRestoreAccountAndLoginKeycardRequestRejectsMnemonicSet(t *testing.T) {
 	requestJSON := `{"mnemonic":"some seed words","keycard":{"keyUID":"0x1","whisperPrivateKey":"0xabc"}}`
 	response := parseAPIResponse(t, restoreAccountAndLogin(requestJSON))

--- a/pkg/backend/backend_test.go
+++ b/pkg/backend/backend_test.go
@@ -740,15 +740,30 @@ func TestLoginAccount(t *testing.T) {
 	require.NotEmpty(t, accounts[0].KeyUID)
 	require.Equal(t, acc.KeyUID, accounts[0].KeyUID)
 
+	migratedLogDir := testContext.config.RootDataDir + "/logs-after-login"
 	loginAccountRequest := &requests.Login{
 		KeyUID:           accounts[0].KeyUID,
 		Password:         testPassword,
 		WakuV2Nameserver: nameserver,
+		LogFilePath:      migratedLogDir,
 	}
 	err = testContext.backend.LoginAccount(loginAccountRequest)
 	require.NoError(t, err)
 	waitForLogin(c)
 	require.Equal(t, nameserver, testContext.backend.config.WakuV2Config.Nameserver)
+
+	// A non-empty LogFilePath overrides and persists the profile's log directory
+	require.Equal(t, migratedLogDir, testContext.backend.config.LogDir)
+	persistedConfig, err := testContext.backend.GetNodeConfig()
+	require.NoError(t, err)
+	require.Equal(t, migratedLogDir, persistedConfig.LogDir)
+
+	// The max-backups setter updates the DB and the live config in one call
+	require.NoError(t, testContext.backend.SetProfileLogMaxBackups(7))
+	require.Equal(t, 7, testContext.backend.config.LogMaxBackups)
+	persistedConfig, err = testContext.backend.GetNodeConfig()
+	require.NoError(t, err)
+	require.Equal(t, 7, persistedConfig.LogMaxBackups)
 }
 
 func TestVerifyDatabasePassword(t *testing.T) {

--- a/pkg/backend/geth_backend.go
+++ b/pkg/backend/geth_backend.go
@@ -756,6 +756,10 @@ func (b *StatusBackend) loginAccount(request *requests.Login) error {
 
 	defaultCfg.WalletConfig = buildWalletConfig(&request.WalletConfig, &request.WalletSecretsConfig)
 
+	if request.LogFilePath != "" {
+		defaultCfg.LogDir = request.LogFilePath
+	}
+
 	err = b.UpdateNodeConfigFleet(acc, request.Password, defaultCfg)
 	if err != nil {
 		return errors.Wrap(err, "failed to update node config fleet")
@@ -2589,6 +2593,19 @@ func (b *StatusBackend) SetProfileLogEnabled(enabled bool) error {
 		return err
 	}
 	b.config.LogEnabled = enabled
+
+	return logutils.OverrideRootLoggerWithConfig(b.config.ProfileLogSettings())
+}
+
+func (b *StatusBackend) SetProfileLogMaxBackups(count uint) error {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	err := nodecfg.SetMaxLogBackups(b.appDB, count)
+	if err != nil {
+		return err
+	}
+	b.config.LogMaxBackups = int(count)
 
 	return logutils.OverrideRootLoggerWithConfig(b.config.ProfileLogSettings())
 }

--- a/protocol/requests/login.go
+++ b/protocol/requests/login.go
@@ -46,6 +46,9 @@ type Login struct {
 	APIConfig              *APIConfig `json:"apiConfig"`
 	StatusProxyEnabled     bool       `json:"statusProxyEnabled"`
 	WalletConnectProjectID string     `json:"walletConnectProjectID"`
+
+	// LogFilePath is a directory where log files are stored (mirrors CreateAccount.LogFilePath).
+	LogFilePath string `json:"logFilePath"`
 }
 
 func (c *Login) Validate() error {

--- a/protocol/requests/login_test.go
+++ b/protocol/requests/login_test.go
@@ -1,0 +1,20 @@
+package requests
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestLoginUnmarshalLogFilePath(t *testing.T) {
+	var request Login
+	err := json.Unmarshal([]byte(`{
+		"keyUid": "0x1234",
+		"password": "pass",
+		"logFilePath": "/data/logs"
+	}`), &request)
+	require.NoError(t, err)
+	require.Equal(t, "/data/logs", request.LogFilePath)
+	require.NoError(t, request.Validate())
+}


### PR DESCRIPTION
Session archives created by rotateLogFileForNewSession used the timestamp format "2006-01-02T15-04-05Z", which lumberjack's cleanup cannot parse (its backupTimeFormat is "2006-01-02T15-04-05.000"). Because of that archives were never counted against MaxBackups and accumulated forever.

Changes:
- rotateLogFileForNewSession now archives with lumberjack's exact backupTimeFormat
- renameLegacySessionArchives renames existing "...Z" archives to the new format on logger init, making old files removable too
- if not set the MaxBackups becomes DefaultLogMaxBackups (10)