### PR TITLE
test(accounts): cover cold-wallet migration and keystore guards

### DIFF
--- a/internal/accounts-management/cold_wallet_test.go
+++ b/internal/accounts-management/cold_wallet_test.go
@@ -22,6 +22,25 @@ func (s *ManagerTestSuite) setupProfileKeystore(storeMasterFile bool) {
 	}
 }
 
+// requireKeypairKeystoreFilesOpen opens the master file and every account file of
+// the keypair with the given password. A file count alone would pass on a wrong
+// child key or a file encrypted under a different password.
+func (s *ManagerTestSuite) requireKeypairKeystoreFilesOpen(mnemonic, password string, paths []string) {
+	master, err := generator.CreateAccountFromMnemonic(mnemonic, "")
+	s.Require().NoError(err)
+	restored, err := s.accManager.loadAccountInternally(master.Address(), password)
+	s.Require().NoError(err, "the restored master keystore file must decrypt with the given password")
+	s.Require().NotNil(restored)
+
+	_, derived, err := generator.CreateAndDeriveAccountsFromMnemonic(mnemonic, paths, "")
+	s.Require().NoError(err)
+	for _, path := range paths {
+		acc, err := s.accManager.loadAccountInternally(derived[path].Address(), password)
+		s.Require().NoError(err, "the restored keystore file for %s must decrypt with the given password", path)
+		s.Require().NotNil(acc)
+	}
+}
+
 // createColdSeedKeypair builds a non-profile seed keypair already migrated to a cold wallet,
 // derived from a fresh mnemonic so its KeyUID differs from the profile keypair's.
 func (s *ManagerTestSuite) createColdSeedKeypair() (mnemonic string, keypair *accsmanagementtypes.Keypair) {
@@ -97,11 +116,7 @@ func (s *ManagerTestSuite) TestMigrateColdWalletKeypairToAppRestoresKeystoreFile
 	s.Require().Equal(filesBefore+2, s.countKeystoreFiles(),
 		"keystore files must be recreated for the master key and every account path, else accounts stay unusable for signing")
 
-	master2, err := generator.CreateAccountFromMnemonic(mnemonic2, "")
-	s.Require().NoError(err)
-	restored, err := s.accManager.loadAccountInternally(master2.Address(), s.password)
-	s.Require().NoError(err, "restored master keystore file must decrypt with the provided password")
-	s.Require().NotNil(restored)
+	s.requireKeypairKeystoreFilesOpen(mnemonic2, s.password, []string{common.PathDefaultWalletAccount})
 }
 
 func (s *ManagerTestSuite) TestMigrateAlreadyMigratedKeypairSwitchesColdWalletTypeWithoutPassword() {
@@ -152,11 +167,33 @@ func (s *ManagerTestSuite) TestAddKeypairStoredToColdWalletPersistsLedgerKeypair
 
 	s.persistence.EXPECT().GetKeypairByKeyUID("ledger-kp-uid").Return(nil, accsmanagementtypes.ErrDbKeypairNotFound).Times(1)
 	s.persistence.EXPECT().GetPositionForNextNewAccount().Return(int64(4), nil).Times(1)
-	s.persistence.EXPECT().SaveOrUpdateKeypair(gomock.Any()).Return(nil).Times(1)
+	// capture what is handed to persistence: asserting only on the returned keypair
+	// would rely on it being the same object that was saved
+	var saved *accsmanagementtypes.Keypair
+	s.persistence.EXPECT().SaveOrUpdateKeypair(gomock.Any()).DoAndReturn(
+		func(kp *accsmanagementtypes.Keypair) error {
+			saved = kp
+			return nil
+		}).Times(1)
 
 	keypair, err := s.accManager.AddKeypairStoredToColdWallet("ledger-kp-uid", "0xmaster-address", "ledger-kp",
 		"ledger-wallet-xpub", accsmanagementtypes.ColdWalletTypeLedger, accounts, 9)
 	s.Require().NoError(err, "importing a ledger keypair with valid wallet-path accounts must succeed")
+
+	s.Require().NotNil(saved, "the keypair must reach persistence")
+	s.Require().Equal("ledger-kp-uid", saved.KeyUID, "the saved keypair must carry the given keyUID")
+	s.Require().Equal("ledger-kp", saved.Name, "the saved keypair must carry the given name")
+	s.Require().Equal(accsmanagementtypes.KeypairTypeSeed, saved.Type, "cold-wallet imports are persisted as seed keypairs")
+	s.Require().Equal("0xmaster-address", saved.DerivedFrom, "the saved keypair must carry the given master address")
+	s.Require().Equal("ledger-wallet-xpub", saved.XPub, "the saved keypair must carry the given xpub")
+	s.Require().Equal(accsmanagementtypes.ColdWalletTypeLedger, saved.ColdWallet, "the saved keypair must carry the given cold-wallet type")
+	s.Require().Equal(uint64(9), saved.Clock, "the saved keypair must carry the given clock")
+	s.Require().Len(saved.Accounts, 2, "both wallet accounts must be saved")
+	s.Require().Equal(int64(4), saved.Accounts[0].Position, "positions must be assigned sequentially from GetPositionForNextNewAccount")
+	s.Require().Equal(int64(5), saved.Accounts[1].Position, "positions must be assigned sequentially from GetPositionForNextNewAccount")
+	s.Require().Equal(accsmanagementtypes.AccountFullyOperable, saved.Accounts[0].Operable, "cold-wallet accounts must be forced fully operable")
+	s.Require().Equal(accsmanagementtypes.AccountFullyOperable, saved.Accounts[1].Operable, "cold-wallet accounts must be forced fully operable")
+
 	s.Require().Equal(accsmanagementtypes.KeypairTypeSeed, keypair.Type, "cold-wallet imports are persisted as seed keypairs")
 	s.Require().Equal("0xmaster-address", keypair.DerivedFrom, "the caller-supplied master address must be stored as DerivedFrom")
 	s.Require().Equal("ledger-wallet-xpub", keypair.XPub, "the caller-supplied wallet xpub must be stored for later no-password derivation")

--- a/internal/accounts-management/cold_wallet_test.go
+++ b/internal/accounts-management/cold_wallet_test.go
@@ -6,8 +6,8 @@ import (
 	common "github.com/status-im/status-go/internal/accounts-management/common"
 	generator "github.com/status-im/status-go/internal/accounts-management/generator"
 	"github.com/status-im/status-go/internal/accounts-management/keystore"
-	"github.com/status-im/status-go/internal/accounts-management/types"
-	types2 "github.com/status-im/status-go/internal/crypto/types"
+	accsmanagementtypes "github.com/status-im/status-go/internal/accounts-management/types"
+	cryptotypes "github.com/status-im/status-go/internal/crypto/types"
 )
 
 // setupProfileKeystore initializes the keystore for the profile keypair's keyUID and
@@ -24,22 +24,22 @@ func (s *ManagerTestSuite) setupProfileKeystore(storeMasterFile bool) {
 
 // createColdSeedKeypair builds a non-profile seed keypair already migrated to a cold wallet,
 // derived from a fresh mnemonic so its KeyUID differs from the profile keypair's.
-func (s *ManagerTestSuite) createColdSeedKeypair() (mnemonic string, keypair *types.Keypair) {
+func (s *ManagerTestSuite) createColdSeedKeypair() (mnemonic string, keypair *accsmanagementtypes.Keypair) {
 	mnemonic, err := common.CreateRandomMnemonicWithDefaultLength()
 	s.Require().NoError(err)
 	master, err := generator.CreateAccountFromMnemonic(mnemonic, "")
 	s.Require().NoError(err)
 
-	keypair = &types.Keypair{
+	keypair = &accsmanagementtypes.Keypair{
 		KeyUID:      master.KeyUID(),
-		Type:        types.KeypairTypeSeed,
-		ColdWallet:  types.ColdWalletTypeStatusKeycard,
+		Type:        accsmanagementtypes.KeypairTypeSeed,
+		ColdWallet:  accsmanagementtypes.ColdWalletTypeStatusKeycard,
 		DerivedFrom: master.Address().Hex(),
-		Accounts: []*types.Account{
+		Accounts: []*accsmanagementtypes.Account{
 			{
 				KeyUID:   master.KeyUID(),
 				Path:     common.PathDefaultWalletAccount,
-				Operable: types.AccountFullyOperable,
+				Operable: accsmanagementtypes.AccountFullyOperable,
 			},
 		},
 	}
@@ -48,11 +48,11 @@ func (s *ManagerTestSuite) createColdSeedKeypair() (mnemonic string, keypair *ty
 
 func (s *ManagerTestSuite) TestMigrateKeypairToColdWalletRejectsWrongPassword() {
 	keypair := s.createAndStoreProfileKeypair()
-	keypair.Type = types.KeypairTypeSeed
+	keypair.Type = accsmanagementtypes.KeypairTypeSeed
 
 	s.persistence.EXPECT().GetKeypairByKeyUID(keypair.KeyUID).Return(keypair, nil).Times(1)
 
-	err := s.accManager.MigrateKeypairToColdWallet(keypair.KeyUID, "wrong-password", types.ColdWalletTypeStatusKeycard, 1)
+	err := s.accManager.MigrateKeypairToColdWallet(keypair.KeyUID, "wrong-password", accsmanagementtypes.ColdWalletTypeStatusKeycard, 1)
 	s.Require().Error(err, "migration with a wrong password must be rejected, else cold_wallet flips while decryptable key files stay on disk")
 	s.Require().ErrorIs(err, keystore.ErrIncorrectPasswordProvided, "rejection must come from the keystore delete step refusing the wrong password")
 	s.Require().Equal(3, s.countKeystoreFiles(), "all keystore files must remain on disk after a rejected migration")
@@ -63,9 +63,9 @@ func (s *ManagerTestSuite) TestMigrateColdWalletKeypairToAppRejectsWrongPassword
 	mnemonic2, coldKp := s.createColdSeedKeypair()
 
 	s.persistence.EXPECT().GetKeypairByKeyUID(coldKp.KeyUID).Return(coldKp, nil).Times(1)
-	s.persistence.EXPECT().GetProfileKeypair().Return(&types.Keypair{
+	s.persistence.EXPECT().GetProfileKeypair().Return(&accsmanagementtypes.Keypair{
 		KeyUID:      s.masterAccount.KeyUID(),
-		Type:        types.KeypairTypeProfile,
+		Type:        accsmanagementtypes.KeypairTypeProfile,
 		DerivedFrom: s.masterAccount.Address().Hex(),
 	}, nil).Times(1)
 
@@ -82,13 +82,13 @@ func (s *ManagerTestSuite) TestMigrateColdWalletKeypairToAppRestoresKeystoreFile
 	mnemonic2, coldKp := s.createColdSeedKeypair()
 
 	s.persistence.EXPECT().GetKeypairByKeyUID(coldKp.KeyUID).Return(coldKp, nil).Times(1)
-	s.persistence.EXPECT().GetProfileKeypair().Return(&types.Keypair{
+	s.persistence.EXPECT().GetProfileKeypair().Return(&accsmanagementtypes.Keypair{
 		KeyUID:      s.masterAccount.KeyUID(),
-		Type:        types.KeypairTypeProfile,
+		Type:        accsmanagementtypes.KeypairTypeProfile,
 		DerivedFrom: s.masterAccount.Address().Hex(),
 	}, nil).Times(1)
 	// the empty xpub argument takes the DB-layer preserve branch: the stored xpub must be retained
-	s.persistence.EXPECT().UpdateKeypairXPub(coldKp.KeyUID, "", types.ColdWalletTypeNone, uint64(7)).Return(nil).Times(1)
+	s.persistence.EXPECT().UpdateKeypairXPub(coldKp.KeyUID, "", accsmanagementtypes.ColdWalletTypeNone, uint64(7)).Return(nil).Times(1)
 
 	filesBefore := s.countKeystoreFiles()
 	keyUID, err := s.accManager.MigrateColdWalletKeypairToApp(mnemonic2, s.password, 7)
@@ -105,23 +105,23 @@ func (s *ManagerTestSuite) TestMigrateColdWalletKeypairToAppRestoresKeystoreFile
 }
 
 func (s *ManagerTestSuite) TestMigrateAlreadyMigratedKeypairSwitchesColdWalletTypeWithoutPassword() {
-	keypair := &types.Keypair{
+	keypair := &accsmanagementtypes.Keypair{
 		KeyUID:     "cold-kp",
-		Type:       types.KeypairTypeSeed,
-		ColdWallet: types.ColdWalletTypeStatusKeycard,
+		Type:       accsmanagementtypes.KeypairTypeSeed,
+		ColdWallet: accsmanagementtypes.ColdWalletTypeStatusKeycard,
 	}
 
 	s.persistence.EXPECT().GetKeypairByKeyUID(keypair.KeyUID).Return(keypair, nil).Times(1)
-	s.persistence.EXPECT().UpdateKeypairXPub(keypair.KeyUID, "", types.ColdWalletTypeLedger, uint64(5)).Return(nil).Times(1)
+	s.persistence.EXPECT().UpdateKeypairXPub(keypair.KeyUID, "", accsmanagementtypes.ColdWalletTypeLedger, uint64(5)).Return(nil).Times(1)
 
-	err := s.accManager.MigrateKeypairToColdWallet(keypair.KeyUID, "", types.ColdWalletTypeLedger, 5)
+	err := s.accManager.MigrateKeypairToColdWallet(keypair.KeyUID, "", accsmanagementtypes.ColdWalletTypeLedger, 5)
 	s.Require().NoError(err, "an already-migrated keypair has no keystore files, so switching cold-wallet type must not demand a password")
 }
 
 func (s *ManagerTestSuite) TestMigrateColdWalletKeypairToAppRejectsNonColdKeypair() {
-	keypair := &types.Keypair{
+	keypair := &accsmanagementtypes.Keypair{
 		KeyUID:      s.masterAccount.KeyUID(),
-		Type:        types.KeypairTypeSeed,
+		Type:        accsmanagementtypes.KeypairTypeSeed,
 		DerivedFrom: s.masterAccount.Address().Hex(),
 	}
 
@@ -133,72 +133,72 @@ func (s *ManagerTestSuite) TestMigrateColdWalletKeypairToAppRejectsNonColdKeypai
 }
 
 func (s *ManagerTestSuite) TestMigrateColdWalletKeypairToAppUnknownKeypairErrors() {
-	s.persistence.EXPECT().GetKeypairByKeyUID(s.masterAccount.KeyUID()).Return(nil, types.ErrDbKeypairNotFound).Times(1)
+	s.persistence.EXPECT().GetKeypairByKeyUID(s.masterAccount.KeyUID()).Return(nil, accsmanagementtypes.ErrDbKeypairNotFound).Times(1)
 
 	_, err := s.accManager.MigrateColdWalletKeypairToApp(s.mnemonic, s.password, 0)
 	s.Require().Error(err, "a mnemonic deriving to an unknown keyUID must surface the persistence error, not panic")
-	s.Require().ErrorIs(err, types.ErrDbKeypairNotFound, "the persistence error must pass through unchanged for app-side matching")
+	s.Require().ErrorIs(err, accsmanagementtypes.ErrDbKeypairNotFound, "the persistence error must pass through unchanged for app-side matching")
 }
 
 func (s *ManagerTestSuite) TestAddKeypairStoredToColdWalletPersistsLedgerKeypairWithoutKeystoreFiles() {
 	s.setupProfileKeystore(false)
 
-	accounts := []*types.Account{
+	accounts := []*accsmanagementtypes.Account{
 		{KeyUID: "ledger-kp-uid", Path: common.PathWalletRoot + "/0",
-			Address: types2.HexToAddress("0x1000000000000000000000000000000000000001"), Operable: types.AccountNonOperable},
+			Address: cryptotypes.HexToAddress("0x1000000000000000000000000000000000000001"), Operable: accsmanagementtypes.AccountNonOperable},
 		{KeyUID: "ledger-kp-uid", Path: common.PathWalletRoot + "/1",
-			Address: types2.HexToAddress("0x1000000000000000000000000000000000000002"), Operable: types.AccountNonOperable},
+			Address: cryptotypes.HexToAddress("0x1000000000000000000000000000000000000002"), Operable: accsmanagementtypes.AccountNonOperable},
 	}
 
-	s.persistence.EXPECT().GetKeypairByKeyUID("ledger-kp-uid").Return(nil, types.ErrDbKeypairNotFound).Times(1)
+	s.persistence.EXPECT().GetKeypairByKeyUID("ledger-kp-uid").Return(nil, accsmanagementtypes.ErrDbKeypairNotFound).Times(1)
 	s.persistence.EXPECT().GetPositionForNextNewAccount().Return(int64(4), nil).Times(1)
 	s.persistence.EXPECT().SaveOrUpdateKeypair(gomock.Any()).Return(nil).Times(1)
 
 	keypair, err := s.accManager.AddKeypairStoredToColdWallet("ledger-kp-uid", "0xmaster-address", "ledger-kp",
-		"ledger-wallet-xpub", types.ColdWalletTypeLedger, accounts, 9)
+		"ledger-wallet-xpub", accsmanagementtypes.ColdWalletTypeLedger, accounts, 9)
 	s.Require().NoError(err, "importing a ledger keypair with valid wallet-path accounts must succeed")
-	s.Require().Equal(types.KeypairTypeSeed, keypair.Type, "cold-wallet imports are persisted as seed keypairs")
+	s.Require().Equal(accsmanagementtypes.KeypairTypeSeed, keypair.Type, "cold-wallet imports are persisted as seed keypairs")
 	s.Require().Equal("0xmaster-address", keypair.DerivedFrom, "the caller-supplied master address must be stored as DerivedFrom")
 	s.Require().Equal("ledger-wallet-xpub", keypair.XPub, "the caller-supplied wallet xpub must be stored for later no-password derivation")
-	s.Require().Equal(types.ColdWalletTypeLedger, keypair.ColdWallet, "the given cold-wallet type must be persisted")
+	s.Require().Equal(accsmanagementtypes.ColdWalletTypeLedger, keypair.ColdWallet, "the given cold-wallet type must be persisted")
 	s.Require().Equal(uint64(9), keypair.Clock, "the given clock must be persisted")
 	s.Require().Equal(int64(4), keypair.Accounts[0].Position, "positions must be assigned sequentially from GetPositionForNextNewAccount")
 	s.Require().Equal(int64(5), keypair.Accounts[1].Position, "positions must be assigned sequentially from GetPositionForNextNewAccount")
-	s.Require().Equal(types.AccountFullyOperable, keypair.Accounts[0].Operable, "cold-wallet accounts must be forced fully operable")
-	s.Require().Equal(types.AccountFullyOperable, keypair.Accounts[1].Operable, "cold-wallet accounts must be forced fully operable")
+	s.Require().Equal(accsmanagementtypes.AccountFullyOperable, keypair.Accounts[0].Operable, "cold-wallet accounts must be forced fully operable")
+	s.Require().Equal(accsmanagementtypes.AccountFullyOperable, keypair.Accounts[1].Operable, "cold-wallet accounts must be forced fully operable")
 	s.Require().Equal(0, s.countKeystoreFiles(), "no keystore file may be written for a cold-wallet keypair import")
 }
 
 func (s *ManagerTestSuite) TestAddKeypairStoredToColdWalletRejectsEmptyWalletAccounts() {
 	_, err := s.accManager.AddKeypairStoredToColdWallet("some-kp-uid", "0xmaster-address", "kp-name",
-		"some-xpub", types.ColdWalletTypeStatusKeycard, nil, 1)
+		"some-xpub", accsmanagementtypes.ColdWalletTypeStatusKeycard, nil, 1)
 	s.Require().Error(err, "a keypair import with zero wallet accounts must be rejected, else later xpub derivation or default-account resolution nil-derefs")
 	s.Require().ErrorIs(err, ErrKeypairMustHaveAtLeastOneWalletAccount, "the typed at-least-one-account error must be returned for app-side matching")
 }
 
 func (s *ManagerTestSuite) TestAddKeypairStoredToColdWalletRejectsNonWalletPath() {
-	accounts := []*types.Account{
+	accounts := []*accsmanagementtypes.Account{
 		{KeyUID: "some-kp-uid", Path: "m/45'/60'/0'/0/0",
-			Address: types2.HexToAddress("0x1000000000000000000000000000000000000003")},
+			Address: cryptotypes.HexToAddress("0x1000000000000000000000000000000000000003")},
 	}
 
 	_, err := s.accManager.AddKeypairStoredToColdWallet("some-kp-uid", "0xmaster-address", "kp-name",
-		"some-xpub", types.ColdWalletTypeStatusKeycard, accounts, 1)
+		"some-xpub", accsmanagementtypes.ColdWalletTypeStatusKeycard, accounts, 1)
 	s.Require().Error(err, "an account path outside the wallet tree must be rejected at import")
 	s.Require().ErrorIs(err, ErrUnsupportedWalletAccountPath, "the typed unsupported-path error must be returned for app-side matching")
 }
 
 func (s *ManagerTestSuite) TestAddKeypairStoredToColdWalletRejectsAlreadyAddedKeypair() {
-	accounts := []*types.Account{
+	accounts := []*accsmanagementtypes.Account{
 		{KeyUID: "existing-kp-uid", Path: common.PathWalletRoot + "/0",
-			Address: types2.HexToAddress("0x1000000000000000000000000000000000000004")},
+			Address: cryptotypes.HexToAddress("0x1000000000000000000000000000000000000004")},
 	}
 
 	s.persistence.EXPECT().GetKeypairByKeyUID("existing-kp-uid").Return(
-		&types.Keypair{KeyUID: "existing-kp-uid", Type: types.KeypairTypeSeed}, nil).Times(1)
+		&accsmanagementtypes.Keypair{KeyUID: "existing-kp-uid", Type: accsmanagementtypes.KeypairTypeSeed}, nil).Times(1)
 
 	_, err := s.accManager.AddKeypairStoredToColdWallet("existing-kp-uid", "0xmaster-address", "kp-name",
-		"some-xpub", types.ColdWalletTypeStatusKeycard, accounts, 1)
+		"some-xpub", accsmanagementtypes.ColdWalletTypeStatusKeycard, accounts, 1)
 	s.Require().Error(err, "re-importing an existing keyUID must be rejected, else SaveOrUpdateKeypair silently clobbers the stored keypair")
 	s.Require().ErrorIs(err, ErrKeypairAlreadyAdded, "the typed already-added error must be returned for app-side matching")
 }
@@ -212,29 +212,29 @@ func (s *ManagerTestSuite) TestMigrateKeypairToColdWalletWithOnlyPartialAndRemov
 	s.Require().NoError(err)
 	s.Require().NoError(s.accManager.storeToKeystore(master2, s.password))
 
-	keypair := &types.Keypair{
+	keypair := &accsmanagementtypes.Keypair{
 		KeyUID:      master2.KeyUID(),
-		Type:        types.KeypairTypeSeed,
+		Type:        accsmanagementtypes.KeypairTypeSeed,
 		DerivedFrom: master2.Address().Hex(),
 		XPub:        "already-set",
-		Accounts: []*types.Account{
+		Accounts: []*accsmanagementtypes.Account{
 			{KeyUID: master2.KeyUID(), Path: common.PathWalletXPub + "/5",
-				Address:  types2.HexToAddress("0x2000000000000000000000000000000000000001"),
-				Operable: types.AccountPartiallyOperable},
+				Address:  cryptotypes.HexToAddress("0x2000000000000000000000000000000000000001"),
+				Operable: accsmanagementtypes.AccountPartiallyOperable},
 			{KeyUID: master2.KeyUID(), Path: common.PathWalletRoot + "/1",
-				Address:  types2.HexToAddress("0x2000000000000000000000000000000000000002"),
-				Operable: types.AccountFullyOperable, Removed: true},
+				Address:  cryptotypes.HexToAddress("0x2000000000000000000000000000000000000002"),
+				Operable: accsmanagementtypes.AccountFullyOperable, Removed: true},
 			{KeyUID: master2.KeyUID(), Path: common.PathWalletRoot + "/2",
-				Address:  types2.HexToAddress("0x2000000000000000000000000000000000000003"),
-				Operable: types.AccountNonOperable},
+				Address:  cryptotypes.HexToAddress("0x2000000000000000000000000000000000000003"),
+				Operable: accsmanagementtypes.AccountNonOperable},
 		},
 	}
 
 	s.persistence.EXPECT().GetKeypairByKeyUID(keypair.KeyUID).Return(keypair, nil).Times(1)
 	s.persistence.EXPECT().MarkKeypairFullyOperable(keypair.KeyUID, uint64(11), true).Return(nil).Times(1)
-	s.persistence.EXPECT().UpdateKeypairXPub(keypair.KeyUID, "", types.ColdWalletTypeStatusKeycard, uint64(11)).Return(nil).Times(1)
+	s.persistence.EXPECT().UpdateKeypairXPub(keypair.KeyUID, "", accsmanagementtypes.ColdWalletTypeStatusKeycard, uint64(11)).Return(nil).Times(1)
 
-	err = s.accManager.MigrateKeypairToColdWallet(keypair.KeyUID, s.password, types.ColdWalletTypeStatusKeycard, 11)
+	err = s.accManager.MigrateKeypairToColdWallet(keypair.KeyUID, s.password, accsmanagementtypes.ColdWalletTypeStatusKeycard, 11)
 	s.Require().NoError(err,
 		"a keypair holding only a partially-operable account (no per-account keystore file) plus removed/non-operable accounts must still migrate")
 	s.Require().Equal(0, s.countKeystoreFiles(),
@@ -253,40 +253,40 @@ func (s *ManagerTestSuite) TestMakePartiallyOperableAccountsFullyOperableSkipsCo
 	keypair := s.createAndStoreProfileKeypair()
 
 	partialAcc := s.deriveTestAccountAtPath(common.PathWalletRoot + "/1")
-	partialAcc.Operable = types.AccountPartiallyOperable
+	partialAcc.Operable = accsmanagementtypes.AccountPartiallyOperable
 	keypair.Accounts = append(keypair.Accounts, partialAcc)
 
 	// the cold keypair is listed FIRST: if the skip-cold guard breaks, its missing master
 	// keystore file errors the loop before the regular keypair is ever reached
-	coldKp := &types.Keypair{
+	coldKp := &accsmanagementtypes.Keypair{
 		KeyUID:      "cold-kp",
-		Type:        types.KeypairTypeSeed,
-		ColdWallet:  types.ColdWalletTypeStatusKeycard,
+		Type:        accsmanagementtypes.KeypairTypeSeed,
+		ColdWallet:  accsmanagementtypes.ColdWalletTypeStatusKeycard,
 		DerivedFrom: "0x000000000000000000000000000000000000dead",
-		Accounts: []*types.Account{
+		Accounts: []*accsmanagementtypes.Account{
 			{KeyUID: "cold-kp", Path: common.PathWalletRoot + "/0",
-				Address:  types2.HexToAddress("0x3000000000000000000000000000000000000001"),
-				Operable: types.AccountPartiallyOperable},
+				Address:  cryptotypes.HexToAddress("0x3000000000000000000000000000000000000001"),
+				Operable: accsmanagementtypes.AccountPartiallyOperable},
 		},
 	}
 
-	s.persistence.EXPECT().GetActiveKeypairs().Return([]*types.Keypair{coldKp, keypair}, nil).Times(1)
+	s.persistence.EXPECT().GetActiveKeypairs().Return([]*accsmanagementtypes.Keypair{coldKp, keypair}, nil).Times(1)
 	s.persistence.EXPECT().MarkAccountFullyOperable(partialAcc.Address).Return(nil).Times(1)
 
 	filesBefore := s.countKeystoreFiles()
 	addresses, err := s.accManager.MakePartiallyOperableAccoutsFullyOperable(s.password)
 	s.Require().NoError(err,
 		"a cold keypair must be skipped entirely, else its missing master keystore file aborts promotion for every keypair at login")
-	s.Require().Equal([]types2.Address{partialAcc.Address}, addresses,
+	s.Require().Equal([]cryptotypes.Address{partialAcc.Address}, addresses,
 		"exactly the regular keypair's partially-operable account must be promoted — cold and fully-operable accounts are untouched")
 	s.Require().Equal(filesBefore+1, s.countKeystoreFiles(),
 		"the promoted account must gain its own keystore file, and nothing may be written for the cold keypair")
 }
 
 func (s *ManagerTestSuite) TestMigrateKeypairToColdWalletUnknownKeyUIDErrors() {
-	s.persistence.EXPECT().GetKeypairByKeyUID("unknown-key-uid").Return(nil, types.ErrDbKeypairNotFound).Times(1)
+	s.persistence.EXPECT().GetKeypairByKeyUID("unknown-key-uid").Return(nil, accsmanagementtypes.ErrDbKeypairNotFound).Times(1)
 
-	err := s.accManager.MigrateKeypairToColdWallet("unknown-key-uid", testPassword, types.ColdWalletTypeStatusKeycard, 1)
+	err := s.accManager.MigrateKeypairToColdWallet("unknown-key-uid", testPassword, accsmanagementtypes.ColdWalletTypeStatusKeycard, 1)
 	s.Require().Error(err, "a non-existent keyUID must surface the persistence error, not panic on the nil keypair")
-	s.Require().ErrorIs(err, types.ErrDbKeypairNotFound, "the persistence error must pass through unchanged for app-side matching")
+	s.Require().ErrorIs(err, accsmanagementtypes.ErrDbKeypairNotFound, "the persistence error must pass through unchanged for app-side matching")
 }

--- a/internal/accounts-management/cold_wallet_test.go
+++ b/internal/accounts-management/cold_wallet_test.go
@@ -1,0 +1,292 @@
+package accountsmanagement
+
+import (
+	"go.uber.org/mock/gomock"
+
+	common "github.com/status-im/status-go/internal/accounts-management/common"
+	generator "github.com/status-im/status-go/internal/accounts-management/generator"
+	"github.com/status-im/status-go/internal/accounts-management/keystore"
+	"github.com/status-im/status-go/internal/accounts-management/types"
+	types2 "github.com/status-im/status-go/internal/crypto/types"
+)
+
+// setupProfileKeystore initializes the keystore for the profile keypair's keyUID and
+// optionally stores the profile master keystore file — the password-verification oracle
+// for cold-wallet reverse migrations.
+func (s *ManagerTestSuite) setupProfileKeystore(storeMasterFile bool) {
+	ks, err := s.accManager.createKeystore(s.masterAccount.KeyUID())
+	s.Require().NoError(err)
+	s.accManager.setKeystore(ks)
+	if storeMasterFile {
+		s.Require().NoError(s.accManager.storeToKeystore(s.masterAccount, s.password))
+	}
+}
+
+// createColdSeedKeypair builds a non-profile seed keypair already migrated to a cold wallet,
+// derived from a fresh mnemonic so its KeyUID differs from the profile keypair's.
+func (s *ManagerTestSuite) createColdSeedKeypair() (mnemonic string, keypair *types.Keypair) {
+	mnemonic, err := common.CreateRandomMnemonicWithDefaultLength()
+	s.Require().NoError(err)
+	master, err := generator.CreateAccountFromMnemonic(mnemonic, "")
+	s.Require().NoError(err)
+
+	keypair = &types.Keypair{
+		KeyUID:      master.KeyUID(),
+		Type:        types.KeypairTypeSeed,
+		ColdWallet:  types.ColdWalletTypeStatusKeycard,
+		DerivedFrom: master.Address().Hex(),
+		Accounts: []*types.Account{
+			{
+				KeyUID:   master.KeyUID(),
+				Path:     common.PathDefaultWalletAccount,
+				Operable: types.AccountFullyOperable,
+			},
+		},
+	}
+	return mnemonic, keypair
+}
+
+func (s *ManagerTestSuite) TestMigrateKeypairToColdWalletRejectsWrongPassword() {
+	keypair := s.createAndStoreProfileKeypair()
+	keypair.Type = types.KeypairTypeSeed
+
+	s.persistence.EXPECT().GetKeypairByKeyUID(keypair.KeyUID).Return(keypair, nil).Times(1)
+
+	err := s.accManager.MigrateKeypairToColdWallet(keypair.KeyUID, "wrong-password", types.ColdWalletTypeStatusKeycard, 1)
+	s.Require().Error(err, "migration with a wrong password must be rejected, else cold_wallet flips while decryptable key files stay on disk")
+	s.Require().ErrorIs(err, keystore.ErrIncorrectPasswordProvided, "rejection must come from the keystore delete step refusing the wrong password")
+	s.Require().Equal(3, s.countKeystoreFiles(), "all keystore files must remain on disk after a rejected migration")
+}
+
+func (s *ManagerTestSuite) TestMigrateColdWalletKeypairToAppRejectsWrongPassword() {
+	s.setupProfileKeystore(true)
+	mnemonic2, coldKp := s.createColdSeedKeypair()
+
+	s.persistence.EXPECT().GetKeypairByKeyUID(coldKp.KeyUID).Return(coldKp, nil).Times(1)
+	s.persistence.EXPECT().GetProfileKeypair().Return(&types.Keypair{
+		KeyUID:      s.masterAccount.KeyUID(),
+		Type:        types.KeypairTypeProfile,
+		DerivedFrom: s.masterAccount.Address().Hex(),
+	}, nil).Times(1)
+
+	filesBefore := s.countKeystoreFiles()
+	_, err := s.accManager.MigrateColdWalletKeypairToApp(mnemonic2, "wrong-password", 2)
+	s.Require().Error(err, "reverse migration must reject a password that fails against the profile master keystore file")
+	s.Require().ErrorIs(err, ErrWrongPasswordProvided(nil), "the typed wrong-password error must be returned for app-side matching")
+	s.Require().Equal(filesBefore, s.countKeystoreFiles(),
+		"no keystore file may be written when the password was not verified, else accounts get encrypted under an unusable password")
+}
+
+func (s *ManagerTestSuite) TestMigrateColdWalletKeypairToAppRestoresKeystoreFilesAndResetsColdState() {
+	s.setupProfileKeystore(true)
+	mnemonic2, coldKp := s.createColdSeedKeypair()
+
+	s.persistence.EXPECT().GetKeypairByKeyUID(coldKp.KeyUID).Return(coldKp, nil).Times(1)
+	s.persistence.EXPECT().GetProfileKeypair().Return(&types.Keypair{
+		KeyUID:      s.masterAccount.KeyUID(),
+		Type:        types.KeypairTypeProfile,
+		DerivedFrom: s.masterAccount.Address().Hex(),
+	}, nil).Times(1)
+	// the empty xpub argument takes the DB-layer preserve branch: the stored xpub must be retained
+	s.persistence.EXPECT().UpdateKeypairXPub(coldKp.KeyUID, "", types.ColdWalletTypeNone, uint64(7)).Return(nil).Times(1)
+
+	filesBefore := s.countKeystoreFiles()
+	keyUID, err := s.accManager.MigrateColdWalletKeypairToApp(mnemonic2, s.password, 7)
+	s.Require().NoError(err, "migrating a cold keypair back to app with the correct profile password must succeed")
+	s.Require().Equal(coldKp.KeyUID, keyUID, "returned keyUID must identify the migrated keypair")
+	s.Require().Equal(filesBefore+2, s.countKeystoreFiles(),
+		"keystore files must be recreated for the master key and every account path, else accounts stay unusable for signing")
+
+	master2, err := generator.CreateAccountFromMnemonic(mnemonic2, "")
+	s.Require().NoError(err)
+	restored, err := s.accManager.loadAccountInternally(master2.Address(), s.password)
+	s.Require().NoError(err, "restored master keystore file must decrypt with the provided password")
+	s.Require().NotNil(restored)
+}
+
+func (s *ManagerTestSuite) TestMigrateAlreadyMigratedKeypairSwitchesColdWalletTypeWithoutPassword() {
+	keypair := &types.Keypair{
+		KeyUID:     "cold-kp",
+		Type:       types.KeypairTypeSeed,
+		ColdWallet: types.ColdWalletTypeStatusKeycard,
+	}
+
+	s.persistence.EXPECT().GetKeypairByKeyUID(keypair.KeyUID).Return(keypair, nil).Times(1)
+	s.persistence.EXPECT().UpdateKeypairXPub(keypair.KeyUID, "", types.ColdWalletTypeLedger, uint64(5)).Return(nil).Times(1)
+
+	err := s.accManager.MigrateKeypairToColdWallet(keypair.KeyUID, "", types.ColdWalletTypeLedger, 5)
+	s.Require().NoError(err, "an already-migrated keypair has no keystore files, so switching cold-wallet type must not demand a password")
+}
+
+func (s *ManagerTestSuite) TestMigrateColdWalletKeypairToAppRejectsNonColdKeypair() {
+	keypair := &types.Keypair{
+		KeyUID:      s.masterAccount.KeyUID(),
+		Type:        types.KeypairTypeSeed,
+		DerivedFrom: s.masterAccount.Address().Hex(),
+	}
+
+	s.persistence.EXPECT().GetKeypairByKeyUID(keypair.KeyUID).Return(keypair, nil).Times(1)
+
+	_, err := s.accManager.MigrateColdWalletKeypairToApp(s.mnemonic, s.password, 0)
+	s.Require().Error(err, "reverse migration on a keypair that is not a cold wallet must be rejected, else healthy keystore state gets overwritten")
+	s.Require().ErrorIs(err, ErrKeypairIsNotColdWallet, "the typed not-cold-wallet error must be returned for app-side matching")
+}
+
+func (s *ManagerTestSuite) TestMigrateColdWalletKeypairToAppUnknownKeypairErrors() {
+	s.persistence.EXPECT().GetKeypairByKeyUID(s.masterAccount.KeyUID()).Return(nil, types.ErrDbKeypairNotFound).Times(1)
+
+	_, err := s.accManager.MigrateColdWalletKeypairToApp(s.mnemonic, s.password, 0)
+	s.Require().Error(err, "a mnemonic deriving to an unknown keyUID must surface the persistence error, not panic")
+	s.Require().ErrorIs(err, types.ErrDbKeypairNotFound, "the persistence error must pass through unchanged for app-side matching")
+}
+
+func (s *ManagerTestSuite) TestAddKeypairStoredToColdWalletPersistsLedgerKeypairWithoutKeystoreFiles() {
+	s.setupProfileKeystore(false)
+
+	accounts := []*types.Account{
+		{KeyUID: "ledger-kp-uid", Path: common.PathWalletRoot + "/0",
+			Address: types2.HexToAddress("0x1000000000000000000000000000000000000001"), Operable: types.AccountNonOperable},
+		{KeyUID: "ledger-kp-uid", Path: common.PathWalletRoot + "/1",
+			Address: types2.HexToAddress("0x1000000000000000000000000000000000000002"), Operable: types.AccountNonOperable},
+	}
+
+	s.persistence.EXPECT().GetKeypairByKeyUID("ledger-kp-uid").Return(nil, types.ErrDbKeypairNotFound).Times(1)
+	s.persistence.EXPECT().GetPositionForNextNewAccount().Return(int64(4), nil).Times(1)
+	s.persistence.EXPECT().SaveOrUpdateKeypair(gomock.Any()).Return(nil).Times(1)
+
+	keypair, err := s.accManager.AddKeypairStoredToColdWallet("ledger-kp-uid", "0xmaster-address", "ledger-kp",
+		"ledger-wallet-xpub", types.ColdWalletTypeLedger, accounts, 9)
+	s.Require().NoError(err, "importing a ledger keypair with valid wallet-path accounts must succeed")
+	s.Require().Equal(types.KeypairTypeSeed, keypair.Type, "cold-wallet imports are persisted as seed keypairs")
+	s.Require().Equal("0xmaster-address", keypair.DerivedFrom, "the caller-supplied master address must be stored as DerivedFrom")
+	s.Require().Equal("ledger-wallet-xpub", keypair.XPub, "the caller-supplied wallet xpub must be stored for later no-password derivation")
+	s.Require().Equal(types.ColdWalletTypeLedger, keypair.ColdWallet, "the given cold-wallet type must be persisted")
+	s.Require().Equal(uint64(9), keypair.Clock, "the given clock must be persisted")
+	s.Require().Equal(int64(4), keypair.Accounts[0].Position, "positions must be assigned sequentially from GetPositionForNextNewAccount")
+	s.Require().Equal(int64(5), keypair.Accounts[1].Position, "positions must be assigned sequentially from GetPositionForNextNewAccount")
+	s.Require().Equal(types.AccountFullyOperable, keypair.Accounts[0].Operable, "cold-wallet accounts must be forced fully operable")
+	s.Require().Equal(types.AccountFullyOperable, keypair.Accounts[1].Operable, "cold-wallet accounts must be forced fully operable")
+	s.Require().Equal(0, s.countKeystoreFiles(), "no keystore file may be written for a cold-wallet keypair import")
+}
+
+func (s *ManagerTestSuite) TestAddKeypairStoredToColdWalletRejectsEmptyWalletAccounts() {
+	_, err := s.accManager.AddKeypairStoredToColdWallet("some-kp-uid", "0xmaster-address", "kp-name",
+		"some-xpub", types.ColdWalletTypeStatusKeycard, nil, 1)
+	s.Require().Error(err, "a keypair import with zero wallet accounts must be rejected, else later xpub derivation or default-account resolution nil-derefs")
+	s.Require().ErrorIs(err, ErrKeypairMustHaveAtLeastOneWalletAccount, "the typed at-least-one-account error must be returned for app-side matching")
+}
+
+func (s *ManagerTestSuite) TestAddKeypairStoredToColdWalletRejectsNonWalletPath() {
+	accounts := []*types.Account{
+		{KeyUID: "some-kp-uid", Path: "m/45'/60'/0'/0/0",
+			Address: types2.HexToAddress("0x1000000000000000000000000000000000000003")},
+	}
+
+	_, err := s.accManager.AddKeypairStoredToColdWallet("some-kp-uid", "0xmaster-address", "kp-name",
+		"some-xpub", types.ColdWalletTypeStatusKeycard, accounts, 1)
+	s.Require().Error(err, "an account path outside the wallet tree must be rejected at import")
+	s.Require().ErrorIs(err, ErrUnsupportedWalletAccountPath, "the typed unsupported-path error must be returned for app-side matching")
+}
+
+func (s *ManagerTestSuite) TestAddKeypairStoredToColdWalletRejectsAlreadyAddedKeypair() {
+	accounts := []*types.Account{
+		{KeyUID: "existing-kp-uid", Path: common.PathWalletRoot + "/0",
+			Address: types2.HexToAddress("0x1000000000000000000000000000000000000004")},
+	}
+
+	s.persistence.EXPECT().GetKeypairByKeyUID("existing-kp-uid").Return(
+		&types.Keypair{KeyUID: "existing-kp-uid", Type: types.KeypairTypeSeed}, nil).Times(1)
+
+	_, err := s.accManager.AddKeypairStoredToColdWallet("existing-kp-uid", "0xmaster-address", "kp-name",
+		"some-xpub", types.ColdWalletTypeStatusKeycard, accounts, 1)
+	s.Require().Error(err, "re-importing an existing keyUID must be rejected, else SaveOrUpdateKeypair silently clobbers the stored keypair")
+	s.Require().ErrorIs(err, ErrKeypairAlreadyAdded, "the typed already-added error must be returned for app-side matching")
+}
+
+func (s *ManagerTestSuite) TestMigrateKeypairToColdWalletWithOnlyPartialAndRemovedAccountsDeletesMasterKeystore() {
+	s.setupProfileKeystore(false)
+
+	mnemonic2, err := common.CreateRandomMnemonicWithDefaultLength()
+	s.Require().NoError(err)
+	master2, err := generator.CreateAccountFromMnemonic(mnemonic2, "")
+	s.Require().NoError(err)
+	s.Require().NoError(s.accManager.storeToKeystore(master2, s.password))
+
+	keypair := &types.Keypair{
+		KeyUID:      master2.KeyUID(),
+		Type:        types.KeypairTypeSeed,
+		DerivedFrom: master2.Address().Hex(),
+		XPub:        "already-set",
+		Accounts: []*types.Account{
+			{KeyUID: master2.KeyUID(), Path: common.PathWalletXPub + "/5",
+				Address:  types2.HexToAddress("0x2000000000000000000000000000000000000001"),
+				Operable: types.AccountPartiallyOperable},
+			{KeyUID: master2.KeyUID(), Path: common.PathWalletRoot + "/1",
+				Address:  types2.HexToAddress("0x2000000000000000000000000000000000000002"),
+				Operable: types.AccountFullyOperable, Removed: true},
+			{KeyUID: master2.KeyUID(), Path: common.PathWalletRoot + "/2",
+				Address:  types2.HexToAddress("0x2000000000000000000000000000000000000003"),
+				Operable: types.AccountNonOperable},
+		},
+	}
+
+	s.persistence.EXPECT().GetKeypairByKeyUID(keypair.KeyUID).Return(keypair, nil).Times(1)
+	s.persistence.EXPECT().MarkKeypairFullyOperable(keypair.KeyUID, uint64(11), true).Return(nil).Times(1)
+	s.persistence.EXPECT().UpdateKeypairXPub(keypair.KeyUID, "", types.ColdWalletTypeStatusKeycard, uint64(11)).Return(nil).Times(1)
+
+	err = s.accManager.MigrateKeypairToColdWallet(keypair.KeyUID, s.password, types.ColdWalletTypeStatusKeycard, 11)
+	s.Require().NoError(err,
+		"a keypair holding only a partially-operable account (no per-account keystore file) plus removed/non-operable accounts must still migrate")
+	s.Require().Equal(0, s.countKeystoreFiles(),
+		"the master keystore file must be deleted on migration, else the master private key stays decryptable on disk for a cold keypair")
+}
+
+func (s *ManagerTestSuite) TestMakePartiallyOperableAccountsFullyOperableRequiresPassword() {
+	addresses, err := s.accManager.MakePartiallyOperableAccoutsFullyOperable("")
+	s.Require().Error(err, "an empty password must be rejected before any keypair is touched")
+	s.Require().ErrorIs(err, ErrNoPasswordProvided,
+		"the typed no-password error must be returned for app-side matching")
+	s.Require().Nil(addresses, "no address may be reported as promoted when the call was rejected")
+}
+
+func (s *ManagerTestSuite) TestMakePartiallyOperableAccountsFullyOperableSkipsColdKeypairAndPromotesRegular() {
+	keypair := s.createAndStoreProfileKeypair()
+
+	partialAcc := s.deriveTestAccountAtPath(common.PathWalletRoot + "/1")
+	partialAcc.Operable = types.AccountPartiallyOperable
+	keypair.Accounts = append(keypair.Accounts, partialAcc)
+
+	// the cold keypair is listed FIRST: if the skip-cold guard breaks, its missing master
+	// keystore file errors the loop before the regular keypair is ever reached
+	coldKp := &types.Keypair{
+		KeyUID:      "cold-kp",
+		Type:        types.KeypairTypeSeed,
+		ColdWallet:  types.ColdWalletTypeStatusKeycard,
+		DerivedFrom: "0x000000000000000000000000000000000000dead",
+		Accounts: []*types.Account{
+			{KeyUID: "cold-kp", Path: common.PathWalletRoot + "/0",
+				Address:  types2.HexToAddress("0x3000000000000000000000000000000000000001"),
+				Operable: types.AccountPartiallyOperable},
+		},
+	}
+
+	s.persistence.EXPECT().GetActiveKeypairs().Return([]*types.Keypair{coldKp, keypair}, nil).Times(1)
+	s.persistence.EXPECT().MarkAccountFullyOperable(partialAcc.Address).Return(nil).Times(1)
+
+	filesBefore := s.countKeystoreFiles()
+	addresses, err := s.accManager.MakePartiallyOperableAccoutsFullyOperable(s.password)
+	s.Require().NoError(err,
+		"a cold keypair must be skipped entirely, else its missing master keystore file aborts promotion for every keypair at login")
+	s.Require().Equal([]types2.Address{partialAcc.Address}, addresses,
+		"exactly the regular keypair's partially-operable account must be promoted — cold and fully-operable accounts are untouched")
+	s.Require().Equal(filesBefore+1, s.countKeystoreFiles(),
+		"the promoted account must gain its own keystore file, and nothing may be written for the cold keypair")
+}
+
+func (s *ManagerTestSuite) TestMigrateKeypairToColdWalletUnknownKeyUIDErrors() {
+	s.persistence.EXPECT().GetKeypairByKeyUID("unknown-key-uid").Return(nil, types.ErrDbKeypairNotFound).Times(1)
+
+	err := s.accManager.MigrateKeypairToColdWallet("unknown-key-uid", testPassword, types.ColdWalletTypeStatusKeycard, 1)
+	s.Require().Error(err, "a non-existent keyUID must surface the persistence error, not panic on the nil keypair")
+	s.Require().ErrorIs(err, types.ErrDbKeypairNotFound, "the persistence error must pass through unchanged for app-side matching")
+}

--- a/internal/accounts-management/cold_wallet_test.go
+++ b/internal/accounts-management/cold_wallet_test.go
@@ -182,31 +182,6 @@ func (s *ManagerTestSuite) TestMigrateColdWalletProfileKeypairToAppRestoresChatW
 	s.requireKeypairKeystoreFilesOpen(s.mnemonic, s.password, []string{common.PathEIP1581Chat, common.PathDefaultWalletAccount})
 }
 
-func (s *ManagerTestSuite) TestMigrateColdWalletKeypairToAppSkipsPasswordCheckWhenProfileKeypairIsCold() {
-	s.setupProfileKeystore(false)
-	mnemonic2, coldKp := s.createColdSeedKeypair()
-
-	s.persistence.EXPECT().GetKeypairByKeyUID(coldKp.KeyUID).Return(coldKp, nil).Times(1)
-	s.persistence.EXPECT().GetProfileKeypair().Return(&accsmanagementtypes.Keypair{
-		KeyUID:      s.masterAccount.KeyUID(),
-		Type:        accsmanagementtypes.KeypairTypeProfile,
-		ColdWallet:  accsmanagementtypes.ColdWalletTypeStatusKeycard,
-		DerivedFrom: "0x000000000000000000000000000000000000dead",
-	}, nil).Times(1)
-	s.persistence.EXPECT().UpdateKeypairXPub(coldKp.KeyUID, "", accsmanagementtypes.ColdWalletTypeNone, uint64(3)).Return(nil).Times(1)
-
-	filesBefore := s.countKeystoreFiles()
-	keyUID, err := s.accManager.MigrateColdWalletKeypairToApp(mnemonic2, "never-verified-password", 3)
-	s.Require().NoError(err, "migration must proceed without password verification when the profile keypair is itself on a cold wallet")
-	s.Require().Equal(coldKp.KeyUID, keyUID)
-	s.Require().Equal(filesBefore+2, s.countKeystoreFiles(),
-		"keystore files must be recreated for the master key and the account path even though the password could not be verified")
-
-	// the manager passes the password through unverified, so the files must open
-	// with exactly that password; a file count alone does not show which secret was used
-	s.requireKeypairKeystoreFilesOpen(mnemonic2, "never-verified-password", []string{common.PathDefaultWalletAccount})
-}
-
 func (s *ManagerTestSuite) TestMigrateAlreadyMigratedKeypairSwitchesColdWalletTypeWithoutPassword() {
 	keypair := &accsmanagementtypes.Keypair{
 		KeyUID:     "cold-kp",

--- a/internal/accounts-management/cold_wallet_test.go
+++ b/internal/accounts-management/cold_wallet_test.go
@@ -77,6 +77,41 @@ func (s *ManagerTestSuite) TestMigrateKeypairToColdWalletRejectsWrongPassword() 
 	s.Require().Equal(3, s.countKeystoreFiles(), "all keystore files must remain on disk after a rejected migration")
 }
 
+func (s *ManagerTestSuite) TestMigrateProfileKeypairToColdWalletDeletesChatWalletAndMasterKeystoreFiles() {
+	keypair := s.createAndStoreProfileKeypair()
+
+	s.persistence.EXPECT().GetKeypairByKeyUID(keypair.KeyUID).Return(keypair, nil).Times(1)
+	s.persistence.EXPECT().MarkKeypairFullyOperable(keypair.KeyUID, uint64(4), true).Return(nil).Times(1)
+	s.persistence.EXPECT().UpdateKeypairXPub(keypair.KeyUID, "", accsmanagementtypes.ColdWalletTypeStatusKeycard, uint64(4)).Return(nil).Times(1)
+
+	err := s.accManager.MigrateKeypairToColdWallet(keypair.KeyUID, s.password, accsmanagementtypes.ColdWalletTypeStatusKeycard, 4)
+	s.Require().NoError(err, "migrating the profile keypair to a keycard must succeed with the profile password")
+	s.Require().Equal(0, s.countKeystoreFiles(),
+		"the chat, wallet and master keystore files must all be deleted, else the profile's private keys stay decryptable on disk")
+
+	_, err = s.accManager.loadAccountInternally(s.chatAddress, s.password)
+	s.Require().ErrorIs(err, keystore.ErrKeystoreFileMissing, "the chat account file must be gone")
+
+	chatAccount, err := s.accManager.SelectedChatAccount()
+	s.Require().NoError(err, "the running session keeps its chat account, the migration only removes the files")
+	s.Require().Equal(s.chatAddress, chatAccount.Address())
+}
+
+func (s *ManagerTestSuite) TestMigrateKeypairToColdWalletRetryAfterInterruptedDeleteSucceeds() {
+	keypair := s.createAndStoreProfileKeypair()
+	// an earlier attempt deleted the wallet account file, then died before flagging the keypair cold
+	s.Require().NoError(s.accManager.deleteAccountFromKeystoreIfExists(s.walletAddress, s.password))
+	s.Require().Equal(2, s.countKeystoreFiles())
+
+	s.persistence.EXPECT().GetKeypairByKeyUID(keypair.KeyUID).Return(keypair, nil).Times(1)
+	s.persistence.EXPECT().MarkKeypairFullyOperable(keypair.KeyUID, uint64(6), true).Return(nil).Times(1)
+	s.persistence.EXPECT().UpdateKeypairXPub(keypair.KeyUID, "", accsmanagementtypes.ColdWalletTypeStatusKeycard, uint64(6)).Return(nil).Times(1)
+
+	err := s.accManager.MigrateKeypairToColdWallet(keypair.KeyUID, s.password, accsmanagementtypes.ColdWalletTypeStatusKeycard, 6)
+	s.Require().NoError(err, "a keystore file that is already gone must not block the retry")
+	s.Require().Equal(0, s.countKeystoreFiles())
+}
+
 func (s *ManagerTestSuite) TestMigrateColdWalletKeypairToAppRejectsWrongPassword() {
 	s.setupProfileKeystore(true)
 	mnemonic2, coldKp := s.createColdSeedKeypair()
@@ -91,9 +126,9 @@ func (s *ManagerTestSuite) TestMigrateColdWalletKeypairToAppRejectsWrongPassword
 	filesBefore := s.countKeystoreFiles()
 	_, err := s.accManager.MigrateColdWalletKeypairToApp(mnemonic2, "wrong-password", 2)
 	s.Require().Error(err, "reverse migration must reject a password that fails against the profile master keystore file")
-	s.Require().ErrorIs(err, ErrWrongPasswordProvided(nil), "the typed wrong-password error must be returned for app-side matching")
+	s.requireAccountsErrorCode(err, ErrCodeWrongPasswordProvided)
 	s.Require().Equal(filesBefore, s.countKeystoreFiles(),
-		"no keystore file may be written when the password was not verified, else accounts get encrypted under an unusable password")
+		"no keystore file may be written when the password was not verified")
 }
 
 func (s *ManagerTestSuite) TestMigrateColdWalletKeypairToAppRestoresKeystoreFilesAndResetsColdState() {
@@ -106,7 +141,7 @@ func (s *ManagerTestSuite) TestMigrateColdWalletKeypairToAppRestoresKeystoreFile
 		Type:        accsmanagementtypes.KeypairTypeProfile,
 		DerivedFrom: s.masterAccount.Address().Hex(),
 	}, nil).Times(1)
-	// the empty xpub argument takes the DB-layer preserve branch: the stored xpub must be retained
+	// the manager passes an empty xpub; the DB layer treats that as keep-existing
 	s.persistence.EXPECT().UpdateKeypairXPub(coldKp.KeyUID, "", accsmanagementtypes.ColdWalletTypeNone, uint64(7)).Return(nil).Times(1)
 
 	filesBefore := s.countKeystoreFiles()
@@ -114,9 +149,62 @@ func (s *ManagerTestSuite) TestMigrateColdWalletKeypairToAppRestoresKeystoreFile
 	s.Require().NoError(err, "migrating a cold keypair back to app with the correct profile password must succeed")
 	s.Require().Equal(coldKp.KeyUID, keyUID, "returned keyUID must identify the migrated keypair")
 	s.Require().Equal(filesBefore+2, s.countKeystoreFiles(),
-		"keystore files must be recreated for the master key and every account path, else accounts stay unusable for signing")
+		"keystore files must be recreated for the master key and every account path")
 
 	s.requireKeypairKeystoreFilesOpen(mnemonic2, s.password, []string{common.PathDefaultWalletAccount})
+}
+
+func (s *ManagerTestSuite) TestMigrateColdWalletProfileKeypairToAppRestoresChatWalletAndMasterKeystoreFiles() {
+	s.setupProfileKeystore(false)
+	coldProfileKp := &accsmanagementtypes.Keypair{
+		KeyUID:      s.masterAccount.KeyUID(),
+		Type:        accsmanagementtypes.KeypairTypeProfile,
+		ColdWallet:  accsmanagementtypes.ColdWalletTypeStatusKeycard,
+		DerivedFrom: s.masterAccount.Address().Hex(),
+		Accounts: []*accsmanagementtypes.Account{
+			{KeyUID: s.masterAccount.KeyUID(), Path: common.PathEIP1581Chat, Address: s.chatAddress,
+				Chat: true, Operable: accsmanagementtypes.AccountFullyOperable},
+			{KeyUID: s.masterAccount.KeyUID(), Path: common.PathDefaultWalletAccount, Address: s.walletAddress,
+				Wallet: true, Operable: accsmanagementtypes.AccountFullyOperable},
+		},
+	}
+
+	// no GetProfileKeypair expectation: the profile keypair is the one being migrated,
+	// so there is no profile master file to verify the password against
+	s.persistence.EXPECT().GetKeypairByKeyUID(coldProfileKp.KeyUID).Return(coldProfileKp, nil).Times(1)
+	s.persistence.EXPECT().UpdateKeypairXPub(coldProfileKp.KeyUID, "", accsmanagementtypes.ColdWalletTypeNone, uint64(8)).Return(nil).Times(1)
+
+	keyUID, err := s.accManager.MigrateColdWalletKeypairToApp(s.mnemonic, s.password, 8)
+	s.Require().NoError(err, "migrating a keycard profile back to the app must succeed without a profile-password check")
+	s.Require().Equal(coldProfileKp.KeyUID, keyUID)
+	s.Require().Equal(3, s.countKeystoreFiles(), "the master, chat and wallet keystore files must all be recreated")
+
+	s.requireKeypairKeystoreFilesOpen(s.mnemonic, s.password, []string{common.PathEIP1581Chat, common.PathDefaultWalletAccount})
+}
+
+func (s *ManagerTestSuite) TestMigrateColdWalletKeypairToAppSkipsPasswordCheckWhenProfileKeypairIsCold() {
+	s.setupProfileKeystore(false)
+	mnemonic2, coldKp := s.createColdSeedKeypair()
+
+	s.persistence.EXPECT().GetKeypairByKeyUID(coldKp.KeyUID).Return(coldKp, nil).Times(1)
+	s.persistence.EXPECT().GetProfileKeypair().Return(&accsmanagementtypes.Keypair{
+		KeyUID:      s.masterAccount.KeyUID(),
+		Type:        accsmanagementtypes.KeypairTypeProfile,
+		ColdWallet:  accsmanagementtypes.ColdWalletTypeStatusKeycard,
+		DerivedFrom: "0x000000000000000000000000000000000000dead",
+	}, nil).Times(1)
+	s.persistence.EXPECT().UpdateKeypairXPub(coldKp.KeyUID, "", accsmanagementtypes.ColdWalletTypeNone, uint64(3)).Return(nil).Times(1)
+
+	filesBefore := s.countKeystoreFiles()
+	keyUID, err := s.accManager.MigrateColdWalletKeypairToApp(mnemonic2, "never-verified-password", 3)
+	s.Require().NoError(err, "migration must proceed without password verification when the profile keypair is itself on a cold wallet")
+	s.Require().Equal(coldKp.KeyUID, keyUID)
+	s.Require().Equal(filesBefore+2, s.countKeystoreFiles(),
+		"keystore files must be recreated for the master key and the account path even though the password could not be verified")
+
+	// the manager passes the password through unverified, so the files must open
+	// with exactly that password; a file count alone does not show which secret was used
+	s.requireKeypairKeystoreFilesOpen(mnemonic2, "never-verified-password", []string{common.PathDefaultWalletAccount})
 }
 
 func (s *ManagerTestSuite) TestMigrateAlreadyMigratedKeypairSwitchesColdWalletTypeWithoutPassword() {
@@ -130,7 +218,7 @@ func (s *ManagerTestSuite) TestMigrateAlreadyMigratedKeypairSwitchesColdWalletTy
 	s.persistence.EXPECT().UpdateKeypairXPub(keypair.KeyUID, "", accsmanagementtypes.ColdWalletTypeLedger, uint64(5)).Return(nil).Times(1)
 
 	err := s.accManager.MigrateKeypairToColdWallet(keypair.KeyUID, "", accsmanagementtypes.ColdWalletTypeLedger, 5)
-	s.Require().NoError(err, "an already-migrated keypair has no keystore files, so switching cold-wallet type must not demand a password")
+	s.Require().NoError(err, "switching the cold-wallet type of an already-migrated keypair must not demand a password")
 }
 
 func (s *ManagerTestSuite) TestMigrateColdWalletKeypairToAppRejectsNonColdKeypair() {
@@ -143,7 +231,7 @@ func (s *ManagerTestSuite) TestMigrateColdWalletKeypairToAppRejectsNonColdKeypai
 	s.persistence.EXPECT().GetKeypairByKeyUID(keypair.KeyUID).Return(keypair, nil).Times(1)
 
 	_, err := s.accManager.MigrateColdWalletKeypairToApp(s.mnemonic, s.password, 0)
-	s.Require().Error(err, "reverse migration on a keypair that is not a cold wallet must be rejected, else healthy keystore state gets overwritten")
+	s.Require().Error(err, "reverse migration on a keypair that is not a cold wallet must be rejected")
 	s.Require().ErrorIs(err, ErrKeypairIsNotColdWallet, "the typed not-cold-wallet error must be returned for app-side matching")
 }
 
@@ -152,7 +240,7 @@ func (s *ManagerTestSuite) TestMigrateColdWalletKeypairToAppUnknownKeypairErrors
 
 	_, err := s.accManager.MigrateColdWalletKeypairToApp(s.mnemonic, s.password, 0)
 	s.Require().Error(err, "a mnemonic deriving to an unknown keyUID must surface the persistence error, not panic")
-	s.Require().ErrorIs(err, accsmanagementtypes.ErrDbKeypairNotFound, "the persistence error must pass through unchanged for app-side matching")
+	s.Require().ErrorIs(err, accsmanagementtypes.ErrDbKeypairNotFound, "the persistence error must be matchable app-side")
 }
 
 func (s *ManagerTestSuite) TestAddKeypairStoredToColdWalletPersistsLedgerKeypairWithoutKeystoreFiles() {
@@ -194,22 +282,14 @@ func (s *ManagerTestSuite) TestAddKeypairStoredToColdWalletPersistsLedgerKeypair
 	s.Require().Equal(accsmanagementtypes.AccountFullyOperable, saved.Accounts[0].Operable, "cold-wallet accounts must be forced fully operable")
 	s.Require().Equal(accsmanagementtypes.AccountFullyOperable, saved.Accounts[1].Operable, "cold-wallet accounts must be forced fully operable")
 
-	s.Require().Equal(accsmanagementtypes.KeypairTypeSeed, keypair.Type, "cold-wallet imports are persisted as seed keypairs")
-	s.Require().Equal("0xmaster-address", keypair.DerivedFrom, "the caller-supplied master address must be stored as DerivedFrom")
-	s.Require().Equal("ledger-wallet-xpub", keypair.XPub, "the caller-supplied wallet xpub must be stored for later no-password derivation")
-	s.Require().Equal(accsmanagementtypes.ColdWalletTypeLedger, keypair.ColdWallet, "the given cold-wallet type must be persisted")
-	s.Require().Equal(uint64(9), keypair.Clock, "the given clock must be persisted")
-	s.Require().Equal(int64(4), keypair.Accounts[0].Position, "positions must be assigned sequentially from GetPositionForNextNewAccount")
-	s.Require().Equal(int64(5), keypair.Accounts[1].Position, "positions must be assigned sequentially from GetPositionForNextNewAccount")
-	s.Require().Equal(accsmanagementtypes.AccountFullyOperable, keypair.Accounts[0].Operable, "cold-wallet accounts must be forced fully operable")
-	s.Require().Equal(accsmanagementtypes.AccountFullyOperable, keypair.Accounts[1].Operable, "cold-wallet accounts must be forced fully operable")
+	s.Require().Same(saved, keypair, "the returned keypair must be the one handed to persistence")
 	s.Require().Equal(0, s.countKeystoreFiles(), "no keystore file may be written for a cold-wallet keypair import")
 }
 
 func (s *ManagerTestSuite) TestAddKeypairStoredToColdWalletRejectsEmptyWalletAccounts() {
 	_, err := s.accManager.AddKeypairStoredToColdWallet("some-kp-uid", "0xmaster-address", "kp-name",
 		"some-xpub", accsmanagementtypes.ColdWalletTypeStatusKeycard, nil, 1)
-	s.Require().Error(err, "a keypair import with zero wallet accounts must be rejected, else later xpub derivation or default-account resolution nil-derefs")
+	s.Require().Error(err, "a keypair import with zero wallet accounts must be rejected")
 	s.Require().ErrorIs(err, ErrKeypairMustHaveAtLeastOneWalletAccount, "the typed at-least-one-account error must be returned for app-side matching")
 }
 
@@ -236,7 +316,7 @@ func (s *ManagerTestSuite) TestAddKeypairStoredToColdWalletRejectsAlreadyAddedKe
 
 	_, err := s.accManager.AddKeypairStoredToColdWallet("existing-kp-uid", "0xmaster-address", "kp-name",
 		"some-xpub", accsmanagementtypes.ColdWalletTypeStatusKeycard, accounts, 1)
-	s.Require().Error(err, "re-importing an existing keyUID must be rejected, else SaveOrUpdateKeypair silently clobbers the stored keypair")
+	s.Require().Error(err, "re-importing an existing keyUID must be rejected")
 	s.Require().ErrorIs(err, ErrKeypairAlreadyAdded, "the typed already-added error must be returned for app-side matching")
 }
 
@@ -313,17 +393,19 @@ func (s *ManagerTestSuite) TestMakePartiallyOperableAccountsFullyOperableSkipsCo
 	filesBefore := s.countKeystoreFiles()
 	addresses, err := s.accManager.MakePartiallyOperableAccoutsFullyOperable(s.password)
 	s.Require().NoError(err,
-		"a cold keypair must be skipped entirely, else its missing master keystore file aborts promotion for every keypair at login")
+		"a cold keypair must be skipped entirely, else its missing master keystore file aborts promotion for every keypair")
 	s.Require().Equal([]cryptotypes.Address{partialAcc.Address}, addresses,
 		"exactly the regular keypair's partially-operable account must be promoted — cold and fully-operable accounts are untouched")
 	s.Require().Equal(filesBefore+1, s.countKeystoreFiles(),
 		"the promoted account must gain its own keystore file, and nothing may be written for the cold keypair")
+	_, err = s.accManager.loadAccountInternally(partialAcc.Address, s.password)
+	s.Require().NoError(err, "the new file must hold the promoted account's own key")
 }
 
 func (s *ManagerTestSuite) TestMigrateKeypairToColdWalletUnknownKeyUIDErrors() {
 	s.persistence.EXPECT().GetKeypairByKeyUID("unknown-key-uid").Return(nil, accsmanagementtypes.ErrDbKeypairNotFound).Times(1)
 
-	err := s.accManager.MigrateKeypairToColdWallet("unknown-key-uid", testPassword, accsmanagementtypes.ColdWalletTypeStatusKeycard, 1)
+	err := s.accManager.MigrateKeypairToColdWallet("unknown-key-uid", s.password, accsmanagementtypes.ColdWalletTypeStatusKeycard, 1)
 	s.Require().Error(err, "a non-existent keyUID must surface the persistence error, not panic on the nil keypair")
-	s.Require().ErrorIs(err, accsmanagementtypes.ErrDbKeypairNotFound, "the persistence error must pass through unchanged for app-side matching")
+	s.Require().ErrorIs(err, accsmanagementtypes.ErrDbKeypairNotFound, "the persistence error must be matchable app-side")
 }

--- a/internal/accounts-management/manager_test.go
+++ b/internal/accounts-management/manager_test.go
@@ -717,6 +717,97 @@ func (s *ManagerTestSuite) TestDeleteKeypair() {
 	s.Equal(0, len(files))
 }
 
+func (s *ManagerTestSuite) TestDeleteProfileKeypairRejected() {
+	keypair := s.createAndStoreProfileKeypair()
+
+	s.persistence.EXPECT().GetKeypairByKeyUID(keypair.KeyUID).Return(keypair, nil).Times(1)
+
+	_, err := s.accManager.DeleteKeypair(keypair.KeyUID, s.password, 0)
+	s.Require().Error(err, "the profile keypair must never be deletable through the generic keypair-removal path")
+	s.Require().ErrorIs(err, ErrCannotRemoveProfileKeypair,
+		"the typed cannot-remove-profile-keypair error must be returned for app-side matching")
+	s.Require().Equal(3, s.countKeystoreFiles(),
+		"chat identity and login keystore files must remain untouched after the rejected deletion")
+}
+
+func (s *ManagerTestSuite) TestDeleteLastAccountOfSeedKeypairAlsoDeletesMasterKeystoreFile() {
+	keypair := s.createAndStoreProfileKeypair()
+
+	walletAccount := keypair.Accounts[1]
+	walletAccount.Wallet = false
+
+	// a non-profile seed keypair whose ONLY account is the wallet account — deleting it
+	// must also remove the master keystore file
+	kpSingleAccount := &accsmanagementtypes.Keypair{
+		KeyUID:      keypair.KeyUID,
+		Type:        accsmanagementtypes.KeypairTypeSeed,
+		DerivedFrom: keypair.DerivedFrom,
+		Accounts:    []*accsmanagementtypes.Account{walletAccount},
+	}
+
+	s.persistence.EXPECT().GetAccountByAddress(s.walletAddress).Return(walletAccount, nil).Times(2)
+	s.persistence.EXPECT().GetKeypairByKeyUID(walletAccount.KeyUID).Return(kpSingleAccount, nil).Times(1)
+	s.persistence.EXPECT().RemoveAccount(walletAccount.Address, uint64(0)).Return(nil).Times(1)
+
+	acc, err := s.accManager.DeleteAccount(s.walletAddress, s.password, 0)
+	s.Require().NoError(err, "deleting the sole account of a non-cold seed keypair must succeed")
+	s.Require().NotNil(acc)
+
+	_, err = s.accManager.loadAccountInternally(s.masterAccount.Address(), s.password)
+	s.Require().Error(err,
+		"the master keystore file must be deleted with the keypair's last account, else decryptable master key material is orphaned on disk")
+	s.Require().Equal(1, s.countKeystoreFiles(),
+		"only the chat account file may remain: the account file and the master keystore file must both be gone")
+}
+
+func (s *ManagerTestSuite) TestCleanKeystoreFilesRequiresPassword() {
+	err := s.accManager.CleanKeystoreFiles("")
+	s.Require().Error(err,
+		"the RPC-exposed destructive cleanup must reject an empty password before touching any keypair")
+	s.Require().ErrorIs(err, ErrNoPasswordProvided,
+		"the typed no-password error must be returned for app-side matching")
+}
+
+func (s *ManagerTestSuite) TestCleanKeystoreFilesWrongPasswordLeavesFilesIntact() {
+	keypair := s.createAndStoreProfileKeypair()
+	keypair.Type = accsmanagementtypes.KeypairTypeSeed
+	keypair.Removed = true
+
+	s.persistence.EXPECT().GetAllKeypairs().Return([]*accsmanagementtypes.Keypair{keypair}, nil).Times(1)
+
+	err := s.accManager.CleanKeystoreFiles("wrong-password")
+	s.Require().Error(err,
+		"cleanup with a password that fails keystore decryption must error, not silently pretend the files were removed")
+	s.Require().ErrorIs(err, keystore.ErrIncorrectPasswordProvided,
+		"the keystore wrong-password error must surface so the caller knows nothing was deleted")
+	s.Require().Equal(3, s.countKeystoreFiles(),
+		"every keystore file must survive a cleanup attempted with the wrong password")
+}
+
+func (s *ManagerTestSuite) TestCreateKeypairSurfacesTypedKeystoreDirectoryError() {
+	if os.Geteuid() == 0 {
+		s.T().Skip("chmod-based write denial does not apply to root")
+	}
+	s.Require().NoError(os.Chmod(s.rootDataDir, 0o555))
+	defer func() {
+		s.Require().NoError(os.Chmod(s.rootDataDir, 0o755))
+	}()
+
+	s.persistence.EXPECT().GetKeypairByKeyUID(s.masterAccount.KeyUID()).Return(
+		nil, accsmanagementtypes.ErrDbKeypairNotFound,
+	).Times(1)
+
+	walletAccount := &accsmanagementtypes.AccountCreationDetails{
+		Path: common.PathDefaultWalletAccount,
+	}
+
+	_, err := s.accManager.CreateKeypairFromMnemonicAndStore(
+		s.mnemonic, s.password, "kp-name", accsmanagementtypes.ColdWalletTypeNone, walletAccount, true, 0)
+	s.Require().Error(err, "keystore directory creation failure must fail the keypair creation")
+	s.Require().ErrorIs(err, ErrKeystoreDirectoryError(nil),
+		"the failure must surface as the typed keystore-directory AccountsError, not a raw os error, so app-side error handling can match it")
+}
+
 func (s *ManagerTestSuite) TestDeleteAccountOfColdWalletKeypairWithoutPassword() {
 	acc := s.deriveTestAccountAtPath(common.PathDefaultWalletAccount)
 	keypair := &accsmanagementtypes.Keypair{
@@ -778,6 +869,8 @@ func (s *ManagerTestSuite) TestCreateKeypairFromMnemonicAndStoreDoesNotWriteKeys
 	s.persistence.EXPECT().SaveOrUpdateKeypair(gomock.Any()).DoAndReturn(
 		func(kp *accsmanagementtypes.Keypair) error {
 			s.Require().Equal(accsmanagementtypes.ColdWalletTypeStatusKeycard, kp.ColdWallet)
+			s.Require().Equal(s.expectedWalletXPub(), kp.XPub,
+				"a cold-created keypair must still store the wallet xpub, else every later no-password AddAccounts is accepted with no address validation")
 			return nil
 		},
 	).Times(1)
@@ -901,4 +994,30 @@ func (s *ManagerTestSuite) TestCleanKeystoreFiles() {
 			}
 		})
 	}
+}
+
+// When the profile keypair is itself on a cold wallet there is no profile master keystore
+// file to verify the password against, so verification is deliberately skipped and the
+// migration proceeds with the password accepted verbatim.
+func (s *ManagerTestSuite) TestMigrateColdWalletKeypairToAppSkipsPasswordCheckWhenProfileKeypairIsCold() {
+	s.setupProfileKeystore(false)
+	mnemonic2, coldKp := s.createColdSeedKeypair()
+
+	s.persistence.EXPECT().GetKeypairByKeyUID(coldKp.KeyUID).Return(coldKp, nil).Times(1)
+	// profile keypair is cold and its DerivedFrom has no keystore file on disk — any
+	// password verification attempt against it would fail
+	s.persistence.EXPECT().GetProfileKeypair().Return(&accsmanagementtypes.Keypair{
+		KeyUID:      s.masterAccount.KeyUID(),
+		Type:        accsmanagementtypes.KeypairTypeProfile,
+		ColdWallet:  accsmanagementtypes.ColdWalletTypeStatusKeycard,
+		DerivedFrom: "0x000000000000000000000000000000000000dead",
+	}, nil).Times(1)
+	s.persistence.EXPECT().UpdateKeypairXPub(coldKp.KeyUID, "", accsmanagementtypes.ColdWalletTypeNone, uint64(3)).Return(nil).Times(1)
+
+	filesBefore := s.countKeystoreFiles()
+	keyUID, err := s.accManager.MigrateColdWalletKeypairToApp(mnemonic2, "never-verified-password", 3)
+	s.Require().NoError(err, "migration must proceed without password verification when the profile keypair is itself on a cold wallet — this is the only un-migrate path for keycard-profile users")
+	s.Require().Equal(coldKp.KeyUID, keyUID)
+	s.Require().Equal(filesBefore+2, s.countKeystoreFiles(),
+		"keystore files must be recreated for the master key and the account path even though the password could not be verified")
 }

--- a/internal/accounts-management/manager_test.go
+++ b/internal/accounts-management/manager_test.go
@@ -314,7 +314,6 @@ type testAccount struct {
 // test function to avoid faulty execution.
 func (s *ManagerTestSuite) SetupTest() {
 	ctrl := gomock.NewController(s.T())
-	defer ctrl.Finish()
 
 	var err error
 	s.accManager, err = NewAccountsManager(testutils.MustCreateTestLogger())
@@ -357,13 +356,6 @@ func (s *ManagerTestSuite) createAndStoreProfileKeypair() *accsmanagementtypes.K
 	s.persistence.EXPECT().GetPositionForNextNewAccount().Return(int64(0), nil).Times(1)
 
 	s.persistence.EXPECT().SaveOrUpdateKeypair(gomock.Any()).Return(nil).Times(1)
-
-	s.persistence.EXPECT().GetProfileKeypair().Return(
-		&accsmanagementtypes.Keypair{
-			KeyUID: s.masterAccount.KeyUID(),
-		},
-		nil,
-	).Times(1)
 
 	walletAccount := &accsmanagementtypes.AccountCreationDetails{
 		Path: common.PathDefaultWalletAccount,
@@ -873,13 +865,6 @@ func (s *ManagerTestSuite) TestCreateKeypairFromMnemonicAndStoreDoesNotWriteKeys
 				"a cold-created keypair must still store the wallet xpub, else every later no-password AddAccounts is accepted with no address validation")
 			return nil
 		},
-	).Times(1)
-
-	s.persistence.EXPECT().GetProfileKeypair().Return(
-		&accsmanagementtypes.Keypair{
-			KeyUID: s.masterAccount.KeyUID(),
-		},
-		nil,
 	).Times(1)
 
 	walletAccount := &accsmanagementtypes.AccountCreationDetails{

--- a/internal/accounts-management/manager_test.go
+++ b/internal/accounts-management/manager_test.go
@@ -1020,4 +1020,8 @@ func (s *ManagerTestSuite) TestMigrateColdWalletKeypairToAppSkipsPasswordCheckWh
 	s.Require().Equal(coldKp.KeyUID, keyUID)
 	s.Require().Equal(filesBefore+2, s.countKeystoreFiles(),
 		"keystore files must be recreated for the master key and the account path even though the password could not be verified")
+
+	// the count alone would pass if the files were written under a different
+	// password, which would leave the migrated keypair unusable
+	s.requireKeypairKeystoreFilesOpen(mnemonic2, "never-verified-password", []string{common.PathDefaultWalletAccount})
 }

--- a/internal/accounts-management/manager_test.go
+++ b/internal/accounts-management/manager_test.go
@@ -348,6 +348,13 @@ func (s *ManagerTestSuite) getKeyDir() string {
 	return fmt.Sprintf("%s/keystore/%s", s.rootDataDir, s.masterAccount.KeyUID())
 }
 
+func (s *ManagerTestSuite) requireAccountsErrorCode(err error, code customerrors.ErrorCode) {
+	var accountsErr *customerrors.AccountsError
+	s.Require().True(errors.As(err, &accountsErr), "expected an AccountsError, got: %v", err)
+	s.Require().Equal(code, accountsErr.Code)
+	s.Require().Equal(getErrorCategory(code), accountsErr.Category)
+}
+
 func (s *ManagerTestSuite) createAndStoreProfileKeypair() *accsmanagementtypes.Keypair {
 	s.persistence.EXPECT().GetKeypairByKeyUID(s.masterAccount.KeyUID()).Return(
 		nil, accsmanagementtypes.ErrDbKeypairNotFound,
@@ -728,8 +735,6 @@ func (s *ManagerTestSuite) TestDeleteLastAccountOfSeedKeypairAlsoDeletesMasterKe
 	walletAccount := keypair.Accounts[1]
 	walletAccount.Wallet = false
 
-	// a non-profile seed keypair whose ONLY account is the wallet account — deleting it
-	// must also remove the master keystore file
 	kpSingleAccount := &accsmanagementtypes.Keypair{
 		KeyUID:      keypair.KeyUID,
 		Type:        accsmanagementtypes.KeypairTypeSeed,
@@ -746,8 +751,7 @@ func (s *ManagerTestSuite) TestDeleteLastAccountOfSeedKeypairAlsoDeletesMasterKe
 	s.Require().NotNil(acc)
 
 	_, err = s.accManager.loadAccountInternally(s.masterAccount.Address(), s.password)
-	s.Require().Error(err,
-		"the master keystore file must be deleted with the keypair's last account, else decryptable master key material is orphaned on disk")
+	s.Require().ErrorIs(err, keystore.ErrKeystoreFileMissing, "the master keystore file must go with the keypair's last account")
 	s.Require().Equal(1, s.countKeystoreFiles(),
 		"only the chat account file may remain: the account file and the master keystore file must both be gone")
 }
@@ -755,7 +759,7 @@ func (s *ManagerTestSuite) TestDeleteLastAccountOfSeedKeypairAlsoDeletesMasterKe
 func (s *ManagerTestSuite) TestCleanKeystoreFilesRequiresPassword() {
 	err := s.accManager.CleanKeystoreFiles("")
 	s.Require().Error(err,
-		"the RPC-exposed destructive cleanup must reject an empty password before touching any keypair")
+		"cleanup must reject an empty password before touching any keypair")
 	s.Require().ErrorIs(err, ErrNoPasswordProvided,
 		"the typed no-password error must be returned for app-side matching")
 }
@@ -796,8 +800,7 @@ func (s *ManagerTestSuite) TestCreateKeypairSurfacesTypedKeystoreDirectoryError(
 	_, err := s.accManager.CreateKeypairFromMnemonicAndStore(
 		s.mnemonic, s.password, "kp-name", accsmanagementtypes.ColdWalletTypeNone, walletAccount, true, 0)
 	s.Require().Error(err, "keystore directory creation failure must fail the keypair creation")
-	s.Require().ErrorIs(err, ErrKeystoreDirectoryError(nil),
-		"the failure must surface as the typed keystore-directory AccountsError, not a raw os error, so app-side error handling can match it")
+	s.requireAccountsErrorCode(err, ErrCodeKeystoreDirectoryError)
 }
 
 func (s *ManagerTestSuite) TestDeleteAccountOfColdWalletKeypairWithoutPassword() {
@@ -979,34 +982,4 @@ func (s *ManagerTestSuite) TestCleanKeystoreFiles() {
 			}
 		})
 	}
-}
-
-// When the profile keypair is itself on a cold wallet there is no profile master keystore
-// file to verify the password against, so verification is deliberately skipped and the
-// migration proceeds with the password accepted verbatim.
-func (s *ManagerTestSuite) TestMigrateColdWalletKeypairToAppSkipsPasswordCheckWhenProfileKeypairIsCold() {
-	s.setupProfileKeystore(false)
-	mnemonic2, coldKp := s.createColdSeedKeypair()
-
-	s.persistence.EXPECT().GetKeypairByKeyUID(coldKp.KeyUID).Return(coldKp, nil).Times(1)
-	// profile keypair is cold and its DerivedFrom has no keystore file on disk — any
-	// password verification attempt against it would fail
-	s.persistence.EXPECT().GetProfileKeypair().Return(&accsmanagementtypes.Keypair{
-		KeyUID:      s.masterAccount.KeyUID(),
-		Type:        accsmanagementtypes.KeypairTypeProfile,
-		ColdWallet:  accsmanagementtypes.ColdWalletTypeStatusKeycard,
-		DerivedFrom: "0x000000000000000000000000000000000000dead",
-	}, nil).Times(1)
-	s.persistence.EXPECT().UpdateKeypairXPub(coldKp.KeyUID, "", accsmanagementtypes.ColdWalletTypeNone, uint64(3)).Return(nil).Times(1)
-
-	filesBefore := s.countKeystoreFiles()
-	keyUID, err := s.accManager.MigrateColdWalletKeypairToApp(mnemonic2, "never-verified-password", 3)
-	s.Require().NoError(err, "migration must proceed without password verification when the profile keypair is itself on a cold wallet — this is the only un-migrate path for keycard-profile users")
-	s.Require().Equal(coldKp.KeyUID, keyUID)
-	s.Require().Equal(filesBefore+2, s.countKeystoreFiles(),
-		"keystore files must be recreated for the master key and the account path even though the password could not be verified")
-
-	// the count alone would pass if the files were written under a different
-	// password, which would leave the migrated keypair unusable
-	s.requireKeypairKeystoreFilesOpen(mnemonic2, "never-verified-password", []string{common.PathDefaultWalletAccount})
 }

--- a/internal/accounts-management/manager_test.go
+++ b/internal/accounts-management/manager_test.go
@@ -785,9 +785,8 @@ func (s *ManagerTestSuite) TestCreateKeypairSurfacesTypedKeystoreDirectoryError(
 		s.T().Skip("chmod-based write denial does not apply to root")
 	}
 	s.Require().NoError(os.Chmod(s.rootDataDir, 0o555))
-	defer func() {
-		s.Require().NoError(os.Chmod(s.rootDataDir, 0o755))
-	}()
+	t := s.T()
+	t.Cleanup(func() { require.NoError(t, os.Chmod(s.rootDataDir, 0o755)) })
 
 	s.persistence.EXPECT().GetKeypairByKeyUID(s.masterAccount.KeyUID()).Return(
 		nil, accsmanagementtypes.ErrDbKeypairNotFound,

--- a/internal/accounts-management/xpub_test.go
+++ b/internal/accounts-management/xpub_test.go
@@ -6,6 +6,7 @@ import (
 
 	common "github.com/status-im/status-go/internal/accounts-management/common"
 	generator "github.com/status-im/status-go/internal/accounts-management/generator"
+	"github.com/status-im/status-go/internal/accounts-management/keystore"
 	accsmanagementtypes "github.com/status-im/status-go/internal/accounts-management/types"
 	cryptotypes "github.com/status-im/status-go/internal/crypto/types"
 )
@@ -180,6 +181,81 @@ func (s *ManagerTestSuite) TestGetVerifiedWalletAccountForPartiallyOperableAccou
 	s.Require().Equal(address, account.Address())
 }
 
+func (s *ManagerTestSuite) TestGetVerifiedWalletAccountOnColdKeypairAccountFailsWithoutKeystoreWrites() {
+	s.setupProfileKeystore(false)
+
+	mnemonic2, err := common.CreateRandomMnemonicWithDefaultLength()
+	s.Require().NoError(err)
+	accPath := common.PathDefaultWalletAccount
+	master2, derived2, err := generator.CreateAndDeriveAccountsFromMnemonic(mnemonic2, []string{accPath}, "")
+	s.Require().NoError(err)
+	address := derived2[accPath].Address()
+
+	s.persistence.EXPECT().AddressExists(address).Return(true, nil).Times(1)
+	s.persistence.EXPECT().GetAccountByAddress(address).Return(&accsmanagementtypes.Account{
+		Address:  address,
+		KeyUID:   master2.KeyUID(),
+		Path:     accPath,
+		Operable: accsmanagementtypes.AccountFullyOperable,
+	}, nil).Times(1)
+	s.persistence.EXPECT().GetKeypairByKeyUID(master2.KeyUID()).Return(&accsmanagementtypes.Keypair{
+		KeyUID:      master2.KeyUID(),
+		Type:        accsmanagementtypes.KeypairTypeSeed,
+		ColdWallet:  accsmanagementtypes.ColdWalletTypeStatusKeycard,
+		DerivedFrom: master2.Address().Hex(),
+	}, nil).Times(1)
+
+	account, err := s.accManager.GetVerifiedWalletAccount(address, s.password)
+	s.Require().Error(err,
+		"signing via a cold keypair's account has no keystore file anywhere — the software-signing path must fail, not fabricate a key")
+	s.Require().ErrorIs(err, keystore.ErrKeystoreFileMissing,
+		"the keystore-file-missing error must surface so the app can route signing to the keycard instead")
+	s.Require().Nil(account, "no signing account may be returned for a cold keypair's account")
+	s.Require().Equal(0, s.countKeystoreFiles(),
+		"the partial-key fallback must not write any keystore file for a keypair still flagged cold")
+}
+
+func (s *ManagerTestSuite) TestAddAccountsRejectsSecondDefaultChatAccountOnProfileKeypair() {
+	keypair := s.createAndStoreProfileKeypair()
+
+	acc := s.deriveTestAccountAtPath(common.PathWalletRoot + "/1")
+	acc.Chat = true
+
+	s.persistence.EXPECT().GetKeypairByKeyUID(keypair.KeyUID).Return(keypair, nil).Times(1)
+
+	err := s.accManager.AddAccounts(keypair.KeyUID, []*accsmanagementtypes.Account{acc}, s.password)
+	s.Require().Error(err, "a second default chat account on the profile keypair must be rejected")
+	s.Require().ErrorIs(err, ErrCannotAddDefaultChatAccount,
+		"the typed cannot-add-default-chat-account error must be returned for app-side matching")
+}
+
+func (s *ManagerTestSuite) TestAddAccountsRejectsSecondDefaultWalletAccountOnProfileKeypair() {
+	keypair := s.createAndStoreProfileKeypair()
+
+	acc := s.deriveTestAccountAtPath(common.PathWalletRoot + "/1")
+	acc.Wallet = true
+
+	s.persistence.EXPECT().GetKeypairByKeyUID(keypair.KeyUID).Return(keypair, nil).Times(1)
+
+	err := s.accManager.AddAccounts(keypair.KeyUID, []*accsmanagementtypes.Account{acc}, s.password)
+	s.Require().Error(err, "a second default wallet account on the profile keypair must be rejected")
+	s.Require().ErrorIs(err, ErrCannotAddDefaultWalletAccount,
+		"the typed cannot-add-default-wallet-account error must be returned for app-side matching")
+}
+
+func (s *ManagerTestSuite) TestAddAccountsRejectsDuplicateAddress() {
+	keypair := s.createAndStoreProfileKeypair()
+
+	dup := s.deriveTestAccountAtPath(common.PathDefaultWalletAccount)
+
+	s.persistence.EXPECT().GetKeypairByKeyUID(keypair.KeyUID).Return(keypair, nil).Times(1)
+
+	err := s.accManager.AddAccounts(keypair.KeyUID, []*accsmanagementtypes.Account{dup}, s.password)
+	s.Require().Error(err, "an account whose address already exists on the keypair must be rejected")
+	s.Require().ErrorIs(err, ErrAccountAlreadyAdded,
+		"the typed already-added error must be returned, else the duplicate row silently overwrites the stored account")
+}
+
 func (s *ManagerTestSuite) TestBackfillKeypairsXPub() {
 	_ = s.createAndStoreProfileKeypair()
 	xpub := s.expectedWalletXPub()
@@ -225,6 +301,118 @@ func (s *ManagerTestSuite) TestBackfillKeypairsXPubReturnsPersistenceError() {
 	s.Require().Error(err)
 	s.Require().ErrorContains(err, kpRegular.KeyUID)
 	s.Require().Empty(kpRegular.XPub)
+}
+
+func (s *ManagerTestSuite) TestAddAccountsWithPasswordToColdKeypairIgnoresPasswordAndWritesNoKeystoreFiles() {
+	s.setupProfileKeystore(false)
+	keypair := &accsmanagementtypes.Keypair{
+		KeyUID:      s.masterAccount.KeyUID(),
+		Type:        accsmanagementtypes.KeypairTypeSeed,
+		ColdWallet:  accsmanagementtypes.ColdWalletTypeStatusKeycard,
+		DerivedFrom: s.masterAccount.Address().Hex(),
+		XPub:        s.expectedWalletXPub(),
+	}
+	acc := s.deriveTestAccountAtPath(common.PathWalletRoot + "/1")
+
+	s.persistence.EXPECT().GetKeypairByKeyUID(keypair.KeyUID).Return(keypair, nil).Times(1)
+	s.persistence.EXPECT().SaveOrUpdateAccounts([]*accsmanagementtypes.Account{acc}, true).Return(nil).Times(1)
+
+	err := s.accManager.AddAccounts(keypair.KeyUID, []*accsmanagementtypes.Account{acc}, s.password)
+	s.Require().NoError(err,
+		"a password passed alongside a cold keypair must be ignored, not used to derive from a keystore that does not exist")
+	s.Require().Equal(accsmanagementtypes.AccountFullyOperable, acc.Operable,
+		"cold-keypair accounts must stay fully operable, they are never demoted to partially operable")
+	s.Require().Equal(0, s.countKeystoreFiles(),
+		"no keystore file may be written for a cold keypair, else key material lands on disk for a keycard keypair")
+}
+
+func (s *ManagerTestSuite) TestAddAccountsWithPasswordToColdKeypairStillValidatesAgainstXPub() {
+	s.setupProfileKeystore(false)
+	keypair := &accsmanagementtypes.Keypair{
+		KeyUID:      s.masterAccount.KeyUID(),
+		Type:        accsmanagementtypes.KeypairTypeSeed,
+		ColdWallet:  accsmanagementtypes.ColdWalletTypeStatusKeycard,
+		DerivedFrom: s.masterAccount.Address().Hex(),
+		XPub:        s.expectedWalletXPub(),
+	}
+	acc := s.deriveTestAccountAtPath(common.PathWalletRoot + "/1")
+	acc.Address = cryptotypes.HexToAddress("0x000000000000000000000000000000000000dead")
+
+	s.persistence.EXPECT().GetKeypairByKeyUID(keypair.KeyUID).Return(keypair, nil).Times(1)
+
+	err := s.accManager.AddAccounts(keypair.KeyUID, []*accsmanagementtypes.Account{acc}, s.password)
+	s.Require().Error(err,
+		"even with a password, a cold keypair must validate the account address against the stored xpub")
+	s.Require().True(errors.Is(err, ErrAccountMismatch),
+		"the xpub-derived-address mismatch must surface as ErrAccountMismatch")
+}
+
+func (s *ManagerTestSuite) TestAddAccountsWithoutPasswordToColdKeypairWithoutXPubAccepted() {
+	s.setupProfileKeystore(false)
+	keypair := &accsmanagementtypes.Keypair{
+		KeyUID:      s.masterAccount.KeyUID(),
+		Type:        accsmanagementtypes.KeypairTypeSeed,
+		ColdWallet:  accsmanagementtypes.ColdWalletTypeStatusKeycard,
+		DerivedFrom: s.masterAccount.Address().Hex(),
+	}
+	acc := s.deriveTestAccountAtPath(common.PathWalletRoot + "/1")
+
+	s.persistence.EXPECT().GetKeypairByKeyUID(keypair.KeyUID).Return(keypair, nil).Times(1)
+	s.persistence.EXPECT().SaveOrUpdateAccounts([]*accsmanagementtypes.Account{acc}, true).Return(nil).Times(1)
+
+	err := s.accManager.AddAccounts(keypair.KeyUID, []*accsmanagementtypes.Account{acc}, "")
+	s.Require().NoError(err,
+		"a cold keypair migrated before xpub tracking has nothing to validate against and must still accept accounts")
+	s.Require().Equal(accsmanagementtypes.AccountFullyOperable, acc.Operable,
+		"legacy cold-keypair accounts must be saved fully operable")
+	s.Require().Equal(0, s.countKeystoreFiles(),
+		"no keystore file may be written on the legacy-compat cold path")
+}
+
+func (s *ManagerTestSuite) TestBackfillKeypairsXPubSkipsKeypairOnWrongPassword() {
+	_ = s.createAndStoreProfileKeypair()
+
+	kpRegular := &accsmanagementtypes.Keypair{
+		KeyUID:      s.masterAccount.KeyUID(),
+		Type:        accsmanagementtypes.KeypairTypeProfile,
+		DerivedFrom: s.masterAccount.Address().Hex(),
+		Clock:       42,
+	}
+
+	s.persistence.EXPECT().GetActiveKeypairs().Return([]*accsmanagementtypes.Keypair{kpRegular}, nil).Times(1)
+
+	err := s.accManager.BackfillKeypairsXPub("wrong-password")
+	s.Require().NoError(err,
+		"a keypair whose master keystore file does not open with the login password must be skipped, not fail the backfill — this runs on every login")
+	s.Require().Empty(kpRegular.XPub,
+		"no xpub may be recorded when the keystore file could not be decrypted")
+}
+
+func (s *ManagerTestSuite) TestBackfillKeypairsXPubJoinsErrorsAndContinuesPastFailures() {
+	_ = s.createAndStoreProfileKeypair()
+	xpub := s.expectedWalletXPub()
+
+	kpFail1 := &accsmanagementtypes.Keypair{KeyUID: "fail-1", Type: accsmanagementtypes.KeypairTypeSeed,
+		DerivedFrom: s.masterAccount.Address().Hex(), Clock: 1}
+	kpFail2 := &accsmanagementtypes.Keypair{KeyUID: "fail-2", Type: accsmanagementtypes.KeypairTypeSeed,
+		DerivedFrom: s.masterAccount.Address().Hex(), Clock: 2}
+	kpHealthy := &accsmanagementtypes.Keypair{KeyUID: "healthy-kp", Type: accsmanagementtypes.KeypairTypeSeed,
+		DerivedFrom: s.masterAccount.Address().Hex(), Clock: 3}
+
+	s.persistence.EXPECT().GetActiveKeypairs().Return([]*accsmanagementtypes.Keypair{kpFail1, kpFail2, kpHealthy}, nil).Times(1)
+	s.persistence.EXPECT().UpdateKeypairXPub(kpFail1.KeyUID, xpub, accsmanagementtypes.ColdWalletTypeNone, uint64(1)).
+		Return(errors.New("db failure 1")).Times(1)
+	s.persistence.EXPECT().UpdateKeypairXPub(kpFail2.KeyUID, xpub, accsmanagementtypes.ColdWalletTypeNone, uint64(2)).
+		Return(errors.New("db failure 2")).Times(1)
+	s.persistence.EXPECT().UpdateKeypairXPub(kpHealthy.KeyUID, xpub, accsmanagementtypes.ColdWalletTypeNone, uint64(3)).
+		Return(nil).Times(1)
+
+	err := s.accManager.BackfillKeypairsXPub(s.password)
+	s.Require().Error(err, "failed keypairs must surface in the returned error")
+	s.Require().ErrorContains(err, kpFail1.KeyUID, "the joined error must name the first failing keypair")
+	s.Require().ErrorContains(err, kpFail2.KeyUID, "the joined error must name the second failing keypair")
+	s.Require().Equal(xpub, kpHealthy.XPub,
+		"a healthy keypair listed after failures must still be backfilled, else login-time backfill is silently incomplete")
 }
 
 func (s *ManagerTestSuite) TestMigrateKeypairToColdWalletBackfillsXPub() {

--- a/internal/accounts-management/xpub_test.go
+++ b/internal/accounts-management/xpub_test.go
@@ -17,6 +17,27 @@ func (s *ManagerTestSuite) expectedWalletXPub() string {
 	return xpub
 }
 
+// storeDistinctSeedKeypair creates a keypair from its own mnemonic and stores its
+// master key, so each keypair in a test derives a different xpub. Sharing one
+// master would let a backfill read the wrong keypair's file undetected.
+func (s *ManagerTestSuite) storeDistinctSeedKeypair(keyUID string, clock uint64) (*accsmanagementtypes.Keypair, string) {
+	mnemonic, err := common.CreateRandomMnemonicWithDefaultLength()
+	s.Require().NoError(err)
+	master, err := generator.CreateAccountFromMnemonic(mnemonic, "")
+	s.Require().NoError(err)
+	s.Require().NoError(s.accManager.storeToKeystore(master, s.password))
+
+	xpub, err := generator.DeriveExtendedPublicKeyAtPath(mnemonic, "", common.PathWalletXPub)
+	s.Require().NoError(err)
+
+	return &accsmanagementtypes.Keypair{
+		KeyUID:      keyUID,
+		Type:        accsmanagementtypes.KeypairTypeSeed,
+		DerivedFrom: master.Address().Hex(),
+		Clock:       clock,
+	}, xpub
+}
+
 func (s *ManagerTestSuite) deriveTestAccountAtPath(path string) *accsmanagementtypes.Account {
 	_, derived, err := generator.CreateAndDeriveAccountsFromMnemonic(s.mnemonic, []string{path}, "")
 	s.Require().NoError(err)
@@ -211,8 +232,12 @@ func (s *ManagerTestSuite) TestGetVerifiedWalletAccountOnColdKeypairAccountFails
 	s.Require().ErrorIs(err, keystore.ErrKeystoreFileMissing,
 		"the keystore-file-missing error must surface so the app can route signing to the keycard instead")
 	s.Require().Nil(account, "no signing account may be returned for a cold keypair's account")
+	// The fallback writes nothing here because the cold keypair has no master file
+	// to derive from, not because it checks the cold-wallet flag:
+	// generatePartialAccountKey has no such check. If a master file were ever left
+	// on disk for a keypair flagged cold, this path would derive and write.
 	s.Require().Equal(0, s.countKeystoreFiles(),
-		"the partial-key fallback must not write any keystore file for a keypair still flagged cold")
+		"no keystore file is written, because the cold keypair has no master file to derive a child key from")
 }
 
 func (s *ManagerTestSuite) TestAddAccountsRejectsSecondDefaultChatAccountOnProfileKeypair() {
@@ -390,28 +415,28 @@ func (s *ManagerTestSuite) TestBackfillKeypairsXPubSkipsKeypairOnWrongPassword()
 
 func (s *ManagerTestSuite) TestBackfillKeypairsXPubJoinsErrorsAndContinuesPastFailures() {
 	_ = s.createAndStoreProfileKeypair()
-	xpub := s.expectedWalletXPub()
 
-	kpFail1 := &accsmanagementtypes.Keypair{KeyUID: "fail-1", Type: accsmanagementtypes.KeypairTypeSeed,
-		DerivedFrom: s.masterAccount.Address().Hex(), Clock: 1}
-	kpFail2 := &accsmanagementtypes.Keypair{KeyUID: "fail-2", Type: accsmanagementtypes.KeypairTypeSeed,
-		DerivedFrom: s.masterAccount.Address().Hex(), Clock: 2}
-	kpHealthy := &accsmanagementtypes.Keypair{KeyUID: "healthy-kp", Type: accsmanagementtypes.KeypairTypeSeed,
-		DerivedFrom: s.masterAccount.Address().Hex(), Clock: 3}
+	// each keypair has its own master key, so the expected xpubs differ and a
+	// backfill reading the wrong keystore file fails the pinned expectations
+	kpFail1, xpub1 := s.storeDistinctSeedKeypair("fail-1", 1)
+	kpFail2, xpub2 := s.storeDistinctSeedKeypair("fail-2", 2)
+	kpHealthy, xpubHealthy := s.storeDistinctSeedKeypair("healthy-kp", 3)
+	s.Require().NotEqual(xpub1, xpub2)
+	s.Require().NotEqual(xpub2, xpubHealthy)
 
 	s.persistence.EXPECT().GetActiveKeypairs().Return([]*accsmanagementtypes.Keypair{kpFail1, kpFail2, kpHealthy}, nil).Times(1)
-	s.persistence.EXPECT().UpdateKeypairXPub(kpFail1.KeyUID, xpub, accsmanagementtypes.ColdWalletTypeNone, uint64(1)).
+	s.persistence.EXPECT().UpdateKeypairXPub(kpFail1.KeyUID, xpub1, accsmanagementtypes.ColdWalletTypeNone, uint64(1)).
 		Return(errors.New("db failure 1")).Times(1)
-	s.persistence.EXPECT().UpdateKeypairXPub(kpFail2.KeyUID, xpub, accsmanagementtypes.ColdWalletTypeNone, uint64(2)).
+	s.persistence.EXPECT().UpdateKeypairXPub(kpFail2.KeyUID, xpub2, accsmanagementtypes.ColdWalletTypeNone, uint64(2)).
 		Return(errors.New("db failure 2")).Times(1)
-	s.persistence.EXPECT().UpdateKeypairXPub(kpHealthy.KeyUID, xpub, accsmanagementtypes.ColdWalletTypeNone, uint64(3)).
+	s.persistence.EXPECT().UpdateKeypairXPub(kpHealthy.KeyUID, xpubHealthy, accsmanagementtypes.ColdWalletTypeNone, uint64(3)).
 		Return(nil).Times(1)
 
 	err := s.accManager.BackfillKeypairsXPub(s.password)
 	s.Require().Error(err, "failed keypairs must surface in the returned error")
 	s.Require().ErrorContains(err, kpFail1.KeyUID, "the joined error must name the first failing keypair")
 	s.Require().ErrorContains(err, kpFail2.KeyUID, "the joined error must name the second failing keypair")
-	s.Require().Equal(xpub, kpHealthy.XPub,
+	s.Require().Equal(xpubHealthy, kpHealthy.XPub,
 		"a healthy keypair listed after failures must still be backfilled, else login-time backfill is silently incomplete")
 }
 

--- a/internal/accounts-management/xpub_test.go
+++ b/internal/accounts-management/xpub_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 
 	common "github.com/status-im/status-go/internal/accounts-management/common"
+	customerrors "github.com/status-im/status-go/internal/accounts-management/errors"
 	generator "github.com/status-im/status-go/internal/accounts-management/generator"
 	"github.com/status-im/status-go/internal/accounts-management/keystore"
 	accsmanagementtypes "github.com/status-im/status-go/internal/accounts-management/types"
@@ -20,12 +21,12 @@ func (s *ManagerTestSuite) expectedWalletXPub() string {
 // storeDistinctSeedKeypair creates a keypair from its own mnemonic and stores its
 // master key, so each keypair in a test derives a different xpub. Sharing one
 // master would let a backfill read the wrong keypair's file undetected.
-func (s *ManagerTestSuite) storeDistinctSeedKeypair(keyUID string, clock uint64) (*accsmanagementtypes.Keypair, string) {
+func (s *ManagerTestSuite) storeDistinctSeedKeypair(keyUID string, clock uint64, password string) (*accsmanagementtypes.Keypair, string) {
 	mnemonic, err := common.CreateRandomMnemonicWithDefaultLength()
 	s.Require().NoError(err)
 	master, err := generator.CreateAccountFromMnemonic(mnemonic, "")
 	s.Require().NoError(err)
-	s.Require().NoError(s.accManager.storeToKeystore(master, s.password))
+	s.Require().NoError(s.accManager.storeToKeystore(master, password))
 
 	xpub, err := generator.DeriveExtendedPublicKeyAtPath(mnemonic, "", common.PathWalletXPub)
 	s.Require().NoError(err)
@@ -202,7 +203,7 @@ func (s *ManagerTestSuite) TestGetVerifiedWalletAccountForPartiallyOperableAccou
 	s.Require().Equal(address, account.Address())
 }
 
-func (s *ManagerTestSuite) TestGetVerifiedWalletAccountOnColdKeypairAccountFailsWithoutKeystoreWrites() {
+func (s *ManagerTestSuite) TestGetVerifiedWalletAccountFailsWhenMasterKeystoreFileMissing() {
 	s.setupProfileKeystore(false)
 
 	mnemonic2, err := common.CreateRandomMnemonicWithDefaultLength()
@@ -222,22 +223,44 @@ func (s *ManagerTestSuite) TestGetVerifiedWalletAccountOnColdKeypairAccountFails
 	s.persistence.EXPECT().GetKeypairByKeyUID(master2.KeyUID()).Return(&accsmanagementtypes.Keypair{
 		KeyUID:      master2.KeyUID(),
 		Type:        accsmanagementtypes.KeypairTypeSeed,
-		ColdWallet:  accsmanagementtypes.ColdWalletTypeStatusKeycard,
 		DerivedFrom: master2.Address().Hex(),
 	}, nil).Times(1)
 
 	account, err := s.accManager.GetVerifiedWalletAccount(address, s.password)
 	s.Require().Error(err,
-		"signing via a cold keypair's account has no keystore file anywhere — the software-signing path must fail, not fabricate a key")
+		"with no keystore file for the account or its master key, the software-signing path must fail, not fabricate a key")
 	s.Require().ErrorIs(err, keystore.ErrKeystoreFileMissing,
-		"the keystore-file-missing error must surface so the app can route signing to the keycard instead")
-	s.Require().Nil(account, "no signing account may be returned for a cold keypair's account")
-	// The fallback writes nothing here because the cold keypair has no master file
-	// to derive from, not because it checks the cold-wallet flag:
-	// generatePartialAccountKey has no such check. If a master file were ever left
-	// on disk for a keypair flagged cold, this path would derive and write.
+		"the keystore-file-missing error must surface")
+	s.Require().Nil(account, "no signing account may be returned")
+	var accountsErr *customerrors.AccountsError
+	s.Require().ErrorAs(err, &accountsErr)
+	s.Require().Equal(master2.Address().Hex(), accountsErr.Context["address"],
+		"the missing file must be the master key's: the partial-account fallback was reached")
 	s.Require().Equal(0, s.countKeystoreFiles(),
-		"no keystore file is written, because the cold keypair has no master file to derive a child key from")
+		"the partial-account fallback has no master file to derive from, so nothing may be written")
+}
+
+func (s *ManagerTestSuite) TestGetVerifiedWalletAccountWrongPasswordDoesNotFallBackToDerivation() {
+	_ = s.createAndStoreProfileKeypair()
+
+	s.persistence.EXPECT().AddressExists(s.walletAddress).Return(true, nil).Times(1)
+	// no GetAccountByAddress expectation: a wrong password must never reach the partial-key fallback
+
+	account, err := s.accManager.GetVerifiedWalletAccount(s.walletAddress, "wrong-password")
+	s.Require().ErrorIs(err, keystore.ErrIncorrectPasswordProvided)
+	s.Require().Nil(account)
+	s.Require().Equal(3, s.countKeystoreFiles())
+}
+
+func (s *ManagerTestSuite) TestAddAccountsWithWrongPasswordRejectedBeforeSave() {
+	keypair := s.createAndStoreProfileKeypair()
+	acc := s.deriveTestAccountAtPath(common.PathWalletRoot + "/1")
+
+	s.persistence.EXPECT().GetKeypairByKeyUID(keypair.KeyUID).Return(keypair, nil).Times(1)
+
+	err := s.accManager.AddAccounts(keypair.KeyUID, []*accsmanagementtypes.Account{acc}, "wrong-password")
+	s.Require().ErrorIs(err, keystore.ErrIncorrectPasswordProvided)
+	s.Require().Equal(3, s.countKeystoreFiles(), "nothing may be written when the password did not open the master file")
 }
 
 func (s *ManagerTestSuite) TestAddAccountsRejectsSecondDefaultChatAccountOnProfileKeypair() {
@@ -278,7 +301,7 @@ func (s *ManagerTestSuite) TestAddAccountsRejectsDuplicateAddress() {
 	err := s.accManager.AddAccounts(keypair.KeyUID, []*accsmanagementtypes.Account{dup}, s.password)
 	s.Require().Error(err, "an account whose address already exists on the keypair must be rejected")
 	s.Require().ErrorIs(err, ErrAccountAlreadyAdded,
-		"the typed already-added error must be returned, else the duplicate row silently overwrites the stored account")
+		"the typed already-added error must be returned")
 }
 
 func (s *ManagerTestSuite) TestBackfillKeypairsXPub() {
@@ -368,7 +391,7 @@ func (s *ManagerTestSuite) TestAddAccountsWithPasswordToColdKeypairStillValidate
 	err := s.accManager.AddAccounts(keypair.KeyUID, []*accsmanagementtypes.Account{acc}, s.password)
 	s.Require().Error(err,
 		"even with a password, a cold keypair must validate the account address against the stored xpub")
-	s.Require().True(errors.Is(err, ErrAccountMismatch),
+	s.Require().ErrorIs(err, ErrAccountMismatch,
 		"the xpub-derived-address mismatch must surface as ErrAccountMismatch")
 }
 
@@ -395,32 +418,25 @@ func (s *ManagerTestSuite) TestAddAccountsWithoutPasswordToColdKeypairWithoutXPu
 }
 
 func (s *ManagerTestSuite) TestBackfillKeypairsXPubSkipsKeypairOnWrongPassword() {
-	_ = s.createAndStoreProfileKeypair()
+	s.setupProfileKeystore(false)
+	kpOtherPassword, _ := s.storeDistinctSeedKeypair("other-password-kp", 1, "other-password")
+	kpHealthy, xpubHealthy := s.storeDistinctSeedKeypair("healthy-kp", 2, s.password)
 
-	kpRegular := &accsmanagementtypes.Keypair{
-		KeyUID:      s.masterAccount.KeyUID(),
-		Type:        accsmanagementtypes.KeypairTypeProfile,
-		DerivedFrom: s.masterAccount.Address().Hex(),
-		Clock:       42,
-	}
+	s.persistence.EXPECT().GetActiveKeypairs().Return([]*accsmanagementtypes.Keypair{kpOtherPassword, kpHealthy}, nil).Times(1)
+	s.persistence.EXPECT().UpdateKeypairXPub(kpHealthy.KeyUID, xpubHealthy, accsmanagementtypes.ColdWalletTypeNone, uint64(2)).Return(nil).Times(1)
 
-	s.persistence.EXPECT().GetActiveKeypairs().Return([]*accsmanagementtypes.Keypair{kpRegular}, nil).Times(1)
-
-	err := s.accManager.BackfillKeypairsXPub("wrong-password")
-	s.Require().NoError(err,
-		"a keypair whose master keystore file does not open with the login password must be skipped, not fail the backfill — this runs on every login")
-	s.Require().Empty(kpRegular.XPub,
-		"no xpub may be recorded when the keystore file could not be decrypted")
+	err := s.accManager.BackfillKeypairsXPub(s.password)
+	s.Require().NoError(err, "a master file that does not open with the login password is skipped, not an error")
+	s.Require().Empty(kpOtherPassword.XPub, "no xpub may be recorded for the keypair whose file could not be decrypted")
+	s.Require().Equal(xpubHealthy, kpHealthy.XPub, "the keypair listed after the skipped one must still be backfilled")
 }
 
 func (s *ManagerTestSuite) TestBackfillKeypairsXPubJoinsErrorsAndContinuesPastFailures() {
 	_ = s.createAndStoreProfileKeypair()
 
-	// each keypair has its own master key, so the expected xpubs differ and a
-	// backfill reading the wrong keystore file fails the pinned expectations
-	kpFail1, xpub1 := s.storeDistinctSeedKeypair("fail-1", 1)
-	kpFail2, xpub2 := s.storeDistinctSeedKeypair("fail-2", 2)
-	kpHealthy, xpubHealthy := s.storeDistinctSeedKeypair("healthy-kp", 3)
+	kpFail1, xpub1 := s.storeDistinctSeedKeypair("fail-1", 1, s.password)
+	kpFail2, xpub2 := s.storeDistinctSeedKeypair("fail-2", 2, s.password)
+	kpHealthy, xpubHealthy := s.storeDistinctSeedKeypair("healthy-kp", 3, s.password)
 	s.Require().NotEqual(xpub1, xpub2)
 	s.Require().NotEqual(xpub2, xpubHealthy)
 
@@ -437,7 +453,7 @@ func (s *ManagerTestSuite) TestBackfillKeypairsXPubJoinsErrorsAndContinuesPastFa
 	s.Require().ErrorContains(err, kpFail1.KeyUID, "the joined error must name the first failing keypair")
 	s.Require().ErrorContains(err, kpFail2.KeyUID, "the joined error must name the second failing keypair")
 	s.Require().Equal(xpubHealthy, kpHealthy.XPub,
-		"a healthy keypair listed after failures must still be backfilled, else login-time backfill is silently incomplete")
+		"a healthy keypair listed after failures must still be backfilled")
 }
 
 func (s *ManagerTestSuite) TestMigrateKeypairToColdWalletBackfillsXPub() {

--- a/internal/db/multiaccounts/database_test.go
+++ b/internal/db/multiaccounts/database_test.go
@@ -110,9 +110,15 @@ func TestAccountKeycardPairingRoundTrip(t *testing.T) {
 }
 
 func TestUpdateAccountKeycardPairingSetsAndClears(t *testing.T) {
+	const bystanderKeyUID = "0x000000000000000000000000000000000000000000000000000000000000beef"
+	const bystanderPairing = "bystander-pairing-must-not-change"
+
 	db, stop := setupTestDB(t)
 	defer stop()
 	require.NoError(t, db.SaveAccount(Account{KeyUID: keyUID, KDFIterations: dbsetup.ReducedKDFIterationsNumber}))
+	// a second account with a pairing of its own, so a write that loses its
+	// WHERE clause shows up as a changed bystander rather than passing silently
+	require.NoError(t, db.SaveAccount(Account{KeyUID: bystanderKeyUID, KeycardPairing: bystanderPairing, KDFIterations: dbsetup.ReducedKDFIterationsNumber}))
 
 	require.NoError(t, db.UpdateAccountKeycardPairing(keyUID, "843edb10045d329f4ecfac73fe66f13d"))
 	account, err := db.GetAccount(keyUID)
@@ -120,11 +126,21 @@ func TestUpdateAccountKeycardPairingSetsAndClears(t *testing.T) {
 	require.Equal(t, "843edb10045d329f4ecfac73fe66f13d", account.KeycardPairing,
 		"Expected UpdateAccountKeycardPairing to persist the pairing key because it is the only writer used when a keycard is paired post-creation")
 
+	bystander, err := db.GetAccount(bystanderKeyUID)
+	require.NoError(t, err)
+	require.Equal(t, bystanderPairing, bystander.KeycardPairing,
+		"Expected the other account's pairing to be untouched because the update must apply to the given keyUID only")
+
 	require.NoError(t, db.UpdateAccountKeycardPairing(keyUID, ""))
 	account, err = db.GetAccount(keyUID)
 	require.NoError(t, err)
 	require.Equal(t, "", account.KeycardPairing,
 		"Expected clearing the pairing to persist because unpairing must not leave a stale key behind")
+
+	bystander, err = db.GetAccount(bystanderKeyUID)
+	require.NoError(t, err)
+	require.Equal(t, bystanderPairing, bystander.KeycardPairing,
+		"Expected clearing one account's pairing to leave the other account's pairing in place")
 }
 
 func TestDatabase_GetAccountsCount(t *testing.T) {

--- a/internal/db/multiaccounts/database_test.go
+++ b/internal/db/multiaccounts/database_test.go
@@ -86,6 +86,47 @@ func TestUpdateHasAcceptedTerms(t *testing.T) {
 	require.Equal(t, &expected, account)
 }
 
+func TestAccountKeycardPairingRoundTrip(t *testing.T) {
+	db, stop := setupTestDB(t)
+	defer stop()
+	expected := Account{
+		Name:           "string",
+		KeyUID:         keyUID,
+		KeycardPairing: "cc9d96f9b65b551595f3cf7c531beacda24b4937cece7fef70f5236ee80a0808",
+		KDFIterations:  dbsetup.ReducedKDFIterationsNumber,
+	}
+	require.NoError(t, db.SaveAccount(expected))
+
+	account, err := db.GetAccount(keyUID)
+	require.NoError(t, err)
+	require.Equal(t, expected.KeycardPairing, account.KeycardPairing,
+		"Expected the saved keycardPairing back because keycard login authenticates against the stored pairing key")
+
+	accounts, err := db.GetAccounts()
+	require.NoError(t, err)
+	require.Len(t, accounts, 1)
+	require.Equal(t, expected.KeycardPairing, accounts[0].KeycardPairing,
+		"Expected GetAccounts to return the same non-empty keycardPairing as GetAccount")
+}
+
+func TestUpdateAccountKeycardPairingSetsAndClears(t *testing.T) {
+	db, stop := setupTestDB(t)
+	defer stop()
+	require.NoError(t, db.SaveAccount(Account{KeyUID: keyUID, KDFIterations: dbsetup.ReducedKDFIterationsNumber}))
+
+	require.NoError(t, db.UpdateAccountKeycardPairing(keyUID, "843edb10045d329f4ecfac73fe66f13d"))
+	account, err := db.GetAccount(keyUID)
+	require.NoError(t, err)
+	require.Equal(t, "843edb10045d329f4ecfac73fe66f13d", account.KeycardPairing,
+		"Expected UpdateAccountKeycardPairing to persist the pairing key because it is the only writer used when a keycard is paired post-creation")
+
+	require.NoError(t, db.UpdateAccountKeycardPairing(keyUID, ""))
+	account, err = db.GetAccount(keyUID)
+	require.NoError(t, err)
+	require.Equal(t, "", account.KeycardPairing,
+		"Expected clearing the pairing to persist because unpairing must not leave a stale key behind")
+}
+
 func TestDatabase_GetAccountsCount(t *testing.T) {
 	db, stop := setupTestDB(t)
 	defer stop()

--- a/internal/db/multiaccounts/database_test.go
+++ b/internal/db/multiaccounts/database_test.go
@@ -42,6 +42,7 @@ func TestAccountsUpdate(t *testing.T) {
 	defer stop()
 	expected := Account{
 		KeyUID:             "string",
+		KeycardPairing:     "843edb10045d329f4ecfac73fe66f13d",
 		CustomizationColor: common.CustomizationColorBlue,
 		ColorHash:          ColorHash{{4, 3}, {4, 0}, {4, 3}, {4, 0}},
 		ColorID:            10,
@@ -99,14 +100,12 @@ func TestAccountKeycardPairingRoundTrip(t *testing.T) {
 
 	account, err := db.GetAccount(keyUID)
 	require.NoError(t, err)
-	require.Equal(t, expected.KeycardPairing, account.KeycardPairing,
-		"Expected the saved keycardPairing back because keycard login authenticates against the stored pairing key")
+	require.Equal(t, expected.KeycardPairing, account.KeycardPairing)
 
 	accounts, err := db.GetAccounts()
 	require.NoError(t, err)
 	require.Len(t, accounts, 1)
-	require.Equal(t, expected.KeycardPairing, accounts[0].KeycardPairing,
-		"Expected GetAccounts to return the same non-empty keycardPairing as GetAccount")
+	require.Equal(t, expected.KeycardPairing, accounts[0].KeycardPairing)
 }
 
 func TestUpdateAccountKeycardPairingSetsAndClears(t *testing.T) {
@@ -115,32 +114,31 @@ func TestUpdateAccountKeycardPairingSetsAndClears(t *testing.T) {
 
 	db, stop := setupTestDB(t)
 	defer stop()
-	require.NoError(t, db.SaveAccount(Account{KeyUID: keyUID, KDFIterations: dbsetup.ReducedKDFIterationsNumber}))
+	target := Account{Name: "target", KeyUID: keyUID, KDFIterations: dbsetup.ReducedKDFIterationsNumber, HasAcceptedTerms: true}
+	require.NoError(t, db.SaveAccount(target))
 	// a second account with a pairing of its own, so a write that loses its
 	// WHERE clause shows up as a changed bystander rather than passing silently
 	require.NoError(t, db.SaveAccount(Account{KeyUID: bystanderKeyUID, KeycardPairing: bystanderPairing, KDFIterations: dbsetup.ReducedKDFIterationsNumber}))
 
 	require.NoError(t, db.UpdateAccountKeycardPairing(keyUID, "843edb10045d329f4ecfac73fe66f13d"))
+	target.KeycardPairing = "843edb10045d329f4ecfac73fe66f13d"
 	account, err := db.GetAccount(keyUID)
 	require.NoError(t, err)
-	require.Equal(t, "843edb10045d329f4ecfac73fe66f13d", account.KeycardPairing,
-		"Expected UpdateAccountKeycardPairing to persist the pairing key because it is the only writer used when a keycard is paired post-creation")
+	require.Equal(t, &target, account, "only keycardPairing may change on the target row")
 
 	bystander, err := db.GetAccount(bystanderKeyUID)
 	require.NoError(t, err)
-	require.Equal(t, bystanderPairing, bystander.KeycardPairing,
-		"Expected the other account's pairing to be untouched because the update must apply to the given keyUID only")
+	require.Equal(t, bystanderPairing, bystander.KeycardPairing)
 
 	require.NoError(t, db.UpdateAccountKeycardPairing(keyUID, ""))
+	target.KeycardPairing = ""
 	account, err = db.GetAccount(keyUID)
 	require.NoError(t, err)
-	require.Equal(t, "", account.KeycardPairing,
-		"Expected clearing the pairing to persist because unpairing must not leave a stale key behind")
+	require.Equal(t, &target, account, "clearing must leave every other column of the target row alone")
 
 	bystander, err = db.GetAccount(bystanderKeyUID)
 	require.NoError(t, err)
-	require.Equal(t, bystanderPairing, bystander.KeycardPairing,
-		"Expected clearing one account's pairing to leave the other account's pairing in place")
+	require.Equal(t, bystanderPairing, bystander.KeycardPairing)
 }
 
 func TestDatabase_GetAccountsCount(t *testing.T) {


### PR DESCRIPTION
The keycard management API was removed in June 2026 (`e762325dff` and related commits). A keycard is now a `cold_wallet` value on a keypair, next to `ledger` and `trezor`. The tests for this area were not updated.

This PR adds tests for the core migration paths in `internal/accounts-management`, plus the `keycardPairing` column in the multiaccounts database.

- Production code is not changed.
- The suite's mock controller was being finished in `SetupTest`, so missing calls were never reported. Fixed here; every expectation below is now enforced.
- Each test was checked by breaking the behaviour it names in production code and confirming it fails. Review then found individual assertions inside those tests that were not load-bearing; those have been strengthened and checked the same way.

## Migrating a keypair to a cold wallet

**`TestMigrateProfileKeypairToColdWalletDeletesChatWalletAndMasterKeystoreFiles`**
- **Given** the profile keypair with its chat, wallet and master keystore files
- **When** it is migrated to a keycard with the profile password
- **Then** all three files are deleted, the chat account can no longer be loaded from disk, and the running session keeps its chat account

**`TestMigrateKeypairToColdWalletRetryAfterInterruptedDeleteSucceeds`**
- **Given** a keypair whose wallet account file was deleted by an earlier attempt that never flagged it cold
- **When** it is migrated again
- **Then** the missing file is tolerated and the migration completes

**`TestMigrateKeypairToColdWalletRejectsWrongPassword`**
- **Given** a stored seed keypair with its keystore files on disk
- **When** it is migrated to a keycard with a wrong password
- **Then** the call is rejected and every keystore file stays

**`TestMigrateAlreadyMigratedKeypairSwitchesColdWalletTypeWithoutPassword`**
- **Given** a keypair already on a keycard
- **When** its cold-wallet type is changed to `ledger` with an empty password
- **Then** it succeeds, because there are no keystore files left to delete

**`TestMigrateKeypairToColdWalletWithOnlyPartialAndRemovedAccountsDeletesMasterKeystore`**
- **Given** a keypair whose accounts are all partial, removed or non-operable
- **When** it is migrated
- **Then** the master keystore file is still deleted

**`TestMigrateKeypairToColdWalletUnknownKeyUIDErrors`**
- **Given** a key UID that persistence does not know
- **When** it is migrated
- **Then** the persistence error passes through instead of a panic

## Migrating back to the app — this path had no tests at all

**`TestMigrateColdWalletProfileKeypairToAppRestoresChatWalletAndMasterKeystoreFiles`**
- **Given** a keycard profile keypair with chat and wallet accounts
- **When** it is migrated back with the profile password
- **Then** no profile-password check runs (there is no file to check against), and the master, chat and wallet keystore files are recreated and open with that password

**`TestMigrateColdWalletKeypairToAppRestoresKeystoreFilesAndResetsColdState`**
- **Given** a keycard keypair and the correct profile password
- **When** it is migrated back
- **Then** the keystore files are recreated and open with that password, and the cold state is reset with an empty xpub, which the DB layer treats as keep-existing

**`TestMigrateColdWalletKeypairToAppRejectsWrongPassword`**
- **Given** the same keypair
- **When** it is migrated back with a wrong password
- **Then** it is rejected and no keystore file is written

**`TestMigrateColdWalletKeypairToAppRejectsNonColdKeypair`**
- **Given** a regular app keypair
- **When** the reverse migration is called on it
- **Then** it is rejected

**`TestMigrateColdWalletKeypairToAppUnknownKeypairErrors`**
- **Given** a mnemonic deriving an unknown key UID
- **When** it is migrated back
- **Then** the persistence error passes through

## Importing a keypair held on a cold wallet — this path had no tests

**`TestAddKeypairStoredToColdWalletPersistsLedgerKeypairWithoutKeystoreFiles`**
- **Given** two ledger accounts on wallet paths
- **When** the keypair is imported
- **Then** the keypair handed to persistence carries the right key UID, name, type, master address, xpub, clock, positions and operability, and no keystore file is written

**`TestAddKeypairStoredToColdWalletRejectsEmptyWalletAccounts`**
- **Given** no wallet accounts
- **When** the keypair is imported
- **Then** it is rejected

**`TestAddKeypairStoredToColdWalletRejectsNonWalletPath`**
- **Given** an account on a non-wallet derivation path
- **When** the keypair is imported
- **Then** it is rejected

**`TestAddKeypairStoredToColdWalletRejectsAlreadyAddedKeypair`**
- **Given** the key UID is already stored
- **When** it is imported again
- **Then** it is rejected and nothing is overwritten

## Promoting partially operable accounts — this path had no tests

**`TestMakePartiallyOperableAccountsFullyOperableSkipsColdKeypairAndPromotesRegular`**
- **Given** a cold keypair listed before a regular one
- **When** accounts are promoted
- **Then** only the regular account is promoted and gains a keystore file

**`TestMakePartiallyOperableAccountsFullyOperableRequiresPassword`**
- **Given** an empty password
- **When** accounts are promoted
- **Then** it is rejected

## Adding accounts to a cold keypair

**`TestAddAccountsWithPasswordToColdKeypairIgnoresPasswordAndWritesNoKeystoreFiles`**
- **Given** a cold keypair with a stored xpub
- **When** an account is added with a password
- **Then** the password is ignored and no keystore file is written

**`TestAddAccountsWithPasswordToColdKeypairStillValidatesAgainstXPub`**
- **Given** the same keypair
- **When** an account whose address does not match its path is added
- **Then** it is rejected, so the xpub check runs even with a password

**`TestAddAccountsWithWrongPasswordRejectedBeforeSave`**
- **Given** a regular keypair
- **When** an account is added with a wrong password
- **Then** it is rejected before anything is saved or written

**`TestAddAccountsWithoutPasswordToColdKeypairWithoutXPubAccepted`**
- **Given** a keypair migrated before the xpub was tracked
- **When** an account is added with no password
- **Then** it is accepted, for backward compatibility

**`TestAddAccountsRejectsSecondDefaultChatAccountOnProfileKeypair`**, **`...SecondDefaultWalletAccount...`**, **`...DuplicateAddress`**
- **Given** the profile keypair
- **When** a second default chat account, a second default wallet account, or a duplicate address is added
- **Then** each is rejected

**`TestGetVerifiedWalletAccountFailsWhenMasterKeystoreFileMissing`**
- **Given** an account whose keypair has no keystore file on this device
- **When** a signing account is requested
- **Then** it fails with the keystore-file-missing error for the master key and writes nothing

**`TestGetVerifiedWalletAccountWrongPasswordDoesNotFallBackToDerivation`**
- **Given** a fully operable account with its keystore file
- **When** a signing account is requested with a wrong password
- **Then** the wrong-password error is returned and the partial-key fallback is never entered

## Login-time xpub backfill — runs on every login

**`TestBackfillKeypairsXPubSkipsKeypairOnWrongPassword`**
- **Given** one keypair whose master file was written under another password and one healthy keypair
- **When** the backfill runs with the login password
- **Then** the first is skipped without error and the healthy one is still backfilled

**`TestBackfillKeypairsXPubJoinsErrorsAndContinuesPastFailures`**
- **Given** three keypairs where the first two fail to save
- **When** the backfill runs
- **Then** the returned error names both and the third is still backfilled

## Keystore and keypair deletion

**`TestDeleteProfileKeypairRejected`**
- **Given** the profile keypair
- **When** it is deleted through the generic path
- **Then** it is rejected and every file remains

**`TestDeleteLastAccountOfSeedKeypairAlsoDeletesMasterKeystoreFile`**
- **Given** a seed keypair with one account
- **When** that account is deleted
- **Then** both the account and the master keystore file are gone

**`TestCleanKeystoreFilesRequiresPassword`**, **`TestCleanKeystoreFilesWrongPasswordLeavesFilesIntact`**
- **Given** a removed keypair with keystore files
- **When** cleanup runs with an empty or wrong password
- **Then** it is rejected and the files survive

**`TestCreateKeypairSurfacesTypedKeystoreDirectoryError`**
- **Given** a data directory that cannot be written to
- **When** a keypair is created
- **Then** the typed keystore-directory error surfaces, not a raw OS error

## multiaccounts `keycardPairing` column

**`TestAccountKeycardPairingRoundTrip`**
- **Given** an account saved with a pairing value
- **When** it is read back
- **Then** both read paths return it, so keycard login can authenticate against it

**`TestUpdateAccountKeycardPairingSetsAndClears`**
- **Given** two accounts each with a pairing
- **When** one is set and then cleared
- **Then** the other is untouched, so a write that lost its `WHERE` clause is caught

