### PR TITLE
fix: map envelope.ErrInvalidKEK from the DB-open  to incorrect password error

### DIFF
--- a/pkg/backend/geth_backend.go
+++ b/pkg/backend/geth_backend.go
@@ -808,7 +808,7 @@ func (b *StatusBackend) loginAccount(request *requests.Login) error {
 
 	err := b.ensureDBsOpened(acc, request.Password)
 	if err != nil {
-		return errors.Wrap(err, "failed to open database")
+		return errors.Wrap(asKeystoreResolutionError(err), "failed to open database")
 	}
 
 	// Fix any interrupted encryption-scheme migration/rekey before the keystore is used.


### PR DESCRIPTION
 Pass the ensureDBsOpened error in loginAccount through asKeystoreResolutionError, so envelope.ErrInvalidKEK maps as ErrIncorrectPasswordProvided instead of the raw "envelope: invalid key-encryption key".