### PR TITLE
refactor: build default networks from params.WalletConfig

### DIFF
--- a/params/config.go
+++ b/params/config.go
@@ -218,6 +218,7 @@ type WalletConfig struct {
 	AlchemyAPIKey         security.SensitiveString `json:"AlchemyAPIKey"`
 	InfuraAPIKey          security.SensitiveString `json:"InfuraAPIKey"`
 	InfuraAPIKeySecret    security.SensitiveString `json:"InfuraAPIKeySecret"`
+	PoktAPIKey            security.SensitiveString `json:"PoktAPIKey"`
 	CoingeckoAPIKey       security.SensitiveString `json:"CoingeckoAPIKey"`
 	CoingeckoDemoAPIKey   security.SensitiveString `json:"CoingeckoDemoAPIKey"`
 	MarketDataProxyConfig MarketDataProxyConfig    `json:"MarketDataProxyConfig"`

--- a/params/networkdefaults/default_networks.go
+++ b/params/networkdefaults/default_networks.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/status-im/status-go/internal/protocol/requests"
 	"github.com/status-im/status-go/params"
 	"github.com/status-im/status-go/params/networkhelper"
 	"github.com/status-im/status-go/pkg/security"
@@ -145,10 +144,10 @@ func defaultNetworks(proxyHost string, thirdpartyServicesEnabled bool, usePuzzle
 	return networks
 }
 
-func setRPCs(networks []params.Network, walletConfig *requests.WalletSecretsConfig) []params.Network {
+func setRPCs(networks []params.Network, walletConfig *params.WalletConfig) []params.Network {
 	authTokens := map[string]security.SensitiveString{
-		"infura.io":  walletConfig.InfuraToken,
-		"grove.city": walletConfig.PoktToken,
+		"infura.io":  walletConfig.InfuraAPIKey,
+		"grove.city": walletConfig.PoktAPIKey,
 	}
 	networks = networkhelper.OverrideDirectProvidersAuth(networks, authTokens)
 
@@ -164,11 +163,11 @@ func setRPCs(networks []params.Network, walletConfig *requests.WalletSecretsConf
 	return networks
 }
 
-func BuildDefaultNetworks(walletSecretsConfig *requests.WalletSecretsConfig, thirdpartyServicesEnabled bool) []params.Network {
-	proxyHost := getProxyHost(walletSecretsConfig.EthRpcProxyUrl.Reveal(), walletSecretsConfig.StatusProxyStageName)
+func BuildDefaultNetworks(walletConfig *params.WalletConfig, thirdpartyServicesEnabled bool) []params.Network {
+	proxyHost := getProxyHost(walletConfig.EthRpcProxyUrl.Reveal(), walletConfig.StatusProxyStageName)
 	networks := setRPCs(
-		defaultNetworks(proxyHost, thirdpartyServicesEnabled, walletSecretsConfig.EthRpcProxyUsePuzzleAuth),
-		walletSecretsConfig,
+		defaultNetworks(proxyHost, thirdpartyServicesEnabled, walletConfig.EthRpcProxyUsePuzzleAuth),
+		walletConfig,
 	)
 	return networkhelper.WithCommunitiesSupported(networks)
 }

--- a/params/networkdefaults/default_networks_test.go
+++ b/params/networkdefaults/default_networks_test.go
@@ -7,7 +7,6 @@ import (
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
 
-	"github.com/status-im/status-go/internal/protocol/requests"
 	"github.com/status-im/status-go/params"
 	"github.com/status-im/status-go/pkg/security"
 	"github.com/status-im/status-go/pkg/services/wallet/common"
@@ -17,15 +16,13 @@ func TestBuildDefaultNetworks(t *testing.T) {
 	infuraToken := security.NewSensitiveString("infura-token")
 	poktToken := security.NewSensitiveString("pokt-token")
 	stageName := "fast-n-bulbous"
-	request := &requests.CreateAccount{
-		WalletSecretsConfig: requests.WalletSecretsConfig{
-			InfuraToken:          infuraToken,
-			PoktToken:            poktToken,
-			StatusProxyStageName: stageName,
-		},
+	walletConfig := &params.WalletConfig{
+		InfuraAPIKey:         infuraToken,
+		PoktAPIKey:           poktToken,
+		StatusProxyStageName: stageName,
 	}
 
-	actualNetworks := BuildDefaultNetworks(&request.WalletSecretsConfig, true)
+	actualNetworks := BuildDefaultNetworks(walletConfig, true)
 
 	require.Len(t, actualNetworks, 31)
 	for _, n := range actualNetworks {

--- a/pkg/backend/defaults.go
+++ b/pkg/backend/defaults.go
@@ -169,6 +169,10 @@ func buildWalletConfig(walletRequest *requests.WalletConfig, request *requests.W
 		walletConfig.InfuraAPIKey = request.InfuraToken
 	}
 
+	if !request.PoktToken.Empty() {
+		walletConfig.PoktAPIKey = request.PoktToken
+	}
+
 	if !request.InfuraSecret.Empty() {
 		walletConfig.InfuraAPIKeySecret = request.InfuraSecret
 	}
@@ -291,10 +295,12 @@ func DefaultNodeConfig(installationID, keyUID string, request *requests.CreateAc
 		nodeConfig.LogEnabled = false
 	}
 
+	nodeConfig.WalletConfig = buildWalletConfig(&request.WalletConfig, &request.WalletSecretsConfig)
+
 	if request.TestOverrideNetworks != nil {
 		nodeConfig.Networks = request.TestOverrideNetworks
 	} else {
-		nodeConfig.Networks = networkdefaults.BuildDefaultNetworks(&request.WalletSecretsConfig, request.ThirdpartyServicesEnabled)
+		nodeConfig.Networks = networkdefaults.BuildDefaultNetworks(&nodeConfig.WalletConfig, request.ThirdpartyServicesEnabled)
 	}
 
 	if request.NetworkID != nil {
@@ -302,8 +308,6 @@ func DefaultNodeConfig(installationID, keyUID string, request *requests.CreateAc
 	} else {
 		nodeConfig.NetworkID = nodeConfig.Networks[0].ChainID
 	}
-
-	nodeConfig.WalletConfig = buildWalletConfig(&request.WalletConfig, &request.WalletSecretsConfig)
 
 	nodeConfig.BrowsersConfig = params.BrowsersConfig{Enabled: true}
 	nodeConfig.PermissionsConfig = params.PermissionsConfig{Enabled: true}

--- a/pkg/backend/geth_backend.go
+++ b/pkg/backend/geth_backend.go
@@ -743,8 +743,8 @@ func (b *StatusBackend) updateAccountColorHashAndColorID(keyUID string, accounts
 	return multiAccount, nil
 }
 
-func (b *StatusBackend) overrideNetworks(conf *params.NodeConfig, request *requests.Login, thirdpartyServicesEnabled bool) {
-	conf.Networks = networkdefaults.BuildDefaultNetworks(&request.WalletSecretsConfig, thirdpartyServicesEnabled)
+func (b *StatusBackend) overrideNetworks(conf *params.NodeConfig, walletConfig *params.WalletConfig, thirdpartyServicesEnabled bool) {
+	conf.Networks = networkdefaults.BuildDefaultNetworks(walletConfig, thirdpartyServicesEnabled)
 }
 
 func (b *StatusBackend) LoginAccount(request *requests.Login) error {
@@ -852,7 +852,7 @@ func (b *StatusBackend) loginAccount(request *requests.Login) error {
 		return errors.Wrap(err, "failed to load accountSettings")
 	}
 
-	b.overrideNetworks(b.config, request, accountSettings.ThirdpartyServicesEnabled)
+	b.overrideNetworks(b.config, &defaultCfg.WalletConfig, accountSettings.ThirdpartyServicesEnabled)
 
 	if request.APIConfig != nil {
 		overrideApiConfig(b.config, request.APIConfig)

--- a/test/unit-network/alchemy-activity/alchemy_activity_test.go
+++ b/test/unit-network/alchemy-activity/alchemy_activity_test.go
@@ -29,8 +29,8 @@ func setupAlchemyActivityManager(t *testing.T) *alchemymanager.Manager {
 	walletDB, err := testutils.SetupTestMemorySQLDB(walletdb.DbInitializer{})
 	require.NoError(t, err)
 
-	walletSecrets := t_common.GetWalletSecretsConfigFromEnv()
-	defaultNetworks := networkdefaults.BuildDefaultNetworks(walletSecrets, true)
+	walletConfig := t_common.GetWalletConfigFromEnv()
+	defaultNetworks := networkdefaults.BuildDefaultNetworks(walletConfig, true)
 	networkManager := network.NewManager(appDB, nil)
 	err = networkManager.InitEmbeddedNetworks(defaultNetworks)
 	require.NoError(t, err)

--- a/test/unit-network/common/utils.go
+++ b/test/unit-network/common/utils.go
@@ -3,12 +3,12 @@ package common
 import (
 	"os"
 
-	"github.com/status-im/status-go/internal/protocol/requests"
+	"github.com/status-im/status-go/params"
 	"github.com/status-im/status-go/pkg/security"
 )
 
-func GetWalletSecretsConfigFromEnv() *requests.WalletSecretsConfig {
-	return &requests.WalletSecretsConfig{
+func GetWalletConfigFromEnv() *params.WalletConfig {
+	return &params.WalletConfig{
 		StatusProxyStageName: os.Getenv("STATUS_BUILD_PROXY_STAGE_NAME"),
 		EthRpcProxyUser:      security.NewSensitiveString(os.Getenv("STATUS_BUILD_ETH_RPC_PROXY_USER")),
 		EthRpcProxyPassword:  security.NewSensitiveString(os.Getenv("STATUS_BUILD_ETH_RPC_PROXY_PASSWORD")),


### PR DESCRIPTION
Iterates #7067

# Description

1. `BuildDefaultNetworks` takes `params.WalletConfig` instead of `requests.WalletSecretsConfig`. This drops `networkdefaults`' dependency on `internal/protocol/requests` and the protocol package graph behind it, which is what lets a networks service be extracted without dragging protocol into it.
2. Added `PoktAPIKey` to `params.WalletConfig` — the only one of the seven fields the builder needs that was missing.
3. `DefaultNodeConfig` now builds the wallet config before the network list.

<details>
<summary>AI-made decisions</summary>

- `params.WalletConfig` already carried six of the seven fields, so it is used directly. A narrow purpose-built input struct was rejected: it would have left the real type in place and added a second thing to keep in sync.
- Moving `WalletSecretsConfig` out of `requests` was also considered and dropped — `pkg/services/wallet` already imports `requests`, so putting it there is an import cycle, and wallet consumes 20 of its 21 fields to networks' 7.
- `PoktAPIKey` is added flat rather than regrouping the shared provider credentials into a nested struct. `NodeConfig` is persisted as JSON: adding a field is additive, restructuring needs a migration.
- On login, `overrideNetworks` takes the wallet config built from the request rather than `b.config.WalletConfig`. The latter is mergo-merged over the stored config, so an empty request field silently falls back to a stored credential or proxy stage name.

</details>
