### PR TITLE
feat: LiFi swap fee

### DIFF
--- a/pkg/services/wallet/thirdparty/lifi/client.go
+++ b/pkg/services/wallet/thirdparty/lifi/client.go
@@ -8,6 +8,8 @@ const (
 	baseURL = "https://li.quest/v1"
 
 	Integrator = "status-app"
+
+	feeFraction = "0.0062" // 0.62%
 )
 
 type Client struct {

--- a/pkg/services/wallet/thirdparty/lifi/client.go
+++ b/pkg/services/wallet/thirdparty/lifi/client.go
@@ -7,7 +7,7 @@ import (
 const (
 	baseURL = "https://li.quest/v1"
 
-	Integrator = "status.app"
+	Integrator = "status-app"
 )
 
 type Client struct {

--- a/pkg/services/wallet/thirdparty/lifi/request_quote.go
+++ b/pkg/services/wallet/thirdparty/lifi/request_quote.go
@@ -53,6 +53,7 @@ func (c *Client) FetchQuote(ctx context.Context, p QuoteParams) (Quote, error) {
 	params.Add("fromAmount", p.AmountIn.String())
 	params.Add("slippage", strconv.FormatFloat(float64(p.SlippagePercentage)/100.0, 'f', -1, 64))
 	params.Add("integrator", c.integrator)
+	params.Add("fee", feeFraction)
 
 	options := []thirdparty.RequestOption{}
 	if c.apiKey != "" {


### PR DESCRIPTION
This PR is primarily about setting the swap fees to 0.62%, and closes https://github.com/status-im/status-app/issues/22042

It also updates the integrator parameter to match what's set in the LiFi portal.