### PR TITLE
refactor: move network defaults into the networks service

### DIFF
--- a/pkg/backend/defaults.go
+++ b/pkg/backend/defaults.go
@@ -16,8 +16,8 @@ import (
 	"github.com/status-im/status-go/internal/protocol/protobuf"
 	"github.com/status-im/status-go/internal/protocol/requests"
 	"github.com/status-im/status-go/params"
-	"github.com/status-im/status-go/params/networkdefaults"
 	"github.com/status-im/status-go/pkg/messaging"
+	"github.com/status-im/status-go/pkg/services/networks"
 	walletcommon "github.com/status-im/status-go/pkg/services/wallet/common"
 )
 
@@ -300,7 +300,7 @@ func DefaultNodeConfig(installationID, keyUID string, request *requests.CreateAc
 	if request.TestOverrideNetworks != nil {
 		nodeConfig.Networks = request.TestOverrideNetworks
 	} else {
-		nodeConfig.Networks = networkdefaults.BuildDefaultNetworks(&nodeConfig.WalletConfig, request.ThirdpartyServicesEnabled)
+		nodeConfig.Networks = networks.BuildDefaultNetworks(&nodeConfig.WalletConfig, request.ThirdpartyServicesEnabled)
 	}
 
 	if request.NetworkID != nil {

--- a/pkg/backend/geth_backend.go
+++ b/pkg/backend/geth_backend.go
@@ -58,12 +58,12 @@ import (
 	"github.com/status-im/status-go/internal/signal"
 	"github.com/status-im/status-go/internal/transactions"
 	"github.com/status-im/status-go/params"
-	"github.com/status-im/status-go/params/networkdefaults"
 	"github.com/status-im/status-go/pkg/backend/node"
 	nodeadapters "github.com/status-im/status-go/pkg/backend/node/adapters"
 	"github.com/status-im/status-go/pkg/sentry"
 	"github.com/status-im/status-go/pkg/services/ens"
 	"github.com/status-im/status-go/pkg/services/ext"
+	"github.com/status-im/status-go/pkg/services/networks"
 	"github.com/status-im/status-go/pkg/services/pairing/statecontrol"
 	"github.com/status-im/status-go/pkg/services/personal"
 	"github.com/status-im/status-go/pkg/services/typeddata"
@@ -744,7 +744,7 @@ func (b *StatusBackend) updateAccountColorHashAndColorID(keyUID string, accounts
 }
 
 func (b *StatusBackend) overrideNetworks(conf *params.NodeConfig, walletConfig *params.WalletConfig, thirdpartyServicesEnabled bool) {
-	conf.Networks = networkdefaults.BuildDefaultNetworks(walletConfig, thirdpartyServicesEnabled)
+	conf.Networks = networks.BuildDefaultNetworks(walletConfig, thirdpartyServicesEnabled)
 }
 
 func (b *StatusBackend) LoginAccount(request *requests.Login) error {

--- a/pkg/services/networks/default_networks.go
+++ b/pkg/services/networks/default_networks.go
@@ -1,4 +1,4 @@
-package networkdefaults
+package networks
 
 import (
 	"fmt"

--- a/pkg/services/networks/default_networks_config.go
+++ b/pkg/services/networks/default_networks_config.go
@@ -1,4 +1,4 @@
-package networkdefaults
+package networks
 
 import (
 	"github.com/status-im/status-go/pkg/security"

--- a/pkg/services/networks/default_networks_test.go
+++ b/pkg/services/networks/default_networks_test.go
@@ -1,4 +1,4 @@
-package networkdefaults
+package networks
 
 import (
 	"strings"

--- a/pkg/services/wallet/thirdparty/collectibles/alchemy/nft_proxy_utils.go
+++ b/pkg/services/wallet/thirdparty/collectibles/alchemy/nft_proxy_utils.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/status-im/status-go/params/networkdefaults"
+	"github.com/status-im/status-go/pkg/services/networks"
 	walletcollectibles "github.com/status-im/status-go/pkg/services/wallet/collectibles"
 	walletCommon "github.com/status-im/status-go/pkg/services/wallet/common"
 	"github.com/status-im/status-go/pkg/services/wallet/thirdparty"
@@ -31,7 +31,7 @@ func GetNftProxyBaseURL(customURL, stageName string, chainID walletCommon.ChainI
 		return "", thirdparty.ErrChainIDNotSupported
 	}
 
-	chainName, networkName := networkdefaults.GetProxyChainAndNetworkName(uint64(chainID))
+	chainName, networkName := networks.GetProxyChainAndNetworkName(uint64(chainID))
 	if networkName == "" || chainName == "" {
 		return "", thirdparty.ErrChainIDNotSupported
 	}

--- a/test/unit-network/alchemy-activity/alchemy_activity_test.go
+++ b/test/unit-network/alchemy-activity/alchemy_activity_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/status-im/status-go/internal/db/walletdb"
 	"github.com/status-im/status-go/internal/rpc"
 	"github.com/status-im/status-go/internal/testutils"
-	"github.com/status-im/status-go/params/networkdefaults"
 	"github.com/status-im/status-go/pkg/services/networks"
 	alchemymanager "github.com/status-im/status-go/pkg/services/wallet/activityfetcher/alchemy"
 	"github.com/status-im/status-go/pkg/services/wallet/common"
@@ -30,7 +29,7 @@ func setupAlchemyActivityManager(t *testing.T) *alchemymanager.Manager {
 	require.NoError(t, err)
 
 	walletConfig := t_common.GetWalletConfigFromEnv()
-	defaultNetworks := networkdefaults.BuildDefaultNetworks(walletConfig, true)
+	defaultNetworks := networks.BuildDefaultNetworks(walletConfig, true)
 	networkManager := networks.NewManager(appDB, nil)
 	err = networkManager.InitEmbeddedNetworks(defaultNetworks)
 	require.NoError(t, err)


### PR DESCRIPTION
Iterates #7067
Requires #7748

# Description

1. Moved `params/networkdefaults` into `pkg/services/networks`, next to the manager that owns networks.

<details>
<summary>AI-made decisions</summary>

- Dissolved into the `networks` package rather than kept as a subpackage: `networks.BuildDefaultNetworks` reads better than `defaults.BuildDefaultNetworks` at the two bootstrap call sites.
- `GetProxyChainAndNetworkName` travels with the defaults rather than moving next to its only caller in `alchemy/`, as originally planned. It reads `defaultNetworkSpecs`, so moving it would have duplicated the chainID-to-proxy-name mapping.

</details>
