### PR TITLE
test(pairing): cover keycard payload and keystore re-pair guards

### DIFF
--- a/pkg/services/pairing/payload_management_test.go
+++ b/pkg/services/pairing/payload_management_test.go
@@ -387,6 +387,107 @@ func (pms *PayloadMarshallerSuite) TestPayloadMarshaller_StorePayloads() {
 	pms.Require().ErrorIs(err, ErrKeyFileAlreadyExists)
 }
 
+func (pms *PayloadMarshallerSuite) TestPayloadMarshaller_StoreRePairSkipsExistingKeysAndKeepsLocalAccount() {
+	pp := new(AccountPayload)
+	ppr, err := NewAccountPayloadLoader(pp, pms.config1)
+	pms.Require().NoError(err)
+	pms.Require().NoError(ppr.Load())
+
+	pb, err := NewPairingPayloadMarshaller(pp, pms.Logger).MarshalProtobuf()
+	pms.Require().NoError(err)
+
+	pp2 := new(AccountPayload)
+	pms.Require().NoError(NewPairingPayloadMarshaller(pp2, pms.Logger).UnmarshalProtobuf(pb))
+	storer, err := NewAccountPayloadStorer(pp2, pms.config2)
+	pms.Require().NoError(err)
+	pms.Require().NoError(storer.Store())
+
+	// the device now knows the account; rename it locally so the DB row is
+	// distinguishable from the wire payload on the second pass
+	localAcc, err := pms.config2.DB.GetAccount(keyUID)
+	pms.Require().NoError(err)
+	localAcc.Name = "locally renamed"
+	pms.Require().NoError(pms.config2.DB.SaveAccount(*localAcc))
+
+	pp3 := new(AccountPayload)
+	pms.Require().NoError(NewPairingPayloadMarshaller(pp3, pms.Logger).UnmarshalProtobuf(pb))
+	storer2, err := NewAccountPayloadStorer(pp3, pms.config2)
+	pms.Require().NoError(err)
+
+	keysBefore := getFiles(pms.T(), filepath.Join(pms.config2.AbsoluteKeystorePath(), keyUID))
+
+	err = storer2.Store()
+	pms.Require().NoError(err, "Expected re-pairing Store() to swallow ErrKeyFileAlreadyExists because the keystore dir for the keyUID already exists on this device")
+	pms.Require().True(storer2.exist, "Expected exist=true because the second Store() must flag the account as already known")
+
+	pms.Require().Equal("locally renamed", storer2.multiaccount.Name, "Expected the multiaccount to be replaced by the local DB row (not the wire payload) on re-pair")
+
+	keys := getFiles(pms.T(), filepath.Join(pms.config2.AbsoluteKeystorePath(), keyUID))
+	pms.Require().Len(keys, 2, "Expected the original two key files to be untouched by the re-pair")
+	pms.Require().Equal(keysBefore, keys, "Expected the key file CONTENT unchanged: an overwrite would keep the count at 2 while corrupting the local keys with the wire payload's")
+}
+
+func (pms *PayloadMarshallerSuite) TestPayloadMarshaller_KeycardPairingSurvivesMarshalUnmarshalStore() {
+	acc := expected
+	acc.KeycardPairing = "keycard-pairing-info"
+	pp := &AccountPayload{
+		password:     "0x1234",
+		multiaccount: &acc,
+		keys:         make(map[string][]byte),
+	}
+
+	pb, err := NewPairingPayloadMarshaller(pp, pms.Logger).MarshalProtobuf()
+	pms.Require().NoError(err)
+
+	pp2 := new(AccountPayload)
+	pms.Require().NoError(NewPairingPayloadMarshaller(pp2, pms.Logger).UnmarshalProtobuf(pb))
+	pms.Require().Equal("keycard-pairing-info", pp2.multiaccount.KeycardPairing, "Expected KeycardPairing to survive the protobuf round-trip because the paired device needs it for keycard login")
+	pms.Require().Equal("0x1234", pp2.password, "Expected an already 0x-prefixed password to pass the keycard adjustment unchanged")
+
+	storer, err := NewAccountPayloadStorer(pp2, pms.config2)
+	pms.Require().NoError(err)
+	pms.Require().NoError(storer.Store())
+
+	storedAcc, err := pms.config2.DB.GetAccount(keyUID)
+	pms.Require().NoError(err)
+	pms.Require().Equal("keycard-pairing-info", storedAcc.KeycardPairing, "Expected the received KeycardPairing to be persisted because the new device must be able to keycard-login")
+}
+
+func (pms *PayloadMarshallerSuite) TestPayloadMarshaller_StoreSkipsStoringWhenLoggedInWithSameKeyUID() {
+	acc := expected
+	pp := &AccountPayload{multiaccount: &acc}
+
+	pms.config2.LoggedInKeyUID = keyUID
+	storer, err := NewAccountPayloadStorer(pp, pms.config2)
+	pms.Require().NoError(err)
+
+	err = storer.Store()
+	pms.Require().NoError(err, "Expected Store() to be a silent no-op because the receiver is already logged in with the payload's keyUID")
+	pms.Require().False(storer.exist, "Expected exist to stay false because the skip returns before the keystore check")
+
+	_, statErr := os.Stat(filepath.Join(pms.config2.AbsoluteKeystorePath(), keyUID))
+	pms.Require().True(os.IsNotExist(statErr), "Expected no keystore dir to be written because the logged-in user's own key material must not be overwritten by wire data")
+
+	storedAcc, dbErr := pms.config2.DB.GetAccount(keyUID)
+	pms.Require().NoError(dbErr)
+	pms.Require().Empty(storedAcc.KeyUID, "Expected no multiaccounts row to be saved because the logged-in user's account must not be clobbered by wire data")
+}
+
+func (pms *PayloadMarshallerSuite) TestPayloadMarshaller_StoreRejectsPayloadForDifferentKeyUIDWhenLoggedIn() {
+	acc := expected
+	pp := &AccountPayload{multiaccount: &acc}
+
+	pms.config2.LoggedInKeyUID = "0x1111111111111111111111111111111111111111111111111111111111111111"
+	storer, err := NewAccountPayloadStorer(pp, pms.config2)
+	pms.Require().NoError(err)
+
+	err = storer.Store()
+	pms.Require().ErrorIs(err, ErrLoggedInKeyUIDConflict, "Expected ErrLoggedInKeyUIDConflict because a foreign account's payload must not be stored under an active session")
+
+	_, statErr := os.Stat(filepath.Join(pms.config2.AbsoluteKeystorePath(), keyUID))
+	pms.Require().True(os.IsNotExist(statErr), "Expected no keystore dir to be written for the rejected foreign payload")
+}
+
 func (pms *PayloadMarshallerSuite) TestPayloadMarshaller_LockPayload() {
 	AESKey := make([]byte, 32)
 	_, err := rand.Read(AESKey)

--- a/pkg/services/pairing/sync_device_test.go
+++ b/pkg/services/pairing/sync_device_test.go
@@ -516,6 +516,210 @@ func (s *SyncDeviceSuite) TestTransferringKeystoreFilesSkipsAlreadyStoredKeystor
 	}
 }
 
+func (s *SyncDeviceSuite) TestTransferringKeystoreFilesAfterColdWalletRoundTrip() {
+	ctx := context.TODO()
+
+	serverTmpDir := filepath.Join(s.tmpdir, "server")
+	serverBackend := s.prepareBackendWithAccount(profileKeypairMnemonic1, serverTmpDir)
+
+	clientTmpDir := filepath.Join(s.tmpdir, "client")
+	clientBackend := s.prepareBackendWithAccount(profileKeypairMnemonic1, clientTmpDir)
+	defer func() {
+		require.NoError(s.T(), clientBackend.Logout())
+		require.NoError(s.T(), serverBackend.Logout())
+	}()
+
+	serverActiveAccount, err := serverBackend.GetActiveAccount()
+	require.NoError(s.T(), err)
+	clientActiveAccount, err := clientBackend.GetActiveAccount()
+	require.NoError(s.T(), err)
+	require.True(s.T(), serverActiveAccount.KeyUID == clientActiveAccount.KeyUID)
+
+	walletAccounts := &accsmanagementtypes.AccountCreationDetails{
+		Path:    accsmanagementcommon.PathDefaultWalletAccount,
+		Name:    "Default Wallet Account",
+		Emoji:   "💰",
+		ColorID: "primary",
+	}
+
+	// the full cold-wallet round-trip happens on the server only; the client is given
+	// the resulting keypair state locally, so no cross-device sync waits are involved
+	serverAccountsAPI := serverBackend.StatusNode().AccountService().APIs()[1].Service.(*accservice.API)
+	serverSeedPhraseKp, err := serverAccountsAPI.AddKeypairViaSeedPhrase(ctx, seedKeypairMnemonic1, s.password, "Seed Phrase Keypair", accsmanagementtypes.ColdWalletTypeNone, walletAccounts)
+	require.NoError(s.T(), err)
+
+	serverKeystorePath := filepath.Join(serverTmpDir, backend.DefaultKeystoreRelativePath, serverActiveAccount.KeyUID)
+
+	err = serverAccountsAPI.MigrateNonProfileKeypairToColdWallet(ctx, serverSeedPhraseKp.KeyUID, s.password, accsmanagementtypes.ColdWalletTypeStatusKeycard)
+	require.NoError(s.T(), err)
+	require.False(s.T(), containsKeystoreFile(serverKeystorePath, serverSeedPhraseKp.DerivedFrom[2:]), "Expected the keycard migration to delete the keypair's keystore files on the server")
+
+	err = serverAccountsAPI.MigrateNonProfileColdWalletKeypairToApp(ctx, seedKeypairMnemonic1, s.password)
+	require.NoError(s.T(), err)
+	require.True(s.T(), containsKeystoreFile(serverKeystorePath, serverSeedPhraseKp.DerivedFrom[2:]), "Expected migrating back to app to recreate the keypair's keystore files on the server")
+
+	serverKp, err := serverAccountsAPI.GetKeypairByKeyUID(ctx, serverSeedPhraseKp.KeyUID)
+	require.NoError(s.T(), err)
+	require.Equal(s.T(), accsmanagementtypes.ColdWalletTypeNone, serverKp.ColdWallet, "Expected the server keypair to be back to a regular app keypair after the round-trip")
+
+	// the client holds the same keypair without keystore files - the state a paired
+	// device is left in after syncing a keycard migration (files deleted) and the
+	// migration back (files cannot be recreated remotely)
+	clientAccountsAPI := clientBackend.StatusNode().AccountService().APIs()[1].Service.(*accservice.API)
+	clientSeedPhraseKp, err := clientAccountsAPI.AddKeypairViaSeedPhrase(ctx, seedKeypairMnemonic1, s.password, "Seed Phrase Keypair", accsmanagementtypes.ColdWalletTypeNone, walletAccounts)
+	require.NoError(s.T(), err)
+
+	clientKeystoreDir := filepath.Join(clientTmpDir, backend.DefaultKeystoreRelativePath, clientActiveAccount.KeyUID)
+	files, err := os.ReadDir(clientKeystoreDir)
+	require.NoError(s.T(), err)
+	for _, file := range files {
+		if strings.Contains(strings.ToLower(file.Name()), strings.ToLower(clientSeedPhraseKp.DerivedFrom[2:])) {
+			require.NoError(s.T(), os.RemoveAll(filepath.Join(clientKeystoreDir, file.Name())))
+			continue
+		}
+		for _, acc := range clientSeedPhraseKp.Accounts {
+			if strings.Contains(strings.ToLower(file.Name()), strings.ToLower(acc.Address.String()[2:])) {
+				require.NoError(s.T(), os.RemoveAll(filepath.Join(clientKeystoreDir, file.Name())))
+			}
+		}
+	}
+	require.False(s.T(), containsKeystoreFile(clientKeystoreDir, clientSeedPhraseKp.DerivedFrom[2:]))
+	for _, acc := range clientSeedPhraseKp.Accounts {
+		require.False(s.T(), containsKeystoreFile(clientKeystoreDir, acc.Address.String()[2:]),
+			"Expected the account keystore file removed before the transfer, else regaining it proves nothing")
+	}
+
+	serverBackend.Messenger().SetLocalPairing(true)
+	clientBackend.Messenger().SetLocalPairing(true)
+
+	config := KeystoreFilesSenderServerConfig{
+		SenderConfig: &KeystoreFilesSenderConfig{
+			KeystoreFilesConfig: KeystoreFilesConfig{
+				KeystorePath:   serverKeystorePath,
+				LoggedInKeyUID: serverActiveAccount.KeyUID,
+				Password:       s.password,
+			},
+			KeypairsToExport: []string{serverKp.KeyUID},
+		},
+		ServerConfig: new(ServerConfig),
+	}
+	configBytes, err := json.Marshal(config)
+	require.NoError(s.T(), err)
+	cs, err := StartUpKeystoreFilesSenderServer(serverBackend, string(configBytes))
+	require.NoError(s.T(), err)
+
+	clientPayloadSourceConfig := KeystoreFilesReceiverClientConfig{
+		ReceiverConfig: &KeystoreFilesReceiverConfig{
+			KeystoreFilesConfig: KeystoreFilesConfig{
+				KeystorePath:   clientKeystoreDir,
+				LoggedInKeyUID: clientActiveAccount.KeyUID,
+				Password:       s.password,
+			},
+			KeypairsToImport: []string{clientSeedPhraseKp.KeyUID},
+		},
+		ClientConfig: new(ClientConfig),
+	}
+	err = StartUpKeystoreFilesReceivingClient(clientBackend, cs, &clientPayloadSourceConfig)
+	require.NoError(s.T(), err, "Expected the keystore transfer to accept the round-tripped keypair because both DBs hold it as a regular app keypair")
+
+	require.True(s.T(), containsKeystoreFile(clientKeystoreDir, clientSeedPhraseKp.DerivedFrom[2:]), "Expected the client to regain the master keystore file it lost at the keycard step")
+	for _, acc := range clientSeedPhraseKp.Accounts {
+		require.True(s.T(), containsKeystoreFile(clientKeystoreDir, acc.Address.String()[2:]), "Expected the client to regain the keystore file for account %s", acc.Address.String())
+	}
+
+	accountsManager := clientBackend.AccountsManager()
+	require.NoError(s.T(), accountsManager.ReloadKeystore())
+	genAcc, err := accountsManager.LoadAccount(types.HexToAddress(clientSeedPhraseKp.DerivedFrom), s.password)
+	require.NoError(s.T(), err, "Expected the regained master keystore file to decrypt with the account password")
+	require.Equal(s.T(), clientSeedPhraseKp.KeyUID, genAcc.ToIdentifiedAccountInfo().KeyUID)
+
+	clientKp, err := clientAccountsAPI.GetKeypairByKeyUID(ctx, clientSeedPhraseKp.KeyUID)
+	require.NoError(s.T(), err)
+	require.Equal(s.T(), accsmanagementtypes.ColdWalletTypeNone, clientKp.ColdWallet, "Expected the client keypair to remain a regular app keypair after the transfer")
+}
+
+func (s *SyncDeviceSuite) TestKeystoreFilesSenderRejectsWrongPasswordForNonKeycardAccount() {
+	serverTmpDir := filepath.Join(s.tmpdir, "server")
+	serverBackend := s.prepareBackendWithAccount(profileKeypairMnemonic, serverTmpDir)
+	defer func() {
+		require.NoError(s.T(), serverBackend.Logout())
+	}()
+
+	serverBackend.Messenger().SetLocalPairing(true)
+
+	serverActiveAccount, err := serverBackend.GetActiveAccount()
+	require.NoError(s.T(), err)
+
+	serverKeystorePath := filepath.Join(serverTmpDir, backend.DefaultKeystoreRelativePath, serverActiveAccount.KeyUID)
+	config := KeystoreFilesSenderServerConfig{
+		SenderConfig: &KeystoreFilesSenderConfig{
+			KeystoreFilesConfig: KeystoreFilesConfig{
+				KeystorePath:   serverKeystorePath,
+				LoggedInKeyUID: serverActiveAccount.KeyUID,
+				Password:       "wrong-password",
+			},
+			KeypairsToExport: []string{serverActiveAccount.KeyUID},
+		},
+		ServerConfig: new(ServerConfig),
+	}
+	configBytes, err := json.Marshal(config)
+	require.NoError(s.T(), err)
+
+	_, err = StartUpKeystoreFilesSenderServer(serverBackend, string(configBytes))
+	require.ErrorContains(s.T(), err, "provided password is not correct", "Expected the sender to reject a wrong password up front because a regular (non-keycard) account's password must be verified before any keystore transfer starts")
+}
+
+func (s *SyncDeviceSuite) TestKeystoreFilesSenderSkipsPasswordVerificationForKeycardAccount() {
+	ctx := context.TODO()
+
+	serverTmpDir := filepath.Join(s.tmpdir, "server")
+	serverBackend := s.prepareBackendWithAccount(profileKeypairMnemonic, serverTmpDir)
+	defer func() {
+		require.NoError(s.T(), serverBackend.Logout())
+	}()
+
+	serverBackend.Messenger().SetLocalPairing(true)
+
+	serverActiveAccount, err := serverBackend.GetActiveAccount()
+	require.NoError(s.T(), err)
+
+	serverAccountsAPI := serverBackend.StatusNode().AccountService().APIs()[1].Service.(*accservice.API)
+	walletAccounts := &accsmanagementtypes.AccountCreationDetails{
+		Path:    accsmanagementcommon.PathDefaultWalletAccount,
+		Name:    "Default Wallet Account",
+		Emoji:   "💰",
+		ColorID: "primary",
+	}
+	serverSeedPhraseKp, err := serverAccountsAPI.AddKeypairViaSeedPhrase(ctx, seedKeypairMnemonic, s.password, "Seed Phrase Keypair", accsmanagementtypes.ColdWalletTypeNone, walletAccounts)
+	require.NoError(s.T(), err)
+
+	err = serverAccountsAPI.MigrateNonProfileKeypairToColdWallet(ctx, serverSeedPhraseKp.KeyUID, s.password, accsmanagementtypes.ColdWalletTypeStatusKeycard)
+	require.NoError(s.T(), err)
+
+	// a keycard user's login password is PIN-derived and matches no keystore file;
+	// the pairing layer discriminates on the multiaccount's KeycardPairing field
+	serverActiveAccount.KeycardPairing = "keycard-pairing-info"
+
+	serverKeystorePath := filepath.Join(serverTmpDir, backend.DefaultKeystoreRelativePath, serverActiveAccount.KeyUID)
+	config := KeystoreFilesSenderServerConfig{
+		SenderConfig: &KeystoreFilesSenderConfig{
+			KeystoreFilesConfig: KeystoreFilesConfig{
+				KeystorePath:   serverKeystorePath,
+				LoggedInKeyUID: serverActiveAccount.KeyUID,
+				Password:       "0x-pin-derived-password",
+			},
+			KeypairsToExport: []string{serverSeedPhraseKp.KeyUID},
+		},
+		ServerConfig: new(ServerConfig),
+	}
+	configBytes, err := json.Marshal(config)
+	require.NoError(s.T(), err)
+
+	cs, err := StartUpKeystoreFilesSenderServer(serverBackend, string(configBytes))
+	require.NoError(s.T(), err, "Expected password verification to be skipped for a keycard account because its login password never matches a keystore file - enforcing it would block every keycard user from keystore transfer")
+	require.NotEmpty(s.T(), cs, "Expected a connection string because the sender server should start for a keycard account")
+}
+
 func (s *SyncDeviceSuite) TestTransferringKeystoreFilesAfterStopUisngKeycard() {
 	s.T().Skip("flaky test")
 
@@ -588,7 +792,7 @@ func (s *SyncDeviceSuite) TestTransferringKeystoreFilesAfterStopUisngKeycard() {
 	require.NoError(s.T(), err)
 	clientActiveAccount, err := clientBackend.GetActiveAccount()
 	require.NoError(s.T(), err)
-	require.True(s.T(), serverActiveAccount.KeyUID == clientActiveAccount.KeyUID)
+	require.Equal(s.T(), serverActiveAccount.KeyUID, clientActiveAccount.KeyUID)
 
 	//////////////////////////////////////////////////////////////////////////////
 	// From this point this test is trying to simulate the following scenario:

--- a/pkg/services/pairing/sync_device_test.go
+++ b/pkg/services/pairing/sync_device_test.go
@@ -20,6 +20,8 @@ import (
 	accsmanagementtypes "github.com/status-im/status-go/internal/accounts-management/types"
 	"github.com/status-im/status-go/internal/crypto/types"
 	"github.com/status-im/status-go/internal/db/dbsetup"
+	"github.com/status-im/status-go/internal/db/multiaccounts"
+	settings "github.com/status-im/status-go/internal/db/multiaccounts/settings"
 	"github.com/status-im/status-go/internal/db/sqlite"
 	"github.com/status-im/status-go/internal/protocol"
 	"github.com/status-im/status-go/internal/protocol/common"
@@ -570,19 +572,7 @@ func (s *SyncDeviceSuite) TestTransferringKeystoreFilesAfterColdWalletRoundTrip(
 	require.NoError(s.T(), err)
 
 	clientKeystoreDir := filepath.Join(clientTmpDir, backend.DefaultKeystoreRelativePath, clientActiveAccount.KeyUID)
-	files, err := os.ReadDir(clientKeystoreDir)
-	require.NoError(s.T(), err)
-	for _, file := range files {
-		if strings.Contains(strings.ToLower(file.Name()), strings.ToLower(clientSeedPhraseKp.DerivedFrom[2:])) {
-			require.NoError(s.T(), os.RemoveAll(filepath.Join(clientKeystoreDir, file.Name())))
-			continue
-		}
-		for _, acc := range clientSeedPhraseKp.Accounts {
-			if strings.Contains(strings.ToLower(file.Name()), strings.ToLower(acc.Address.String()[2:])) {
-				require.NoError(s.T(), os.RemoveAll(filepath.Join(clientKeystoreDir, file.Name())))
-			}
-		}
-	}
+	removeKeypairKeystoreFiles(s.T(), clientKeystoreDir, clientSeedPhraseKp)
 	require.False(s.T(), containsKeystoreFile(clientKeystoreDir, clientSeedPhraseKp.DerivedFrom[2:]))
 	for _, acc := range clientSeedPhraseKp.Accounts {
 		require.False(s.T(), containsKeystoreFile(clientKeystoreDir, acc.Address.String()[2:]),
@@ -605,8 +595,7 @@ func (s *SyncDeviceSuite) TestTransferringKeystoreFilesAfterColdWalletRoundTrip(
 	}
 	configBytes, err := json.Marshal(config)
 	require.NoError(s.T(), err)
-	cs, err := StartUpKeystoreFilesSenderServer(serverBackend, string(configBytes))
-	require.NoError(s.T(), err)
+	cs := s.startKeystoreFilesSenderServer(serverBackend, configBytes)
 
 	clientPayloadSourceConfig := KeystoreFilesReceiverClientConfig{
 		ReceiverConfig: &KeystoreFilesReceiverConfig{
@@ -636,6 +625,47 @@ func (s *SyncDeviceSuite) TestTransferringKeystoreFilesAfterColdWalletRoundTrip(
 	clientKp, err := clientAccountsAPI.GetKeypairByKeyUID(ctx, clientSeedPhraseKp.KeyUID)
 	require.NoError(s.T(), err)
 	require.Equal(s.T(), accsmanagementtypes.ColdWalletTypeNone, clientKp.ColdWallet, "Expected the client keypair to remain a regular app keypair after the transfer")
+}
+
+func removeKeypairKeystoreFiles(t *testing.T, keystoreDir string, kp *accsmanagementtypes.Keypair) {
+	files, err := os.ReadDir(keystoreDir)
+	require.NoError(t, err)
+	for _, file := range files {
+		name := strings.ToLower(file.Name())
+		if strings.Contains(name, strings.ToLower(kp.DerivedFrom[2:])) {
+			require.NoError(t, os.RemoveAll(filepath.Join(keystoreDir, file.Name())))
+			continue
+		}
+		for _, acc := range kp.Accounts {
+			if strings.Contains(name, strings.ToLower(acc.Address.String()[2:])) {
+				require.NoError(t, os.RemoveAll(filepath.Join(keystoreDir, file.Name())))
+			}
+		}
+	}
+}
+
+func convertProfileToKeycard(t *testing.T, b *backend.StatusBackend, account multiaccounts.Account, keycardPairing, oldPassword, keycardPassword string) {
+	account.KeycardPairing = keycardPairing
+	require.NoError(t, b.ConvertToKeycardAccount(account, settings.Settings{}, account.KeyUID, oldPassword, keycardPassword))
+}
+
+// startKeystoreFilesSenderServer stands in for StartUpKeystoreFilesSenderServer,
+// which returns only a connection string: the server it starts has no owner, no
+// timeout, and is not brought down by Logout, so it keeps its listener for the
+// rest of the package run.
+func (s *SyncDeviceSuite) startKeystoreFilesSenderServer(b *backend.StatusBackend, configBytes []byte) string {
+	conf := NewKeystoreFilesSenderServerConfig()
+	require.NoError(s.T(), json.Unmarshal(configBytes, conf))
+	require.NoError(s.T(), validateKeystoreFilesConfig(b, conf))
+
+	senderServer, err := MakeKeystoreFilesSenderServer(b, conf)
+	require.NoError(s.T(), err)
+	s.T().Cleanup(func() { require.NoError(s.T(), senderServer.Stop()) })
+	require.NoError(s.T(), senderServer.startSendingData())
+
+	connectionParams, err := senderServer.MakeConnectionParams()
+	require.NoError(s.T(), err)
+	return connectionParams.ToString()
 }
 
 func (s *SyncDeviceSuite) TestKeystoreFilesSenderRejectsWrongPasswordForNonKeycardAccount() {
@@ -669,44 +699,79 @@ func (s *SyncDeviceSuite) TestKeystoreFilesSenderRejectsWrongPasswordForNonKeyca
 	require.ErrorContains(s.T(), err, "provided password is not correct", "Expected the sender to reject a wrong password up front because a regular (non-keycard) account's password must be verified before any keystore transfer starts")
 }
 
-func (s *SyncDeviceSuite) TestKeystoreFilesSenderSkipsPasswordVerificationForKeycardAccount() {
+func (s *SyncDeviceSuite) TestTransferringKeystoreFilesForKeycardAccountSkipsPasswordVerification() {
 	ctx := context.TODO()
+	const keycardPassword = "222222"
+	const keycardPairing = "keycard-pairing-info"
 
 	serverTmpDir := filepath.Join(s.tmpdir, "server")
 	serverBackend := s.prepareBackendWithAccount(profileKeypairMnemonic, serverTmpDir)
+
+	clientTmpDir := filepath.Join(s.tmpdir, "client")
+	clientBackend := s.prepareBackendWithAccount(profileKeypairMnemonic, clientTmpDir)
 	defer func() {
+		require.NoError(s.T(), clientBackend.Logout())
 		require.NoError(s.T(), serverBackend.Logout())
 	}()
 
-	serverBackend.Messenger().SetLocalPairing(true)
-
 	serverActiveAccount, err := serverBackend.GetActiveAccount()
 	require.NoError(s.T(), err)
+	clientActiveAccount, err := clientBackend.GetActiveAccount()
+	require.NoError(s.T(), err)
+	require.Equal(s.T(), serverActiveAccount.KeyUID, clientActiveAccount.KeyUID)
 
-	serverAccountsAPI := serverBackend.StatusNode().AccountService().APIs()[1].Service.(*accservice.API)
 	walletAccounts := &accsmanagementtypes.AccountCreationDetails{
 		Path:    accsmanagementcommon.PathDefaultWalletAccount,
 		Name:    "Default Wallet Account",
 		Emoji:   "💰",
 		ColorID: "primary",
 	}
+
+	// a keycard profile still holds regular app keypairs, and those are what a
+	// keystore transfer moves - the profile keypair itself has no files to send
+	serverAccountsAPI := serverBackend.StatusNode().AccountService().APIs()[1].Service.(*accservice.API)
 	serverSeedPhraseKp, err := serverAccountsAPI.AddKeypairViaSeedPhrase(ctx, seedKeypairMnemonic, s.password, "Seed Phrase Keypair", accsmanagementtypes.ColdWalletTypeNone, walletAccounts)
 	require.NoError(s.T(), err)
 
-	err = serverAccountsAPI.MigrateNonProfileKeypairToColdWallet(ctx, serverSeedPhraseKp.KeyUID, s.password, accsmanagementtypes.ColdWalletTypeStatusKeycard)
+	clientAccountsAPI := clientBackend.StatusNode().AccountService().APIs()[1].Service.(*accservice.API)
+	clientSeedPhraseKp, err := clientAccountsAPI.AddKeypairViaSeedPhrase(ctx, seedKeypairMnemonic, s.password, "Seed Phrase Keypair", accsmanagementtypes.ColdWalletTypeNone, walletAccounts)
 	require.NoError(s.T(), err)
 
-	// a keycard user's login password is PIN-derived and matches no keystore file;
-	// the pairing layer discriminates on the multiaccount's KeycardPairing field
-	serverActiveAccount.KeycardPairing = "keycard-pairing-info"
-
 	serverKeystorePath := filepath.Join(serverTmpDir, backend.DefaultKeystoreRelativePath, serverActiveAccount.KeyUID)
+	clientKeystoreDir := filepath.Join(clientTmpDir, backend.DefaultKeystoreRelativePath, clientActiveAccount.KeyUID)
+
+	removeKeypairKeystoreFiles(s.T(), clientKeystoreDir, clientSeedPhraseKp)
+	require.False(s.T(), containsKeystoreFile(clientKeystoreDir, clientSeedPhraseKp.DerivedFrom[2:]))
+	for _, acc := range clientSeedPhraseKp.Accounts {
+		require.False(s.T(), containsKeystoreFile(clientKeystoreDir, acc.Address.String()[2:]),
+			"Expected the account keystore file removed before the transfer, else regaining it proves nothing")
+	}
+
+	// both devices go through the real keycard conversion: the profile keypair's
+	// keystore files are deleted and the DEK envelope is rewrapped to the
+	// PIN-derived password, which becomes the login password on both sides
+	convertProfileToKeycard(s.T(), serverBackend, *serverActiveAccount, keycardPairing, s.password, keycardPassword)
+	convertProfileToKeycard(s.T(), clientBackend, *clientActiveAccount, keycardPairing, s.password, keycardPassword)
+
+	serverActiveAccount, err = serverBackend.GetActiveAccount()
+	require.NoError(s.T(), err)
+	require.Equal(s.T(), keycardPairing, serverActiveAccount.KeycardPairing, "Expected the conversion to set KeycardPairing on the live session, not just in the database")
+
+	require.False(s.T(), serverAccountsAPI.VerifyPassword(keycardPassword),
+		"Expected the check the sender skips to fail even for the correct keycard password, because the conversion deleted the chat keystore file it verifies against")
+
+	require.True(s.T(), containsKeystoreFile(serverKeystorePath, serverSeedPhraseKp.DerivedFrom[2:]),
+		"Expected the regular keypair's keystore files to survive the profile's keycard conversion, else there is nothing to transfer")
+
+	serverBackend.Messenger().SetLocalPairing(true)
+	clientBackend.Messenger().SetLocalPairing(true)
+
 	config := KeystoreFilesSenderServerConfig{
 		SenderConfig: &KeystoreFilesSenderConfig{
 			KeystoreFilesConfig: KeystoreFilesConfig{
 				KeystorePath:   serverKeystorePath,
 				LoggedInKeyUID: serverActiveAccount.KeyUID,
-				Password:       "0x-pin-derived-password",
+				Password:       keycardPassword,
 			},
 			KeypairsToExport: []string{serverSeedPhraseKp.KeyUID},
 		},
@@ -714,10 +779,38 @@ func (s *SyncDeviceSuite) TestKeystoreFilesSenderSkipsPasswordVerificationForKey
 	}
 	configBytes, err := json.Marshal(config)
 	require.NoError(s.T(), err)
+	conf := NewKeystoreFilesSenderServerConfig()
+	require.NoError(s.T(), json.Unmarshal(configBytes, conf))
 
-	cs, err := StartUpKeystoreFilesSenderServer(serverBackend, string(configBytes))
-	require.NoError(s.T(), err, "Expected password verification to be skipped for a keycard account because its login password never matches a keystore file - enforcing it would block every keycard user from keystore transfer")
-	require.NotEmpty(s.T(), cs, "Expected a connection string because the sender server should start for a keycard account")
+	require.NoError(s.T(), validateKeystoreFilesConfig(serverBackend, conf),
+		"Expected password verification to be skipped for a keycard account because its login password never matches a keystore file - enforcing it would block every keycard user from keystore transfer")
+
+	cs := s.startKeystoreFilesSenderServer(serverBackend, configBytes)
+
+	clientPayloadSourceConfig := KeystoreFilesReceiverClientConfig{
+		ReceiverConfig: &KeystoreFilesReceiverConfig{
+			KeystoreFilesConfig: KeystoreFilesConfig{
+				KeystorePath:   clientKeystoreDir,
+				LoggedInKeyUID: clientActiveAccount.KeyUID,
+				Password:       keycardPassword,
+			},
+			KeypairsToImport: []string{clientSeedPhraseKp.KeyUID},
+		},
+		ClientConfig: new(ClientConfig),
+	}
+	err = StartUpKeystoreFilesReceivingClient(clientBackend, cs, &clientPayloadSourceConfig)
+	require.NoError(s.T(), err, "Expected the transfer to complete under a keycard login password, which is the password the DEK envelope is now wrapped with")
+
+	require.True(s.T(), containsKeystoreFile(clientKeystoreDir, clientSeedPhraseKp.DerivedFrom[2:]), "Expected the client to receive the master keystore file")
+	for _, acc := range clientSeedPhraseKp.Accounts {
+		require.True(s.T(), containsKeystoreFile(clientKeystoreDir, acc.Address.String()[2:]), "Expected the client to receive the keystore file for account %s", acc.Address.String())
+	}
+
+	accountsManager := clientBackend.AccountsManager()
+	require.NoError(s.T(), accountsManager.ReloadKeystore())
+	genAcc, err := accountsManager.LoadAccount(types.HexToAddress(clientSeedPhraseKp.DerivedFrom), keycardPassword)
+	require.NoError(s.T(), err, "Expected the transferred keystore file to decrypt with the keycard login password")
+	require.Equal(s.T(), clientSeedPhraseKp.KeyUID, genAcc.ToIdentifiedAccountInfo().KeyUID)
 }
 
 func (s *SyncDeviceSuite) TestTransferringKeystoreFilesAfterStopUisngKeycard() {

--- a/pkg/services/pairing/sync_device_test.go
+++ b/pkg/services/pairing/sync_device_test.go
@@ -46,6 +46,7 @@ const (
 	seedKeypairMnemonic     = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about"
 	profileKeypairMnemonic1 = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about about"
 	seedKeypairMnemonic1    = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about abandon"
+	testKeycardUID          = "a84599394887b742eed9a99d3834a797"
 	path0                   = "m/44'/60'/0'/0/0"
 	path1                   = "m/44'/60'/0'/0/1"
 	expectedKDFIterations   = 1024
@@ -646,7 +647,7 @@ func removeKeypairKeystoreFiles(t *testing.T, keystoreDir string, kp *accsmanage
 
 func convertProfileToKeycard(t *testing.T, b *backend.StatusBackend, account multiaccounts.Account, keycardPairing, oldPassword, keycardPassword string) {
 	account.KeycardPairing = keycardPairing
-	require.NoError(t, b.ConvertToKeycardAccount(account, settings.Settings{}, account.KeyUID, oldPassword, keycardPassword))
+	require.NoError(t, b.ConvertToKeycardAccount(account, settings.Settings{}, testKeycardUID, oldPassword, keycardPassword))
 }
 
 // startKeystoreFilesSenderServer stands in for StartUpKeystoreFilesSenderServer,
@@ -660,7 +661,8 @@ func (s *SyncDeviceSuite) startKeystoreFilesSenderServer(b *backend.StatusBacken
 
 	senderServer, err := MakeKeystoreFilesSenderServer(b, conf)
 	require.NoError(s.T(), err)
-	s.T().Cleanup(func() { require.NoError(s.T(), senderServer.Stop()) })
+	t := s.T()
+	t.Cleanup(func() { require.NoError(t, senderServer.Stop()) })
 	require.NoError(s.T(), senderServer.startSendingData())
 
 	connectionParams, err := senderServer.MakeConnectionParams()


### PR DESCRIPTION
The keycard management API was removed in June 2026 (`e762325dff` and related commits). A keycard is now a `cold_wallet` value on a keypair, next to `ledger` and `trezor`. The tests for this area were not updated.

This PR adds tests for the keycard paths in local pairing (`pkg/services/pairing`).

- Production code is not changed.
- Each test was checked by breaking the behaviour it names in production code and confirming it fails. Review then found individual assertions inside those tests that were not load-bearing; those have been strengthened and checked the same way.

## Storing a received account payload

**`TestPayloadMarshaller_StoreRePairSkipsExistingKeysAndKeepsLocalAccount`**
- **Given** device B has stored account X and renamed it locally
- **When** the same payload arrives again
- **Then** there is no error, the key files keep their count and their content, and the account held in memory is B's own database row rather than the wire data

**`TestPayloadMarshaller_KeycardPairingSurvivesMarshalUnmarshalStore`**
- **Given** a payload carrying a keycard pairing value
- **When** it is encoded to protobuf, decoded and stored
- **Then** the value reaches the database, without which the new device cannot log in with the card, and a password already starting with `0x` is left alone

**`TestPayloadMarshaller_StoreSkipsStoringWhenLoggedInWithSameKeyUID`**
- **Given** device B is logged in to account X
- **When** a payload for account X arrives
- **Then** storing returns at once with no keystore directory, no database row and `exist` still false, so B's own keys are not overwritten

**`TestPayloadMarshaller_StoreRejectsPayloadForDifferentKeyUIDWhenLoggedIn`**
- **Given** device B is logged in to account Y
- **When** a payload for account X arrives
- **Then** it fails with `ErrLoggedInKeyUIDConflict` and no keystore directory is written

## Transferring keystore files

**`TestTransferringKeystoreFilesAfterColdWalletRoundTrip`**
- **Given** the server has migrated a seed keypair to a keycard and back, and the client holds the same keypair with its key files removed, which is the state a paired device is left in
- **When** the server exports it and the client imports it
- **Then** the client regains the files, the master file opens with the account password and matches the keypair, and the keypair stays a normal app keypair on both sides

**`TestKeystoreFilesSenderRejectsWrongPasswordForNonKeycardAccount`**
- **Given** a normal, non-keycard profile
- **When** the sender starts with the wrong password
- **Then** it is rejected before any transfer begins

**`TestTransferringKeystoreFilesForKeycardAccountSkipsPasswordVerification`**
- **Given** both devices converted through `ConvertToKeycardAccount`, so the profile key files are gone and the DEK is rewrapped with the PIN password, and a normal app keypair still holding its files on the server
- **When** the transfer runs
- **Then** the usual password check fails even with the correct keycard password, because the conversion deleted the file it checks against, and the transfer still completes with the client able to open the received files

Part of the series restoring keycard and cold-wallet test coverage (#7756). #7696 and #7697 are merged. #7758, #7759 and #7760 are open.
