### PR TITLE
feat(messaging)_: link liblogosdelivery through the Go bindings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -129,3 +129,8 @@ libs
 
 # CODEX (ChatGPT plugin)
 .codex
+
+# Nimble
+nimble.develop
+nimble.paths
+nimbledeps

--- a/Makefile
+++ b/Makefile
@@ -105,26 +105,16 @@ GIT_AUTHOR ?= $(shell git config user.email || echo $$USER)
 BUILD_TAGS ?= gowaku_no_rln
 
 # `nim-sds` variables
+#
+# The revision is pinned by sds-go-bindings, which status_go.nimble depends on,
+# and resolves transitively. Nothing names it here.
+#
+# Option 1 (default): Nimble resolves it and the bindings' task builds libsds,
+# staged into build/ so the flags below do not depend on where Nimble put it.
+# Option 2: Provide NIM_SDS_LIB_DIR and NIM_SDS_INC_DIR (used by Nix).
 
-# Pin nim-sds revision here. Can be a tag (default) or commit hash.
-# v0.3.3 lives on the release/v0.3 branch: it carries the SDS retrieval-hint
-# provider required by the sds-go-bindings pin in go.mod, on the CamelCase FFI
-# ABI, with the causalHistory wire format kept backward-compatible with released
-# (v0.2.x) nodes. master/release-v0.4 moved to the snake_case CBOR ABI, which
-# these bindings do not link against, so we track release/v0.3.
-NIM_SDS_VERSION ?= v0.3.3
+NIMBLE ?= nimble
 
-# Option 1: Provide NIM_SDS_SOURCE_DIR. Make force-reclones a fresh copy (with submodules)
-# to guarantee a clean checkout on every build.
-NIM_SDS_SOURCE_DIR ?= $(GIT_ROOT)/../nim-sds
-# Normalize path separators for Windows (backslashes cause issues when passed through shells)
-ifeq ($(mkspecs),win32)
-	NIM_SDS_SOURCE_DIR := $(subst \,/,$(NIM_SDS_SOURCE_DIR))
-endif
-
-# Option 2: Provide NIM_SDS_LIB_DIR and NIM_SDS_INC_DIR
-
-# Determine which approach to use
 ifdef NIM_SDS_LIB_DIR
 ifdef NIM_SDS_INC_DIR
     # External lib/include approach (e.g. used in Nix)
@@ -133,11 +123,17 @@ else
     $(error NIM_SDS_INC_DIR must be provided when NIM_SDS_LIB_DIR is set)
 endif
 else
-    # Source directory approach
-    NIM_SDS_LIB_DIR := $(NIM_SDS_SOURCE_DIR)/build
-    NIM_SDS_INC_DIR := $(NIM_SDS_SOURCE_DIR)/library
+    # Nimble approach
+    NIM_SDS_LIB_DIR := $(CURDIR)/build
+    NIM_SDS_INC_DIR := $(CURDIR)/build
     NIM_SDS_BUILD_FROM_SOURCE := true
 endif
+
+# nimble.paths carries the --path set the compile needs: the packages sit
+# outside this tree, where Nim finds no ancestor config.nims.
+NIMBLE_SDS_ENV = \
+	LIBSDS_OUT="$(NIM_SDS_LIB_DIR)" \
+	NIM_PARAMS="$$NIM_PARAMS $$(tr '\n' ' ' < $(CURDIR)/nimble.paths)"
 
 LIBSDS ?= $(NIM_SDS_LIB_DIR)/libsds.$(LIB_EXT)
 CGO_CFLAGS+=-I$(NIM_SDS_INC_DIR)
@@ -328,26 +324,20 @@ USE_SYSTEM_NIM ?= 1
 
 # libsds targets
 
-.PHONY: clone-nim-sds
-clone-nim-sds: ##@build Clone or update nim-sds
-ifeq ($(NIM_SDS_BUILD_FROM_SOURCE),true)
-	@echo "Cloning or updating nim-sds ..."
-	if [ ! -d "$(NIM_SDS_SOURCE_DIR)" ]; then \
-		git clone --recurse-submodules https://github.com/waku-org/nim-sds.git "$(NIM_SDS_SOURCE_DIR)"; \
-	else \
-		cd "$(NIM_SDS_SOURCE_DIR)" && git fetch --tags; \
-	fi
-	cd "$(NIM_SDS_SOURCE_DIR)" && \
-		git switch --no-recurse-submodules --force --detach "$(NIM_SDS_VERSION)" && \
-		git clean -fdx && \
-		git submodule update --init --recursive --force
-endif
+.PHONY: nimble-deps
 
-$(LIBSDS): clone-nim-sds
+nimble.paths:
+	$(NIMBLE) setup --localdeps -y
+
+nimble-deps: nimble.paths ##@build Resolve the Nim dependencies
+
+# The bindings own the build: they pin the nim-sds revision their C ABI matches
+# and their Nimble task delegates to nim-sds'. status-go only says where the
+# result goes.
+$(LIBSDS): | nimble.paths
 ifeq ($(NIM_SDS_BUILD_FROM_SOURCE),true)
 	@echo "Building nim-sds: $(LIBSDS)"
-	$(MAKE) -C $(NIM_SDS_SOURCE_DIR) update USE_SYSTEM_NIM=$(USE_SYSTEM_NIM)
-	$(MAKE) -C $(NIM_SDS_SOURCE_DIR) libsds USE_SYSTEM_NIM=$(USE_SYSTEM_NIM) NIMFLAGS=-d:noSignalHandler SHELL=$(MAKE_SHELL)
+	$(NIMBLE_SDS_ENV) $(NIMBLE) libsds
 	@test -f $(LIBSDS) || (echo "Error: libsds not found at $(LIBSDS) after build" && exit 1)
 else
 	@test -f $(LIBSDS) || (echo "Error: libsds not found at $(LIBSDS)" && exit 1)
@@ -363,13 +353,14 @@ build-libsds-android: SDSARCH = $(strip $(if $(filter arm64,$(ARCH)),arm64,\
 	$(if $(filter amd64,$(ARCH)),amd64,\
 	$(if $(filter x86 x86_64,$(ARCH)),amd64,\
 	$(error Unsupported ARCH '$(ARCH)'. Please set ARCH to one of: arm64, arm, amd64, x86, x86_64))))))
-build-libsds-android: clone-nim-sds
+build-libsds-android: | nimble.paths
 	@echo "Building nim-sds for Android" $(LIBSDS)
-	$(MAKE) -C $(NIM_SDS_SOURCE_DIR) libsds-android ARCH=$(SDSARCH) ANDROID_NDK_ROOT=$(ANDROID_NDK_ROOT) USE_SYSTEM_NIM=1 SHELL=$(MAKE_SHELL)
+	$(NIMBLE_SDS_ENV) ARCH="$(SDSARCH)" ANDROID_NDK_ROOT="$(ANDROID_NDK_ROOT)" \
+		$(NIMBLE) libsdsAndroid
 
-build-libsds-ios: clone-nim-sds
+build-libsds-ios: | nimble.paths
 	@echo "Building nim-sds for iOS" $(LIBSDS)
-	$(MAKE) -C $(NIM_SDS_SOURCE_DIR) libsds-ios USE_SYSTEM_NIM=$(USE_SYSTEM_NIM) SHELL=$(MAKE_SHELL)
+	$(NIMBLE_SDS_ENV) $(NIMBLE) libsdsIOS
 
 clean-libsds:
 	@echo "Removing libsds"

--- a/Makefile
+++ b/Makefile
@@ -139,6 +139,47 @@ LIBSDS ?= $(NIM_SDS_LIB_DIR)/libsds.$(LIB_EXT)
 CGO_CFLAGS+=-I$(NIM_SDS_INC_DIR)
 CGO_LDFLAGS+=-L$(NIM_SDS_LIB_DIR) -lsds
 
+# `logos-delivery` variables (liblogosdelivery, linked via logos-delivery-go-bindings).
+# Provide LOGOS_DELIVERY_LIB_DIR and LOGOS_DELIVERY_INC_DIR; the Nix shell sets
+# both from the flake input.
+ifdef LOGOS_DELIVERY_LIB_DIR
+ifndef LOGOS_DELIVERY_INC_DIR
+    $(error LOGOS_DELIVERY_INC_DIR must be provided when LOGOS_DELIVERY_LIB_DIR is set)
+endif
+LIBLOGOSDELIVERY ?= $(LOGOS_DELIVERY_LIB_DIR)/liblogosdelivery.$(LIB_EXT)
+CGO_CFLAGS+=-I$(LOGOS_DELIVERY_INC_DIR)
+CGO_LDFLAGS+=-L$(LOGOS_DELIVERY_LIB_DIR) -llogosdelivery
+endif
+
+# Built without Nix the same way libsds is.
+NIMBLE_LIB := $(CURDIR)/build/liblogosdelivery.$(LIB_EXT)
+
+.PHONY: liblogosdelivery-nimble statusgo-nim-delivery
+
+$(NIMBLE_LIB): | nimble.paths
+	LIBLOGOSDELIVERY_OUT="$(CURDIR)/build" \
+		NIM_PARAMS="$$NIM_PARAMS -d:disable_rln $$(tr '\n' ' ' < $(CURDIR)/nimble.paths)" \
+		$(NIMBLE) liblogosdelivery
+	@test -f $@ || (echo "ERROR: $@ was not produced" && exit 1)
+
+liblogosdelivery-nimble: $(NIMBLE_LIB) ##@build Build liblogosdelivery via the Go bindings' Nimble task
+
+# Temporary: builds libstatus.a linked against the Nimble-built liblogosdelivery,
+# so the Nix-free path can be exercised end to end. Folds into statusgo-library
+# once the delivery backend is wired in.
+statusgo-nim-delivery: STATUS_GO_BINDINGS_PATH ?= build/bin/statusgo-lib
+statusgo-nim-delivery: STATUS_GO_LIBRARY_OUT ?= build/bin
+statusgo-nim-delivery: $(NIMBLE_LIB) generate statusgo-c-bindings $(LIBSDS) ##@build libstatus.a against the Nimble-built liblogosdelivery
+	CGO_CFLAGS="$(CGO_CFLAGS) -I$(CURDIR)/build" \
+	CGO_LDFLAGS="$(CGO_LDFLAGS) -L$(CURDIR)/build -llogosdelivery -Wl,-rpath,$(CURDIR)/build" \
+	go build \
+		-tags '$(BUILD_TAGS)' \
+		$(BUILD_FLAGS) \
+		-buildmode=c-archive \
+		-o $(STATUS_GO_LIBRARY_OUT)/libstatus.a \
+		"$(STATUS_GO_BINDINGS_PATH)/main.go"
+	@echo "Static library built: $(STATUS_GO_LIBRARY_OUT)/libstatus.a"
+
 # `logos-storage` variables (opt-in)
 USE_LOGOS_STORAGE ?= false
 USE_TORRENT ?= false
@@ -163,6 +204,9 @@ endif
 LIBSTORAGE ?= $(LOGOS_STORAGE_LIB_DIR)/libstorage.$(LIB_EXT)
 
 RUNTIME_LIB_DIRS := $(NIM_SDS_LIB_DIR)
+ifdef LOGOS_DELIVERY_LIB_DIR
+    RUNTIME_LIB_DIRS := $(LOGOS_DELIVERY_LIB_DIR):$(RUNTIME_LIB_DIRS)
+endif
 LOGOS_STORAGE_BUILD_DEPS :=
 ifeq ($(USE_LOGOS_STORAGE),true)
 	override BUILD_TAGS += use_logos_storage

--- a/config.nims
+++ b/config.nims
@@ -1,0 +1,4 @@
+# begin Nimble config (version 2)
+when withDir(thisDir(), system.fileExists("nimble.paths")):
+  include "nimble.paths"
+# end Nimble config

--- a/flake.lock
+++ b/flake.lock
@@ -19,6 +19,31 @@
         "type": "github"
       }
     },
+    "logos-delivery": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "rust-overlay": "rust-overlay",
+        "zerokit": "zerokit"
+      },
+      "locked": {
+        "lastModified": 1787213774,
+        "narHash": "sha256-KaX7fDFfoSo/PKPzdRhFLksANz+qtMu2k1oyQL/zdMQ=",
+        "ref": "refs/heads/master",
+        "rev": "69fbffa3a0cfd862a2d04a4a0f57432063ecfba1",
+        "revCount": 2447,
+        "submodules": true,
+        "type": "git",
+        "url": "https://github.com/logos-messaging/logos-delivery"
+      },
+      "original": {
+        "rev": "69fbffa3a0cfd862a2d04a4a0f57432063ecfba1",
+        "submodules": true,
+        "type": "git",
+        "url": "https://github.com/logos-messaging/logos-delivery"
+      }
+    },
     "logos-storage-nim": {
       "inputs": {
         "circom-compat": "circom-compat",
@@ -114,9 +139,76 @@
     },
     "root": {
       "inputs": {
+        "logos-delivery": "logos-delivery",
         "logos-storage-nim": "logos-storage-nim",
         "nim-sds": "nim-sds",
         "nixpkgs": "nixpkgs_3"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "nixpkgs": [
+          "logos-delivery",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1775099554,
+        "narHash": "sha256-3xBsGnGDLOFtnPZ1D3j2LU19wpAlYefRKTlkv648rU0=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "8d6387ed6d8e6e6672fd3ed4b61b59d44b124d99",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "rust-overlay_2": {
+      "inputs": {
+        "nixpkgs": [
+          "logos-delivery",
+          "zerokit",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1771297684,
+        "narHash": "sha256-wieWskQxZLPlNXX06JEB0bMoS/ZYQ89xBzF0RL9lyLs=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "755d3669699a7c62aef35af187d75dc2728cfd85",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "zerokit": {
+      "inputs": {
+        "nixpkgs": [
+          "logos-delivery",
+          "nixpkgs"
+        ],
+        "rust-overlay": "rust-overlay_2"
+      },
+      "locked": {
+        "lastModified": 1779168423,
+        "narHash": "sha256-OmCnpM+ZcI79EVozdKADj9h4sFsLwfCs5w7OK8Ir6fc=",
+        "owner": "vacp2p",
+        "repo": "zerokit",
+        "rev": "5e64cb8822bee65eed6cf459f95ae72b80c6ba63",
+        "type": "github"
+      },
+      "original": {
+        "owner": "vacp2p",
+        "repo": "zerokit",
+        "rev": "5e64cb8822bee65eed6cf459f95ae72b80c6ba63",
+        "type": "github"
       }
     }
   },

--- a/flake.lock
+++ b/flake.lock
@@ -48,18 +48,17 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1783637210,
-        "narHash": "sha256-O5M45RPTtaKVYeiyB6LSBawqcBuAHwyhYbvk5HMyh/M=",
-        "ref": "refs/tags/v0.3.3",
-        "rev": "259830c9cfa7dbad3bd2f792097ad3e180fb2e1c",
-        "revCount": 84,
+        "lastModified": 1787680029,
+        "narHash": "sha256-GeS4OB312R+E6CHMYwZ6zJ4kMGloD1m3eRcz7qvtvek=",
+        "ref": "refs/heads/master",
+        "rev": "2fec23ad292b0f9d0924a2f1a69995d23b37822d",
+        "revCount": 105,
         "submodules": true,
         "type": "git",
         "url": "https://github.com/logos-messaging/nim-sds"
       },
       "original": {
-        "ref": "refs/tags/v0.3.3",
-        "rev": "259830c9cfa7dbad3bd2f792097ad3e180fb2e1c",
+        "rev": "2fec23ad292b0f9d0924a2f1a69995d23b37822d",
         "submodules": true,
         "type": "git",
         "url": "https://github.com/logos-messaging/nim-sds"
@@ -83,17 +82,17 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1757590060,
-        "narHash": "sha256-EWwwdKLMZALkgHFyKW7rmyhxECO74+N+ZO5xTDnY/5c=",
+        "lastModified": 1770464364,
+        "narHash": "sha256-z5NJPSBwsLf/OfD8WTmh79tlSU8XgIbwmk6qB1/TFzY=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "0ef228213045d2cdb5a169a95d63ded38670b293",
+        "rev": "23d72dabcb3b12469f57b37170fcbc1789bd7457",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "0ef228213045d2cdb5a169a95d63ded38670b293",
+        "rev": "23d72dabcb3b12469f57b37170fcbc1789bd7457",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -23,9 +23,14 @@
     };
     # We cannot do follows since the nim-unwrapped-2_0 doesn't exist in this nixpkgs version above
     nim-sds.url = "git+https://github.com/logos-messaging/nim-sds?submodules=1&rev=2fec23ad292b0f9d0924a2f1a69995d23b37822d";
+    # logos-delivery pins the same nixpkgs rev as we do, so following is safe.
+    logos-delivery = {
+      url = "git+https://github.com/logos-messaging/logos-delivery?submodules=1&rev=69fbffa3a0cfd862a2d04a4a0f57432063ecfba1";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
   };
 
-  outputs = { self, nixpkgs, logos-storage-nim, nim-sds }:
+  outputs = { self, nixpkgs, logos-storage-nim, nim-sds, logos-delivery }:
   let
     stableSystems = [
       "x86_64-linux" "aarch64-linux"
@@ -51,6 +56,11 @@
           (final: prev: {
             libsds     = useTmpdirForNimCache nim-sds.packages.${system}.libsds;
             libstorage = useTmpdirForNimCache logos-storage-nim.packages.${system}.libstorage;
+            # Postgres is only used by fleet store nodes; without this the
+            # library dlopens libpq at startup and a client node fails to start.
+            liblogosdelivery = logos-delivery.packages.${system}.liblogosdelivery.override {
+              enablePostgres = false;
+            };
           })
         ];
       }

--- a/flake.nix
+++ b/flake.nix
@@ -22,7 +22,7 @@
       inputs.nixpkgs.follows = "nixpkgs";
     };
     # We cannot do follows since the nim-unwrapped-2_0 doesn't exist in this nixpkgs version above
-    nim-sds.url = "git+https://github.com/logos-messaging/nim-sds?submodules=1&ref=refs/tags/v0.3.3&rev=259830c9cfa7dbad3bd2f792097ad3e180fb2e1c";
+    nim-sds.url = "git+https://github.com/logos-messaging/nim-sds?submodules=1&rev=2fec23ad292b0f9d0924a2f1a69995d23b37822d";
   };
 
   outputs = { self, nixpkgs, logos-storage-nim, nim-sds }:

--- a/go.mod
+++ b/go.mod
@@ -340,6 +340,7 @@ require (
 	github.com/libp2p/go-netroute v0.2.2 // indirect
 	github.com/libp2p/go-reuseport v0.4.0 // indirect
 	github.com/libp2p/go-yamux/v4 v4.0.2 // indirect
+	github.com/logos-messaging/logos-delivery-go-bindings v0.0.0-20260824151035-280a7889a3d6 // indirect
 	github.com/macabu/inamedparam v0.2.0 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/maratori/testableexamples v1.0.1 // indirect

--- a/go.mod
+++ b/go.mod
@@ -100,7 +100,7 @@ require (
 	github.com/status-im/extkeys v1.4.0
 	github.com/status-im/go-wallet-sdk v0.0.0-20260728092705-f70963a74b0e
 	github.com/waku-org/go-waku v0.10.3
-	github.com/waku-org/sds-go-bindings v0.3.1
+	github.com/waku-org/sds-go-bindings v0.0.0-20260828080232-c94172d700f6
 	github.com/wk8/go-ordered-map/v2 v2.1.7
 	go.uber.org/atomic v1.11.0
 	go.uber.org/mock v0.6.0

--- a/go.sum
+++ b/go.sum
@@ -2511,6 +2511,12 @@ github.com/waku-org/go-zerokit-rln-arm v0.0.0-20230916171929-1dd9494ff065 h1:Sd7
 github.com/waku-org/go-zerokit-rln-arm v0.0.0-20230916171929-1dd9494ff065/go.mod h1:7cSGUoGVIla1IpnChrLbkVjkYgdOcr7rcifEfh4ReR4=
 github.com/waku-org/go-zerokit-rln-x86_64 v0.0.0-20230916171518-2a77c3734dd1 h1:4HSdWMFMufpRo3ECTX6BrvA+VzKhXZf7mS0rTa5cCWU=
 github.com/waku-org/go-zerokit-rln-x86_64 v0.0.0-20230916171518-2a77c3734dd1/go.mod h1:+LeEYoW5/uBUTVjtBGLEVCUe9mOYAlu5ZPkIxLOSr5Y=
+github.com/waku-org/sds-go-bindings v0.0.0-20260619075528-a33b3ec5a971 h1:pVzW2TXI+6DlFRt0Y3uJJazXY5SUGtQJcZe8ZyXR8ao=
+github.com/waku-org/sds-go-bindings v0.0.0-20260619075528-a33b3ec5a971/go.mod h1:GW6bN8Ski1GCOb2f5JbKKstH70wlPen1h8f1nzSDfSI=
+github.com/waku-org/sds-go-bindings v0.0.0-20260825125841-3b204dbc806f h1:ZlBxpla6Adzg/faHiY7kRh9G914rVKrKk1ecRyzpNQo=
+github.com/waku-org/sds-go-bindings v0.0.0-20260825125841-3b204dbc806f/go.mod h1:GW6bN8Ski1GCOb2f5JbKKstH70wlPen1h8f1nzSDfSI=
+github.com/waku-org/sds-go-bindings v0.0.0-20260828080232-c94172d700f6 h1:iiya74nJ8EIjh7zP9ypxucqqYfAAut7/HN2tFvBvow8=
+github.com/waku-org/sds-go-bindings v0.0.0-20260828080232-c94172d700f6/go.mod h1:GW6bN8Ski1GCOb2f5JbKKstH70wlPen1h8f1nzSDfSI=
 github.com/waku-org/sds-go-bindings v0.3.1 h1:u4k0XHxGnjLIwJsgtelSBA5GmN4YMiDfzpk2wfpexf4=
 github.com/waku-org/sds-go-bindings v0.3.1/go.mod h1:GW6bN8Ski1GCOb2f5JbKKstH70wlPen1h8f1nzSDfSI=
 github.com/wealdtech/go-ens/v3 v3.6.0 h1:EAByZlHRQ3vxqzzwNi0GvEq1AjVozfWO4DMldHcoVg8=

--- a/go.sum
+++ b/go.sum
@@ -1631,6 +1631,8 @@ github.com/libp2p/go-yamux/v4 v4.0.2/go.mod h1:C808cCRgOs1iBwY4S71T5oxgMxgLmqUw5
 github.com/lightstep/lightstep-tracer-common/golang/gogo v0.0.0-20190605223551-bc2310a04743/go.mod h1:qklhhLq1aX+mtWk9cPHPzaBjWImj5ULL6C7HFJtXQMM=
 github.com/lightstep/lightstep-tracer-go v0.18.1/go.mod h1:jlF1pusYV4pidLvZ+XD0UBX0ZE6WURAspgAczcDHrL4=
 github.com/linuxkit/virtsock v0.0.0-20201010232012-f8cee7dfc7a3/go.mod h1:3r6x7q95whyfWQpmGZTu3gk3v2YkMi05HEzl7Tf7YEo=
+github.com/logos-messaging/logos-delivery-go-bindings v0.0.0-20260824151035-280a7889a3d6 h1:KsmMjJUSnE9ZuWNAwiF6hNx4iHOaW05hrwF4kEkkrf0=
+github.com/logos-messaging/logos-delivery-go-bindings v0.0.0-20260824151035-280a7889a3d6/go.mod h1:M7L0+Jdeb+jDYv+i05ItbXFuMDBwzuVzeG8ymJ5ycWg=
 github.com/logos-storage/logos-storage-go-bindings v0.0.30 h1:9shX7u87WjsZKwUVzWxafpNSd/X5ii33WvYLjo5vTBs=
 github.com/logos-storage/logos-storage-go-bindings v0.0.30/go.mod h1:5NzkHakOYX0iwgJk9X6NKN3AoDIvr8JTwpnl5SWdPVg=
 github.com/lucas-clemente/quic-go v0.7.1-0.20190401152353-907071221cf9/go.mod h1:PpMmPfPKO9nKJ/psF49ESTAGQSdfXxlg1otPbEB2nOw=

--- a/internal/nimble/src/README.md
+++ b/internal/nimble/src/README.md
@@ -1,0 +1,7 @@
+# Nimble srcDir placeholder
+
+`status_go.nimble` needs a `srcDir`, and status-go has no Nim source. Pointing it here keeps the
+installed Nimble package empty: only the `.nimble` file itself is installed, so nothing of status-go
+reaches a dependent's Nim module path.
+
+Do not put Nim modules here.

--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -11,7 +11,7 @@ in pkgs.mkShell {
     git jq which gcc rustc cargo openjdk openssl nim go
     golangci-lint go-junit-report gopls
     protobuf_29 protoc-gen-go gotestsum
-    libsds libstorage
+    libsds libstorage liblogosdelivery
   ] ++ lib.optionals (isDarwin) [
     pkgs.xcodeWrapper
   ] ++ lib.optionals (!(stdenv.isLinux && isAarch64)) [
@@ -28,7 +28,10 @@ in pkgs.mkShell {
     export NIM_SDS_INC_DIR="${pkgs.libsds}/include"
     export NIM_SDS_LIB_DIR="${pkgs.libsds}/lib"
 
-    export LD_LIBRARY_PATH="${lib.makeLibraryPath (with pkgs; [libsds libstorage])}"
+    export LOGOS_DELIVERY_INC_DIR="${pkgs.liblogosdelivery}/include"
+    export LOGOS_DELIVERY_LIB_DIR="${pkgs.liblogosdelivery}/lib"
+
+    export LD_LIBRARY_PATH="${lib.makeLibraryPath (with pkgs; [libsds libstorage liblogosdelivery])}"
   '' + lib.optionalString (!isDarwin && isAarch64) ''
     export ANDROID_HOME=${pkgs.androidPkgs.androidsdk}/libexec/android-sdk/
     export ANDROID_NDK=\$ANDROID_HOME/ndk-bundle

--- a/pkg/messaging/delivery/doc.go
+++ b/pkg/messaging/delivery/doc.go
@@ -1,0 +1,3 @@
+package delivery
+
+import _ "github.com/logos-messaging/logos-delivery-go-bindings/pkg/messaging"

--- a/status_go.nimble
+++ b/status_go.nimble
@@ -28,6 +28,10 @@ requires "nim >= 2.2.4"
 # express a range instead.
 requires "https://github.com/logos-messaging/sds-go-bindings#c94172d"
 
+# Same arrangement for the delivery side: the bindings pin the liblogosdelivery
+# revision their C ABI matches, and it resolves transitively.
+requires "https://github.com/logos-messaging/logos-delivery-go-bindings#280a7889"
+
 
 ### Helpers
 
@@ -59,3 +63,7 @@ task libsdsAndroid, "Build libsds for Android; ARCH selects the architecture":
 task libsdsIOS, "Build libsds for iOS":
   runBindingsTask("libsdsIOS")
 
+task liblogosdelivery, "Build the liblogosdelivery status-go links against":
+  ## LIBLOGOSDELIVERY_OUT and NIM_PARAMS come from the caller.
+  withDir nimblePkgDir("logos_delivery_go_bindings"):
+    exec "nimble liblogosdelivery"

--- a/status_go.nimble
+++ b/status_go.nimble
@@ -1,0 +1,61 @@
+mode = ScriptMode.Verbose
+
+import std/[os, strutils]
+
+### Package
+version     = "0.0.1"
+author      = "Status Research & Development GmbH"
+description = "Status messaging and wallet backend, built as a C archive for status-app"
+license     = "MPL-2.0"
+
+# status-go is a Go project; this package exists to resolve its Nim native
+# dependencies through Nimble, and to let status-app depend on status-go the
+# same way (status-im/status-app#19907).
+#
+# srcDir points at an empty directory and every Go tree is skipped, so this
+# contributes dependencies, not Nim modules. The Makefile orchestrates the
+# build: Nimble resolves the Nim side, Go resolves the Go side, and Make links
+# them together.
+srcDir = "internal/nimble/src"
+
+
+### Dependencies
+requires "nim >= 2.2.4"
+
+# The bindings pin the nim-sds revision their C ABI matches, and it resolves
+# transitively. A pin there overrides anything named here, so this does not name
+# one; that changes when nim-sds publishes versioned tags and the bindings can
+# express a range instead.
+requires "https://github.com/logos-messaging/sds-go-bindings#c94172d"
+
+
+### Helpers
+
+proc nimblePkgDir(name: string): string =
+  ## Where the dependency was installed. `nimble path` prints one line per
+  ## installed version and exits 0 even when the package is missing, so take the
+  ## one that carries its nimble file rather than trusting position.
+  let (output, _) = gorgeEx("nimble path " & name)
+  for line in output.strip().splitLines():
+    let candidate = line.strip()
+    if candidate.isAbsolute() and fileExists(candidate / (name & ".nimble")):
+      return candidate
+  raise newException(CatchableError, name & " unresolved - run `nimble setup`")
+
+### Tasks
+
+proc runBindingsTask(taskName: string) =
+  ## Delegates to the bindings' own task; they pin the nim-sds revision their
+  ## C ABI matches. LIBSDS_OUT and NIM_PARAMS come from the caller.
+  withDir nimblePkgDir("sds_go_bindings"):
+    exec "nimble " & taskName
+
+task libsds, "Build the libsds status-go links against":
+  runBindingsTask("libsds")
+
+task libsdsAndroid, "Build libsds for Android; ARCH selects the architecture":
+  runBindingsTask("libsdsAndroid")
+
+task libsdsIOS, "Build libsds for iOS":
+  runBindingsTask("libsdsIOS")
+


### PR DESCRIPTION
Iterates https://github.com/logos-messaging/pm/issues/380
Blocked by #7757

# Description

1. Added `logos-delivery-go-bindings` as a Nim dependency, so liblogosdelivery is resolved and built the same way #7757 does it for libsds. The bindings pin the revision their C ABI matches; status-go only says where the result goes and that it does not need RLN.
2. Added `statusgo-nim-delivery`, which builds `libstatus.a` against that library so the Nix-free path can be exercised end to end. Temporary — it folds into `statusgo-library` once the delivery backend is wired in.
3. Added `pkg/messaging/delivery/doc.go`, a blank import so `go mod tidy` keeps the bindings module.
4. Added the logos-delivery flake input, with `enablePostgres = false` — the default build dlopens libpq at startup.

<details>
<summary>AI-made decisions</summary>

- The adapter itself is deliberately absent. This PR only establishes that the library builds and links; the `transport.MessagingAPI` / `wakutypes.Waku` seams are separate work.
- The bindings are pinned to a commit rather than a range because logos-delivery still reports 0.38.1 on every revision, so no range can express "at least the one with the liblogosdelivery task".
- `statusgo-nim-delivery` is unverified end to end here — `make generate` needs protoc from the Nix shell, so CI is the first real check. Its composition is confirmed: `-lsds` and `-llogosdelivery` both land in the cgo flags.
</details>
