### PR TITLE
test(logutils): give TestRotateLogFileForNewSessionKeepsActiveFile a real margin

### DIFF
--- a/internal/logutils/logrotation_test.go
+++ b/internal/logutils/logrotation_test.go
@@ -39,8 +39,14 @@ func TestRotateLogFileForNewSessionProducesLumberjackParseableName(t *testing.T)
 func TestRotateLogFileForNewSessionKeepsActiveFile(t *testing.T) {
 	dir := t.TempDir()
 	file := filepath.Join(dir, "test.log")
-	// mtime is now, i.e. after processStartTime: the file belongs to this session.
 	require.NoError(t, os.WriteFile(file, []byte("x"), 0600))
+	// Stamp the mtime rather than relying on the write landing after processStartTime.
+	// That assumption has almost no margin: processStartTime is set when this package is
+	// initialised, and the test runs ~0.5ms later (~0.1ms when gotestsum --rerun-fails
+	// re-runs it alone). Filesystem mtimes are coarser than time.Now() and can lag it by
+	// more than that, so the file would stat as older than the process and be archived.
+	active := processStartTime.Add(time.Minute)
+	require.NoError(t, os.Chtimes(file, active, active))
 
 	require.NoError(t, rotateLogFileForNewSession(file))
 


### PR DESCRIPTION
`TestRotateLogFileForNewSessionKeepsActiveFile` is flaky, but only on some of the CI hosts. 
Increasing the time gap for a reliable behaviour

# AI Decsription

The test needs a file it has just written to have an mtime later than `processStartTime`, which
is stamped when `internal/logutils` is initialised. Measured, that margin is **~300 µs**.

Filesystem mtimes are coarser than `time.Now()` and *lag* it — 0.2–1.3 ms on the machine I
measured on, with consecutive writes sharing a single mtime. Where the lag exceeds the margin the
test fails on essentially every run; where it doesn't, it passes on every run. So it presents as
deterministic per machine rather than flaky.

That is what we are hitting now: **#7724 fails this test on every CI run, while its base #7723 and
the PRs stacked on top of it (#7725, #7726) all pass** — even though `logrotation_test.go` is the
same blob on all four, and the `internal/logutils` test binary is identical (4 status-go packages,
empty diff either way). Nothing in that PR's content reaches this test; it comes down to which
agent the job lands on.

## Fix

Stamp the mtime explicitly, exactly as the sibling test already does for its "previous session"
file, so the test exercises `rotateLogFileForNewSession`'s session logic instead of filesystem
timestamp resolution.

Verified: **0/15** failures on a full `-coverpkg ./...` run and **0/10** on an isolated rerun
(what `--rerun-fails` does), against consistent failures before.

Production is unaffected — `rotateLogFileForNewSession` runs once at startup, when the file it
inspects is either absent or genuinely from an earlier session with a much older mtime.
