### PR TITLE
refactor: fold networkhelper into the networks service

### DIFF
--- a/internal/rpc/client_test.go
+++ b/internal/rpc/client_test.go
@@ -25,7 +25,6 @@ import (
 	"github.com/status-im/status-go/internal/rpc/chain/rpclimiter"
 	"github.com/status-im/status-go/internal/testutils"
 	"github.com/status-im/status-go/params"
-	"github.com/status-im/status-go/params/networkhelper"
 	"github.com/status-im/status-go/pkg/security"
 	"github.com/status-im/status-go/pkg/services/networks"
 )
@@ -95,7 +94,7 @@ func TestGetClientsUsingCache(t *testing.T) {
 		},
 	}
 
-	testNetworks = networkhelper.OverrideBasicAuth(
+	testNetworks = networks.OverrideBasicAuth(
 		testNetworks,
 		params.EmbeddedEthRpcProxyProviderType,
 		true,

--- a/pkg/services/networks/communities_supported.go
+++ b/pkg/services/networks/communities_supported.go
@@ -1,22 +1,22 @@
-package networkhelper
+package networks
 
 import (
 	communitytokendeployer "github.com/status-im/status-go/internal/contracts/community-tokens/deployer"
 	"github.com/status-im/status-go/params"
 )
 
-// WithCommunitiesSupported returns a copy of the given networks slice with CommunitiesSupported
+// withCommunitiesSupported returns a copy of the given networks slice with CommunitiesSupported
 // set based on CommunitiesSupportedOnChain(chainID).
-func WithCommunitiesSupported(networks []params.Network) []params.Network {
-	updated := DeepCopyNetworks(networks)
+func withCommunitiesSupported(networks []params.Network) []params.Network {
+	updated := deepCopyNetworks(networks)
 	for i := range updated {
 		updated[i].CommunitiesSupported = communitytokendeployer.CommunitiesSupportedOnChain(updated[i].ChainID)
 	}
 	return updated
 }
 
-// ApplyCommunitiesSupported sets CommunitiesSupported in-place for each network.
-func ApplyCommunitiesSupported(networks []*params.Network) {
+// applyCommunitiesSupported sets CommunitiesSupported in-place for each network.
+func applyCommunitiesSupported(networks []*params.Network) {
 	for _, n := range networks {
 		if n == nil {
 			continue

--- a/pkg/services/networks/default_networks.go
+++ b/pkg/services/networks/default_networks.go
@@ -5,7 +5,6 @@ import (
 	"strings"
 
 	"github.com/status-im/status-go/params"
-	"github.com/status-im/status-go/params/networkhelper"
 	"github.com/status-im/status-go/pkg/security"
 )
 
@@ -149,11 +148,11 @@ func setRPCs(networks []params.Network, walletConfig *params.WalletConfig) []par
 		"infura.io":  walletConfig.InfuraAPIKey,
 		"grove.city": walletConfig.PoktAPIKey,
 	}
-	networks = networkhelper.OverrideDirectProvidersAuth(networks, authTokens)
+	networks = overrideDirectProvidersAuth(networks, authTokens)
 
 	// Apply auth for new smart proxy
 	hasSmartProxyCredentials := !walletConfig.EthRpcProxyUser.Empty() && !walletConfig.EthRpcProxyPassword.Empty()
-	networks = networkhelper.OverrideBasicAuth(
+	networks = OverrideBasicAuth(
 		networks,
 		params.EmbeddedEthRpcProxyProviderType,
 		hasSmartProxyCredentials,
@@ -169,7 +168,7 @@ func BuildDefaultNetworks(walletConfig *params.WalletConfig, thirdpartyServicesE
 		defaultNetworks(proxyHost, thirdpartyServicesEnabled, walletConfig.EthRpcProxyUsePuzzleAuth),
 		walletConfig,
 	)
-	return networkhelper.WithCommunitiesSupported(networks)
+	return withCommunitiesSupported(networks)
 }
 
 func GetProxyChainAndNetworkName(chainID uint64) (string, string) {

--- a/pkg/services/networks/network.go
+++ b/pkg/services/networks/network.go
@@ -12,7 +12,6 @@ import (
 	"github.com/status-im/status-go/internal/logutils"
 	"github.com/status-im/status-go/internal/panics"
 	"github.com/status-im/status-go/params"
-	"github.com/status-im/status-go/params/networkhelper"
 	"github.com/status-im/status-go/pkg/pubsub"
 	"github.com/status-im/status-go/pkg/services/networks/db"
 	persistence "github.com/status-im/status-go/pkg/services/networks/db"
@@ -166,11 +165,11 @@ func (nm *Manager) InitEmbeddedNetworks(embeddedNetworks []params.Network) error
 		var updatedNetworks []params.Network
 		for _, newNetwork := range embeddedNetworks {
 			if existingNetwork, exists := currentNetworskMap[newNetwork.ChainID]; exists {
-				newNetwork.RpcProviders = networkhelper.GetUserProviders(existingNetwork.RpcProviders)
+				newNetwork.RpcProviders = getUserProviders(existingNetwork.RpcProviders)
 				newNetwork.Enabled = existingNetwork.Enabled
 				newNetwork.IsActive = existingNetwork.IsActive
 			} else {
-				newNetwork.RpcProviders = networkhelper.GetUserProviders(newNetwork.RpcProviders)
+				newNetwork.RpcProviders = getUserProviders(newNetwork.RpcProviders)
 			}
 			updatedNetworks = append(updatedNetworks, newNetwork)
 		}
@@ -201,19 +200,19 @@ func (nm *Manager) setEmbeddedFields(networks []*params.Network) {
 		if embeddedNetwork != nil {
 			network.IsDeactivatable = embeddedNetwork.IsDeactivatable
 			// Append embedded providers to the user providers
-			network.RpcProviders = networkhelper.ReplaceEmbeddedProviders(
+			network.RpcProviders = replaceEmbeddedProviders(
 				network.RpcProviders, embeddedNetwork.RpcProviders)
 		}
 	}
 
 	// CommunitiesSupported is derived (not persisted) and should always reflect the contract availability.
-	networkhelper.ApplyCommunitiesSupported(networks)
+	applyCommunitiesSupported(networks)
 }
 
 // networkWithoutEmbeddedProviders returns a copy of the given network without embedded RPC providers.
 func (nm *Manager) networkWithoutEmbeddedProviders(network *params.Network) *params.Network {
 	networkCopy := network.DeepCopy()
-	networkCopy.RpcProviders = networkhelper.GetUserProviders(network.RpcProviders)
+	networkCopy.RpcProviders = getUserProviders(network.RpcProviders)
 	return &networkCopy
 }
 
@@ -248,7 +247,7 @@ func (nm *Manager) Delete(chainID uint64) error {
 // SetUserRpcProviders updates user RPC providers, wrapped in a transaction.
 func (nm *Manager) SetUserRpcProviders(chainID uint64, userProviders []params.RpcProvider) error {
 	rpcPersistence := nm.networkPersistence.GetRpcPersistence()
-	return rpcPersistence.SetRpcProviders(chainID, networkhelper.GetUserProviders(userProviders))
+	return rpcPersistence.SetRpcProviders(chainID, getUserProviders(userProviders))
 }
 
 // SetActive updates the active status of a network

--- a/pkg/services/networks/network_test.go
+++ b/pkg/services/networks/network_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/status-im/status-go/internal/db/appdatabase"
 	"github.com/status-im/status-go/internal/testutils"
 	"github.com/status-im/status-go/params"
-	"github.com/status-im/status-go/params/networkhelper"
 	"github.com/status-im/status-go/pkg/security"
 	"github.com/status-im/status-go/pkg/services/networks"
 	"github.com/status-im/status-go/pkg/services/networks/db"
@@ -101,7 +100,7 @@ func (s *NetworkManagerTestSuite) TestUserAddsCustomProviders() {
 	// Assert providers
 	foundNetwork := s.manager.Find(common.EthereumMainnet)
 	s.Require().NotNil(foundNetwork)
-	expectedProviders := append(customProviders, networkhelper.GetEmbeddedProviders(foundNetwork.RpcProviders)...)
+	expectedProviders := append(customProviders, networks.GetEmbeddedProviders(foundNetwork.RpcProviders)...)
 	testutil.CompareProvidersList(s.T(), expectedProviders, foundNetwork.RpcProviders)
 }
 
@@ -126,7 +125,7 @@ func (s *NetworkManagerTestSuite) TestInitNetworksKeepsUserProviders() {
 	// Check that custom providers are retained
 	foundNetwork := s.manager.Find(common.EthereumMainnet)
 	s.Require().NotNil(foundNetwork)
-	expectedProviders := append(customProviders, networkhelper.GetEmbeddedProviders(initNetworks[0].RpcProviders)...)
+	expectedProviders := append(customProviders, networks.GetEmbeddedProviders(initNetworks[0].RpcProviders)...)
 	testutil.CompareProvidersList(s.T(), expectedProviders, foundNetwork.RpcProviders)
 }
 
@@ -144,10 +143,10 @@ func (s *NetworkManagerTestSuite) TestInitNetworksDoesNotSaveEmbeddedProviders()
 	s.Require().NoError(err)
 
 	// Check that embedded providers are not saved using persistence
-	networks, err := persistence.GetNetworks(false, nil)
+	storedNetworks, err := persistence.GetNetworks(false, nil)
 	s.Require().NoError(err)
-	s.Require().Len(networks, 1)
-	s.Require().Len(networks[0].RpcProviders, 0)
+	s.Require().Len(storedNetworks, 1)
+	s.Require().Len(storedNetworks[0].RpcProviders, 0)
 }
 
 func (s *NetworkManagerTestSuite) TestInitEmbeddedNetworks() {
@@ -157,45 +156,45 @@ func (s *NetworkManagerTestSuite) TestInitEmbeddedNetworks() {
 			testutil.CreateProvider(common.EthereumMainnet, "Infura Mainnet", params.EmbeddedEthRpcProxyProviderType, true, security.NewSensitiveString("https://mainnet.infura.io")),
 		}),
 	}
-	expectedProviders := networkhelper.GetEmbeddedProviders(initNetworks[0].RpcProviders)
+	expectedProviders := networks.GetEmbeddedProviders(initNetworks[0].RpcProviders)
 	err := s.manager.InitEmbeddedNetworks(initNetworks)
 	s.Require().NoError(err)
 
 	// functor tests if embedded providers are present in the networks
-	expectEmbeddedProviders := func(networks []*params.Network) {
-		for _, network := range networks {
+	expectEmbeddedProviders := func(nets []*params.Network) {
+		for _, network := range nets {
 			if network.ChainID == common.EthereumMainnet {
-				storedEmbeddedProviders := networkhelper.GetEmbeddedProviders(network.RpcProviders)
+				storedEmbeddedProviders := networks.GetEmbeddedProviders(network.RpcProviders)
 				testutil.CompareProvidersList(s.T(), expectedProviders, storedEmbeddedProviders)
 			}
 		}
 	}
 
 	// GetAll
-	networks, err := s.manager.GetAll()
+	storedNetworks, err := s.manager.GetAll()
 	s.Require().NoError(err)
-	expectEmbeddedProviders(networks)
+	expectEmbeddedProviders(storedNetworks)
 
 	// Get
-	networks, err = s.manager.Get(false)
+	storedNetworks, err = s.manager.Get(false)
 	s.Require().NoError(err)
-	expectEmbeddedProviders(networks)
+	expectEmbeddedProviders(storedNetworks)
 
 	// GetActiveNetworks
-	networks, err = s.manager.GetActiveNetworks()
+	storedNetworks, err = s.manager.GetActiveNetworks()
 	s.Require().NoError(err)
-	expectEmbeddedProviders(networks)
+	expectEmbeddedProviders(storedNetworks)
 
 	// GetCombinedNetworks
 	combinedNetworks, err := s.manager.GetCombinedNetworks()
 	s.Require().NoError(err)
 	for _, combinedNetwork := range combinedNetworks {
 		if combinedNetwork.Test != nil && combinedNetwork.Test.ChainID == common.EthereumMainnet {
-			storedEmbeddedProviders := networkhelper.GetEmbeddedProviders(combinedNetwork.Test.RpcProviders)
+			storedEmbeddedProviders := networks.GetEmbeddedProviders(combinedNetwork.Test.RpcProviders)
 			testutil.CompareProvidersList(s.T(), expectedProviders, storedEmbeddedProviders)
 		}
 		if combinedNetwork.Prod != nil && combinedNetwork.Prod.ChainID == common.EthereumMainnet {
-			storedEmbeddedProviders := networkhelper.GetEmbeddedProviders(combinedNetwork.Prod.RpcProviders)
+			storedEmbeddedProviders := networks.GetEmbeddedProviders(combinedNetwork.Prod.RpcProviders)
 			testutil.CompareProvidersList(s.T(), expectedProviders, storedEmbeddedProviders)
 		}
 	}
@@ -225,11 +224,11 @@ func (s *NetworkManagerTestSuite) TestLegacyFieldPopulation() {
 	s.Require().NoError(err)
 
 	// Fetch networks and verify legacy field population
-	networks, err := persistence.GetNetworks(false, nil)
+	storedNetworks, err := persistence.GetNetworks(false, nil)
 	s.Require().NoError(err)
-	s.Require().Len(networks, 1)
+	s.Require().Len(storedNetworks, 1)
 
-	network := networks[0]
+	network := storedNetworks[0]
 
 	// Check legacy fields
 	s.Equal("https://direct1.ethereum.io", network.OriginalRPCURL)
@@ -254,11 +253,11 @@ func (s *NetworkManagerTestSuite) TestLegacyFieldPopulationWithoutUserProviders(
 	s.Require().NoError(err)
 
 	// Fetch networks and verify legacy field population
-	networks, err := persistence.GetNetworks(false, nil)
+	storedNetworks, err := persistence.GetNetworks(false, nil)
 	s.Require().NoError(err)
-	s.Require().Len(networks, 1)
+	s.Require().Len(storedNetworks, 1)
 
-	network := networks[0]
+	network := storedNetworks[0]
 
 	// Check legacy fields
 	s.Equal("https://direct1.sepolia.io", network.OriginalRPCURL)
@@ -284,12 +283,12 @@ func (s *NetworkManagerTestSuite) TestUpsertNetwork() {
 
 	// Verify the network was upserted without embedded providers
 	persistence := db.NewNetworksPersistence(s.db)
-	networks, err := persistence.GetNetworks(false, &chainID)
+	storedNetworks, err := persistence.GetNetworks(false, &chainID)
 	s.Require().NoError(err)
-	s.Require().Len(networks, 1)
-	s.Require().Len(networkhelper.GetEmbeddedProviders(networks[0].RpcProviders), 0)
-	s.Require().False(networks[0].IsActive)
-	s.Require().True(networks[0].IsDeactivatable)
+	s.Require().Len(storedNetworks, 1)
+	s.Require().Len(networks.GetEmbeddedProviders(storedNetworks[0].RpcProviders), 0)
+	s.Require().False(storedNetworks[0].IsActive)
+	s.Require().True(storedNetworks[0].IsDeactivatable)
 }
 
 func (s *NetworkManagerTestSuite) TestSetActive() {

--- a/pkg/services/networks/provider_utils.go
+++ b/pkg/services/networks/provider_utils.go
@@ -1,4 +1,4 @@
-package networkhelper
+package networks
 
 import (
 	"net/url"
@@ -9,9 +9,9 @@ import (
 	"github.com/status-im/status-go/pkg/services/networks/db"
 )
 
-// MergeProvidersPreservingUsersAndEnabledState merges new embedded providers with the current ones,
+// mergeProvidersPreservingUsersAndEnabledState merges new embedded providers with the current ones,
 // preserving user-defined providers and maintaining the Enabled state.
-func MergeProvidersPreservingUsersAndEnabledState(currentProviders, newProviders []params.RpcProvider) []params.RpcProvider {
+func mergeProvidersPreservingUsersAndEnabledState(currentProviders, newProviders []params.RpcProvider) []params.RpcProvider {
 	// Create a map for quick lookup of the Enabled state by Name
 	enabledState := make(map[string]bool, len(currentProviders))
 	for _, provider := range currentProviders {
@@ -50,8 +50,8 @@ func GetEmbeddedProviders(providers []params.RpcProvider) []params.RpcProvider {
 	return embeddedProviders
 }
 
-// GetUserProviders returns the user-defined providers from the list.
-func GetUserProviders(providers []params.RpcProvider) []params.RpcProvider {
+// getUserProviders returns the user-defined providers from the list.
+func getUserProviders(providers []params.RpcProvider) []params.RpcProvider {
 	userProviders := make([]params.RpcProvider, 0, len(providers))
 	for _, provider := range providers {
 		if provider.Type == params.UserProviderType {
@@ -61,10 +61,10 @@ func GetUserProviders(providers []params.RpcProvider) []params.RpcProvider {
 	return userProviders
 }
 
-// ReplaceEmbeddedProviders replaces embedded providers with new ones, retaining user-defined providers.
-func ReplaceEmbeddedProviders(currentProviders, newEmbeddedProviders []params.RpcProvider) []params.RpcProvider {
+// replaceEmbeddedProviders replaces embedded providers with new ones, retaining user-defined providers.
+func replaceEmbeddedProviders(currentProviders, newEmbeddedProviders []params.RpcProvider) []params.RpcProvider {
 	// Extract user-defined providers from the current list
-	userProviders := GetUserProviders(currentProviders)
+	userProviders := getUserProviders(currentProviders)
 	embeddedProviders := GetEmbeddedProviders(newEmbeddedProviders)
 
 	// Combine existing user-defined providers with the new embedded providers
@@ -74,7 +74,7 @@ func ReplaceEmbeddedProviders(currentProviders, newEmbeddedProviders []params.Rp
 // OverrideBasicAuth updates providers of the specified type in the given networks.
 // It sets the `Enabled` flag and configures the `AuthLogin` and `AuthPassword` for each matching provider.
 func OverrideBasicAuth(networks []params.Network, providerType params.RpcProviderType, enabled bool, user, password security.SensitiveString) []params.Network {
-	updatedNetworks := DeepCopyNetworks(networks)
+	updatedNetworks := deepCopyNetworks(networks)
 
 	for i := range updatedNetworks {
 		network := &updatedNetworks[i]
@@ -96,7 +96,7 @@ func OverrideBasicAuth(networks []params.Network, providerType params.RpcProvide
 	return updatedNetworks
 }
 
-func DeepCopyNetworks(networks []params.Network) []params.Network {
+func deepCopyNetworks(networks []params.Network) []params.Network {
 	updatedNetworks := make([]params.Network, len(networks))
 	for i, network := range networks {
 		updatedNetworks[i] = network.DeepCopy()
@@ -104,8 +104,8 @@ func DeepCopyNetworks(networks []params.Network) []params.Network {
 	return updatedNetworks
 }
 
-func OverrideDirectProvidersAuth(networks []params.Network, authTokens map[string]security.SensitiveString) []params.Network {
-	updatedNetworks := DeepCopyNetworks(networks)
+func overrideDirectProvidersAuth(networks []params.Network, authTokens map[string]security.SensitiveString) []params.Network {
+	updatedNetworks := deepCopyNetworks(networks)
 
 	for i := range updatedNetworks {
 		network := &updatedNetworks[i]

--- a/pkg/services/networks/provider_utils_test.go
+++ b/pkg/services/networks/provider_utils_test.go
@@ -1,4 +1,4 @@
-package networkhelper_test
+package networks
 
 import (
 	"reflect"
@@ -13,7 +13,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/status-im/status-go/params"
-	"github.com/status-im/status-go/params/networkhelper"
 	"github.com/status-im/status-go/pkg/security"
 	"github.com/status-im/status-go/pkg/services/networks/testutil"
 	walletcommon "github.com/status-im/status-go/pkg/services/wallet/common"
@@ -40,7 +39,7 @@ func TestMergeProvidersPreserveEnabledAndOrder(t *testing.T) {
 	}
 
 	// Call MergeProviders
-	mergedProviders := networkhelper.MergeProvidersPreservingUsersAndEnabledState(currentProviders, newProviders)
+	mergedProviders := mergeProvidersPreservingUsersAndEnabledState(currentProviders, newProviders)
 
 	expectedEmbeddedProvider1 := newProviders[0]
 	expectedEmbeddedProvider1.Enabled = false // Should retain Enabled: false
@@ -79,7 +78,7 @@ func TestOverrideBasicAuth(t *testing.T) {
 	// Test updating EmbeddedEthRpcProxyProviderType providers
 	user2 := security.NewSensitiveString(gofakeit.Username())
 	password2 := security.NewSensitiveString(gofakeit.LetterN(5))
-	updatedNetworks := networkhelper.OverrideBasicAuth(networks, params.EmbeddedEthRpcProxyProviderType, true, user2, password2)
+	updatedNetworks := OverrideBasicAuth(networks, params.EmbeddedEthRpcProxyProviderType, true, user2, password2)
 
 	// Verify the networks
 	for i, network := range updatedNetworks {
@@ -122,7 +121,7 @@ func TestOverrideBasicAuth_PuzzleProvidersLeftUntouched(t *testing.T) {
 	user := security.NewSensitiveString("u")
 	pass := security.NewSensitiveString("p")
 
-	updated := networkhelper.OverrideBasicAuth(networks, params.EmbeddedEthRpcProxyProviderType, true, user, pass)
+	updated := OverrideBasicAuth(networks, params.EmbeddedEthRpcProxyProviderType, true, user, pass)
 	require.Len(t, updated, 1)
 	for _, p := range updated[0].RpcProviders {
 		if p.AuthType == params.PuzzleAuth {
@@ -138,7 +137,7 @@ func TestOverrideBasicAuth_PuzzleProvidersLeftUntouched(t *testing.T) {
 		}
 	}
 
-	disabled := networkhelper.OverrideBasicAuth(networks, params.EmbeddedEthRpcProxyProviderType, false, user, pass)
+	disabled := OverrideBasicAuth(networks, params.EmbeddedEthRpcProxyProviderType, false, user, pass)
 	for _, p := range disabled[0].RpcProviders {
 		if p.AuthType == params.PuzzleAuth {
 			require.Equal(t, params.PuzzleAuth, p.AuthType)
@@ -174,8 +173,8 @@ func TestOverrideDirectProvidersAuth(t *testing.T) {
 		"example.com": security.NewSensitiveString(gofakeit.UUID()),
 	}
 
-	// Call OverrideDirectProvidersAuth
-	updatedNetworks := networkhelper.OverrideDirectProvidersAuth(networks, authTokens)
+	// Call overrideDirectProvidersAuth
+	updatedNetworks := overrideDirectProvidersAuth(networks, authTokens)
 
 	// Verify the networks have updated auth tokens correctly
 	for i, network := range updatedNetworks {

--- a/pkg/services/networks/validate.go
+++ b/pkg/services/networks/validate.go
@@ -1,4 +1,4 @@
-package networkhelper
+package networks
 
 import (
 	"gopkg.in/go-playground/validator.v9"
@@ -6,7 +6,7 @@ import (
 	"github.com/status-im/status-go/params"
 )
 
-func GetValidator() *validator.Validate {
+func getValidator() *validator.Validate {
 	validate := validator.New()
 
 	// Register struct-level validation for RpcProvider

--- a/pkg/services/networks/validate_test.go
+++ b/pkg/services/networks/validate_test.go
@@ -1,4 +1,4 @@
-package networkhelper_test
+package networks
 
 import (
 	"testing"
@@ -8,12 +8,11 @@ import (
 	"gopkg.in/go-playground/validator.v9"
 
 	"github.com/status-im/status-go/params"
-	"github.com/status-im/status-go/params/networkhelper"
 	"github.com/status-im/status-go/pkg/security"
 )
 
 func TestValidation(t *testing.T) {
-	validate := networkhelper.GetValidator()
+	validate := getValidator()
 
 	// Test cases for RpcProvider
 	providerTests := []struct {

--- a/pkg/services/wallet/api_impl_test.go
+++ b/pkg/services/wallet/api_impl_test.go
@@ -23,7 +23,6 @@ import (
 	"github.com/status-im/status-go/internal/rpc"
 	"github.com/status-im/status-go/internal/testutils"
 	"github.com/status-im/status-go/params"
-	"github.com/status-im/status-go/params/networkhelper"
 	"github.com/status-im/status-go/pkg/pubsub"
 	"github.com/status-im/status-go/pkg/security"
 	"github.com/status-im/status-go/pkg/services/networks"
@@ -66,7 +65,7 @@ func TestAPI_GetAddressDetails(t *testing.T) {
 		),
 	}
 
-	testNetworks = networkhelper.OverrideBasicAuth(testNetworks, params.EmbeddedEthRpcProxyProviderType, true, security.NewSensitiveString(gofakeit.Username()), security.NewSensitiveString(gofakeit.LetterN(5)))
+	testNetworks = networks.OverrideBasicAuth(testNetworks, params.EmbeddedEthRpcProxyProviderType, true, security.NewSensitiveString(gofakeit.Username()), security.NewSensitiveString(gofakeit.LetterN(5)))
 	require.NotEmpty(t, testNetworks)
 
 	networkManager := networks.NewManager(appDB, nil)


### PR DESCRIPTION
Iterates #7067
Requires #7749

# Description

1. Moved `params/networkhelper` into `pkg/services/networks` and unexported eight of its ten functions, now that their callers sit in the same package. With this, `params/` carries no network-building code.
2. Its two test files become internal tests, since what they cover is no longer exported.

<details>
<summary>AI-made decisions</summary>

- `OverrideBasicAuth` and `GetEmbeddedProviders` stay exported: tests in `internal/rpc` and `pkg/services/wallet` build networks with them.
- Local variables named `networks` were renamed where they shadowed the package.

</details>
