### PR TITLE
build: upgrade protobuf to v36

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Setup Protocol Buffer Compiler
         uses: arduino/setup-protoc@v3
         with:
-          version: '29.3'
+          version: '36.0'
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Cache go-generate-fast

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,9 +6,23 @@ ENV CC=clang
 ENV CXX=clang++
 
 RUN apt-get update \
-    && apt-get install -y git bash make cmake llvm clang protobuf-compiler build-essential pkg-config curl xz-utils jq unzip \
+    && apt-get install -y git bash make cmake llvm clang build-essential pkg-config curl xz-utils jq unzip \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
+
+# Install protoc from pre-built binaries
+ARG PROTOC_VERSION=36.0
+RUN set -eu && \
+    DPKG_ARCH="$(dpkg --print-architecture)" && \
+    case "$DPKG_ARCH" in \
+    amd64) PROTOC_ARCH="x86_64" ;; \
+    arm64) PROTOC_ARCH="aarch_64" ;; \
+    *) echo "Unsupported architecture: $DPKG_ARCH" >&2; exit 1 ;; \
+    esac && \
+    curl -sSfL "https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VERSION}/protoc-${PROTOC_VERSION}-linux-${PROTOC_ARCH}.zip" -o /tmp/protoc.zip && \
+    unzip -q /tmp/protoc.zip -d /usr/local bin/protoc 'include/*' && \
+    rm /tmp/protoc.zip && \
+    protoc --version
 
 # Install Nim from pre-built binaries
 ARG NIM_VERSION=2.2.4

--- a/go.mod
+++ b/go.mod
@@ -63,7 +63,7 @@ require (
 	go.uber.org/zap v1.27.1
 	golang.org/x/crypto v0.46.0
 	golang.org/x/image v0.24.0
-	google.golang.org/protobuf v1.36.11
+	google.golang.org/protobuf v1.36.12
 	gopkg.in/go-playground/assert.v1 v1.2.1 // indirect
 	gopkg.in/go-playground/validator.v9 v9.31.0
 	gopkg.in/natefinch/lumberjack.v2 v2.2.1

--- a/go.sum
+++ b/go.sum
@@ -3487,8 +3487,8 @@ google.golang.org/protobuf v1.25.0/go.mod h1:9JNX74DMeImyA3h4bdi1ymwjUzf21/xIlba
 google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
 google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
 google.golang.org/protobuf v1.27.1/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
-google.golang.org/protobuf v1.36.11 h1:fV6ZwhNocDyBLK0dj+fg8ektcVegBBuEolpbTQyBNVE=
-google.golang.org/protobuf v1.36.11/go.mod h1:HTf+CrKn2C3g5S8VImy6tdcUvCska2kB7j23XfzDpco=
+google.golang.org/protobuf v1.36.12 h1:pJOKDDOyeXErUroCihFAd5LQuwXBSpVnKGrj5o/fwxc=
+google.golang.org/protobuf v1.36.12/go.mod h1:HTf+CrKn2C3g5S8VImy6tdcUvCska2kB7j23XfzDpco=
 gopkg.in/airbrake/gobrake.v2 v2.0.9/go.mod h1:/h5ZAUhDkGaJfjzjKLSjv6zCL6O0LLBxU4K+aSYdM/U=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -55,4 +55,10 @@ in rec {
 
   # Custom packages
   codecov-cli = callPackage ./pkgs/codecov-cli { };
+
+  # Not yet packaged in the pinned nixpkgs.
+  protobuf_36 = callPackage "${prev.path}/pkgs/development/libraries/protobuf/generic.nix" {
+    version = "36.0";
+    hash = "sha256-VGXFfqLm7IEJ9MQpMYhdVW5qPZbrYZ6q+0Y1TqQkjks=";
+  };
 }

--- a/nix/pkgs/status-go/library/default.nix
+++ b/nix/pkgs/status-go/library/default.nix
@@ -16,14 +16,14 @@ in pkgs.buildGoModule {
   src = builtins.path { path = ./../../../..; name = "status-go-library"; };
 
   # WARNING: Needs to be updated when go.mod is changed.
-  vendorHash = "sha256-8uVFPNkTvYQno/GaXtY0Flq4mW49tbboTi5A18SZu94=";
+  vendorHash = "sha256-JlN0oiZANaF95hZOYFEKSHtmu5CHtWLE3uKDSTnMpI4=";
 
   inherit meta version;
 
   nativeBuildInputs = with pkgs; [
     mockgen
     protoc-gen-go
-    protobuf_29
+    protobuf_36
   ];
 
   phases = ["unpackPhase" "configurePhase" "buildPhase"];

--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -10,7 +10,7 @@ in pkgs.mkShell {
   buildInputs = with pkgs; [
     git jq which gcc rustc cargo openjdk openssl nim go
     golangci-lint go-junit-report gopls
-    protobuf_29 protoc-gen-go gotestsum
+    protobuf_36 protoc-gen-go gotestsum
     libsds libstorage
   ] ++ lib.optionals (isDarwin) [
     pkgs.xcodeWrapper


### PR DESCRIPTION
Iterates #7099

Stacked on #7746. GitHub will not let me retarget the base of a PR that is part of a stack, so this still reads against `develop` and its diff includes #7746's commits until that one merges.

# Description

1. Upgraded protoc to v36 everywhere it is provisioned: the Nix dev shell and `status-go-library` derivation (`protobuf_29` -> `protobuf_36`), GitHub Actions (`arduino/setup-protoc` 29.3 -> 36.0), and the `Dockerfile`, where Debian's `protobuf-compiler` (3.21.12) is replaced by the upstream release build.
2. Bumped `google.golang.org/protobuf` to v1.36.12 and recomputed `vendorHash`.

<details>
<summary>AI-made decisions</summary>

- `protobuf_36` is defined in `nix/overlay.nix` because the pinned nixpkgs only packages up to `protobuf_33`. It calls nixpkgs' own `protobuf/generic.nix` builder, the same way `33.nix` and friends do, so it inherits future fixes to that builder.
- No wire-format change: regenerating all 27 `.pb.go` under protoc 29.5 vs 36.0 gives byte-identical output. Against the v1.34.1 generator that CI used to pin, every `protobuf:"..."` field tag and every enum value is identical; the only delta is a cosmetic `,proto3` marker dropped from map key/value tags.
- `.pb.go` is gitignored, so there is no generated-code churn to review.

</details>
