### PR TITLE
test: media server 

### DIFF
--- a/server/handlers.go
+++ b/server/handlers.go
@@ -612,7 +612,8 @@ func (s *MediaServer) handleAccountInitials(w http.ResponseWriter, r *http.Reque
 
 // handleContactImages render contacts custom profile image
 func (s *MediaServer) handleContactImages(w http.ResponseWriter, r *http.Request) {
-	if s.db == nil {
+	db := s.appDatabase()
+	if db == nil {
 		s.logger.Warn("can't handle media request without appdb")
 		w.WriteHeader(http.StatusServiceUnavailable)
 		return
@@ -637,7 +638,7 @@ func (s *MediaServer) handleContactImages(w http.ResponseWriter, r *http.Request
 	}
 
 	var payload []byte
-	err := s.db.QueryRow(`SELECT payload FROM chat_identity_contacts WHERE contact_id = ? and image_type = ?`, parsed.PublicKey, parsed.ImageName).Scan(&payload)
+	err := db.QueryRow(`SELECT payload FROM chat_identity_contacts WHERE contact_id = ? and image_type = ?`, parsed.PublicKey, parsed.ImageName).Scan(&payload)
 	if err != nil {
 		s.logger.Error("failed to load image.", zap.String("contact id", gocommon.TruncateWithDot(parsed.PublicKey)), zap.String("image type", parsed.ImageName), zap.Error(err))
 		return
@@ -725,7 +726,8 @@ func getTheme(params url.Values, logger *zap.Logger) ring.Theme {
 }
 
 func (s *MediaServer) handleDiscordAuthorAvatar(w http.ResponseWriter, r *http.Request) {
-	if s.db == nil {
+	db := s.appDatabase()
+	if db == nil {
 		s.logger.Warn("can't handle media request without appdb")
 		w.WriteHeader(http.StatusServiceUnavailable)
 		return
@@ -740,7 +742,7 @@ func (s *MediaServer) handleDiscordAuthorAvatar(w http.ResponseWriter, r *http.R
 	}
 
 	var image []byte
-	err := s.db.QueryRow(`SELECT avatar_image_payload FROM discord_message_authors WHERE id = ?`, parsed.AuthorID).Scan(&image)
+	err := db.QueryRow(`SELECT avatar_image_payload FROM discord_message_authors WHERE id = ?`, parsed.AuthorID).Scan(&image)
 	if err != nil {
 		s.logger.Error("failed to find image", zap.Error(err))
 		return
@@ -764,7 +766,8 @@ func (s *MediaServer) handleDiscordAuthorAvatar(w http.ResponseWriter, r *http.R
 }
 
 func (s *MediaServer) handleDiscordAttachment(w http.ResponseWriter, r *http.Request) {
-	if s.db == nil {
+	db := s.appDatabase()
+	if db == nil {
 		s.logger.Warn("can't handle media request without appdb")
 		w.WriteHeader(http.StatusServiceUnavailable)
 		return
@@ -783,7 +786,7 @@ func (s *MediaServer) handleDiscordAttachment(w http.ResponseWriter, r *http.Req
 	}
 
 	var image []byte
-	err := s.db.QueryRow(`SELECT payload FROM discord_message_attachments WHERE discord_message_id = ? AND id = ?`, parsed.MessageID, parsed.AttachmentID).Scan(&image)
+	err := db.QueryRow(`SELECT payload FROM discord_message_attachments WHERE discord_message_id = ? AND id = ?`, parsed.MessageID, parsed.AttachmentID).Scan(&image)
 	if err != nil {
 		s.logger.Error("failed to find image", zap.Error(err))
 		return
@@ -807,7 +810,8 @@ func (s *MediaServer) handleDiscordAttachment(w http.ResponseWriter, r *http.Req
 }
 
 func (s *MediaServer) handleImage(w http.ResponseWriter, r *http.Request) {
-	if s.db == nil {
+	db := s.appDatabase()
+	if db == nil {
 		s.logger.Warn("can't handle media request without appdb")
 		w.WriteHeader(http.StatusServiceUnavailable)
 		return
@@ -822,7 +826,7 @@ func (s *MediaServer) handleImage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var image []byte
-	err := s.db.QueryRow(`SELECT image_payload FROM user_messages WHERE id = ?`, parsed.MessageID).Scan(&image)
+	err := db.QueryRow(`SELECT image_payload FROM user_messages WHERE id = ?`, parsed.MessageID).Scan(&image)
 	if err != nil {
 		s.logger.Error("failed to find image", zap.Error(err))
 		return
@@ -846,7 +850,8 @@ func (s *MediaServer) handleImage(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *MediaServer) handleAudio(w http.ResponseWriter, r *http.Request) {
-	if s.db == nil {
+	db := s.appDatabase()
+	if db == nil {
 		s.logger.Warn("can't handle media request without appdb")
 		w.WriteHeader(http.StatusServiceUnavailable)
 		return
@@ -861,7 +866,7 @@ func (s *MediaServer) handleAudio(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var audio []byte
-	err := s.db.QueryRow(`SELECT audio_payload FROM user_messages WHERE id = ?`, parsed.MessageID).Scan(&audio)
+	err := db.QueryRow(`SELECT audio_payload FROM user_messages WHERE id = ?`, parsed.MessageID).Scan(&audio)
 	if err != nil {
 		s.logger.Error("failed to find image", zap.Error(err))
 		return
@@ -881,7 +886,8 @@ func (s *MediaServer) handleAudio(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *MediaServer) handleIPFS(w http.ResponseWriter, r *http.Request) {
-	if s.downloader == nil {
+	downloader := s.ipfsDownloader()
+	if downloader == nil {
 		s.logger.Warn("can't handle media request without ipfs downloader")
 		w.WriteHeader(http.StatusServiceUnavailable)
 		return
@@ -895,7 +901,7 @@ func (s *MediaServer) handleIPFS(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	content, err := s.downloader.Get(parsed.Hash, parsed.Download)
+	content, err := downloader.Get(parsed.Hash, parsed.Download)
 	if err != nil {
 		s.logger.Error("could not download hash", zap.Error(err))
 		return
@@ -911,7 +917,8 @@ func (s *MediaServer) handleIPFS(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *MediaServer) handleCommunityTokenImages(w http.ResponseWriter, r *http.Request) {
-	if s.db == nil {
+	db := s.appDatabase()
+	if db == nil {
 		s.logger.Warn("can't handle media request without appdb")
 		w.WriteHeader(http.StatusServiceUnavailable)
 		return
@@ -939,7 +946,7 @@ func (s *MediaServer) handleCommunityTokenImages(w http.ResponseWriter, r *http.
 	}
 
 	var base64Image string
-	err = s.db.QueryRow("SELECT image_base64 FROM community_tokens WHERE community_id = ? AND chain_id = ? AND symbol = ?", params["communityID"][0], chainID, params["symbol"][0]).Scan(&base64Image)
+	err = db.QueryRow("SELECT image_base64 FROM community_tokens WHERE community_id = ? AND chain_id = ? AND symbol = ?", params["communityID"][0], chainID, params["symbol"][0]).Scan(&base64Image)
 	if err != nil {
 		s.logger.Error("failed to find community token image", zap.Error(err))
 		return
@@ -968,7 +975,7 @@ func (s *MediaServer) handleCommunityTokenImages(w http.ResponseWriter, r *http.
 }
 
 func (s *MediaServer) handleCommunityDescriptionImages(w http.ResponseWriter, r *http.Request) {
-	if s.db == nil {
+	if s.appDatabase() == nil {
 		s.logger.Warn("can't handle media request without appdb")
 		w.WriteHeader(http.StatusServiceUnavailable)
 		return
@@ -1017,7 +1024,7 @@ func (s *MediaServer) handleCommunityDescriptionImages(w http.ResponseWriter, r 
 }
 
 func (s *MediaServer) handleCommunityDescriptionTokenImages(w http.ResponseWriter, r *http.Request) {
-	if s.db == nil {
+	if s.appDatabase() == nil {
 		s.logger.Warn("can't handle media request without appdb")
 		w.WriteHeader(http.StatusServiceUnavailable)
 		return
@@ -1072,7 +1079,8 @@ func (s *MediaServer) handleCommunityDescriptionTokenImages(w http.ResponseWrite
 }
 
 func (s *MediaServer) handleWalletCommunityImages(w http.ResponseWriter, r *http.Request) {
-	if s.walletDB == nil {
+	walletDB := s.walletDatabase()
+	if walletDB == nil {
 		s.logger.Warn("can't handle media request without wallet db")
 		w.WriteHeader(http.StatusServiceUnavailable)
 		return
@@ -1086,7 +1094,7 @@ func (s *MediaServer) handleWalletCommunityImages(w http.ResponseWriter, r *http
 	}
 
 	var image []byte
-	err := s.walletDB.QueryRow(`SELECT image_payload FROM community_data_cache WHERE id = ?`, params["communityID"][0]).Scan(&image)
+	err := walletDB.QueryRow(`SELECT image_payload FROM community_data_cache WHERE id = ?`, params["communityID"][0]).Scan(&image)
 	if err != nil {
 		s.logger.Error("failed to find wallet community image", zap.Error(err))
 		return
@@ -1110,7 +1118,8 @@ func (s *MediaServer) handleWalletCommunityImages(w http.ResponseWriter, r *http
 }
 
 func (s *MediaServer) handleWalletCollectionImages(w http.ResponseWriter, r *http.Request) {
-	if s.walletDB == nil {
+	walletDB := s.walletDatabase()
+	if walletDB == nil {
 		s.logger.Warn("can't handle media request without wallet db")
 		w.WriteHeader(http.StatusServiceUnavailable)
 		return
@@ -1140,7 +1149,7 @@ func (s *MediaServer) handleWalletCollectionImages(w http.ResponseWriter, r *htt
 	}
 
 	var image []byte
-	err = s.walletDB.QueryRow(`SELECT image_payload FROM collection_data_cache WHERE chain_id = ? AND contract_address = ?`,
+	err = walletDB.QueryRow(`SELECT image_payload FROM collection_data_cache WHERE chain_id = ? AND contract_address = ?`,
 		chainID,
 		contractAddress).Scan(&image)
 	if err != nil {
@@ -1166,7 +1175,8 @@ func (s *MediaServer) handleWalletCollectionImages(w http.ResponseWriter, r *htt
 }
 
 func (s *MediaServer) handleWalletCollectibleImages(w http.ResponseWriter, r *http.Request) {
-	if s.walletDB == nil {
+	walletDB := s.walletDatabase()
+	if walletDB == nil {
 		s.logger.Warn("can't handle media request without wallet db")
 		w.WriteHeader(http.StatusServiceUnavailable)
 		return
@@ -1206,7 +1216,7 @@ func (s *MediaServer) handleWalletCollectibleImages(w http.ResponseWriter, r *ht
 	}
 
 	var image []byte
-	err = s.walletDB.QueryRow(`SELECT image_payload FROM collectible_data_cache WHERE chain_id = ? AND contract_address = ? AND token_id = ?`,
+	err = walletDB.QueryRow(`SELECT image_payload FROM collectible_data_cache WHERE chain_id = ? AND contract_address = ? AND token_id = ?`,
 		chainID,
 		contractAddress,
 		(*bigint.SQLBigIntBytes)(tokenID)).Scan(&image)

--- a/server/handlers_linkpreview.go
+++ b/server/handlers_linkpreview.go
@@ -227,6 +227,13 @@ func getStatusLinkPreviewThumbnail(db *sql.DB, messageID string, URL string, ima
 }
 
 func (s *MediaServer) handleStatusLinkPreviewThumbnail(w http.ResponseWriter, r *http.Request) {
+	db := s.appDatabase()
+	if db == nil {
+		s.logger.Warn("can't handle media request without appdb")
+		w.WriteHeader(http.StatusServiceUnavailable)
+		return
+	}
+
 	params := r.URL.Query()
 	parsed := ParseImageParams(s.logger, params)
 
@@ -245,7 +252,7 @@ func (s *MediaServer) handleStatusLinkPreviewThumbnail(w http.ResponseWriter, r 
 		return
 	}
 
-	thumbnail, httpsStatusCode, err := getStatusLinkPreviewThumbnail(s.appDatabase(), parsed.MessageID, parsed.URL, common.MediaServerImageID(parsed.ImageID))
+	thumbnail, httpsStatusCode, err := getStatusLinkPreviewThumbnail(db, parsed.MessageID, parsed.URL, common.MediaServerImageID(parsed.ImageID))
 	if err != nil {
 		http.Error(w, err.Error(), httpsStatusCode)
 		return

--- a/server/handlers_linkpreview.go
+++ b/server/handlers_linkpreview.go
@@ -106,7 +106,8 @@ func checkForFetchImageError(err error, logger *zap.Logger, parsedImageParams Im
 }
 
 func (s *MediaServer) handleLinkPreviewThumbnail(w http.ResponseWriter, r *http.Request) {
-	if s.db == nil {
+	db := s.appDatabase()
+	if db == nil {
 		s.logger.Warn("can't handle media request without appdb")
 		w.WriteHeader(http.StatusServiceUnavailable)
 		return
@@ -114,14 +115,15 @@ func (s *MediaServer) handleLinkPreviewThumbnail(w http.ResponseWriter, r *http.
 
 	parsed := validateAndReturnImageParams(r, w, s.logger)
 	if parsed.URL != "" {
-		thumbnail, err := getThumbnailPayload(s.db, parsed.MessageID, parsed.URL)
+		thumbnail, err := getThumbnailPayload(db, parsed.MessageID, parsed.URL)
 		checkForFetchImageError(err, s.logger, parsed, w, "thumbnail")
 		getMimeTypeAndWriteImage(w, s.logger, thumbnail)
 	}
 }
 
 func (s *MediaServer) handleLinkPreviewFavicon(w http.ResponseWriter, r *http.Request) {
-	if s.db == nil {
+	db := s.appDatabase()
+	if db == nil {
 		s.logger.Warn("can't handle media request without appdb")
 		w.WriteHeader(http.StatusServiceUnavailable)
 		return
@@ -129,7 +131,7 @@ func (s *MediaServer) handleLinkPreviewFavicon(w http.ResponseWriter, r *http.Re
 
 	parsed := validateAndReturnImageParams(r, w, s.logger)
 	if parsed.URL != "" {
-		favicon, err := getFaviconPayload(s.db, parsed.MessageID, parsed.URL)
+		favicon, err := getFaviconPayload(db, parsed.MessageID, parsed.URL)
 		checkForFetchImageError(err, s.logger, parsed, w, "favicon")
 		getMimeTypeAndWriteImage(w, s.logger, favicon)
 	}
@@ -243,7 +245,7 @@ func (s *MediaServer) handleStatusLinkPreviewThumbnail(w http.ResponseWriter, r 
 		return
 	}
 
-	thumbnail, httpsStatusCode, err := getStatusLinkPreviewThumbnail(s.db, parsed.MessageID, parsed.URL, common.MediaServerImageID(parsed.ImageID))
+	thumbnail, httpsStatusCode, err := getStatusLinkPreviewThumbnail(s.appDatabase(), parsed.MessageID, parsed.URL, common.MediaServerImageID(parsed.ImageID))
 	if err != nil {
 		http.Error(w, err.Error(), httpsStatusCode)
 		return

--- a/server/provider_race_test.go
+++ b/server/provider_race_test.go
@@ -1,0 +1,53 @@
+package server
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/netip"
+	"sync"
+	"testing"
+
+	"go.uber.org/zap"
+)
+
+// Regression: StatusNode.Stop calls SetDataProviders(nil, nil, nil) while the
+// media server is still serving, so handlers read the provider fields while
+// they are being written. Run with -race.
+func TestSetDataProvidersRacesHandlers(t *testing.T) {
+	s := &MediaServer{
+		Server: NewServer(zap.NewNop(), &Config{
+			AddrPort: netip.MustParseAddrPort("127.0.0.1:0"),
+		}),
+	}
+
+	var wg sync.WaitGroup
+	stop := make(chan struct{})
+
+	// Reader: the same two-step read handleIPFS does (nil check, then use).
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+			}
+			rec := httptest.NewRecorder()
+			req := httptest.NewRequest(http.MethodGet, "/ipfs?hash=x", nil)
+			s.handleIPFS(rec, req)
+		}
+	}()
+
+	// Writer: teardown clearing the providers underneath it.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 500; i++ {
+			s.SetDataProviders(nil, nil, nil)
+		}
+		close(stop)
+	}()
+
+	wg.Wait()
+}

--- a/server/provider_teardown_repro_test.go
+++ b/server/provider_teardown_repro_test.go
@@ -1,0 +1,89 @@
+package server
+
+import (
+	"net/netip"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"github.com/status-im/status-go/internal/ipfs"
+	"github.com/status-im/status-go/protocol/protobuf"
+)
+
+// Valid ENS/sticker contenthash; decodeStringHash succeeds so Get() reaches inputTaskChan.
+const validIPFSContentHash = "e3010170122050efc0a3e661339f31e1e44b3d15a1bf4e501c965a0523f57b701667fa90ccca"
+
+func newReproMediaServer() *MediaServer {
+	return &MediaServer{
+		Server: NewServer(zap.NewNop(), &Config{
+			AddrPort: netip.MustParseAddrPort("127.0.0.1:0"),
+		}),
+	}
+}
+
+// Repro: StatusNode.Stop snapshots-then-stops the downloader under an in-flight
+// handleIPFS. Get() sends on a closed inputTaskChan and panics.
+//
+//	n.mediaServer.SetDataProviders(nil, nil, nil)
+//	n.downloader.Stop()
+func TestHandleIPFSDoesNotPanicWhenDownloaderStoppedUnderInflightRequest(t *testing.T) {
+	d := ipfs.NewDownloader(t.TempDir())
+	s := newReproMediaServer()
+	s.SetDataProviders(nil, nil, d)
+
+	// Same two-step read handleIPFS does: copy the pointer, then use it.
+	downloader := s.ipfsDownloader()
+	require.NotNil(t, downloader)
+
+	s.SetDataProviders(nil, nil, nil)
+	d.Stop()
+
+	require.NotPanics(t, func() {
+		_, _ = downloader.Get(validIPFSContentHash, false)
+	})
+}
+
+// Repro: community reader function pointers are written without providersMu
+// while HTTP handlers already read them. Media server starts before messenger
+// calls SetCommunityImageReader. Run with -race.
+func TestCommunityImageReaderRacesHandlers(t *testing.T) {
+	s := newReproMediaServer()
+
+	png := []byte{0x89, 0x50, 0x4E, 0x47}
+	makeReader := func(id int) func(string) (map[string]*protobuf.IdentityImage, error) {
+		return func(string) (map[string]*protobuf.IdentityImage, error) {
+			_ = id
+			return map[string]*protobuf.IdentityImage{
+				"thumb": {Payload: png},
+			}, nil
+		}
+	}
+	s.SetCommunityImageReader(makeReader(0))
+
+	var wg sync.WaitGroup
+	stop := make(chan struct{})
+
+	for range 4 {
+		wg.Go(func() {
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+				}
+				_, _ = s.getCommunityImage("c1")
+			}
+		})
+	}
+
+	wg.Go(func() {
+		for i := range 10000 {
+			s.SetCommunityImageReader(makeReader(i))
+		}
+		close(stop)
+	})
+
+	wg.Wait()
+}

--- a/server/server_media.go
+++ b/server/server_media.go
@@ -10,6 +10,7 @@ import (
 	"net/url"
 	"os"
 	"strconv"
+	"sync"
 
 	"go.uber.org/zap"
 
@@ -64,6 +65,9 @@ type MediaServerConfig struct {
 type MediaServer struct {
 	*Server
 
+	// providersMu guards db, walletDB and downloader, which are swapped at
+	// teardown while handlers are still running.
+	providersMu                 sync.RWMutex
 	db                          *sql.DB
 	downloader                  *ipfs.Downloader
 	multiaccountsDB             *multiaccounts.Database
@@ -191,10 +195,38 @@ func NewMediaServer(db *sql.DB, downloader *ipfs.Downloader, multiaccountsDB *mu
 	return s, nil
 }
 
+// SetDataProviders swaps the backing data sources. It is called during node
+// teardown while handlers are still in flight, so the fields are only ever
+// touched under providersMu; handlers must read them via the accessors below
+// and keep the result, never re-reading between a nil check and a use.
 func (s *MediaServer) SetDataProviders(db *sql.DB, walletDB *sql.DB, downloader *ipfs.Downloader) {
+	s.providersMu.Lock()
+	defer s.providersMu.Unlock()
+
 	s.db = db
 	s.walletDB = walletDB
 	s.downloader = downloader
+}
+
+func (s *MediaServer) appDatabase() *sql.DB {
+	s.providersMu.RLock()
+	defer s.providersMu.RUnlock()
+
+	return s.db
+}
+
+func (s *MediaServer) walletDatabase() *sql.DB {
+	s.providersMu.RLock()
+	defer s.providersMu.RUnlock()
+
+	return s.walletDB
+}
+
+func (s *MediaServer) ipfsDownloader() *ipfs.Downloader {
+	s.providersMu.RLock()
+	defer s.providersMu.RUnlock()
+
+	return s.downloader
 }
 
 func (s *MediaServer) Start() error {


### PR DESCRIPTION
red test for #7679 


> The mutex only snapshots the downloader pointer; StatusNode.Stop() then calls downloader.Stop() and closes inputTaskChan while the HTTP server is still serving. An in-flight handleIPFS that already copied the pointer will panic in Get() with send on closed channel.

