### PR TITLE
feat: collect db stats

### DIFF
--- a/internal/signal/events_storage_stats.go
+++ b/internal/signal/events_storage_stats.go
@@ -1,0 +1,45 @@
+package signal
+
+const (
+	// EventStorageStatsProgress is emitted once per collection step.
+	EventStorageStatsProgress = "storage-stats.progress"
+
+	// EventStorageStatsResult is emitted once per collection, with either the
+	// profile or an error.
+	EventStorageStatsResult = "storage-stats.result"
+)
+
+// StorageStatsProgressEvent carries a Total that is final from the first event.
+type StorageStatsProgressEvent struct {
+	RequestID string `json:"requestId"`
+	Step      int    `json:"step"`
+	Total     int    `json:"total"`
+}
+
+// StorageStatsResultEvent carries the finished profile in Data.
+type StorageStatsResultEvent struct {
+	RequestID string      `json:"requestId"`
+	Error     string      `json:"error,omitempty"`
+	Data      interface{} `json:"data,omitempty"`
+}
+
+// SendStorageStatsProgress emits a progress update for a running collection.
+func SendStorageStatsProgress(requestID string, step, total int) {
+	send(EventStorageStatsProgress, StorageStatsProgressEvent{
+		RequestID: requestID,
+		Step:      step,
+		Total:     total,
+	})
+}
+
+// SendStorageStatsResult emits the outcome of a collection.
+func SendStorageStatsResult(requestID string, data interface{}, err error) {
+	event := StorageStatsResultEvent{
+		RequestID: requestID,
+		Data:      data,
+	}
+	if err != nil {
+		event.Error = err.Error()
+	}
+	send(EventStorageStatsResult, event)
+}

--- a/pkg/backend/node/get_status_node.go
+++ b/pkg/backend/node/get_status_node.go
@@ -53,6 +53,7 @@ import (
 	"github.com/status-im/status-go/pkg/services/rpcstats"
 	"github.com/status-im/status-go/pkg/services/sharedurls"
 	"github.com/status-im/status-go/pkg/services/stickers"
+	"github.com/status-im/status-go/pkg/services/storagestats"
 	"github.com/status-im/status-go/pkg/services/updates"
 	"github.com/status-im/status-go/pkg/services/utils"
 	"github.com/status-im/status-go/pkg/services/wakuv2ext"
@@ -126,6 +127,7 @@ type StatusNode struct {
 	newsfeedSrvc           *newsfeed.Service
 	preferencesSrvc        *preferences.Service
 	sharedUrlsSrvc         *sharedurls.Service
+	storageStatsSrvc       *storagestats.Service
 	linkPreviewSrvc        *linkpreview.Service
 
 	walletFeed        event.Feed
@@ -581,6 +583,7 @@ func (n *StatusNode) Stop() error {
 	n.appGeneralSrvc = nil
 	n.newsfeedSrvc = nil
 	n.preferencesSrvc = nil
+	n.storageStatsSrvc = nil
 
 	n.logger.Debug("status node stopped")
 	return errors.Join(errs...)

--- a/pkg/backend/node/status_node_services.go
+++ b/pkg/backend/node/status_node_services.go
@@ -35,6 +35,7 @@ import (
 	"github.com/status-im/status-go/pkg/services/preferences"
 	"github.com/status-im/status-go/pkg/services/rpcstats"
 	"github.com/status-im/status-go/pkg/services/stickers"
+	"github.com/status-im/status-go/pkg/services/storagestats"
 	"github.com/status-im/status-go/pkg/services/updates"
 	"github.com/status-im/status-go/pkg/services/wakuv2ext"
 	"github.com/status-im/status-go/pkg/services/wallet"
@@ -83,6 +84,7 @@ func (b *StatusNode) initServices(config *params.NodeConfig, mediaServer *media.
 	services = appendIf(config.BrowsersConfig.Enabled, services, b.browsersService())
 	services = appendIf(config.PermissionsConfig.Enabled, services, b.permissionsService())
 	services = appendIf(b.appDB != nil, services, b.preferencesService())
+	services = appendIf(b.appDB != nil, services, b.storageStatsService())
 	services = appendIf(config.ConnectorConfig.Enabled, services, b.connectorService())
 	services = append(services, b.gifService(accDB))
 	services = append(services, b.ChatService(accDB))
@@ -305,6 +307,13 @@ func (b *StatusNode) appgeneralService() *appgeneral.Service {
 		b.appGeneralSrvc = appgeneral.New()
 	}
 	return b.appGeneralSrvc
+}
+
+func (b *StatusNode) storageStatsService() *storagestats.Service {
+	if b.storageStatsSrvc == nil {
+		b.storageStatsSrvc = storagestats.New(b.appDB, b.walletDB, b.logger)
+	}
+	return b.storageStatsSrvc
 }
 
 func (b *StatusNode) WalletService() *wallet.Service {

--- a/pkg/services/storagestats/collector.go
+++ b/pkg/services/storagestats/collector.go
@@ -1,0 +1,636 @@
+package storagestats
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"math"
+	"slices"
+	"sort"
+	"strings"
+	"time"
+
+	"go.uber.org/zap"
+)
+
+// Chat types, mirroring protocol.ChatType. Duplicated because importing
+// protocol would pull in the whole messenger and its native waku dependencies.
+const (
+	chatTypeOneToOne         = 1
+	chatTypePublic           = 2
+	chatTypePrivateGroupChat = 3
+	chatTypeCommunityChat    = 6
+)
+
+// Contact request states, mirroring contacts.ContactRequestState.
+const (
+	contactRequestStateSent     = 2
+	contactRequestStateReceived = 3
+)
+
+// ProgressFunc is called once per completed step. total is final from the first
+// call: the table list is enumerated before any counting starts.
+type ProgressFunc func(done, total int)
+
+// migrationTableMarker matches the golang-migrate bookkeeping tables. A file
+// holds one per migration tree, and the marker appears as both prefix and
+// suffix (status_go_schema_migrations, status_schema_migrations_waku), so
+// matching is by substring.
+const migrationTableMarker = "schema_migrations"
+
+// mainMigrationTable owns the database file itself and supplies schemaVersion.
+const mainMigrationTable = "status_go_" + migrationTableMarker
+
+// Collect walks both databases and builds a Profile. It must stay serial and
+// off the caller's thread: COUNT(*) on a sqlcipher table is a full decrypting
+// scan, so parallel steps would starve the rest of the process.
+func Collect(ctx context.Context, appDB, walletDB *sql.DB, now time.Time, logger *zap.Logger, progress ProgressFunc) (*Profile, error) {
+	if appDB == nil {
+		return nil, fmt.Errorf("storagestats: no app database, is an account logged in?")
+	}
+	if logger == nil {
+		logger = zap.NewNop()
+	}
+
+	c := &collector{
+		now:    now,
+		logger: logger,
+		profile: Profile{
+			ProfileVersion: ProfileVersion,
+			Tables: Tables{
+				AppDB:    map[string]TableStats{},
+				WalletDB: map[string]TableStats{},
+			},
+			Incomplete: []string{},
+		},
+	}
+	c.profile.Messaging.PerChatHistogram = newHistogram()
+	c.profile.DB.AppDB.MigrationVersions = map[string]int64{}
+	c.profile.DB.WalletDB.MigrationVersions = map[string]int64{}
+
+	var err error
+	if c.app, err = newScope(ctx, appDB); err != nil {
+		return nil, fmt.Errorf("storagestats: enumerating app database tables: %w", err)
+	}
+	if walletDB != nil {
+		if c.wallet, err = newScope(ctx, walletDB); err != nil {
+			return nil, fmt.Errorf("storagestats: enumerating wallet database tables: %w", err)
+		}
+	}
+
+	steps := c.plan()
+	total := len(steps)
+	for i, step := range steps {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		// One unreadable table must not cost the whole profile; Incomplete is
+		// what distinguishes the resulting 0 from a genuine 0.
+		if err := step.run(ctx); err != nil {
+			c.logger.Warn("storage stats step failed",
+				zap.String("step", step.name), zap.Error(err))
+			c.profile.Incomplete = append(c.profile.Incomplete, step.name)
+		}
+		if progress != nil {
+			progress(i+1, total)
+		}
+	}
+
+	return &c.profile, nil
+}
+
+type collector struct {
+	now     time.Time
+	logger  *zap.Logger
+	app     *scope
+	wallet  *scope
+	profile Profile
+
+	// chatCount places chats with no messages into the first histogram bucket.
+	chatCount int64
+}
+
+type step struct {
+	name string
+	run  func(ctx context.Context) error
+}
+
+func (c *collector) plan() []step {
+	steps := []step{
+		{"messages", c.collectMessages},
+		{"chats", c.collectChats},
+		{"perChatHistogram", c.collectPerChatHistogram},
+		{"communities", c.collectCommunities},
+		{"contacts", c.collectContacts},
+		{"activityCenter", c.collectActivityCenter},
+		{"sync", c.collectSync},
+		{"profileAge", c.collectProfileAge},
+		{"wallet", c.collectWallet},
+		{"appDbPhysical", func(ctx context.Context) error {
+			return c.collectPhysical(ctx, c.app, &c.profile.DB.AppDB, &c.profile.DB.AppDBBytes)
+		}},
+		{"walletDbPhysical", func(ctx context.Context) error {
+			return c.collectPhysical(ctx, c.wallet, &c.profile.DB.WalletDB, &c.profile.DB.WalletDBBytes)
+		}},
+	}
+
+	steps = append(steps, tableSteps(c.app, c.profile.Tables.AppDB)...)
+	steps = append(steps, tableSteps(c.wallet, c.profile.Tables.WalletDB)...)
+	return steps
+}
+
+func tableSteps(s *scope, out map[string]TableStats) []step {
+	if s == nil {
+		return nil
+	}
+	steps := make([]step, 0, len(s.names))
+	for _, name := range s.names {
+		steps = append(steps, step{
+			name: name,
+			run: func(ctx context.Context) error {
+				stats, err := s.tableStats(ctx, name)
+				if err != nil {
+					return err
+				}
+				out[name] = stats
+				return nil
+			},
+		})
+	}
+	return steps
+}
+
+// --- curated metrics --------------------------------------------------------
+
+func (c *collector) collectMessages(ctx context.Context) error {
+	if !c.app.has("user_messages") {
+		return nil
+	}
+	d7 := c.now.AddDate(0, 0, -7).UnixMilli()
+	d30 := c.now.AddDate(0, 0, -30).UnixMilli()
+
+	var total, oldest, tail7, tail30 int64
+	err := c.app.db.QueryRowContext(ctx, `
+		SELECT COUNT(*),
+		       COALESCE(MIN(NULLIF(whisper_timestamp, 0)), 0),
+		       COALESCE(SUM(CASE WHEN whisper_timestamp >= ? THEN 1 ELSE 0 END), 0),
+		       COALESCE(SUM(CASE WHEN whisper_timestamp >= ? THEN 1 ELSE 0 END), 0)
+		FROM user_messages`, d7, d30).Scan(&total, &oldest, &tail7, &tail30)
+	if err != nil {
+		return err
+	}
+
+	c.profile.Messaging.MessagesTotal = total
+	c.profile.Messaging.OldestMessageDays = daysSinceUnixMillis(c.now, oldest)
+	c.profile.Messaging.RecentTailPct = RecentTailPct{
+		D7:  percent(tail7, total),
+		D30: percent(tail30, total),
+	}
+	return nil
+}
+
+func (c *collector) collectChats(ctx context.Context) error {
+	if !c.app.has("chats") {
+		return nil
+	}
+	rows, err := c.app.db.QueryContext(ctx, `SELECT type, COUNT(*) FROM chats GROUP BY type`)
+	if err != nil {
+		return err
+	}
+	defer rows.Close()
+
+	counts := &c.profile.Messaging.Chats
+	for rows.Next() {
+		var chatType, count int64
+		if err := rows.Scan(&chatType, &count); err != nil {
+			return err
+		}
+		c.chatCount += count
+		switch chatType {
+		case chatTypeOneToOne:
+			counts.OneToOne += count
+		case chatTypePublic:
+			counts.Public += count
+		case chatTypePrivateGroupChat:
+			counts.Group += count
+		case chatTypeCommunityChat:
+			counts.CommunityChannels += count
+		default:
+			counts.Other += count
+		}
+	}
+	return rows.Err()
+}
+
+// collectPerChatHistogram selects counts only, never a chat id, so no
+// per-entity data can reach the profile.
+func (c *collector) collectPerChatHistogram(ctx context.Context) error {
+	if !c.app.has("user_messages") {
+		return nil
+	}
+	rows, err := c.app.db.QueryContext(ctx, `SELECT COUNT(*) FROM user_messages GROUP BY local_chat_id`)
+	if err != nil {
+		return err
+	}
+	defer rows.Close()
+
+	histogram := c.profile.Messaging.PerChatHistogram
+	var chatsWithMessages int64
+	for rows.Next() {
+		var count int64
+		if err := rows.Scan(&count); err != nil {
+			return err
+		}
+		chatsWithMessages++
+		histogram.add(count)
+	}
+	if err := rows.Err(); err != nil {
+		return err
+	}
+
+	// Chats with no messages are absent from the GROUP BY but belong in the
+	// distribution.
+	if empty := c.chatCount - chatsWithMessages; empty > 0 {
+		for i := 0; i < int(empty); i++ {
+			histogram.add(0)
+		}
+	}
+	return nil
+}
+
+func (c *collector) collectCommunities(ctx context.Context) error {
+	count, err := c.app.count(ctx, "communities_communities", "")
+	if err != nil {
+		return err
+	}
+	c.profile.Messaging.Communities = count
+	return nil
+}
+
+func (c *collector) collectContacts(ctx context.Context) error {
+	total, err := c.app.count(ctx, "contacts", "")
+	if err != nil {
+		return err
+	}
+	// Mutual means request sent and request received; two separate columns.
+	mutual, err := c.app.count(ctx, "contacts", fmt.Sprintf(
+		"contact_request_state = %d AND contact_request_remote_state = %d",
+		contactRequestStateSent, contactRequestStateReceived))
+	if err != nil {
+		return err
+	}
+	c.profile.Messaging.Contacts = ContactCounts{Total: total, Mutual: mutual}
+	return nil
+}
+
+func (c *collector) collectActivityCenter(ctx context.Context) error {
+	total, err := c.app.count(ctx, "activity_center_notifications", "")
+	if err != nil {
+		return err
+	}
+	unread, err := c.app.count(ctx, "activity_center_notifications", "read = 0")
+	if err != nil {
+		return err
+	}
+	c.profile.Messaging.ActivityCenter = ActivityCenter{Total: total, Unread: unread}
+	return nil
+}
+
+// collectSync measures how far behind the mailserver sync state is.
+func (c *collector) collectSync(ctx context.Context) error {
+	if c.app.has("chats") {
+		rows, err := c.app.db.QueryContext(ctx,
+			`SELECT COALESCE(synced_to, 0) FROM chats WHERE active = 1`)
+		if err != nil {
+			return err
+		}
+		defer rows.Close()
+
+		var gaps []int64
+		var max, neverSynced int64
+		for rows.Next() {
+			var syncedTo int64
+			if err := rows.Scan(&syncedTo); err != nil {
+				return err
+			}
+			// Never-synced chats have no gap to measure; counting them
+			// separately keeps max/median comparable across profiles.
+			if syncedTo <= 0 {
+				neverSynced++
+				continue
+			}
+			gap := daysSinceUnixSeconds(c.now, syncedTo)
+			gaps = append(gaps, gap)
+			if gap > max {
+				max = gap
+			}
+		}
+		if err := rows.Err(); err != nil {
+			return err
+		}
+		c.profile.Sync.MaxSyncGapDays = max
+		c.profile.Sync.MedianSyncGapDays = median(gaps)
+		c.profile.Sync.NeverSyncedChats = neverSynced
+	}
+
+	// mailserver_topics is the persisted content-topic set.
+	filters, err := c.app.count(ctx, "mailserver_topics", "")
+	if err != nil {
+		return err
+	}
+	c.profile.Sync.WakuFilters = filters
+
+	installations, err := c.app.count(ctx, "installations", "deleted = 0")
+	if err != nil {
+		return err
+	}
+	c.profile.Sync.Installations = installations
+	return nil
+}
+
+// collectProfileAge dates the profile from its oldest wallet account.
+func (c *collector) collectProfileAge(ctx context.Context) error {
+	if !c.app.has("keypairs_accounts") {
+		return nil
+	}
+	// created_at is datetime('now') text; the second branch covers older rows
+	// written as raw unix seconds.
+	var createdAt sql.NullInt64
+	err := c.app.db.QueryRowContext(ctx, `
+		SELECT MIN(COALESCE(
+			CAST(strftime('%s', created_at) AS INTEGER),
+			CAST(created_at AS INTEGER)
+		)) FROM keypairs_accounts`).Scan(&createdAt)
+	if err != nil {
+		return err
+	}
+	if createdAt.Valid {
+		c.profile.ProfileAgeDays = daysSinceUnixSeconds(c.now, createdAt.Int64)
+	}
+	return nil
+}
+
+func (c *collector) collectWallet(ctx context.Context) error {
+	// Every counter is collected even if an earlier one failed - partial data
+	// beats none - but the errors are returned so the step lands in Incomplete.
+	var errs []error
+
+	// Wallet accounts live in the app database. The filter matches the one the
+	// rest of status-go lists accounts with, excluding chat and removed rows.
+	accounts, err := c.app.count(ctx, "keypairs_accounts", "chat = 0 AND removed = 0")
+	if err != nil {
+		errs = append(errs, err)
+	}
+	c.profile.Wallet.Accounts = accounts
+
+	for _, m := range []struct {
+		table string
+		out   *int64
+	}{
+		{"collectibles_ownership_cache", &c.profile.Wallet.Collectibles},
+		{"token_balances", &c.profile.Wallet.TokenBalanceRows},
+		{"tokens", &c.profile.Wallet.CustomTokens},
+		{"fetched_alchemy_transfers", &c.profile.Wallet.ActivityRows},
+		{"saved_addresses", &c.profile.Wallet.SavedAddresses},
+	} {
+		// A wallet database that has no such table has been renamed or migrated
+		// under us; reporting 0 would read as "this account has none".
+		if c.wallet != nil && !c.wallet.has(m.table) {
+			errs = append(errs, fmt.Errorf("wallet table %s is missing", m.table))
+			continue
+		}
+		count, err := c.wallet.count(ctx, m.table, "")
+		if err != nil {
+			errs = append(errs, err)
+			continue
+		}
+		*m.out = count
+	}
+	return errors.Join(errs...)
+}
+
+func (c *collector) collectPhysical(ctx context.Context, s *scope, out *DBFile, bytes *int64) error {
+	if s == nil {
+		return nil
+	}
+	out.MigrationVersions = map[string]int64{}
+
+	var errs []error
+	for _, p := range []struct {
+		pragma string
+		out    *int64
+	}{
+		{"page_count", &out.PageCount},
+		{"page_size", &out.PageSize},
+		{"freelist_count", &out.FreelistCount},
+	} {
+		var value int64
+		if err := s.db.QueryRowContext(ctx, "PRAGMA "+p.pragma).Scan(&value); err != nil {
+			errs = append(errs, fmt.Errorf("reading pragma %s: %w", p.pragma, err))
+			continue
+		}
+		*p.out = value
+	}
+	*bytes = out.PageCount * out.PageSize
+
+	for _, name := range s.names {
+		if !strings.Contains(name, migrationTableMarker) {
+			continue
+		}
+		var version sql.NullInt64
+		if err := s.db.QueryRowContext(ctx, `SELECT MAX(version) FROM "`+name+`"`).Scan(&version); err != nil {
+			errs = append(errs, fmt.Errorf("reading migration version of %s: %w", name, err))
+			continue
+		}
+		if version.Valid {
+			out.MigrationVersions[name] = version.Int64
+		}
+	}
+	// The status_go_ table is this file's own tree; the rest share the file.
+	out.SchemaVersion = out.MigrationVersions[mainMigrationTable]
+	return errors.Join(errs...)
+}
+
+// --- generic per-table walk -------------------------------------------------
+
+// scope is one database plus the tables it actually has, so a query against a
+// missing table is skipped rather than failed.
+type scope struct {
+	db     *sql.DB
+	names  []string
+	lookup map[string]struct{}
+}
+
+func newScope(ctx context.Context, db *sql.DB) (*scope, error) {
+	rows, err := db.QueryContext(ctx,
+		`SELECT name FROM sqlite_master WHERE type = 'table' AND name NOT LIKE 'sqlite_%'`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	s := &scope{db: db, lookup: map[string]struct{}{}}
+	for rows.Next() {
+		var name string
+		if err := rows.Scan(&name); err != nil {
+			return nil, err
+		}
+		s.names = append(s.names, name)
+		s.lookup[name] = struct{}{}
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	sort.Strings(s.names)
+	return s, nil
+}
+
+func (s *scope) has(name string) bool {
+	if s == nil {
+		return false
+	}
+	_, ok := s.lookup[name]
+	return ok
+}
+
+// count returns COUNT(*) for a table, or 0 when the table is absent.
+func (s *scope) count(ctx context.Context, table, where string) (int64, error) {
+	if !s.has(table) {
+		return 0, nil
+	}
+	query := `SELECT COUNT(*) FROM "` + table + `"`
+	if where != "" {
+		query += " WHERE " + where
+	}
+	var count int64
+	if err := s.db.QueryRowContext(ctx, query).Scan(&count); err != nil {
+		return 0, fmt.Errorf("counting %s: %w", table, err)
+	}
+	return count, nil
+}
+
+// tableStats returns row count and summed payload length in a single scan.
+// Bytes is a logical size, not the on-disk footprint: our sqlcipher build has
+// no dbstat virtual table.
+func (s *scope) tableStats(ctx context.Context, table string) (TableStats, error) {
+	columns, err := s.columns(ctx, table)
+	if err != nil {
+		return TableStats{}, err
+	}
+	if len(columns) == 0 {
+		return TableStats{}, nil
+	}
+
+	lengths := make([]string, 0, len(columns))
+	for _, column := range columns {
+		// CAST to BLOB makes LENGTH count bytes, not characters; COALESCE keeps
+		// a NULL from voiding the whole sum.
+		lengths = append(lengths, `COALESCE(LENGTH(CAST("`+column+`" AS BLOB)), 0)`)
+	}
+
+	var stats TableStats
+	query := `SELECT COUNT(*), COALESCE(SUM(` + strings.Join(lengths, " + ") + `), 0) FROM "` + table + `"`
+	if err := s.db.QueryRowContext(ctx, query).Scan(&stats.Rows, &stats.Bytes); err != nil {
+		return TableStats{}, fmt.Errorf("measuring %s: %w", table, err)
+	}
+	return stats, nil
+}
+
+func (s *scope) columns(ctx context.Context, table string) ([]string, error) {
+	rows, err := s.db.QueryContext(ctx, `SELECT name FROM pragma_table_info(?)`, table)
+	if err != nil {
+		return nil, fmt.Errorf("listing columns of %s: %w", table, err)
+	}
+	defer rows.Close()
+
+	var columns []string
+	for rows.Next() {
+		var name string
+		if err := rows.Scan(&name); err != nil {
+			return nil, err
+		}
+		columns = append(columns, name)
+	}
+	return columns, rows.Err()
+}
+
+// --- helpers ----------------------------------------------------------------
+
+// bucketBounds are part of the artifact contract: changing them requires
+// bumping ProfileVersion.
+var bucketBounds = []struct {
+	label string
+	from  int64
+	to    int64 // exclusive; math.MaxInt64 for the open-ended last bucket
+}{
+	{"0-9", 0, 10},
+	{"10-99", 10, 100},
+	{"100-999", 100, 1000},
+	{"1000-9999", 1000, 10000},
+	{"10000+", 10000, math.MaxInt64},
+}
+
+// newHistogram returns every bucket, empty, so the artifact's shape does not
+// depend on the data.
+func newHistogram() Histogram {
+	h := make(Histogram, 0, len(bucketBounds))
+	for _, b := range bucketBounds {
+		h = append(h, Bucket{Label: b.label})
+	}
+	return h
+}
+
+// add places one chat, holding count messages, into its bucket.
+func (h Histogram) add(count int64) {
+	for i, b := range bucketBounds {
+		if count >= b.from && count < b.to {
+			h[i].Chats++
+			return
+		}
+	}
+}
+
+// daysSince returns whole days elapsed, clamped at 0 for future timestamps.
+func daysSince(now time.Time, then time.Time) int64 {
+	if then.IsZero() || then.After(now) {
+		return 0
+	}
+	return int64(now.Sub(then).Hours() / 24)
+}
+
+func daysSinceUnixSeconds(now time.Time, seconds int64) int64 {
+	if seconds <= 0 {
+		return 0
+	}
+	return daysSince(now, time.Unix(seconds, 0))
+}
+
+// Message timestamps in the protocol database are milliseconds.
+func daysSinceUnixMillis(now time.Time, millis int64) int64 {
+	if millis <= 0 {
+		return 0
+	}
+	return daysSince(now, time.UnixMilli(millis))
+}
+
+// percent returns part/total in whole percent, 0 when total is 0.
+func percent(part, total int64) int64 {
+	if total <= 0 {
+		return 0
+	}
+	return int64(math.Round(float64(part) * 100 / float64(total)))
+}
+
+// median returns the median of values, which it sorts in place.
+func median(values []int64) int64 {
+	if len(values) == 0 {
+		return 0
+	}
+	slices.Sort(values)
+	mid := len(values) / 2
+	if len(values)%2 == 1 {
+		return values[mid]
+	}
+	return (values[mid-1] + values[mid]) / 2
+}

--- a/pkg/services/storagestats/collector_test.go
+++ b/pkg/services/storagestats/collector_test.go
@@ -1,0 +1,430 @@
+package storagestats
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"github.com/status-im/status-go/internal/db/appdatabase"
+	"github.com/status-im/status-go/internal/db/walletdatabase"
+	protocolsqlite "github.com/status-im/status-go/internal/protocol/sqlite"
+	"github.com/status-im/status-go/internal/testutils"
+)
+
+// collectedAt pins "now" so that every day count in the assertions is exact.
+var collectedAt = time.Date(2026, 8, 19, 12, 0, 0, 0, time.UTC)
+
+func setupAppDB(t *testing.T) *sql.DB {
+	db, cleanup, err := testutils.SetupTestSQLDB(appdatabase.DbInitializer{}, "storage-stats-app-")
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, cleanup()) })
+
+	// The protocol tables (chats, messages, contacts, ...) live in the app
+	// database file but are migrated by the messenger, not by appdatabase.
+	require.NoError(t, protocolsqlite.Migrate(db))
+	return db
+}
+
+func setupWalletDB(t *testing.T) *sql.DB {
+	db, cleanup, err := testutils.SetupTestSQLDB(walletdatabase.DbInitializer{}, "storage-stats-wallet-")
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, cleanup()) })
+	return db
+}
+
+func exec(t *testing.T, db *sql.DB, query string, args ...interface{}) {
+	t.Helper()
+	_, err := db.Exec(query, args...)
+	require.NoError(t, err, query)
+}
+
+// seedAccount writes an account whose shape is known exactly, so that the
+// assertions below can be literal numbers rather than recomputed formulas.
+func seedAccount(t *testing.T, appDB, walletDB *sql.DB) {
+	daysAgoSeconds := func(days int) int64 { return collectedAt.AddDate(0, 0, -days).Unix() }
+	// The same text format sqlite's datetime('now') produces, but pinned to
+	// collectedAt so the assertions do not drift with wall-clock time.
+	daysAgoDatetime := func(days int) string {
+		return collectedAt.AddDate(0, 0, -days).UTC().Format("2006-01-02 15:04:05")
+	}
+	daysAgoMillis := func(days int) int64 { return collectedAt.AddDate(0, 0, -days).UnixMilli() }
+
+	// 11 chats: 3 one-to-one, 2 public, 1 group, 4 community channels and one
+	// deprecated profile chat that must land in "other".
+	chatTypes := []int{1, 1, 1, 2, 2, 3, 6, 6, 6, 6, 4}
+	// Three chats carry a sync position; the rest have never synced.
+	syncedToDaysAgo := map[int]int{0: 10, 1: 60, 2: 20}
+	for i, chatType := range chatTypes {
+		syncedTo := int64(0)
+		if days, ok := syncedToDaysAgo[i]; ok {
+			syncedTo = daysAgoSeconds(days)
+		}
+		exec(t, appDB,
+			`INSERT INTO chats (id, name, type, active, timestamp, synced_to) VALUES (?, ?, ?, 1, ?, ?)`,
+			fmt.Sprintf("chat-%d", i), fmt.Sprintf("chat %d", i), chatType, daysAgoMillis(400), syncedTo)
+	}
+
+	// 200 messages over three chats: 5, 15 and 180. The remaining eight chats
+	// hold none, which is exactly the case a GROUP BY cannot see.
+	messageID := 0
+	insertMessages := func(chatID string, count int, ageDays int) {
+		for i := 0; i < count; i++ {
+			messageID++
+			exec(t, appDB, `
+				INSERT INTO user_messages
+					(id, whisper_timestamp, source, text, content_type, timestamp, chat_id, local_chat_id, clock_value, seen)
+				VALUES (?, ?, 'source', 'text', 1, ?, ?, ?, ?, 1)`,
+				fmt.Sprintf("msg-%d", messageID), daysAgoMillis(ageDays), daysAgoMillis(ageDays),
+				chatID, chatID, messageID)
+		}
+	}
+	// 20 messages in the last 7 days, 20 more inside 30 days, the rest older,
+	// and the oldest message exactly 370 days back.
+	insertMessages("chat-0", 5, 3)
+	insertMessages("chat-1", 15, 3)
+	insertMessages("chat-2", 20, 20)
+	insertMessages("chat-2", 159, 200)
+	insertMessages("chat-2", 1, 370)
+
+	for i := 0; i < 5; i++ {
+		// Two of the five contacts are mutual: request sent and received.
+		requestState, remoteState := 0, 0
+		if i < 2 {
+			requestState, remoteState = contactRequestStateSent, contactRequestStateReceived
+		}
+		exec(t, appDB, `
+			INSERT INTO contacts (id, address, name, alias, identicon, photo, tribute_to_talk,
+				contact_request_state, contact_request_remote_state)
+			VALUES (?, '', '', '', '', '', '', ?, ?)`,
+			fmt.Sprintf("contact-%d", i), requestState, remoteState)
+	}
+
+	for i := 0; i < 7; i++ {
+		read := 1
+		if i < 3 {
+			read = 0
+		}
+		exec(t, appDB, `
+			INSERT INTO activity_center_notifications (id, timestamp, notification_type, read)
+			VALUES (?, ?, 1, ?)`, fmt.Sprintf("notification-%d", i), daysAgoMillis(1), read)
+	}
+
+	for i := 0; i < 2; i++ {
+		exec(t, appDB, `INSERT INTO communities_communities (id, private_key, description) VALUES (?, '', '')`,
+			[]byte(fmt.Sprintf("community-%d", i)))
+	}
+
+	// Wallet accounts live in the app database; the oldest one dates the
+	// profile. created_at must be seeded the way production writes it -
+	// datetime('now') text, not unix seconds - or the test cannot catch a
+	// profile-age query that only works on numbers.
+	exec(t, appDB, `INSERT INTO keypairs (key_uid, name, type) VALUES ('key-uid', 'profile', 'profile')`)
+	accounts := []struct {
+		chat    int
+		removed int
+		ageDays int
+	}{
+		{chat: 1, removed: 0, ageDays: 400}, // the chat account, created with the profile
+		{chat: 0, removed: 0, ageDays: 390},
+		{chat: 0, removed: 0, ageDays: 380},
+		{chat: 0, removed: 1, ageDays: 370}, // soft-deleted, must not be counted
+	}
+	for i, a := range accounts {
+		exec(t, appDB, `
+			INSERT INTO keypairs_accounts (address, key_uid, pubkey, path, name, color, emoji,
+				wallet, chat, removed, hidden, operable, created_at, updated_at)
+			VALUES (?, 'key-uid', '', '', '', '', '', 0, ?, ?, 0, 'fully', ?, ?)`,
+			fmt.Sprintf("0xaddress-%d", i), a.chat, a.removed,
+			daysAgoDatetime(a.ageDays), daysAgoDatetime(0))
+	}
+
+	// The transport and encryption migration trees share the app database file.
+	for i := 0; i < 2; i++ {
+		exec(t, appDB, `
+			INSERT INTO installations (identity, installation_id, timestamp, enabled)
+			VALUES (?, ?, ?, 1)`, []byte("identity"), fmt.Sprintf("installation-%d", i), daysAgoSeconds(1))
+	}
+	for i := 0; i < 6; i++ {
+		exec(t, appDB, `INSERT INTO mailserver_topics (topic, chat_ids) VALUES (?, '')`,
+			fmt.Sprintf("0x0000000%d", i))
+	}
+
+	for i := 0; i < 4; i++ {
+		exec(t, walletDB, `
+			INSERT INTO collectibles_ownership_cache (chain_id, contract_address, token_id, owner_address)
+			VALUES (1, ?, ?, '0xowner')`, fmt.Sprintf("0xcontract-%d", i), []byte{byte(i)})
+	}
+	for i := 0; i < 9; i++ {
+		exec(t, walletDB, `
+			INSERT INTO token_balances (user_address, token_address, balance, chain_id)
+			VALUES (?, '0xtoken', '1', ?)`, "0xuser", i)
+	}
+	for i := 0; i < 3; i++ {
+		exec(t, walletDB, `
+			INSERT INTO tokens (address, network_id, name, symbol, decimals)
+			VALUES (?, 1, 'Token', ?, 18)`, fmt.Sprintf("0xcustom-%d", i), fmt.Sprintf("TKN%d", i))
+	}
+	for i := 0; i < 12; i++ {
+		exec(t, walletDB, `
+			INSERT INTO fetched_alchemy_transfers (transfer, chain_id, address)
+			VALUES (?, 1, ?)`, fmt.Sprintf(`{"hash":"0x%d"}`, i), []byte("0xaddress"))
+	}
+	for i := 0; i < 2; i++ {
+		exec(t, walletDB, `
+			INSERT INTO saved_addresses (address, name, is_test) VALUES (?, ?, 0)`,
+			fmt.Sprintf("0xsaved-%d", i), fmt.Sprintf("saved %d", i))
+	}
+}
+
+func TestCollectProducesTheExpectedProfile(t *testing.T) {
+	appDB := setupAppDB(t)
+	walletDB := setupWalletDB(t)
+	seedAccount(t, appDB, walletDB)
+
+	profile, err := Collect(context.Background(), appDB, walletDB, collectedAt, zap.NewNop(), nil)
+	require.NoError(t, err)
+
+	require.Equal(t, ProfileVersion, profile.ProfileVersion)
+
+	m := profile.Messaging
+	require.Equal(t, int64(200), m.MessagesTotal)
+	require.Equal(t, ChatCounts{OneToOne: 3, Public: 2, Group: 1, CommunityChannels: 4, Other: 1}, m.Chats)
+	require.Equal(t, int64(2), m.Communities)
+	require.Equal(t, ContactCounts{Total: 5, Mutual: 2}, m.Contacts)
+	require.Equal(t, ActivityCenter{Total: 7, Unread: 3}, m.ActivityCenter)
+	require.Equal(t, int64(370), m.OldestMessageDays)
+	require.Equal(t, RecentTailPct{D7: 10, D30: 20}, m.RecentTailPct)
+
+	require.Equal(t, Histogram{
+		{Label: "0-9", Chats: 9}, // one chat with 5 messages plus the eight empty ones
+		{Label: "10-99", Chats: 1},
+		{Label: "100-999", Chats: 1},
+		{Label: "1000-9999", Chats: 0},
+		{Label: "10000+", Chats: 0},
+	}, m.PerChatHistogram)
+
+	require.Equal(t, Sync{
+		MaxSyncGapDays:    60,
+		MedianSyncGapDays: 20,
+		// 11 active chats, 3 of which carry a sync position.
+		NeverSyncedChats: 8,
+		WakuFilters:      6,
+		Installations:    2,
+	}, profile.Sync)
+
+	// created_at is seeded as datetime text; a query that cannot read that
+	// format reports 0, which would read as "profile created today".
+	require.Equal(t, int64(400), profile.ProfileAgeDays)
+
+	// Every wallet counter has to be wired to a table that actually exists;
+	// a renamed table would otherwise report a silent, plausible zero.
+	require.Equal(t, Wallet{
+		Accounts:         2,
+		Collectibles:     4,
+		TokenBalanceRows: 9,
+		CustomTokens:     3,
+		ActivityRows:     12,
+		SavedAddresses:   2,
+	}, profile.Wallet)
+
+	require.Positive(t, profile.DB.AppDBBytes)
+	require.Positive(t, profile.DB.AppDB.PageCount)
+	require.Positive(t, profile.DB.AppDB.PageSize)
+	require.Positive(t, profile.DB.AppDB.SchemaVersion)
+	require.Contains(t, profile.DB.AppDB.MigrationVersions, "status_go_schema_migrations")
+	// The app database file is shared by several migration trees, and their
+	// table names both prefix and suffix the marker.
+	require.Contains(t, profile.DB.AppDB.MigrationVersions, "status_protocol_go_schema_migrations")
+	require.Contains(t, profile.DB.AppDB.MigrationVersions, "status_schema_migrations_transport")
+	require.Contains(t, profile.DB.AppDB.MigrationVersions, "mvds_schema_migrations")
+	require.Positive(t, profile.DB.WalletDBBytes)
+
+	// Section 2 must cover every table in both files, blob weight included.
+	require.Equal(t, int64(200), profile.Tables.AppDB["user_messages"].Rows)
+	require.Positive(t, profile.Tables.AppDB["user_messages"].Bytes)
+	require.Equal(t, int64(11), profile.Tables.AppDB["chats"].Rows)
+	require.Equal(t, int64(4), profile.Tables.WalletDB["collectibles_ownership_cache"].Rows)
+	require.Greater(t, len(profile.Tables.AppDB), 50)
+	require.Greater(t, len(profile.Tables.WalletDB), 20)
+}
+
+// The artifact a reporter pastes into a ticket and the data the UI drew must be
+// the same profile.
+func TestCollectedProfileSurvivesTheJSONRoundTrip(t *testing.T) {
+	appDB := setupAppDB(t)
+	walletDB := setupWalletDB(t)
+	seedAccount(t, appDB, walletDB)
+
+	profile, err := Collect(context.Background(), appDB, walletDB, collectedAt, zap.NewNop(), nil)
+	require.NoError(t, err)
+
+	rendered, err := json.Marshal(profile)
+	require.NoError(t, err)
+
+	var parsed Profile
+	require.NoError(t, json.Unmarshal(rendered, &parsed))
+	require.Equal(t, *profile, parsed)
+}
+
+func TestCollectReportsDeterministicProgress(t *testing.T) {
+	appDB := setupAppDB(t)
+	walletDB := setupWalletDB(t)
+
+	var steps []int
+	var totals []int
+	_, err := Collect(context.Background(), appDB, walletDB, collectedAt, zap.NewNop(),
+		func(done, total int) {
+			steps = append(steps, done)
+			totals = append(totals, total)
+		})
+	require.NoError(t, err)
+
+	require.NotEmpty(t, steps)
+	for i, done := range steps {
+		require.Equal(t, i+1, done, "progress must be reported once per step, in order")
+		require.Equal(t, totals[0], totals[i], "the total must be known upfront and never move")
+	}
+	require.Equal(t, len(steps), totals[0])
+}
+
+func TestCollectSurvivesAWalletDatabaseThatIsNotThere(t *testing.T) {
+	appDB := setupAppDB(t)
+	seedAccount(t, appDB, setupWalletDB(t))
+
+	profile, err := Collect(context.Background(), appDB, nil, collectedAt, zap.NewNop(), nil)
+	require.NoError(t, err)
+
+	require.Equal(t, int64(200), profile.Messaging.MessagesTotal)
+	require.Equal(t, Wallet{Accounts: 2}, profile.Wallet,
+		"with no wallet database only the app-database-backed counter survives")
+	require.Empty(t, profile.Tables.WalletDB)
+	require.Equal(t, int64(0), profile.DB.WalletDBBytes)
+}
+
+func TestCollectRefusesWithoutAnAppDatabase(t *testing.T) {
+	_, err := Collect(context.Background(), nil, nil, collectedAt, zap.NewNop(), nil)
+	require.Error(t, err)
+}
+
+func TestCollectStopsWhenTheContextIsCancelled(t *testing.T) {
+	appDB := setupAppDB(t)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := Collect(ctx, appDB, nil, collectedAt, zap.NewNop(), nil)
+	require.ErrorIs(t, err, context.Canceled)
+}
+
+// A step that fails must say so. Without this the fields it feeds stay at zero,
+// and a zero nobody flagged reads as "this account has none" - which is exactly
+// how a table renamed out from under us stays invisible in a ticket.
+func TestCollectNamesTheStepsThatFailed(t *testing.T) {
+	appDB := setupAppDB(t)
+	seedAccount(t, appDB, setupWalletDB(t))
+
+	// The sync step counts installations with `deleted = 0`; removing the
+	// column makes that query fail the way a schema change would.
+	exec(t, appDB, `ALTER TABLE installations DROP COLUMN deleted`)
+
+	profile, err := Collect(context.Background(), appDB, nil, collectedAt, zap.NewNop(), nil)
+	require.NoError(t, err, "one broken step must not cost the whole profile")
+
+	require.Contains(t, profile.Incomplete, "sync")
+	require.Equal(t, int64(0), profile.Sync.Installations)
+	// Everything else still has to be collected.
+	require.Equal(t, int64(200), profile.Messaging.MessagesTotal)
+}
+
+func TestCollectReportsNothingIncompleteOnAHealthyAccount(t *testing.T) {
+	appDB := setupAppDB(t)
+	walletDB := setupWalletDB(t)
+	seedAccount(t, appDB, walletDB)
+
+	profile, err := Collect(context.Background(), appDB, walletDB, collectedAt, zap.NewNop(), nil)
+	require.NoError(t, err)
+	require.Empty(t, profile.Incomplete)
+	require.NotNil(t, profile.Incomplete, "the field must always be present, empty or not")
+}
+
+func TestHistogramBucketsChatsByMessageCount(t *testing.T) {
+	h := newHistogram()
+	for _, count := range []int64{0, 5, 9, 10, 99, 100, 999, 1000, 9999, 10_000, 250_000} {
+		h.add(count)
+	}
+
+	require.Equal(t, Histogram{
+		{Label: "0-9", Chats: 3},
+		{Label: "10-99", Chats: 2},
+		{Label: "100-999", Chats: 2},
+		{Label: "1000-9999", Chats: 2},
+		{Label: "10000+", Chats: 2},
+	}, h)
+}
+
+func TestDaysAreRelativeAndNeverNegative(t *testing.T) {
+	now := time.Date(2026, 8, 19, 12, 0, 0, 0, time.UTC)
+
+	require.Equal(t, int64(10), daysSinceUnixSeconds(now, now.AddDate(0, 0, -10).Unix()))
+	require.Equal(t, int64(0), daysSinceUnixSeconds(now, 0))
+	require.Equal(t, int64(0), daysSinceUnixSeconds(now, now.AddDate(0, 0, 5).Unix()),
+		"a clock skewed into the future must not produce a negative age")
+	require.Equal(t, int64(370), daysSinceUnixMillis(now, now.AddDate(0, 0, -370).UnixMilli()))
+}
+
+func TestPercentAndMedian(t *testing.T) {
+	require.Equal(t, int64(0), percent(5, 0))
+	require.Equal(t, int64(5), percent(5, 100))
+	require.Equal(t, int64(33), percent(1, 3))
+
+	require.Equal(t, int64(0), median(nil))
+	require.Equal(t, int64(3), median([]int64{5, 1, 3}))
+	require.Equal(t, int64(4), median([]int64{1, 3, 5, 7}))
+}
+
+// A chat that has never synced is the #21605 condition, and it has no gap to
+// average into max/median - so it has to be counted separately rather than
+// disappearing into a healthy-looking 0.
+func TestCollectCountsNeverSyncedChatsSeparately(t *testing.T) {
+	appDB := setupAppDB(t)
+	seedAccount(t, appDB, setupWalletDB(t))
+
+	// Wipe every sync position: the account is now entirely unsynced.
+	exec(t, appDB, `UPDATE chats SET synced_to = 0`)
+
+	profile, err := Collect(context.Background(), appDB, nil, collectedAt, zap.NewNop(), nil)
+	require.NoError(t, err)
+
+	require.Equal(t, int64(11), profile.Sync.NeverSyncedChats)
+	require.Equal(t, int64(0), profile.Sync.MaxSyncGapDays,
+		"max/median stay over synced chats only")
+	require.Equal(t, int64(0), profile.Sync.MedianSyncGapDays)
+	require.NotContains(t, profile.Incomplete, "sync")
+}
+
+// A wallet table renamed out from under us must not read as "this account has
+// no collectibles": the step has to name itself in Incomplete.
+func TestCollectFlagsAMissingWalletTable(t *testing.T) {
+	appDB := setupAppDB(t)
+	walletDB := setupWalletDB(t)
+	seedAccount(t, appDB, walletDB)
+
+	exec(t, walletDB, `ALTER TABLE collectibles_ownership_cache RENAME TO collectibles_ownership_cache_v2`)
+
+	profile, err := Collect(context.Background(), appDB, walletDB, collectedAt, zap.NewNop(), nil)
+	require.NoError(t, err, "a missing table must not fail the whole profile")
+
+	require.Contains(t, profile.Incomplete, "wallet")
+	require.Equal(t, int64(0), profile.Wallet.Collectibles)
+	// The other counters are still collected: partial data beats none.
+	require.Equal(t, int64(9), profile.Wallet.TokenBalanceRows)
+	require.Equal(t, int64(2), profile.Wallet.SavedAddresses)
+	// And the renamed table is still visible in the generic walk.
+	require.Equal(t, int64(4), profile.Tables.WalletDB["collectibles_ownership_cache_v2"].Rows)
+}

--- a/pkg/services/storagestats/profile.go
+++ b/pkg/services/storagestats/profile.go
@@ -1,0 +1,136 @@
+// Package storagestats collects an "account load profile": the quantitative
+// shape of the logged-in account's databases, safe to paste into a public bug
+// report.
+//
+// The profile must stay publishable, so new fields have to keep these rules:
+// time only as relative day counts, no per-entity rows (aggregates and
+// histograms only), and no strings other than table names from our own schema.
+package storagestats
+
+// ProfileVersion must be bumped when a field's meaning or a histogram bucket
+// boundary changes.
+const ProfileVersion = 1
+
+// Profile is serialised as JSON: the UI renders it and the reporter pastes the
+// same bytes into a ticket.
+type Profile struct {
+	ProfileVersion int `json:"profileVersion"`
+
+	// ProfileAgeDays is derived from the oldest wallet account.
+	ProfileAgeDays int64 `json:"profileAgeDays"`
+
+	// Incomplete names the steps that hit an error, including a step whose
+	// table has been renamed away. Fields fed by a listed step may read 0
+	// because they could not be measured; fields of unlisted steps are real.
+	Incomplete []string `json:"incomplete"`
+
+	Messaging Messaging `json:"messaging"`
+	Sync      Sync      `json:"sync"`
+	Wallet    Wallet    `json:"wallet"`
+	DB        DB        `json:"db"`
+	Tables    Tables    `json:"tables"`
+}
+
+// Messaging field names mirror the seeder harness knobs, so a profile maps 1:1
+// onto a seeder run.
+type Messaging struct {
+	MessagesTotal     int64          `json:"messagesTotal"`
+	Chats             ChatCounts     `json:"chats"`
+	Communities       int64          `json:"communities"`
+	Contacts          ContactCounts  `json:"contacts"`
+	ActivityCenter    ActivityCenter `json:"activityCenter"`
+	OldestMessageDays int64          `json:"oldestMessageDays"`
+	// RecentTailPct is the share of all messages in the last 7 / 30 days, in
+	// whole percent (the seeder's `tailpct` knob).
+	RecentTailPct    RecentTailPct `json:"recentTailPct"`
+	PerChatHistogram Histogram     `json:"perChatHistogram"`
+}
+
+// ChatCounts breaks chats down by protocol chat type; Other catches the
+// deprecated profile/timeline types and any type added later.
+type ChatCounts struct {
+	OneToOne          int64 `json:"oneToOne"`
+	Public            int64 `json:"public"`
+	Group             int64 `json:"group"`
+	CommunityChannels int64 `json:"communityChannels"`
+	Other             int64 `json:"other"`
+}
+
+// ContactCounts counts rows in the contacts table, not the UI's contact list.
+type ContactCounts struct {
+	Total  int64 `json:"total"`
+	Mutual int64 `json:"mutual"`
+}
+
+// ActivityCenter counts all notification rows, dismissed and deleted included.
+type ActivityCenter struct {
+	Total  int64 `json:"total"`
+	Unread int64 `json:"unread"`
+}
+
+type RecentTailPct struct {
+	D7  int64 `json:"d7"`
+	D30 int64 `json:"d30"`
+}
+
+// Sync describes how far behind the local mailserver sync state is.
+type Sync struct {
+	// MaxSyncGapDays and MedianSyncGapDays cover only chats that have synced at
+	// least once; NeverSyncedChats counts the active chats they exclude.
+	MaxSyncGapDays    int64 `json:"maxSyncGapDays"`
+	MedianSyncGapDays int64 `json:"medianSyncGapDays"`
+	NeverSyncedChats  int64 `json:"neverSyncedChats"`
+	// WakuFilters is the row count of mailserver_topics.
+	WakuFilters   int64 `json:"wakuFilters"`
+	Installations int64 `json:"installations"`
+}
+
+type Wallet struct {
+	Accounts         int64 `json:"accounts"`
+	Collectibles     int64 `json:"collectibles"`
+	TokenBalanceRows int64 `json:"tokenBalanceRows"`
+	CustomTokens     int64 `json:"customTokens"`
+	ActivityRows     int64 `json:"activityRows"`
+	SavedAddresses   int64 `json:"savedAddresses"`
+}
+
+// DB is the physical shape of the two database files.
+type DB struct {
+	AppDBBytes    int64  `json:"appDbBytes"`
+	WalletDBBytes int64  `json:"walletDbBytes"`
+	AppDB         DBFile `json:"appDb"`
+	WalletDB      DBFile `json:"walletDb"`
+}
+
+// DBFile describes one sqlite file. MigrationVersions maps each migration table
+// in the file to its applied version.
+type DBFile struct {
+	PageCount         int64            `json:"pageCount"`
+	PageSize          int64            `json:"pageSize"`
+	FreelistCount     int64            `json:"freelistCount"`
+	SchemaVersion     int64            `json:"schemaVersion"`
+	MigrationVersions map[string]int64 `json:"migrationVersions"`
+}
+
+// TableStats holds one table's row count and Bytes, the summed logical length
+// of every column value - not the on-disk page footprint.
+type TableStats struct {
+	Rows  int64 `json:"rows"`
+	Bytes int64 `json:"bytes"`
+}
+
+// Tables covers every table in both databases, so a surprise in an unforeseen
+// table is still visible.
+type Tables struct {
+	AppDB    map[string]TableStats `json:"appDb"`
+	WalletDB map[string]TableStats `json:"walletDb"`
+}
+
+// Bucket is one column of the per-chat histogram.
+type Bucket struct {
+	Label string `json:"bucket"`
+	Chats int64  `json:"chats"`
+}
+
+// Histogram keeps its buckets in bucketBounds order.
+type Histogram []Bucket

--- a/pkg/services/storagestats/service.go
+++ b/pkg/services/storagestats/service.go
@@ -1,0 +1,166 @@
+package storagestats
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+	"go.uber.org/zap"
+
+	"github.com/ethereum/go-ethereum/rpc"
+
+	"github.com/status-im/status-go/internal/panics"
+	"github.com/status-im/status-go/internal/signal"
+)
+
+var (
+	// ErrNoAccount is returned when no account is logged in.
+	ErrNoAccount = errors.New("storagestats: no account is logged in")
+
+	// ErrAlreadyRunning is returned while another collection is in flight.
+	ErrAlreadyRunning = errors.New("storagestats: a collection is already running")
+
+	// ErrCancelled is the result error when Stop aborts a collection. Clients
+	// treat it as "no result", not as a failure worth showing.
+	ErrCancelled = errors.New("cancelled")
+)
+
+// Service collects the account load profile on demand. Nothing is collected or
+// emitted unless a caller asks.
+type Service struct {
+	appDB    *sql.DB
+	walletDB *sql.DB
+	logger   *zap.Logger
+
+	// mu publishes requestID and cancel together: Stop must never observe a
+	// started collection whose cancel func is not yet visible, or logout would
+	// close sqlcipher under a live COUNT(*). A non-empty requestID is the
+	// in-flight guard.
+	mu        sync.Mutex
+	requestID string
+	cancel    context.CancelFunc
+}
+
+func New(appDB, walletDB *sql.DB, logger *zap.Logger) *Service {
+	return &Service{
+		appDB:    appDB,
+		walletDB: walletDB,
+		logger:   logger.Named("StorageStatsService"),
+	}
+}
+
+func (s *Service) APIs() []rpc.API {
+	return []rpc.API{
+		{
+			Namespace: "storagestats",
+			Version:   "0.1.0",
+			Service:   &API{s: s},
+		},
+	}
+}
+
+func (s *Service) Start() error { return nil }
+
+// Stop cancels a collection in flight.
+func (s *Service) Stop() error {
+	s.mu.Lock()
+	cancel := s.cancel
+	s.mu.Unlock()
+
+	if cancel != nil {
+		cancel()
+	}
+	return nil
+}
+
+// API is the JSON-RPC surface.
+type API struct {
+	s *Service
+}
+
+// Collect starts a collection and returns the request id the resulting
+// storage-stats.progress and storage-stats.result signals will carry. It must
+// stay non-blocking: clients call it from their UI thread, and COUNT(*) on a
+// sqlcipher table is a full decrypting scan.
+func (api *API) Collect(ctx context.Context) (string, error) {
+	return api.s.StartCollect()
+}
+
+func (s *Service) StartCollect() (string, error) {
+	if s.appDB == nil {
+		return "", ErrNoAccount
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	requestID := uuid.New().String()
+
+	s.mu.Lock()
+	if s.requestID != "" {
+		s.mu.Unlock()
+		cancel()
+		return "", ErrAlreadyRunning
+	}
+	s.requestID = requestID
+	s.cancel = cancel
+	s.mu.Unlock()
+
+	go func() {
+		defer panics.LogOnPanic()
+		defer cancel()
+		// finish releases the guard; this covers a panic before it does.
+		defer s.release(requestID)
+		s.collect(ctx, requestID)
+	}()
+
+	return requestID, nil
+}
+
+// release clears the guard unless a later collection already owns it: finish
+// releases before emitting the result, so a client may start the next
+// collection from inside the signal handler.
+func (s *Service) release(requestID string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.requestID != requestID {
+		return
+	}
+	s.requestID = ""
+	s.cancel = nil
+}
+
+func (s *Service) collect(ctx context.Context, requestID string) {
+	profile, err := Collect(ctx, s.appDB, s.walletDB, time.Now(), s.logger,
+		func(done, total int) {
+			signal.SendStorageStatsProgress(requestID, done, total)
+		})
+
+	// Exactly one result per request, cancellation included: clients clear
+	// their in-progress state on this signal and on nothing else.
+	if ctx.Err() != nil {
+		s.finish(requestID, nil, ErrCancelled)
+		return
+	}
+	if err != nil {
+		s.logger.Warn("collecting storage stats failed", zap.Error(err))
+	}
+	s.finish(requestID, profile, err)
+}
+
+// finish releases the guard before the result signal, so a client reacting to
+// it may collect again immediately.
+func (s *Service) finish(requestID string, profile *Profile, err error) {
+	s.release(requestID)
+
+	// A nil *Profile inside an interface is not a nil interface: passed
+	// straight through it would marshal as "data": null instead of being
+	// omitted.
+	var data interface{}
+	if profile != nil {
+		data = profile
+	}
+	signal.SendStorageStatsResult(requestID, data, err)
+}

--- a/pkg/services/storagestats/service_test.go
+++ b/pkg/services/storagestats/service_test.go
@@ -1,0 +1,205 @@
+package storagestats
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"github.com/status-im/status-go/internal/signal"
+)
+
+func TestServiceRefusesWithoutAnAccount(t *testing.T) {
+	s := New(nil, nil, zap.NewNop())
+	_, err := s.StartCollect()
+	require.ErrorIs(t, err, ErrNoAccount)
+}
+
+func TestServiceRefusesASecondCollectionWhileOneRuns(t *testing.T) {
+	s := New(setupAppDB(t), nil, zap.NewNop())
+
+	// Hold the guard the way a running collection does, and prove a second
+	// start is rejected rather than queued: two concurrent full-table walks
+	// would only make both slower.
+	s.mu.Lock()
+	s.requestID = "in-flight"
+	s.mu.Unlock()
+
+	_, err := s.StartCollect()
+	require.ErrorIs(t, err, ErrAlreadyRunning)
+}
+
+// TestServiceEmitsProgressThenResult exercises the whole delivery path: the
+// start call must return immediately and everything else must arrive as
+// signals.
+func TestServiceEmitsProgressThenResult(t *testing.T) {
+	appDB := setupAppDB(t)
+	walletDB := setupWalletDB(t)
+	seedAccount(t, appDB, walletDB)
+
+	type envelope struct {
+		Type  string          `json:"type"`
+		Event json.RawMessage `json:"event"`
+	}
+
+	// The profile arrives as raw JSON, which is what a client actually forwards
+	// to its UI and clipboard.
+	done := make(chan resultEnvelope, 1)
+	progress := make(chan signal.StorageStatsProgressEvent, 1024)
+
+	signal.SetHandler(func(data []byte) {
+		var e envelope
+		if err := json.Unmarshal(data, &e); err != nil {
+			return
+		}
+		switch e.Type {
+		case signal.EventStorageStatsProgress:
+			var event signal.StorageStatsProgressEvent
+			if err := json.Unmarshal(e.Event, &event); err == nil {
+				select {
+				case progress <- event:
+				default:
+				}
+			}
+		case signal.EventStorageStatsResult:
+			var event resultEnvelope
+			if err := json.Unmarshal(e.Event, &event); err == nil {
+				done <- event
+			}
+		}
+	})
+	t.Cleanup(signal.ResetHandler)
+
+	s := New(appDB, walletDB, zap.NewNop())
+	requestID, err := s.StartCollect()
+	require.NoError(t, err)
+	require.NotEmpty(t, requestID)
+
+	var result resultEnvelope
+	select {
+	case result = <-done:
+	case <-time.After(60 * time.Second):
+		t.Fatal("no storage-stats.result signal arrived")
+	}
+
+	require.Empty(t, result.Error)
+	require.Equal(t, requestID, result.RequestID)
+
+	// The signal has to carry a profile the client can actually render.
+	var profile Profile
+	require.NoError(t, json.Unmarshal(result.Data, &profile))
+	require.Equal(t, ProfileVersion, profile.ProfileVersion)
+	require.Equal(t, int64(200), profile.Messaging.MessagesTotal)
+
+	// Every progress event belongs to this request and carries the same total.
+	require.NotEmpty(t, progress)
+	close(progress)
+	var last signal.StorageStatsProgressEvent
+	for event := range progress {
+		require.Equal(t, requestID, event.RequestID)
+		require.Positive(t, event.Total)
+		if last.Total != 0 {
+			require.Equal(t, last.Total, event.Total)
+			require.Greater(t, event.Step, last.Step)
+		}
+		last = event
+	}
+	require.Equal(t, last.Total, last.Step, "the last progress event must complete the walk")
+
+	// The guard has to be released, or the section could never be used twice.
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	require.Empty(t, s.requestID)
+}
+
+// captureResults routes storage-stats.result signals into a channel.
+func captureResults(t *testing.T) <-chan resultEnvelope {
+	t.Helper()
+
+	results := make(chan resultEnvelope, 8)
+	signal.SetHandler(func(data []byte) {
+		var e struct {
+			Type  string          `json:"type"`
+			Event json.RawMessage `json:"event"`
+		}
+		if err := json.Unmarshal(data, &e); err != nil || e.Type != signal.EventStorageStatsResult {
+			return
+		}
+		var event resultEnvelope
+		if err := json.Unmarshal(e.Event, &event); err == nil {
+			select {
+			case results <- event:
+			default:
+			}
+		}
+	})
+	t.Cleanup(signal.ResetHandler)
+	return results
+}
+
+type resultEnvelope struct {
+	RequestID string          `json:"requestId"`
+	Error     string          `json:"error"`
+	Data      json.RawMessage `json:"data"`
+}
+
+// Every request gets exactly one result, cancellation included: a client that
+// clears its in-progress state only on this signal must never be left hanging.
+func TestServiceEmitsACancelledResult(t *testing.T) {
+	appDB := setupAppDB(t)
+	seedAccount(t, appDB, setupWalletDB(t))
+	results := captureResults(t)
+
+	s := New(appDB, nil, zap.NewNop())
+	requestID, err := s.StartCollect()
+	require.NoError(t, err)
+	require.NoError(t, s.Stop())
+
+	select {
+	case result := <-results:
+		require.Equal(t, requestID, result.RequestID)
+		require.Equal(t, ErrCancelled.Error(), result.Error)
+		require.Empty(t, result.Data)
+	case <-time.After(60 * time.Second):
+		t.Fatal("a cancelled collection produced no result signal")
+	}
+
+	// And the guard is free again, so the next Collect is accepted.
+	s.mu.Lock()
+	requestIDAfter := s.requestID
+	s.mu.Unlock()
+	require.Empty(t, requestIDAfter)
+}
+
+// Stop must cancel a collection that StartCollect has already returned from.
+// The cancel func has to be published together with the guard, or logout races
+// the walk and closes sqlcipher under a live COUNT(*).
+func TestServiceStopAlwaysCancelsAStartedCollection(t *testing.T) {
+	appDB := setupAppDB(t)
+	seedAccount(t, appDB, setupWalletDB(t))
+	results := captureResults(t)
+
+	for attempt := 0; attempt < 20; attempt++ {
+		requestID, err := func() (string, error) {
+			s := New(appDB, nil, zap.NewNop())
+			id, err := s.StartCollect()
+			if err != nil {
+				return "", err
+			}
+			// Stop immediately: the walk may not even have been scheduled yet.
+			return id, s.Stop()
+		}()
+		require.NoError(t, err)
+
+		select {
+		case result := <-results:
+			require.Equal(t, requestID, result.RequestID)
+			require.Equal(t, ErrCancelled.Error(), result.Error,
+				"Stop after StartCollect must always cancel, attempt %d", attempt)
+		case <-time.After(60 * time.Second):
+			t.Fatalf("attempt %d: Stop did not cancel the collection", attempt)
+		}
+	}
+}


### PR DESCRIPTION
* add `storagestats` service and collector
* serial table walk, one table at a time
* covers both app and wallet databases
* exact counts, plain JSON output
* async RPC `storagestats_collect`, no sync calls
* progress and result signals
* `incomplete` list names failed steps
* collection cancelled on logout

Desktop PR: https://github.com/status-im/status-app/pull/22038

Part of status-im/status-app#21605