### PR TITLE
test(protocol): cover cold-wallet keypair sync edge paths

### DIFF
--- a/internal/protocol/messenger_sync_keypairs_auto_apply_test.go
+++ b/internal/protocol/messenger_sync_keypairs_auto_apply_test.go
@@ -3,6 +3,7 @@ package protocol
 import (
 	"testing"
 
+	gethcommon "github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/suite"
 
 	accsmanagementtypes "github.com/status-im/status-go/internal/accounts-management/types"
@@ -10,6 +11,8 @@ import (
 	"github.com/status-im/status-go/internal/db/multiaccounts/accounts"
 	"github.com/status-im/status-go/internal/db/multiaccounts/settings"
 	"github.com/status-im/status-go/internal/protocol/protobuf"
+	"github.com/status-im/status-go/pkg/pubsub"
+	"github.com/status-im/status-go/pkg/services/accounts/accountsevent"
 )
 
 func TestMessengerSyncKeypairsAutoApplyTest(t *testing.T) {
@@ -284,4 +287,266 @@ func (s *MessengerSyncKeypairsAutoApplySuite) TestEmptyWireXPubDoesNotWipeStored
 	s.Require().Equal("Renamed On Paired Device", dbKp.Name)
 	s.Require().Equal(accsmanagementtypes.ColdWalletTypeStatusKeycard, dbKp.ColdWallet)
 	s.Require().Equal(storedXPub, dbKp.XPub, "empty SyncKeypair.xpub must leave the stored wallet xpub unchanged")
+}
+
+func (s *MessengerSyncKeypairsAutoApplySuite) handleSyncWithState(message *protobuf.SyncKeypair, fromLocalPairing bool) *ReceivedMessageState {
+	state := s.m.buildMessageState()
+	err := s.m.handleSyncKeypairInternal(state, message, fromLocalPairing)
+	s.Require().NoError(err)
+	return state
+}
+
+func (s *MessengerSyncKeypairsAutoApplySuite) TestNonEmptyWireXPubAdoptedForUnknownKeypair() {
+	const wireXPub = "xpub6WireXPubForUnknownKeypairAdoption"
+
+	kp, _, _, err := accounts.GetSeedImportedKeypair1ForTest()
+	s.Require().NoError(err)
+	kp.XPub = wireXPub
+	// not saved locally — this device has never seen the keypair
+
+	s.handleSync(s.syncMessageFor(kp, 2, kp.Name, accsmanagementtypes.ColdWalletTypeStatusKeycard), false)
+
+	dbKp := s.dbKeypair(kp.KeyUID)
+	s.Require().Equal(wireXPub, dbKp.XPub, "a newly adopted keypair must store the wire xpub, otherwise no-password derivation is impossible on this device")
+}
+
+func (s *MessengerSyncKeypairsAutoApplySuite) TestNonEmptyWireXPubUpdatesStoredXPubOnKeypairUpdate() {
+	const storedXPub = "xpub6StoredBeforeTheSyncArrives"
+	const wireXPub = "xpub6NewerValueSentByThePairedDevice"
+
+	kp, _, _, err := accounts.GetSeedImportedKeypair1ForTest()
+	s.Require().NoError(err)
+	kp.Clock = 1
+	kp.XPub = storedXPub
+	for _, acc := range kp.Accounts {
+		acc.Operable = accsmanagementtypes.AccountFullyOperable
+	}
+	s.Require().NoError(s.m.settings.SaveOrUpdateKeypair(kp))
+
+	message := s.syncMessageFor(kp, 2, kp.Name, accsmanagementtypes.ColdWalletTypeNone)
+	message.Xpub = wireXPub
+
+	s.handleSync(message, false)
+
+	dbKp := s.dbKeypair(kp.KeyUID)
+	s.Require().Equal(wireXPub, dbKp.XPub, "a non-empty wire xpub must replace the stored one on keypair update")
+}
+
+func (s *MessengerSyncKeypairsAutoApplySuite) TestLedgerMigrationAdoptedVerbatimWhenAutoApplyEnabled() {
+	kp := s.saveSeedKeypair(accsmanagementtypes.ColdWalletTypeNone)
+
+	s.handleSync(s.syncMessageFor(kp, 2, kp.Name, accsmanagementtypes.ColdWalletTypeLedger), false)
+
+	dbKp := s.dbKeypair(kp.KeyUID)
+	s.Require().Equal(accsmanagementtypes.ColdWalletTypeLedger, dbKp.ColdWallet, "the wire cold wallet string must be stored verbatim")
+	s.Require().True(dbKp.MigratedToColdWallet(), "a ledger keypair must count as migrated to a cold wallet")
+	for _, acc := range dbKp.Accounts {
+		s.Require().Equal(accsmanagementtypes.AccountFullyOperable, acc.Operable, "accounts must stay operable after a ledger migration because no keystore is needed")
+	}
+}
+
+func (s *MessengerSyncKeypairsAutoApplySuite) TestTrezorMigrationAdoptedVerbatimWhenAutoApplyEnabled() {
+	kp := s.saveSeedKeypair(accsmanagementtypes.ColdWalletTypeNone)
+
+	s.handleSync(s.syncMessageFor(kp, 2, kp.Name, accsmanagementtypes.ColdWalletTypeTrezor), false)
+
+	dbKp := s.dbKeypair(kp.KeyUID)
+	s.Require().Equal(accsmanagementtypes.ColdWalletTypeTrezor, dbKp.ColdWallet, "the wire cold wallet string must be stored verbatim")
+	s.Require().True(dbKp.MigratedToColdWallet(), "a trezor keypair must count as migrated to a cold wallet")
+}
+
+func (s *MessengerSyncKeypairsAutoApplySuite) TestUnknownColdWalletStringAdoptedVerbatimForUnknownKeypair() {
+	kp, _, _, err := accounts.GetSeedImportedKeypair1ForTest()
+	s.Require().NoError(err)
+	// not saved locally — this device has never seen the keypair
+
+	message := s.syncMessageFor(kp, 2, kp.Name, accsmanagementtypes.ColdWalletTypeNone)
+	message.ColdWallet = "future-hw-wallet"
+
+	s.handleSync(message, false)
+
+	dbKp := s.dbKeypair(kp.KeyUID)
+	s.Require().Equal(accsmanagementtypes.ColdWalletType("future-hw-wallet"), dbKp.ColdWallet, "an unrecognized cold wallet string from a newer client must be adopted verbatim, not normalized away")
+	s.Require().True(dbKp.MigratedToColdWallet(), "any non-empty cold wallet value must count as migrated")
+}
+
+func (s *MessengerSyncKeypairsAutoApplySuite) TestEqualClockSyncKeypairLeavesKeypairUntouched() {
+	kp, _, _, err := accounts.GetSeedImportedKeypair1ForTest()
+	s.Require().NoError(err)
+	kp.Clock = 5
+	kp.ColdWallet = accsmanagementtypes.ColdWalletTypeStatusKeycard
+	for _, acc := range kp.Accounts {
+		acc.Operable = accsmanagementtypes.AccountFullyOperable
+	}
+	s.Require().NoError(s.m.settings.SaveOrUpdateKeypair(kp))
+
+	state := s.handleSyncWithState(s.syncMessageFor(kp, 5, "Stale Name", accsmanagementtypes.ColdWalletTypeNone), false)
+
+	s.Require().Empty(state.Response.Keypairs, "a stale sync must not be echoed to clients")
+	dbKp := s.dbKeypair(kp.KeyUID)
+	s.Require().Equal("Seed Imported 1", dbKp.Name, "an equal-clock sync must not apply metadata")
+	s.Require().Equal(accsmanagementtypes.ColdWalletTypeStatusKeycard, dbKp.ColdWallet, "an equal-clock sync must not undo the cold wallet migration")
+}
+
+func (s *MessengerSyncKeypairsAutoApplySuite) TestLowerClockSyncKeypairLeavesKeypairUntouched() {
+	kp, _, _, err := accounts.GetSeedImportedKeypair1ForTest()
+	s.Require().NoError(err)
+	kp.Clock = 5
+	kp.ColdWallet = accsmanagementtypes.ColdWalletTypeStatusKeycard
+	for _, acc := range kp.Accounts {
+		acc.Operable = accsmanagementtypes.AccountFullyOperable
+	}
+	s.Require().NoError(s.m.settings.SaveOrUpdateKeypair(kp))
+
+	state := s.handleSyncWithState(s.syncMessageFor(kp, 4, "Stale Name", accsmanagementtypes.ColdWalletTypeNone), false)
+
+	s.Require().Empty(state.Response.Keypairs, "a stale sync must not be echoed to clients")
+	dbKp := s.dbKeypair(kp.KeyUID)
+	s.Require().Equal("Seed Imported 1", dbKp.Name, "a lower-clock sync must not apply metadata")
+	s.Require().Equal(accsmanagementtypes.ColdWalletTypeStatusKeycard, dbKp.ColdWallet, "a lower-clock sync must not undo the cold wallet migration")
+}
+
+func (s *MessengerSyncKeypairsAutoApplySuite) TestStaleProfileSyncDoesNotSetProfileMigrationNeeded() {
+	kp := s.saveProfileKeypair(accsmanagementtypes.ColdWalletTypeNone)
+
+	state := s.handleSyncWithState(s.syncMessageFor(kp, 1, kp.Name, accsmanagementtypes.ColdWalletTypeStatusKeycard), false)
+
+	s.Require().Empty(state.Response.Keypairs, "a stale profile sync must not be echoed to clients")
+	migrationNeeded, err := s.m.settings.ProfileMigrationNeeded()
+	s.Require().NoError(err)
+	s.Require().False(migrationNeeded, "a replayed stale sync must not prompt the user with a profile migration banner")
+	dbKp := s.dbKeypair(kp.KeyUID)
+	s.Require().Equal(accsmanagementtypes.ColdWalletTypeNone, dbKp.ColdWallet)
+}
+
+func (s *MessengerSyncKeypairsAutoApplySuite) TestRemovedKeypairSyncRemovesKnownKeypair() {
+	kp := s.saveSeedKeypair(accsmanagementtypes.ColdWalletTypeNone)
+
+	message := s.syncMessageFor(kp, 2, kp.Name, accsmanagementtypes.ColdWalletTypeNone)
+	message.Removed = true
+	for _, sAcc := range message.Accounts {
+		sAcc.Removed = true
+	}
+
+	state := s.handleSyncWithState(message, false)
+
+	s.Require().Len(state.Response.Keypairs, 1, "clients need the removal echoed in the response")
+	s.Require().True(state.Response.Keypairs[0].Removed, "the echoed keypair must carry the removal flag")
+	s.Require().Empty(state.Response.ActivityCenterNotifications(), "removing a keypair must not raise a new-keypair notification")
+
+	_, err := s.m.settings.GetKeypairByKeyUID(kp.KeyUID)
+	s.Require().ErrorIs(err, accsmanagementtypes.ErrDbKeypairNotFound, "a keypair removed on a paired device must no longer be active on this device")
+}
+
+func (s *MessengerSyncKeypairsAutoApplySuite) TestRevertSyncMarksLocallyUnknownAccountNonOperable() {
+	kp := s.saveSeedKeypair(accsmanagementtypes.ColdWalletTypeStatusKeycard)
+
+	extraAddress := types.Address{0xde, 0xad, 0xbe, 0xef}
+	message := s.syncMessageFor(kp, 2, kp.Name, accsmanagementtypes.ColdWalletTypeNone)
+	message.Accounts = append(message.Accounts, &protobuf.SyncAccount{
+		Clock:    2,
+		Address:  extraAddress.Bytes(),
+		KeyUid:   kp.KeyUID,
+		Path:     "m/44'/60'/1'/0/0",
+		Name:     "Never Seen Locally",
+		Operable: string(accsmanagementtypes.AccountFullyOperable),
+	})
+
+	s.handleSync(message, false)
+
+	dbKp := s.dbKeypair(kp.KeyUID)
+	extraFound := false
+	for _, acc := range dbKp.Accounts {
+		if acc.Address == extraAddress {
+			s.Require().Equal(accsmanagementtypes.AccountNonOperable, acc.Operable, "an account this device never saw, arriving in a keycard-to-app revert, has no key material here and must be non operable")
+			extraFound = true
+		}
+	}
+	s.Require().True(extraFound)
+}
+
+func (s *MessengerSyncKeypairsAutoApplySuite) TestNewKeypairFromPairedDeviceAddsACNotification() {
+	kp, _, _, err := accounts.GetSeedImportedKeypair1ForTest()
+	s.Require().NoError(err)
+	// not saved locally — this device has never seen the keypair
+
+	state := s.handleSyncWithState(s.syncMessageFor(kp, 2, kp.Name, accsmanagementtypes.ColdWalletTypeNone), false)
+
+	notifications := state.Response.ActivityCenterNotifications()
+	s.Require().Len(notifications, 1, "the user must be told another device added keys to the profile")
+	s.Require().Equal(ActivityCenterNotificationTypeNewKeypairAddedToPairedDevice, notifications[0].Type)
+	s.Require().Equal(kp.KeyUID, notifications[0].Message.ID)
+	s.Require().Equal(kp.Name, notifications[0].Message.Text)
+}
+
+func (s *MessengerSyncKeypairsAutoApplySuite) TestKnownKeypairUpdateDoesNotAddACNotification() {
+	kp := s.saveSeedKeypair(accsmanagementtypes.ColdWalletTypeNone)
+
+	state := s.handleSyncWithState(s.syncMessageFor(kp, 2, "Renamed On Paired Device", accsmanagementtypes.ColdWalletTypeNone), false)
+
+	s.Require().Empty(state.Response.ActivityCenterNotifications(), "routine keypair updates must not spam the activity centre")
+}
+
+func (s *MessengerSyncKeypairsAutoApplySuite) TestSyncedFromPreservedOnKeypairUpdate() {
+	kp, _, _, err := accounts.GetSeedImportedKeypair1ForTest()
+	s.Require().NoError(err)
+	kp.Clock = 1
+	kp.SyncedFrom = "origin-device"
+	for _, acc := range kp.Accounts {
+		acc.Operable = accsmanagementtypes.AccountFullyOperable
+	}
+	s.Require().NoError(s.m.settings.SaveOrUpdateKeypair(kp))
+
+	message := s.syncMessageFor(kp, 2, kp.Name, accsmanagementtypes.ColdWalletTypeNone)
+	message.SyncedFrom = "other-device"
+
+	s.handleSync(message, false)
+
+	dbKp := s.dbKeypair(kp.KeyUID)
+	s.Require().Equal("origin-device", dbKp.SyncedFrom, "keypair provenance must not be rewritten by routine syncs")
+}
+
+func (s *MessengerSyncKeypairsAutoApplySuite) TestAccountsPublisherEmitsAddedEventForSyncedNewKeypair() {
+	publisher := pubsub.NewPublisher()
+	m2, err := newRunningTestMessenger(s.T(), s.messagingEnv, testMessengerConfig{
+		extraOptions: []Option{WithAccountsPublisher(publisher)},
+	})
+	s.Require().NoError(err)
+
+	addedCh, unsubAdded := pubsub.Subscribe[accountsevent.AccountsAddedEvent](publisher, 8)
+	defer unsubAdded()
+	removedCh, unsubRemoved := pubsub.Subscribe[accountsevent.AccountsRemovedEvent](publisher, 8)
+	defer unsubRemoved()
+
+	kp, _, _, err := accounts.GetSeedImportedKeypair1ForTest()
+	s.Require().NoError(err)
+	remoteKp := *kp
+	remoteKp.Clock = 2
+	message, err := m2.prepareSyncKeypairMessage(&remoteKp)
+	s.Require().NoError(err)
+	for _, sAcc := range message.Accounts {
+		sAcc.Clock = 2
+	}
+
+	s.Require().NoError(m2.handleSyncKeypairInternal(m2.buildMessageState(), message, false))
+
+	select {
+	case ev := <-addedCh:
+		s.Require().Len(ev.Accounts, len(kp.Accounts), "every synced-in wallet account must be announced so balances get fetched")
+		announced := make(map[gethcommon.Address]bool)
+		for _, addr := range ev.Accounts {
+			announced[addr] = true
+		}
+		for _, acc := range kp.Accounts {
+			s.Require().True(announced[gethcommon.Address(acc.Address)], "account %s arrived via sync but was not announced", acc.Address.String())
+		}
+	default:
+		s.Require().FailNow("expected an AccountsAddedEvent because a keypair with wallet accounts arrived via sync")
+	}
+
+	select {
+	case <-removedCh:
+		s.Require().FailNow("no AccountsRemovedEvent expected when a new keypair arrives")
+	default:
+	}
 }

--- a/internal/protocol/messenger_sync_keypairs_auto_apply_test.go
+++ b/internal/protocol/messenger_sync_keypairs_auto_apply_test.go
@@ -310,18 +310,21 @@ func (s *MessengerSyncKeypairsAutoApplySuite) TestNonEmptyWireXPubAdoptedForUnkn
 	s.Require().Equal(wireXPub, dbKp.XPub, "a newly adopted keypair must store the wire xpub, otherwise no-password derivation is impossible on this device")
 }
 
-func (s *MessengerSyncKeypairsAutoApplySuite) TestNonEmptyWireXPubUpdatesStoredXPubOnKeypairUpdate() {
-	const storedXPub = "xpub6StoredBeforeTheSyncArrives"
-	const wireXPub = "xpub6NewerValueSentByThePairedDevice"
+func (s *MessengerSyncKeypairsAutoApplySuite) TestNonEmptyWireXPubBackfillsMissingStoredXPubOnKeypairUpdate() {
+	const wireXPub = "xpub6ValueSentByThePairedDevice"
 
+	// the xpub is derived at a fixed path from the keypair's master key, so two
+	// devices never hold two different non-empty values for it; the state that
+	// does occur is a device predating the xpub column, holding none
 	kp, _, _, err := accounts.GetSeedImportedKeypair1ForTest()
 	s.Require().NoError(err)
 	kp.Clock = 1
-	kp.XPub = storedXPub
+	kp.XPub = ""
 	for _, acc := range kp.Accounts {
 		acc.Operable = accsmanagementtypes.AccountFullyOperable
 	}
 	s.Require().NoError(s.m.settings.SaveOrUpdateKeypair(kp))
+	s.Require().Empty(s.dbKeypair(kp.KeyUID).XPub, "the keypair must start without an xpub, else the backfill proves nothing")
 
 	message := s.syncMessageFor(kp, 2, kp.Name, accsmanagementtypes.ColdWalletTypeNone)
 	message.Xpub = wireXPub
@@ -329,7 +332,7 @@ func (s *MessengerSyncKeypairsAutoApplySuite) TestNonEmptyWireXPubUpdatesStoredX
 	s.handleSync(message, false)
 
 	dbKp := s.dbKeypair(kp.KeyUID)
-	s.Require().Equal(wireXPub, dbKp.XPub, "a non-empty wire xpub must replace the stored one on keypair update")
+	s.Require().Equal(wireXPub, dbKp.XPub, "a keypair stored without an xpub must take the one a paired device sends")
 }
 
 func (s *MessengerSyncKeypairsAutoApplySuite) TestLedgerMigrationAdoptedVerbatimWhenAutoApplyEnabled() {
@@ -353,6 +356,9 @@ func (s *MessengerSyncKeypairsAutoApplySuite) TestTrezorMigrationAdoptedVerbatim
 	dbKp := s.dbKeypair(kp.KeyUID)
 	s.Require().Equal(accsmanagementtypes.ColdWalletTypeTrezor, dbKp.ColdWallet, "the wire cold wallet string must be stored verbatim")
 	s.Require().True(dbKp.MigratedToColdWallet(), "a trezor keypair must count as migrated to a cold wallet")
+	for _, acc := range dbKp.Accounts {
+		s.Require().Equal(accsmanagementtypes.AccountFullyOperable, acc.Operable, "accounts must stay operable after a trezor migration because no keystore is needed")
+	}
 }
 
 func (s *MessengerSyncKeypairsAutoApplySuite) TestUnknownColdWalletStringAdoptedVerbatimForUnknownKeypair() {
@@ -542,6 +548,14 @@ func (s *MessengerSyncKeypairsAutoApplySuite) TestAccountsPublisherEmitsAddedEve
 		}
 	default:
 		s.Require().FailNow("expected an AccountsAddedEvent because a keypair with wallet accounts arrived via sync")
+	}
+
+	// publishing happens before handleSyncKeypairInternal returns, so a second
+	// event would already be waiting here; a duplicate means duplicate balance work
+	select {
+	case <-addedCh:
+		s.Require().FailNow("expected exactly one AccountsAddedEvent, a second announces the same accounts twice")
+	default:
 	}
 
 	select {

--- a/internal/protocol/messenger_sync_wallets_test.go
+++ b/internal/protocol/messenger_sync_wallets_test.go
@@ -678,19 +678,8 @@ func (s *MessengerSyncWalletSuite) pairOtherDevice() *Messenger {
 	}
 	err := otherDevice.SetInstallationMetadata(otherDevice.installationID, im)
 	s.Require().NoError(err)
-	response, err := otherDevice.SendPairInstallation(context.Background(), "", nil)
-	s.Require().NoError(err)
-	s.Require().NotNil(response)
 
-	_, err = WaitOnMessengerResponse(
-		s.m,
-		func(r *MessengerResponse) bool { return len(r.Installations()) > 0 },
-		"installation not received",
-	)
-	s.Require().NoError(err)
-
-	_, err = s.m.EnableInstallation(otherDevice.installationID)
-	s.Require().NoError(err)
+	PairDevices(&s.Suite, otherDevice, s.m)
 
 	return otherDevice
 }

--- a/internal/protocol/messenger_sync_wallets_test.go
+++ b/internal/protocol/messenger_sync_wallets_test.go
@@ -777,6 +777,9 @@ func (s *MessengerSyncWalletSuite) TestAddKeypairStoredToColdWalletSyncsKeypairT
 		AddKeypairStoredToColdWallet(kp.KeyUID, kp.DerivedFrom, kp.Name, kp.XPub, accsmanagementtypes.ColdWalletTypeLedger, gomock.Any(), gomock.Any()).
 		DoAndReturn(func(keyUID string, masterAddress string, name string, walletXPub string, coldWallet accsmanagementtypes.ColdWalletType,
 			walletAccounts []*accsmanagementtypes.Account, clock uint64) (*accsmanagementtypes.Keypair, error) {
+			// the accounts the messenger forwarded, not the ones captured above:
+			// otherwise a nil or wrong slice would still sync two accounts
+			s.Require().Equal(kp.Accounts, walletAccounts, "the messenger must forward the wallet accounts it was given")
 			kp.Clock = clock
 			for i, acc := range kp.Accounts {
 				acc.Position = int64(i)

--- a/internal/protocol/messenger_sync_wallets_test.go
+++ b/internal/protocol/messenger_sync_wallets_test.go
@@ -668,3 +668,145 @@ func (s *MessengerSyncWalletSuite) TestSyncWalletAccountOrderAfterDeletion() {
 
 	s.Require().True(haveSameElements(dbAccounts1, dbAccounts2, accounts.SameAccountsIncludingPosition))
 }
+
+func (s *MessengerSyncWalletSuite) pairOtherDevice() *Messenger {
+	otherDevice := s.anotherMessenger()
+
+	im := &messagingtypes.InstallationMetadata{
+		Name:       "alice's-other-device",
+		DeviceType: "alice's-other-device-type",
+	}
+	err := otherDevice.SetInstallationMetadata(otherDevice.installationID, im)
+	s.Require().NoError(err)
+	response, err := otherDevice.SendPairInstallation(context.Background(), "", nil)
+	s.Require().NoError(err)
+	s.Require().NotNil(response)
+
+	_, err = WaitOnMessengerResponse(
+		s.m,
+		func(r *MessengerResponse) bool { return len(r.Installations()) > 0 },
+		"installation not received",
+	)
+	s.Require().NoError(err)
+
+	_, err = s.m.EnableInstallation(otherDevice.installationID)
+	s.Require().NoError(err)
+
+	return otherDevice
+}
+
+func (s *MessengerSyncWalletSuite) saveSeedKeypairOn(m *Messenger, coldWallet accsmanagementtypes.ColdWalletType) *accsmanagementtypes.Keypair {
+	kp, _, _, err := accounts.GetSeedImportedKeypair1ForTest()
+	s.Require().NoError(err)
+	kp.Clock = 1
+	kp.ColdWallet = coldWallet
+	for _, acc := range kp.Accounts {
+		acc.Operable = accsmanagementtypes.AccountFullyOperable
+	}
+	s.Require().NoError(m.settings.SaveOrUpdateKeypair(kp))
+	return kp
+}
+
+func (s *MessengerSyncWalletSuite) waitForKeypairOn(otherDevice *Messenger) {
+	err := testutils.RetryWithBackOff(func() error {
+		response, err := otherDevice.RetrieveAll()
+		if err != nil {
+			return err
+		}
+		if len(response.Keypairs) != 1 {
+			return errors.New("no sync keypair received")
+		}
+		return nil
+	})
+	s.Require().NoError(err)
+}
+
+func (s *MessengerSyncWalletSuite) TestMigrateKeypairToColdWalletSyncsColdStateToPairedDevice() {
+	kp := s.saveSeedKeypairOn(s.m, accsmanagementtypes.ColdWalletTypeNone)
+	otherDevice := s.pairOtherDevice()
+	s.saveSeedKeypairOn(otherDevice, accsmanagementtypes.ColdWalletTypeNone)
+
+	s.accountsManagerMock.EXPECT().
+		MigrateKeypairToColdWallet(kp.KeyUID, "password", accsmanagementtypes.ColdWalletTypeStatusKeycard, gomock.Any()).
+		DoAndReturn(func(keyUID string, password string, coldWallet accsmanagementtypes.ColdWalletType, clock uint64) error {
+			return s.m.settings.UpdateKeypairXPub(keyUID, "", coldWallet, clock)
+		}).Times(1)
+
+	err := s.m.MigrateKeypairToColdWallet(context.Background(), kp.KeyUID, "password", accsmanagementtypes.ColdWalletTypeStatusKeycard)
+	s.Require().NoError(err)
+
+	s.waitForKeypairOn(otherDevice)
+
+	dbKp, err := otherDevice.settings.GetKeypairByKeyUID(kp.KeyUID)
+	s.Require().NoError(err)
+	s.Require().Equal(accsmanagementtypes.ColdWalletTypeStatusKeycard, dbKp.ColdWallet,
+		"the paired device must learn the keypair signs via keycard now, or it will keep trying deleted keystore files")
+}
+
+func (s *MessengerSyncWalletSuite) TestMigrateColdWalletKeypairToAppSyncsRevertToPairedDevice() {
+	kp := s.saveSeedKeypairOn(s.m, accsmanagementtypes.ColdWalletTypeStatusKeycard)
+	otherDevice := s.pairOtherDevice()
+	s.saveSeedKeypairOn(otherDevice, accsmanagementtypes.ColdWalletTypeStatusKeycard)
+
+	s.accountsManagerMock.EXPECT().
+		MigrateColdWalletKeypairToApp("some mnemonic", "password", gomock.Any()).
+		DoAndReturn(func(mnemonic string, password string, clock uint64) (string, error) {
+			return kp.KeyUID, s.m.settings.UpdateKeypairXPub(kp.KeyUID, "", accsmanagementtypes.ColdWalletTypeNone, clock)
+		}).Times(1)
+
+	err := s.m.MigrateColdWalletKeypairToApp(context.Background(), "some mnemonic", "password")
+	s.Require().NoError(err)
+
+	s.waitForKeypairOn(otherDevice)
+
+	dbKp, err := otherDevice.settings.GetKeypairByKeyUID(kp.KeyUID)
+	s.Require().NoError(err)
+	s.Require().Equal(accsmanagementtypes.ColdWalletTypeNone, dbKp.ColdWallet,
+		"the paired device must learn the keypair signs via keystore again, or its signing method stays keycard forever")
+}
+
+func (s *MessengerSyncWalletSuite) TestAddKeypairStoredToColdWalletSyncsKeypairToPairedDevice() {
+	otherDevice := s.pairOtherDevice()
+
+	kp, _, _, err := accounts.GetSeedImportedKeypair1ForTest()
+	s.Require().NoError(err)
+	kp.XPub = "xpub6LedgerColdWalletKeypair"
+	kp.ColdWallet = accsmanagementtypes.ColdWalletTypeLedger
+
+	s.accountsManagerMock.EXPECT().
+		AddKeypairStoredToColdWallet(kp.KeyUID, kp.DerivedFrom, kp.Name, kp.XPub, accsmanagementtypes.ColdWalletTypeLedger, gomock.Any(), gomock.Any()).
+		DoAndReturn(func(keyUID string, masterAddress string, name string, walletXPub string, coldWallet accsmanagementtypes.ColdWalletType,
+			walletAccounts []*accsmanagementtypes.Account, clock uint64) (*accsmanagementtypes.Keypair, error) {
+			kp.Clock = clock
+			for i, acc := range kp.Accounts {
+				acc.Position = int64(i)
+				acc.Operable = accsmanagementtypes.AccountFullyOperable
+			}
+			return kp, s.m.settings.SaveOrUpdateKeypair(kp)
+		}).Times(1)
+
+	returnedKp, err := s.m.AddKeypairStoredToColdWallet(kp.KeyUID, kp.DerivedFrom, kp.Name, kp.XPub, accsmanagementtypes.ColdWalletTypeLedger, kp.Accounts)
+	s.Require().NoError(err)
+
+	s.waitForKeypairOn(otherDevice)
+
+	dbKp, err := otherDevice.settings.GetKeypairByKeyUID(kp.KeyUID)
+	s.Require().NoError(err)
+	s.Require().Equal(accsmanagementtypes.ColdWalletTypeLedger, dbKp.ColdWallet,
+		"the paired device must know the keypair lives on a ledger, there are no keystore files to fall back to")
+	s.Require().Equal(kp.XPub, dbKp.XPub,
+		"the xpub must survive the wire trip, password-less account derivation on the paired device depends on it")
+	s.Require().Equal(returnedKp.Name, dbKp.Name, "the keypair must arrive under the name it was created with")
+	s.Require().Equal(returnedKp.DerivedFrom, dbKp.DerivedFrom, "the master address must survive the wire trip")
+	s.Require().Equal(len(returnedKp.Accounts), len(dbKp.Accounts), "every ledger wallet account must reach the paired device")
+	for _, expected := range returnedKp.Accounts {
+		found := false
+		for _, got := range dbKp.Accounts {
+			if got.Address == expected.Address {
+				found = true
+				break
+			}
+		}
+		s.Require().True(found, "wallet account %s must exist on the paired device", expected.Address.Hex())
+	}
+}

--- a/internal/protocol/messenger_wallet_test.go
+++ b/internal/protocol/messenger_wallet_test.go
@@ -210,7 +210,7 @@ func (s *WalletSuite) saveColdSeedKeypairWithXPub() *accsmanagementtypes.Keypair
 	return kp
 }
 
-func (s *WalletSuite) TestUpdateKeypairPreservesColdWalletStateOnRename() {
+func (s *WalletSuite) TestUpdateKeypairRoundTripsColdWalletStateOnRename() {
 	kp := s.saveColdSeedKeypairWithXPub()
 
 	dbKp, err := s.m.settings.GetKeypairByKeyUID(kp.KeyUID)

--- a/internal/protocol/messenger_wallet_test.go
+++ b/internal/protocol/messenger_wallet_test.go
@@ -3,6 +3,7 @@ package protocol
 import (
 	"testing"
 
+	accsmanagementtypes "github.com/status-im/status-go/internal/accounts-management/types"
 	"github.com/status-im/status-go/internal/crypto/types"
 	"github.com/status-im/status-go/internal/db/multiaccounts/accounts"
 
@@ -194,4 +195,32 @@ func (s *WalletSuite) TestRemainingCapacity() {
 	s.Require().Error(err)
 	s.Require().Equal("no more watch-only accounts can be added", err.Error())
 	s.Require().Equal(0, capacity)
+}
+
+func (s *WalletSuite) saveColdSeedKeypairWithXPub() *accsmanagementtypes.Keypair {
+	kp, _, _, err := accounts.GetSeedImportedKeypair1ForTest()
+	s.Require().NoError(err)
+	kp.Clock = 1
+	kp.ColdWallet = accsmanagementtypes.ColdWalletTypeStatusKeycard
+	kp.XPub = "xpub6ColdWalletKeypairStoredXPub"
+	for _, acc := range kp.Accounts {
+		acc.Operable = accsmanagementtypes.AccountFullyOperable
+	}
+	s.Require().NoError(s.m.settings.SaveOrUpdateKeypair(kp))
+	return kp
+}
+
+func (s *WalletSuite) TestUpdateKeypairPreservesColdWalletStateOnRename() {
+	kp := s.saveColdSeedKeypairWithXPub()
+
+	dbKp, err := s.m.settings.GetKeypairByKeyUID(kp.KeyUID)
+	s.Require().NoError(err)
+	dbKp.Name = "Renamed Cold Keypair"
+	s.Require().NoError(s.m.UpdateKeypair(dbKp))
+
+	dbKp, err = s.m.settings.GetKeypairByKeyUID(kp.KeyUID)
+	s.Require().NoError(err)
+	s.Require().Equal("Renamed Cold Keypair", dbKp.Name, "the rename itself must apply")
+	s.Require().Equal(accsmanagementtypes.ColdWalletTypeStatusKeycard, dbKp.ColdWallet, "renaming a keypair must not change its signing method")
+	s.Require().Equal(kp.XPub, dbKp.XPub, "renaming a keypair must not drop the stored xpub, password-less derivation depends on it")
 }

--- a/internal/protocol/requests/restore_account_test.go
+++ b/internal/protocol/requests/restore_account_test.go
@@ -8,6 +8,24 @@ import (
 
 const validWhisperPrivateKey = "0x1111111111111111111111111111111111111111111111111111111111111111"
 
+// keycardDataFromCard mirrors the shape the client sends after reading a card:
+// every field the backend maps into a derived address is present. The values are
+// the same card fixture used by TestRestoreKeycardAccountAndLogin.
+func keycardDataFromCard() *KeycardData {
+	return &KeycardData{
+		KeyUID:              "0x579324c53f347e18961c775a00ec13ed7d59a225b1859d5125ff36b450b8778d",
+		Address:             "0xbf9dE86774051537b2192Ce9c8d2496f129bA24b",
+		WhisperPrivateKey:   "5a42b4f15ff1a5da95d116442ce11a31e9020f562224bf60b1d8d3a99d90653d",
+		WhisperPublicKey:    "0x0441468c39b579259676350b9736b01cdadb740f67bfd022fa2b985123b1d66fc3191cfe73205e3d3d84148f0248f9a2978afeeda16d7c3db90bd2579f0de33459",
+		WhisperAddress:      "0xBa122B9c0Ef560813b5D2C0961094aC36289f846",
+		WalletPublicKey:     "0x04c16e7748f34e0ab2c9c13350d7872d928e942934dd8b8abd3fb12b8c742a5ee8cf0919731e800907068afec25f577bde3a9c534795e359ee48097e4e55f4aaca",
+		WalletAddress:       "0xB9E1998e1A8854887CA327D1aF5894B6CB0AC07D",
+		WalletRootAddress:   "0xFf59db9F2f97Db7104A906C390D33C342a1309C8",
+		Eip1581Address:      "0xA8d50f0B3bc581298446be8FBfF5c71684Ea6c01",
+		EncryptionPublicKey: "0x04c4b16f670b51702dc130673bf9c64ffd1f69383cef2127dfa05031b9b1359120f7342134af9a350465126a85e87cb003b7c4f93d2ba2ff98bb73277b119c7a87",
+	}
+}
+
 func validRestoreAccount() RestoreAccount {
 	return RestoreAccount{
 		CreateAccount: CreateAccount{
@@ -94,10 +112,18 @@ func TestRestoreAccountValidateRejectsMissingMnemonicForRegularRestore(t *testin
 
 func TestRestoreAccountValidateAcceptsCompleteKeycardRestore(t *testing.T) {
 	req := validRestoreAccount()
-	req.Keycard = &KeycardData{
-		KeyUID:            "0x1",
-		WhisperPrivateKey: validWhisperPrivateKey,
-	}
+	req.Keycard = keycardDataFromCard()
 
-	require.NoError(t, req.Validate(true), "a keycard restore with card details and a whisper key is the supported happy path")
+	require.NoError(t, req.Validate(true), "a keycard restore carrying the full card details is the supported happy path")
+}
+
+// Validate only checks which fields are present, so a malformed key reaches the
+// backend and fails later at key generation. Login.Validate parses its keycard
+// whisper key; RestoreAccount.Validate does not.
+func TestRestoreAccountValidateAcceptsUnparseableWhisperPrivateKey(t *testing.T) {
+	req := validRestoreAccount()
+	req.Keycard = keycardDataFromCard()
+	req.Keycard.WhisperPrivateKey = "not-a-key"
+
+	require.NoError(t, req.Validate(true), "documents that restore does not parse the whisper key, unlike login")
 }

--- a/internal/protocol/requests/restore_account_test.go
+++ b/internal/protocol/requests/restore_account_test.go
@@ -1,0 +1,103 @@
+package requests
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+const validWhisperPrivateKey = "0x1111111111111111111111111111111111111111111111111111111111111111"
+
+func validRestoreAccount() RestoreAccount {
+	return RestoreAccount{
+		CreateAccount: CreateAccount{
+			Password:           "test-password",
+			CustomizationColor: "primary",
+			RootDataDir:        "/tmp/status-test",
+		},
+	}
+}
+
+func TestLoginValidateRejectsEmptyKeyUID(t *testing.T) {
+	login := Login{}
+
+	err := login.Validate()
+	require.ErrorIs(t, err, ErrLoginInvalidKeyUID, "a login without a key-uid cannot resolve an account and must be rejected")
+}
+
+func TestLoginValidateRejectsUnparseableKeycardWhisperPrivateKey(t *testing.T) {
+	login := Login{
+		KeyUID:                   "0x1",
+		KeycardWhisperPrivateKey: "not-a-private-key",
+	}
+
+	err := login.Validate()
+	require.ErrorIs(t, err, ErrLoginInvalidKeycardWhisperPrivateKey, "an unparseable keycard whisper key must be rejected at validation because ChatPrivateKey ignores the parse error later")
+}
+
+func TestLoginValidateAcceptsParseableKeycardWhisperPrivateKey(t *testing.T) {
+	login := Login{
+		KeyUID:                   "0x1",
+		KeycardWhisperPrivateKey: validWhisperPrivateKey,
+	}
+
+	require.NoError(t, login.Validate(), "a well-formed keycard whisper key must pass validation")
+	require.NotNil(t, login.ChatPrivateKey(), "a validated keycard login must yield a chat identity")
+}
+
+func TestLoginValidateAllowsMissingKeycardWhisperPrivateKey(t *testing.T) {
+	login := Login{KeyUID: "0x1"}
+
+	require.NoError(t, login.Validate(), "a regular password login carries no keycard whisper key and must validate")
+	require.Nil(t, login.ChatPrivateKey(), "without a keycard whisper key there is no derived chat key")
+}
+
+func TestRestoreAccountValidateRejectsMnemonicForKeycardRestore(t *testing.T) {
+	req := validRestoreAccount()
+	req.Mnemonic = "some mnemonic words"
+	req.Keycard = &KeycardData{WhisperPrivateKey: validWhisperPrivateKey}
+
+	err := req.Validate(true)
+	require.ErrorIs(t, err, ErrRestoreKeycardAccountMnemonicSet, "keycard restore derives keys from the card, a mnemonic alongside is contradictory input")
+}
+
+func TestRestoreAccountValidateRejectsMissingKeycardDataForKeycardRestore(t *testing.T) {
+	req := validRestoreAccount()
+
+	err := req.Validate(true)
+	require.ErrorIs(t, err, ErrRestoreKeycardAccountKecardDetatilsMissing, "keycard restore without keycard data would proceed with nil card details")
+}
+
+func TestRestoreAccountValidateRejectsKeycardDataWithoutWhisperPrivateKey(t *testing.T) {
+	req := validRestoreAccount()
+	req.Keycard = &KeycardData{KeyUID: "0x1"}
+
+	err := req.Validate(true)
+	require.ErrorIs(t, err, ErrRestoreKeycardAccountNoWhisperPrivateKey, "keycard restore without the whisper private key would leave the account with no chat identity")
+}
+
+func TestRestoreAccountValidateRejectsKeycardDataForRegularRestore(t *testing.T) {
+	req := validRestoreAccount()
+	req.Mnemonic = "some mnemonic words"
+	req.Keycard = &KeycardData{WhisperPrivateKey: validWhisperPrivateKey}
+
+	err := req.Validate(false)
+	require.ErrorIs(t, err, ErrRestoreRegularAccountKeycardSet, "a regular restore must not silently carry keycard details")
+}
+
+func TestRestoreAccountValidateRejectsMissingMnemonicForRegularRestore(t *testing.T) {
+	req := validRestoreAccount()
+
+	err := req.Validate(false)
+	require.ErrorIs(t, err, ErrRestoreRegularAccountMnemonicMissing, "a regular restore has nothing to restore from without a mnemonic")
+}
+
+func TestRestoreAccountValidateAcceptsCompleteKeycardRestore(t *testing.T) {
+	req := validRestoreAccount()
+	req.Keycard = &KeycardData{
+		KeyUID:            "0x1",
+		WhisperPrivateKey: validWhisperPrivateKey,
+	}
+
+	require.NoError(t, req.Validate(true), "a keycard restore with card details and a whisper key is the supported happy path")
+}


### PR DESCRIPTION
The keycard management API was removed in June 2026 (`e762325dff` and related commits). A keycard is now a `cold_wallet` value on a keypair, next to `ledger` and `trezor`. The tests for this area were not updated.

This PR adds tests for how keypair sync handles cold wallets in `internal/protocol`, plus request validation in `internal/protocol/requests`.

- Production code is not changed.
- Each test was checked by breaking the behaviour it names in production code and confirming it fails. Review then found individual assertions inside those tests that were not load-bearing; those have been strengthened and checked the same way.

## Applying a keypair sync message

**`TestLedgerMigrationAdoptedVerbatimWhenAutoApplyEnabled`**, **`TestTrezorMigrationAdoptedVerbatimWhenAutoApplyEnabled`**
- **Given** a saved seed keypair with no cold wallet
- **When** a newer sync marks it as ledger or trezor
- **Then** the value is stored as sent, the keypair counts as migrated, and its accounts stay operable, because a cold wallet needs no keystore file

**`TestUnknownColdWalletStringAdoptedVerbatimForUnknownKeypair`**
- **Given** a keypair this device has never seen
- **When** its sync carries a cold-wallet string this build does not know
- **Then** the string is stored as-is, so a newer client's value is not normalised away

**`TestNonEmptyWireXPubAdoptedForUnknownKeypair`**
- **Given** a keypair unknown to this device
- **When** its sync carries an xpub
- **Then** the keypair is stored with it

**`TestNonEmptyWireXPubBackfillsMissingStoredXPubOnKeypairUpdate`**
- **Given** a keypair saved without an xpub, which is how a device predating the column holds it
- **When** a newer sync carries one
- **Then** it is adopted. The xpub is derived at a fixed path from the master key, so a missing value is the only case that occurs

**`TestSyncedFromPreservedOnKeypairUpdate`**
- **Given** a keypair saved as synced from one device
- **When** a newer sync claims a different origin
- **Then** the stored value stays

## Ignoring stale messages

**`TestEqualClockSyncKeypairLeavesKeypairUntouched`**, **`TestLowerClockSyncKeypairLeavesKeypairUntouched`**
- **Given** a saved keycard keypair
- **When** a sync arrives at the same or an older clock, with a different name and no cold wallet
- **Then** nothing changes in the database and nothing is echoed to clients

**`TestStaleProfileSyncDoesNotSetProfileMigrationNeeded`**
- **Given** the profile keypair saved at a clock
- **When** a replayed sync at that clock claims a keycard migration
- **Then** the migration-needed flag stays false, so the user gets no banner from a stale message

## Removals, notifications and events

**`TestRemovedKeypairSyncRemovesKnownKeypair`**
- **Given** a saved seed keypair
- **When** a newer sync marks it and its accounts removed
- **Then** the removal is echoed to clients, no notification is added, and the keypair stops being returned as active

**`TestNewKeypairFromPairedDeviceAddsACNotification`**, **`TestKnownKeypairUpdateDoesNotAddACNotification`**
- **Given** a keypair that is either unknown or already saved
- **When** its sync arrives
- **Then** a new keypair adds exactly one activity-centre notification and an update to a known one adds none

**`TestRevertSyncMarksLocallyUnknownAccountNonOperable`**
- **Given** a saved keycard keypair
- **When** a revert-to-app sync also carries an account this device has never seen
- **Then** that account is stored non-operable, because there is no key material for it

**`TestAccountsPublisherEmitsAddedEventForSyncedNewKeypair`**
- **Given** a messenger subscribed to accounts events
- **When** a keypair with two wallet accounts arrives by sync
- **Then** exactly one added event names every account, so balances get fetched once, and no removed event fires

## Reaching a paired device

These mock the accounts manager, so they cover the messenger, the wire and the receiving side, not the migration internals.

**`TestMigrateKeypairToColdWalletSyncsColdStateToPairedDevice`**, **`TestMigrateColdWalletKeypairToAppSyncsRevertToPairedDevice`**
- **Given** two paired devices holding the same keypair
- **When** one migrates it to a keycard and later back to the app
- **Then** the other device stores each change

**`TestAddKeypairStoredToColdWalletSyncsKeypairToPairedDevice`**
- **Given** two paired devices where one has never seen the keypair
- **When** a ledger keypair is added
- **Then** the accounts the messenger forwards are asserted, and the other device stores the keypair with its xpub, name, master address and both accounts

## Renaming

**`TestUpdateKeypairRoundTripsColdWalletStateOnRename`**
- **Given** a saved keycard keypair with an xpub
- **When** only its name is changed
- **Then** the new name applies and the cold-wallet type and xpub are unchanged

## Request validation

**`TestRestoreAccountValidateAcceptsCompleteKeycardRestore`**
- **Given** a keycard restore carrying the full card details
- **When** it is validated
- **Then** it passes

**`TestRestoreAccountValidateRejectsMnemonicForKeycardRestore`**, **`...RejectsMissingKeycardData...`**, **`...RejectsKeycardDataWithoutWhisperPrivateKey`**
- **Given** a keycard restore that also carries a mnemonic, or is missing the card details, or is missing the whisper key
- **When** it is validated
- **Then** each is rejected

**`TestRestoreAccountValidateRejectsKeycardDataForRegularRestore`**, **`...RejectsMissingMnemonicForRegularRestore`**
- **Given** a regular restore that carries card details, or no mnemonic
- **When** it is validated
- **Then** each is rejected

**`TestLoginValidateRejectsEmptyKeyUID`**, **`...RejectsUnparseableKeycardWhisperPrivateKey`**, **`...AcceptsParseableKeycardWhisperPrivateKey`**, **`...AllowsMissingKeycardWhisperPrivateKey`**
- **Given** a login request
- **When** it is validated
- **Then** an empty key UID and an unparseable keycard whisper key are rejected, while a parseable key and no key at all are accepted

**`TestRestoreAccountValidateAcceptsUnparseableWhisperPrivateKey`**
- **Given** a keycard restore whose whisper key is malformed
- **When** it is validated
- **Then** it passes, because restore only checks which fields are present. `Login.Validate` parses its whisper key; `RestoreAccount.Validate` does not, so a malformed key fails later at key generation instead. Recorded rather than fixed: changing it means changing production code

Part of the series restoring keycard and cold-wallet test coverage (#7756). #7696 and #7697 are merged. #7758, #7760 and #7761 are open.
