### PR TITLE
refactor: drop the network RPC methods from the wallet service

### DIFF
--- a/pkg/services/networks/api.go
+++ b/pkg/services/networks/api.go
@@ -36,3 +36,27 @@ func (api *API) SetChainActive(ctx context.Context, chainID uint64, active bool)
 func (api *API) SetChainEnabled(ctx context.Context, chainID uint64, enabled bool) error {
 	return api.manager.SetEnabled(chainID, enabled)
 }
+
+// AddEthereumChain adds or updates a network.
+//
+// Deprecated: custom networks are not currently supported. Change settings
+// using specific API functions.
+func (api *API) AddEthereumChain(ctx context.Context, network params.Network) error {
+	return api.manager.Upsert(&network)
+}
+
+// DeleteEthereumChain removes a network.
+//
+// Deprecated: custom networks are not currently supported. Change settings
+// using specific API functions.
+func (api *API) DeleteEthereumChain(ctx context.Context, chainID uint64) error {
+	return api.manager.Delete(chainID)
+}
+
+// GetEthereumChains returns networks paired by prod and test chain.
+//
+// Deprecated: combined networks are not used anymore, use
+// GetFlatEthereumChains instead.
+func (api *API) GetEthereumChains(ctx context.Context) ([]*CombinedNetwork, error) {
+	return api.manager.GetCombinedNetworks()
+}

--- a/pkg/services/wallet/api.go
+++ b/pkg/services/wallet/api.go
@@ -25,7 +25,6 @@ import (
 	"github.com/status-im/status-go/internal/healthmanager"
 	"github.com/status-im/status-go/internal/logutils"
 	"github.com/status-im/status-go/params"
-	"github.com/status-im/status-go/pkg/services/networks"
 	"github.com/status-im/status-go/pkg/services/typeddata"
 	"github.com/status-im/status-go/pkg/services/wallet/activity"
 	"github.com/status-im/status-go/pkg/services/wallet/collectibles"
@@ -324,47 +323,6 @@ func (api *API) GetUnsupportedCollectibleChainIds(_ context.Context) ([]uint64, 
 /*
    Collectibles API End
 */
-
-// @deprecated: Custom networks not currently supported. Change settings using specific API functions.
-func (api *API) AddEthereumChain(ctx context.Context, network params.Network) error {
-	logutils.ZapLogger().Debug("call to AddEthereumChain")
-	return api.s.rpcClient.GetNetworkManager().Upsert(&network)
-}
-
-// @deprecated: Custom networks not currently supported. Change settings using specific API functions.
-func (api *API) DeleteEthereumChain(ctx context.Context, chainID uint64) error {
-	logutils.ZapLogger().Debug("call to DeleteEthereumChain")
-	return api.s.rpcClient.GetNetworkManager().Delete(chainID)
-}
-
-func (api *API) SetChainUserRpcProviders(ctx context.Context, chainID uint64, rpcProviders []params.RpcProvider) error {
-	logutils.ZapLogger().Debug("call to SetChainUserRpcProviders")
-	return api.s.rpcClient.GetNetworkManager().SetUserRpcProviders(chainID, rpcProviders)
-}
-
-// Active chains are the ones that are available for selection across the whole application
-// Providers are expected to be accessed only for active chains.
-func (api *API) SetChainActive(ctx context.Context, chainID uint64, active bool) error {
-	logutils.ZapLogger().Debug("call to SetChainActive")
-	return api.s.rpcClient.GetNetworkManager().SetActive(chainID, active)
-}
-
-// Enabled chains are the ones taken into account when displaying balances, collectibles, activity, etc.
-func (api *API) SetChainEnabled(ctx context.Context, chainID uint64, enabled bool) error {
-	logutils.ZapLogger().Debug("call to SetChainEnabled")
-	return api.s.rpcClient.GetNetworkManager().SetEnabled(chainID, enabled)
-}
-
-// @deprecated: Combined networks are not used anymore, use GetFlatEthereumChains instead
-func (api *API) GetEthereumChains(ctx context.Context) ([]*networks.CombinedNetwork, error) {
-	logutils.ZapLogger().Debug("call to GetEthereumChains")
-	return api.s.rpcClient.GetNetworkManager().GetCombinedNetworks()
-}
-
-func (api *API) GetFlatEthereumChains(ctx context.Context) ([]*params.Network, error) {
-	logutils.ZapLogger().Debug("call to GetFlatEthereumChains")
-	return api.s.rpcClient.GetNetworkManager().GetAll()
-}
 
 // @deprecated
 // FetchPrices fetches prices for a given token keys and currencies. If no tokens are provided, all tokens of interest are fetched.

--- a/test/functional/clients/services/networks.py
+++ b/test/functional/clients/services/networks.py
@@ -1,0 +1,28 @@
+from clients.rpc import RpcClient
+from clients.services.service import Service
+
+
+class NetworksService(Service):
+    def __init__(self, client: RpcClient):
+        super().__init__(client, "networks")
+
+    def add_ethereum_chain(self, network: dict):
+        return self.rpc_request("addEthereumChain", [network])
+
+    def delete_ethereum_chain(self, chain_id: int):
+        return self.rpc_request("deleteEthereumChain", [chain_id])
+
+    def get_ethereum_chains(self):
+        return self.rpc_request("getEthereumChains")
+
+    def get_flat_ethereum_chains(self):
+        return self.rpc_request("getFlatEthereumChains")
+
+    def set_chain_active(self, chain_id: int, active: bool):
+        return self.rpc_request("setChainActive", [chain_id, active])
+
+    def set_chain_enabled(self, chain_id: int, enabled: bool):
+        return self.rpc_request("setChainEnabled", [chain_id, enabled])
+
+    def set_chain_user_rpc_providers(self, chain_id: int, rpc_providers: list):
+        return self.rpc_request("setChainUserRpcProviders", [chain_id, rpc_providers])

--- a/test/functional/clients/services/wallet.py
+++ b/test/functional/clients/services/wallet.py
@@ -18,9 +18,6 @@ class WalletService(Service):
     def start_wallet(self):
         return self.rpc_request("startWallet")
 
-    def add_ethereum_chain(self, network: dict):
-        return self.rpc_request("addEthereumChain", [network])
-
     def get_derived_addresses_for_mnemonic(self, mnemonic: str, paths: list):
         params = [mnemonic, paths]
         return self.rpc_request("getDerivedAddressesForMnemonic", params)
@@ -57,11 +54,6 @@ class WalletService(Service):
     def sign_message(self, message: str, address: str, password: str):
         params = [message, address, password]
         return self.rpc_request("signMessage", params)
-
-    def get_ethereum_chain(
-        self,
-    ):
-        return self.rpc_request("getEthereumChains")
 
     def get_all_token_lists(
         self,

--- a/test/functional/clients/status_backend.py
+++ b/test/functional/clients/status_backend.py
@@ -23,6 +23,7 @@ from clients.services.ens import EnsService
 from clients.services.eth import EthService
 from clients.services.linkpreview import LinkPreviewService
 from clients.services.multiaccounts import MultiAccountsService
+from clients.services.networks import NetworksService
 from clients.services.newsfeed import NewsFeedService
 from clients.services.settings import SettingsService
 from clients.services.sharedurls import SharedURLsService
@@ -101,6 +102,7 @@ class StatusBackend(RpcClient, SignalClient, ApiClient):
                 SignalClient.connect(self)
 
             self.wallet_service = WalletService(self)
+            self.networks_service = NetworksService(self)
             self.wakuext_service = WakuextService(self)
             self.accounts_service = AccountService(self)
             self.newsfeed_service = NewsFeedService(self)
@@ -252,11 +254,11 @@ class StatusBackend(RpcClient, SignalClient, ApiClient):
     def add_anvil_network(self, **kwargs):
         # LoginAccount rebuilds the network list from defaults (status-im/status-go#6010, #5597), so a
         # paired device that signs in via login() never gets the Anvil chain and drops token-gated
-        # community messages. wallet_addEthereumChain (Upsert) keeps only USER providers, so add the
+        # community messages. networks_addEthereumChain (Upsert) keeps only USER providers, so add the
         # chain with a user provider — an embedded one is stripped, leaving the chain with no usable
         # provider, which fails as "could not find any enabled RPC providers for chain: 31337".
         network = self._build_anvil_network(provider_type="user", **kwargs)
-        return self.wallet_service.add_ethereum_chain(network)
+        return self.networks_service.add_ethereum_chain(network)
 
     def _set_proxy_credentials(self, data):
         if "STATUS_BUILD_PROXY_USER" not in os.environ:

--- a/test/functional/tests/test_wallet_rpc.py
+++ b/test/functional/tests/test_wallet_rpc.py
@@ -61,7 +61,7 @@ class TestRpc:
         assert result is None
 
     def test_get_ethereum_chain(self):
-        result = self.rpc_client.wallet_service.get_ethereum_chain()
+        result = self.rpc_client.networks_service.get_ethereum_chains()
         assert result[0].get("Prod").get("chainId") == ANVIL_NETWORK_ID
         assert result[0].get("Prod").get("chainName") == "Anvil"
         assert result[0].get("Prod").get("nativeCurrencyName") == "Ether"


### PR DESCRIPTION
Iterates #7067
Requires #7750
Requires https://github.com/status-im/status-app/pull/22061

# Description

1. Removed the seven network methods from the wallet API. This is a breaking change to the RPC surface: `wallet_getFlatEthereumChains`, `wallet_setChainActive`, `wallet_setChainEnabled`, `wallet_setChainUserRpcProviders`, `wallet_addEthereumChain`, `wallet_deleteEthereumChain` and `wallet_getEthereumChains` stop existing, so the app must be calling `networks_` before this merges.
2. Carried the three deprecated methods across to the networks service.
3. Added a `NetworksService` to the python client and moved the two functional-test call sites onto it.

<details>
<summary>AI-made decisions</summary>

- The deprecated three were going to be dropped rather than ported. The functional tests still use `addEthereumChain` to attach the Anvil chain with a user provider, and `getEthereumChains` to read it back.
- Method names are unchanged, so the migration is a namespace swap and nothing else.

</details>
