### PR TITLE
test(logutils): stop TestRotateLogFileForNewSessionKeepsActiveFile racing the clock

### DIFF
--- a/internal/logutils/logrotation_test.go
+++ b/internal/logutils/logrotation_test.go
@@ -39,8 +39,13 @@ func TestRotateLogFileForNewSessionProducesLumberjackParseableName(t *testing.T)
 func TestRotateLogFileForNewSessionKeepsActiveFile(t *testing.T) {
 	dir := t.TempDir()
 	file := filepath.Join(dir, "test.log")
-	// mtime is now, i.e. after processStartTime: the file belongs to this session.
 	require.NoError(t, os.WriteFile(file, []byte("x"), 0600))
+	// Stamp the mtime explicitly rather than relying on the write happening "now".
+	// Filesystem mtimes are coarse and can lag the wall clock -- on ext4 here, by
+	// up to a millisecond -- so a file written immediately after package init can
+	// still stat as older than processStartTime, and the file would be archived.
+	active := processStartTime.Add(time.Minute)
+	require.NoError(t, os.Chtimes(file, active, active))
 
 	require.NoError(t, rotateLogFileForNewSession(file))
 


### PR DESCRIPTION
`TestRotateLogFileForNewSessionKeepsActiveFile` is flaky, and it is flaky on `develop` —
this was raised against #7724, but that PR is not the cause.

## Evidence

Same machine (aarch64 Linux, ext4), `go test ./internal/logutils/ -count=1`, 20 runs each:

| ref | failures |
|---|---|
| `develop` (untouched) | **16 / 20** |
| #7724 branch | 17 / 20 |

Statistically the same. The failure reproduces on a clean `develop` checkout with no layout
changes present.

## Why it fails

The test writes a file and assumes its mtime is therefore "now", i.e. after `processStartTime`:

```go
// mtime is now, i.e. after processStartTime: the file belongs to this session.
require.NoError(t, os.WriteFile(file, []byte("x"), 0600))
```

That assumption does not hold. Filesystem mtimes are coarser than `time.Now()` and can *lag* it.
Measured here:

```
wall=1787178012.756468 mtime=1787178012.755729 delta=-0.000740
wall=1787178012.756582 mtime=1787178012.755729 delta=-0.000853
wall=1787178012.756622 mtime=1787178012.755729 delta=-0.000893
wall=1787178012.756668 mtime=1787178012.755729 delta=-0.000939
wall=1787178012.756701 mtime=1787178012.755729 delta=-0.000973
```

Five writes at five different wall-clock times, all landing on the *same* mtime, ~0.7–1.0 ms
*behind* the clock. `processStartTime` is a package-level `var … = time.Now()` with full
nanosecond precision. When the test runs inside that ~1 ms window after package init, the file
stats as older than `processStartTime`, `rotateLogFileForNewSession` treats it as a previous
session's log and archives it, and the `Stat` assertion fails.

This also explains why it looks intermittent: running the whole package suite burns enough time
before this test that the clock usually moves past the window, while `-run`-filtered or fast runs
hit it almost every time.

## The fix

Stamp the mtime explicitly instead of relying on the write happening "now" — which is exactly
what the sibling test already does for its "previous session" file. The test then asserts the
session logic rather than the clock.

25/25 passes with this change, against 16/20 failures before.

## Not a production bug

`rotateLogFileForNewSession` runs once at startup, when the file it inspects is either absent or
genuinely from an earlier session with a much older mtime. The sub-millisecond window only
matters to a test that creates the file itself.
