### PR TITLE
build: run protoc-gen-go as a go tool

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -19,20 +19,6 @@ jobs:
       - name: Get dependencies
         run: go mod download
 
-      - name: Cache Go dependencies
-        uses: actions/cache@v4
-        id: cache-go-deps
-        with:
-          path: ~/go/bin
-          key: go-deps-${{ runner.os }}-v4.0.2-protoc-gen-go-v1.34.1
-          restore-keys: |
-            go-deps-${{ runner.os }}-
-
-      - name: Install Go dependencies
-        if: steps.cache-go-deps.outputs.cache-hit != 'true'
-        run: |
-          go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.34.1
-
       - name: Setup Protocol Buffer Compiler
         uses: arduino/setup-protoc@v3
         with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -58,7 +58,6 @@ WORKDIR /go/src/github.com/status-im/status-go
 
 ADD go.mod go.sum ./
 RUN go mod download
-RUN go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.34.1
 
 ADD . .
 ARG cache_id='local'

--- a/Makefile
+++ b/Makefile
@@ -401,7 +401,6 @@ cmd: status-backend push-notification-server
 status-go-deps:
 	go clean -cache || true
 	go clean -modcache || true
-	go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.34.1
 
 # GOOS and GOARCH are essential to generate cbindings when cross compiling on macos
 GO_HOST_ENV = GOOS=$(shell go env GOHOSTOS) GOARCH=$(shell go env GOHOSTARCH)

--- a/_assets/ci/Jenkinsfile.desktop
+++ b/_assets/ci/Jenkinsfile.desktop
@@ -138,7 +138,7 @@ def assembePath(List<String> extraPaths) {
       'C:/ProgramData/scoop/apps/msys2/current/mingw64/lib',
       'C:/ProgramData/scoop/apps/vcredist2022/14.44.35211.0',
       'C:/ProgramData/scoop/apps/openssl-lts/3.0.19/bin',
-      'C:/ProgramData/scoop/apps/protobuf/3.20.1/bin',
+      'C:/ProgramData/scoop/apps/protobuf/36.0/bin',
       'C:/ProgramData/scoop/apps/inno-setup/6.7.0',
       'C:/ProgramData/scoop/apps/git/current/bin',
       'C:/ProgramData/scoop/shims',

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ tool (
 	github.com/status-im/goroutine-defer-guard/cmd/goroutine-defer-guard
 	github.com/wadey/gocovmerge
 	go.uber.org/mock/mockgen
+	google.golang.org/protobuf/cmd/protoc-gen-go
 )
 
 replace github.com/rjeczalik/notify => github.com/status-im/notify v1.0.2-status

--- a/internal/protocol/protobuf/service.go
+++ b/internal/protocol/protobuf/service.go
@@ -4,7 +4,7 @@ import (
 	"github.com/golang/protobuf/proto"
 )
 
-//go:generate protoc --go_out=. ./chat_message.proto ./application_metadata_message.proto ./membership_update_message.proto ./command.proto ./contact.proto ./pairing.proto ./push_notifications.proto ./emoji_reaction.proto ./enums.proto ./group_chat_invitation.proto ./chat_identity.proto ./communities.proto ./pin_message.proto ./anon_metrics.proto ./status_update.proto ./sync_settings.proto ./contact_verification.proto ./community_update.proto ./url_data.proto ./community_privileged_user_sync_message.proto ./profile_showcase.proto ./messenger_local_backup.proto ./wallet_local_backup.proto ./accounts_local_backup.proto
+//go:generate protoc "--go_prefix=go tool" --go_out=. ./chat_message.proto ./application_metadata_message.proto ./membership_update_message.proto ./command.proto ./contact.proto ./pairing.proto ./push_notifications.proto ./emoji_reaction.proto ./enums.proto ./group_chat_invitation.proto ./chat_identity.proto ./communities.proto ./pin_message.proto ./anon_metrics.proto ./status_update.proto ./sync_settings.proto ./contact_verification.proto ./community_update.proto ./url_data.proto ./community_privileged_user_sync_message.proto ./profile_showcase.proto ./messenger_local_backup.proto ./wallet_local_backup.proto ./accounts_local_backup.proto
 
 func Unmarshal(payload []byte) (*ApplicationMetadataMessage, error) {
 	var message ApplicationMetadataMessage

--- a/nix/pkgs/status-go/library/default.nix
+++ b/nix/pkgs/status-go/library/default.nix
@@ -22,7 +22,6 @@ in pkgs.buildGoModule {
 
   nativeBuildInputs = with pkgs; [
     mockgen
-    protoc-gen-go
     protobuf_36
   ];
 

--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -10,7 +10,7 @@ in pkgs.mkShell {
   buildInputs = with pkgs; [
     git jq which gcc rustc cargo openjdk openssl nim go
     golangci-lint go-junit-report gopls
-    protobuf_36 protoc-gen-go gotestsum
+    protobuf_36 gotestsum
     libsds libstorage
   ] ++ lib.optionals (isDarwin) [
     pkgs.xcodeWrapper

--- a/pkg/messaging/layers/encryption/protocol.go
+++ b/pkg/messaging/layers/encryption/protocol.go
@@ -21,7 +21,7 @@ import (
 	"github.com/status-im/status-go/pkg/messaging/layers/encryption/sharedsecret"
 )
 
-//go:generate protoc --go_out=. ./protocol_message.proto
+//go:generate protoc "--go_prefix=go tool" --go_out=. ./protocol_message.proto
 
 const (
 	protocolVersion                = 1

--- a/pkg/messaging/layers/reliability/protobuf/generate.go
+++ b/pkg/messaging/layers/reliability/protobuf/generate.go
@@ -1,3 +1,3 @@
 package protobuf
 
-//go:generate protoc --go_out=. ./retrieval_hint.proto
+//go:generate protoc "--go_prefix=go tool" --go_out=. ./retrieval_hint.proto

--- a/pkg/messaging/layers/segmentation/protobuf/generate.go
+++ b/pkg/messaging/layers/segmentation/protobuf/generate.go
@@ -1,3 +1,3 @@
 package protobuf
 
-//go:generate protoc --go_out=. ./segment_message.proto
+//go:generate protoc "--go_prefix=go tool" --go_out=. ./segment_message.proto


### PR DESCRIPTION
Closes the protobuf half of #7099

Stacked on #7738.

# Description

1. Declared `google.golang.org/protobuf/cmd/protoc-gen-go` in the `go.mod` `tool` block and made the four `//go:generate protoc` directives pass `"--go_prefix=go tool"`, so protoc runs the generator out of `go.mod` instead of `PATH`. The flag shipped in protobuf v36 (protocolbuffers/protobuf#24824).
2. Dropped every hand-rolled install of `protoc-gen-go`: the Nix dev shell, the `status-go-library` derivation, the `Dockerfile`, `status-go-deps`, and the GitHub Actions step with the `~/go/bin` cache that existed only to serve it.
3. Moved Windows CI to scoop `protobuf` 36.0, which 3.20.1 cannot replace — it does not understand `--go_prefix`.

<details>
<summary>AI-made decisions</summary>

- The directive is `"--go_prefix=go tool"`, not `--go_prefix="go tool"`. `go generate` only unquotes a word that starts with a quote, so the latter splits into two arguments and protoc rejects it.
- The generator version was pinned in four places that had drifted apart (v1.34.1 in the Makefile, Dockerfile and Actions; whatever nixpkgs shipped in Nix). It now comes from `go.mod` alone.
- go-generate-fast v0.5.0 executes the directive correctly but splits it with `strings.Fields`, so it does not recognise `--go_prefix` as a flag and stops tracking the `.proto` files as cache inputs. Generation is right; editing a `.proto` will not invalidate its cache. Worth a follow-up upstream to restore quote-aware splitting.
- Windows CI needs scoop `protobuf` 36.0 published before this can go green — status-im/infra-scoop-bucket#2.

</details>
