### PR TITLE
feat: support for using a profile's DEK as a login and session password (credential)

### DIFF
--- a/internal/accounts-management/keystore/envelope/envelope.go
+++ b/internal/accounts-management/keystore/envelope/envelope.go
@@ -21,7 +21,7 @@ const (
 
 	pendingSuffix = ".pending" // used for deep rekey (when a new DEK is generated)
 
-	dekLength = 32 // DEK size in bytes
+	DekLength = 32 // DEK size in bytes
 
 	scryptN = 1 << 18
 	scryptP = 1
@@ -60,7 +60,7 @@ func PendingExists(rootDataDir, keyUID string) bool {
 
 // Generate creates a new random DEK and returns it as a lowercase hex string.
 func Generate() (string, error) {
-	dek := make([]byte, dekLength)
+	dek := make([]byte, DekLength)
 	if _, err := rand.Read(dek); err != nil {
 		return "", err
 	}
@@ -79,8 +79,8 @@ func WritePending(rootDataDir, keyUID, dekHex, kek string, dbKdfIterations int) 
 
 func writeToPath(path, keyUID, dekHex, kek string, dbKdfIterations int) error {
 	dek, err := hex.DecodeString(dekHex)
-	if err != nil || len(dek) != dekLength {
-		return fmt.Errorf("envelope: DEK must be %d hex-encoded bytes", dekLength)
+	if err != nil || len(dek) != DekLength {
+		return fmt.Errorf("envelope: DEK must be %d hex-encoded bytes", DekLength)
 	}
 
 	cryptoJSON, err := geth.EncryptDataV3(dek, []byte(kek), scryptN, scryptP)
@@ -130,11 +130,30 @@ func unwrapFromPath(path, kek string) (dekHex string, dbKdfIterations int, err e
 		// MAC mismatch (or any decrypt failure) means the KEK is wrong.
 		return "", 0, ErrInvalidKEK
 	}
-	if len(dek) != dekLength {
+	if len(dek) != DekLength {
 		return "", 0, fmt.Errorf("envelope: unexpected DEK length %d", len(dek))
 	}
 
 	return hex.EncodeToString(dek), file.DBKdfIterations, nil
+}
+
+// ReadDBKdfIterations returns the profile's database kdf_iter without needing the KEK
+// (the value is plaintext metadata in the wrapped-DEK file).
+func ReadDBKdfIterations(rootDataDir, keyUID string) (int, error) {
+	content, err := os.ReadFile(Path(rootDataDir, keyUID))
+	if err != nil {
+		return 0, err
+	}
+
+	var file wrappedKeyFile
+	if err := json.Unmarshal(content, &file); err != nil {
+		return 0, fmt.Errorf("envelope: malformed wrapped-DEK file: %w", err)
+	}
+	if file.Version != fileVersion {
+		return 0, fmt.Errorf("envelope: unsupported wrapped-DEK file version %d", file.Version)
+	}
+
+	return file.DBKdfIterations, nil
 }
 
 // Rewrap re-encrypts the profile's DEK with a new KEK, atomically replacing the wrapped-DEK file.

--- a/internal/accounts-management/keystore/envelope/envelope_test.go
+++ b/internal/accounts-management/keystore/envelope/envelope_test.go
@@ -18,11 +18,26 @@ const (
 func TestGenerate(t *testing.T) {
 	dek1, err := Generate()
 	require.NoError(t, err)
-	require.Len(t, dek1, 2*dekLength)
+	require.Len(t, dek1, 2*DekLength)
 
 	dek2, err := Generate()
 	require.NoError(t, err)
 	require.NotEqual(t, dek1, dek2)
+}
+
+func TestReadDBKdfIterations(t *testing.T) {
+	dir := t.TempDir()
+
+	_, err := ReadDBKdfIterations(dir, testKeyUID)
+	require.Error(t, err)
+
+	dek, err := Generate()
+	require.NoError(t, err)
+	require.NoError(t, Write(dir, testKeyUID, dek, testKEK, 3200))
+
+	iterations, err := ReadDBKdfIterations(dir, testKeyUID)
+	require.NoError(t, err)
+	require.Equal(t, 3200, iterations)
 }
 
 func TestWriteUnwrapRoundTrip(t *testing.T) {

--- a/internal/logutils/callog/status_request_log.go
+++ b/internal/logutils/callog/status_request_log.go
@@ -20,6 +20,7 @@ var sensitiveKeys = []string{
 	"password",
 	"newPassword",
 	"mnemonic",
+	"dek",
 	"poktToken",
 	"infuraToken",
 	"infuraSecret",

--- a/internal/logutils/callog/status_request_log_test.go
+++ b/internal/logutils/callog/status_request_log_test.go
@@ -59,6 +59,16 @@ func TestRemoveSensitiveInfo(t *testing.T) {
 			input:    `["{\"mnemonic\":\"a b c d\"}"]`,
 			expected: fmt.Sprintf(`["{\"mnemonic\":\"%s\"}"]`, redactionPlaceholder),
 		},
+		{
+			name:     "dek field in login request",
+			input:    `{"keyUid":"0x1234","dek":"8a9f7d2b6c1e4f3a5d8b9c0e2f4a6b8d0c2e4f6a8b0d2c4e6f8a0b2d4c6e8f0a"}`,
+			expected: fmt.Sprintf(`{"keyUid":"0x1234","dek":"%s"}`, redactionPlaceholder),
+		},
+		{
+			name:     "dek field in export response",
+			input:    `{"dek":"8a9f7d2b6c1e4f3a5d8b9c0e2f4a6b8d0c2e4f6a8b0d2c4e6f8a0b2d4c6e8f0a"}`,
+			expected: fmt.Sprintf(`{"dek":"%s"}`, redactionPlaceholder),
+		},
 	}
 
 	for _, tc := range testCases {

--- a/internal/protocol/requests/export_profile_dek.go
+++ b/internal/protocol/requests/export_profile_dek.go
@@ -1,0 +1,23 @@
+package requests
+
+import "errors"
+
+var (
+	ErrExportProfileDEKInvalidKeyUID   = errors.New("export-profile-dek: no keyUID provided")
+	ErrExportProfileDEKInvalidPassword = errors.New("export-profile-dek: no password provided")
+)
+
+type ExportProfileDEK struct {
+	KeyUID   string `json:"keyUID"`
+	Password string `json:"password"`
+}
+
+func (r *ExportProfileDEK) Validate() error {
+	if len(r.KeyUID) == 0 {
+		return ErrExportProfileDEKInvalidKeyUID
+	}
+	if len(r.Password) == 0 {
+		return ErrExportProfileDEKInvalidPassword
+	}
+	return nil
+}

--- a/internal/protocol/requests/login.go
+++ b/internal/protocol/requests/login.go
@@ -2,15 +2,19 @@ package requests
 
 import (
 	"crypto/ecdsa"
+	"encoding/hex"
 	"errors"
 	"strings"
 
+	"github.com/status-im/status-go/internal/accounts-management/keystore/envelope"
 	"github.com/status-im/status-go/internal/crypto"
 )
 
 var (
 	ErrLoginInvalidKeyUID                   = errors.New("login: invalid key-uid")
 	ErrLoginInvalidKeycardWhisperPrivateKey = errors.New("login: invalid keycard whisper private key")
+	ErrLoginInvalidDEK                      = errors.New("login: DEK must be 32 hex-encoded bytes")
+	ErrLoginDEKMutuallyExclusive            = errors.New("login: DEK cannot be combined with password, mnemonic or keycard keys")
 )
 
 type Login struct {
@@ -40,6 +44,9 @@ type Login struct {
 	// - KeyUID is ignored and replaced with hash of the master public key
 	Mnemonic string `json:"mnemonic"`
 
+	// DEK is the profile's raw data-encryption key used for biometric login on profiles migrated to the DEK encryption scheme.
+	DEK string `json:"dek"`
+
 	WalletConfig
 	WalletSecretsConfig
 
@@ -61,6 +68,17 @@ func (c *Login) Validate() error {
 		if err != nil {
 			return ErrLoginInvalidKeycardWhisperPrivateKey
 		}
+	}
+
+	if c.DEK != "" {
+		if c.Password != "" || c.Mnemonic != "" || c.KeycardWhisperPrivateKey != "" {
+			return ErrLoginDEKMutuallyExclusive
+		}
+		dek, err := hex.DecodeString(c.DEK)
+		if err != nil || len(dek) != envelope.DekLength {
+			return ErrLoginInvalidDEK
+		}
+		c.DEK = hex.EncodeToString(dek)
 	}
 
 	return nil

--- a/internal/protocol/requests/login_test.go
+++ b/internal/protocol/requests/login_test.go
@@ -2,10 +2,49 @@ package requests
 
 import (
 	"encoding/json"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 )
+
+func TestLoginValidateDEK(t *testing.T) {
+	validDEK := "8a9f7d2b6c1e4f3a5d8b9c0e2f4a6b8d0c2e4f6a8b0d2c4e6f8a0b2d4c6e8f0a"
+
+	testCases := []struct {
+		name    string
+		request Login
+		err     error
+	}{
+		{"valid DEK", Login{KeyUID: "0x1234", DEK: validDEK}, nil},
+		{"DEK too short", Login{KeyUID: "0x1234", DEK: "abcdef"}, ErrLoginInvalidDEK},
+		{"DEK not hex", Login{KeyUID: "0x1234", DEK: "zz" + validDEK[2:]}, ErrLoginInvalidDEK},
+		{"DEK with 0x prefix", Login{KeyUID: "0x1234", DEK: "0x" + validDEK}, ErrLoginInvalidDEK},
+		{"DEK with password", Login{KeyUID: "0x1234", DEK: validDEK, Password: "pass"}, ErrLoginDEKMutuallyExclusive},
+		{"DEK with mnemonic", Login{KeyUID: "0x1234", DEK: validDEK, Mnemonic: "some words"}, ErrLoginDEKMutuallyExclusive},
+		{"DEK with keycard key", Login{KeyUID: "0x1234", DEK: validDEK,
+			KeycardWhisperPrivateKey: "1111111111111111111111111111111111111111111111111111111111111111"}, ErrLoginDEKMutuallyExclusive},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.request.Validate()
+			if tc.err == nil {
+				require.NoError(t, err)
+			} else {
+				require.ErrorIs(t, err, tc.err)
+			}
+		})
+	}
+}
+
+func TestLoginValidateNormalizesDEKCase(t *testing.T) {
+	lowercaseDEK := "8a9f7d2b6c1e4f3a5d8b9c0e2f4a6b8d0c2e4f6a8b0d2c4e6f8a0b2d4c6e8f0a"
+
+	request := Login{KeyUID: "0x1234", DEK: strings.ToUpper(lowercaseDEK)}
+	require.NoError(t, request.Validate())
+	require.Equal(t, lowercaseDEK, request.DEK)
+}
 
 func TestLoginUnmarshalLogFilePath(t *testing.T) {
 	var request Login

--- a/mobile/status.go
+++ b/mobile/status.go
@@ -1241,6 +1241,38 @@ func getProfileEncryptionInfo(requestJSON string) string {
 	return string(respJSON)
 }
 
+// ExportProfileDEK returns the profile's data-encryption key given a valid credential
+// (the client-hashed password). Only valid for profiles on the DEK encryption scheme.
+func ExportProfileDEK(requestJSON string) string {
+	return callWithResponse(exportProfileDEK, requestJSON)
+}
+
+func exportProfileDEK(requestJSON string) string {
+	var request requests.ExportProfileDEK
+	err := json.Unmarshal([]byte(requestJSON), &request)
+	if err != nil {
+		return makeJSONResponse(err)
+	}
+
+	if err := request.Validate(); err != nil {
+		return makeJSONResponse(err)
+	}
+
+	dek, err := statusBackend.ExportProfileDEK(request.KeyUID, request.Password)
+	if err != nil {
+		return makeJSONResponse(err)
+	}
+
+	respJSON, err := json.Marshal(struct {
+		DEK string `json:"dek"`
+	}{DEK: dek})
+	if err != nil {
+		return makeJSONResponse(err)
+	}
+
+	return string(respJSON)
+}
+
 // Deprecated: Use ConvertToKeycardAccountV2 instead.
 func ConvertToKeycardAccount(accountData, settingsJSON, keycardUID, password, newPassword string) string {
 	return convertToKeycardAccount(accountData, settingsJSON, keycardUID, password, newPassword)

--- a/pkg/backend/dek_login_test.go
+++ b/pkg/backend/dek_login_test.go
@@ -1,0 +1,123 @@
+package backend
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/status-im/status-go/internal/accounts-management/keystore/envelope"
+	"github.com/status-im/status-go/internal/db/sqlite"
+	"github.com/status-im/status-go/internal/protocol/requests"
+)
+
+// TestDEKLoginPrepare verifies the happy path of a biometric (DEK) login: the request is
+// turned into an ordinary password login riding on the primed session cache, the databases
+// open with the DEK, and the login-time encryption repair is a no-op (the envelope keeps
+// unwrapping with the real password).
+func TestDEKLoginPrepare(t *testing.T) {
+	testContext, password, dek := migratedFixture(t)
+	b := testContext.backend
+	keyUID := testContext.profileKeypair.KeyUID
+
+	request := &requests.Login{KeyUID: keyUID, DEK: dek}
+	require.NoError(t, request.Validate())
+	require.NoError(t, b.prepareDEKLogin(request))
+	require.Equal(t, dek, request.Password)
+
+	// The primed cache serves the DEK and its client-hashed form, with no KEK known.
+	resolved, err := b.resolveProfileSecret(keyUID, dek, 0)
+	require.NoError(t, err)
+	require.True(t, resolved.migrated)
+	require.Equal(t, dek, resolved.secret)
+	resolved, err = b.resolveProfileSecret(keyUID, clientHashOf(dek), 0)
+	require.NoError(t, err)
+	require.Equal(t, dek, resolved.secret)
+
+	require.NoError(t, b.ensureDBsOpened(*testContext.multiAcc, request.Password))
+	require.NoError(t, b.repairProfileEncryption(keyUID, request.Password, testContext.multiAcc.KDFIterations))
+
+	require.True(t, envelope.Exists(b.rootDataDir, keyUID))
+	unwrapped, _, err := envelope.Unwrap(b.rootDataDir, keyUID, password)
+	require.NoError(t, err)
+	require.Equal(t, dek, unwrapped)
+
+	require.NoError(t, b.Logout())
+}
+
+// TestDEKLoginWrongDEK verifies that a wrong (but well-formed) DEK fails like a wrong
+// password: the databases simply do not open.
+func TestDEKLoginWrongDEK(t *testing.T) {
+	testContext, password, dek := migratedFixture(t)
+	b := testContext.backend
+	keyUID := testContext.profileKeypair.KeyUID
+
+	wrongDEK, err := envelope.Generate()
+	require.NoError(t, err)
+	require.NotEqual(t, dek, wrongDEK)
+
+	request := &requests.Login{KeyUID: keyUID, DEK: wrongDEK}
+	require.NoError(t, b.prepareDEKLogin(request))
+	require.Error(t, b.ensureDBsOpened(*testContext.multiAcc, request.Password))
+
+	// The envelope is untouched and the real password still works.
+	b.clearProfileSecretCache()
+	unwrapped, _, err := envelope.Unwrap(b.rootDataDir, keyUID, password)
+	require.NoError(t, err)
+	require.Equal(t, dek, unwrapped)
+}
+
+func TestDEKLoginRejectedForLegacyProfile(t *testing.T) {
+	b := newSecretTestBackend(t)
+
+	dek, err := envelope.Generate()
+	require.NoError(t, err)
+
+	request := &requests.Login{KeyUID: secretTestKeyUID, DEK: dek}
+	require.ErrorContains(t, b.prepareDEKLogin(request), "not on the DEK encryption scheme")
+}
+
+// TestDEKLoginRejectedWhenRekeyPending: a DEK login must never run the interrupted-rekey
+// repair — with the DEK as "password" the repair would remove the envelope and permanently
+// lock the real KEK out. Such a state requires a password login.
+func TestDEKLoginRejectedWhenRekeyPending(t *testing.T) {
+	testContext, password, dek := migratedFixture(t)
+	b := testContext.backend
+	keyUID := testContext.profileKeypair.KeyUID
+
+	pendingDEK, err := envelope.Generate()
+	require.NoError(t, err)
+	require.NoError(t, envelope.WritePending(b.rootDataDir, keyUID, pendingDEK, password, sqlite.ReducedKDFIterationsNumber))
+
+	request := &requests.Login{KeyUID: keyUID, DEK: dek}
+	require.ErrorContains(t, b.prepareDEKLogin(request), "interrupted rekey pending")
+	require.True(t, envelope.PendingExists(b.rootDataDir, keyUID))
+}
+
+// TestFastPasswordChangeWithSessionCredential verifies the fast-path fallback: a caller
+// holding only a session credential (the client-hashed DEK, e.g. from biometrics) can still
+// re-wrap the envelope to a new password, consistent with the endpoint's session-based
+// password pre-check.
+func TestFastPasswordChangeWithSessionCredential(t *testing.T) {
+	testContext, password, dek := migratedFixture(t)
+	b := testContext.backend
+	keyUID := testContext.profileKeypair.KeyUID
+
+	// Warm the session as a login would.
+	_, err := b.resolveProfileSecret(keyUID, password, testContext.multiAcc.KDFIterations)
+	require.NoError(t, err)
+
+	const newPassword = "new-password-after-biometric-auth"
+	require.NoError(t, b.ChangeDatabasePassword(keyUID, clientHashOf(dek), newPassword, false))
+
+	// The envelope unwraps with the new KEK only; the DEK is unchanged.
+	unwrapped, _, err := envelope.Unwrap(b.rootDataDir, keyUID, newPassword)
+	require.NoError(t, err)
+	require.Equal(t, dek, unwrapped)
+	_, _, err = envelope.Unwrap(b.rootDataDir, keyUID, password)
+	require.ErrorIs(t, err, envelope.ErrInvalidKEK)
+
+	// The refreshed KEK fingerprint accepts the new password in-session.
+	resolved, err := b.resolveProfileSecret(keyUID, newPassword, 0)
+	require.NoError(t, err)
+	require.Equal(t, dek, resolved.secret)
+}

--- a/pkg/backend/geth_backend.go
+++ b/pkg/backend/geth_backend.go
@@ -752,6 +752,7 @@ func (b *StatusBackend) LoginAccount(request *requests.Login) error {
 	if err != nil {
 		// Stop node for clean up
 		_ = b.StopNode()
+		b.clearProfileSecretCache()
 	}
 	if b.LocalPairingStateManager.IsPairing() {
 		if err == nil {
@@ -770,6 +771,12 @@ func (b *StatusBackend) LoginAccount(request *requests.Login) error {
 func (b *StatusBackend) loginAccount(request *requests.Login) error {
 	if err := request.Validate(); err != nil {
 		return err
+	}
+
+	if request.DEK != "" {
+		if err := b.prepareDEKLogin(request); err != nil {
+			return err
+		}
 	}
 
 	if request.Mnemonic != "" {
@@ -1211,7 +1218,16 @@ func (b *StatusBackend) changeDatabasePasswordSerialized(keyUID, password, newPa
 		if !rekey {
 			// Fast path: nothing that is open (databases, keystore, node) changes.
 			if err := envelope.Rewrap(b.rootDataDir, keyUID, password, newPassword); err != nil {
-				return nil, err
+				if !errors.Is(err, envelope.ErrInvalidKEK) {
+					return nil, err
+				}
+				resolved, rerr := b.resolveProfileSecret(keyUID, password, 0)
+				if rerr != nil || !resolved.migrated {
+					return nil, err
+				}
+				if werr := envelope.Write(b.rootDataDir, keyUID, resolved.secret, newPassword, resolved.dbKdfIter); werr != nil {
+					return nil, werr
+				}
 			}
 			b.refreshSecretCacheKEK(keyUID, newPassword)
 			return nil, nil

--- a/pkg/backend/profile_secret.go
+++ b/pkg/backend/profile_secret.go
@@ -3,12 +3,18 @@ package backend
 import (
 	"crypto/sha256"
 	"crypto/subtle"
+	"encoding/hex"
 	"errors"
 	"sync"
 
+	ethcrypto "github.com/ethereum/go-ethereum/crypto"
+
 	"github.com/status-im/status-go/internal/accounts-management/keystore"
 	"github.com/status-im/status-go/internal/accounts-management/keystore/envelope"
+	"github.com/status-im/status-go/internal/protocol/requests"
 )
+
+var ErrProfileNotMigratedToDEK = errors.New("profile is not migrated to the DEK encryption scheme")
 
 // profileSecretCache remembers the unwrapped DEK of the profile bound to the current session.
 // The KEK itself is not stored — only its sha256 fingerprint, enough to re-verify an incoming password.
@@ -17,7 +23,9 @@ type profileSecretCache struct {
 	keyUID         string
 	kekFingerprint []byte
 	dekHex         string
-	dbKdfIter      int
+	dekClientHash  string // clientHashOf(dekHex); lets a client-hashed DEK act as the session credential, the only need to have a client-hashed DEK
+	// on the stauts-go side is to avoid updating those ~20 places on the client side and continue using the already established mechanism that is being used for passwords
+	dbKdfIter int
 
 	primaryFromPending bool // true when dekHex came from the pending envelope
 
@@ -51,7 +59,8 @@ func (b *StatusBackend) resolveProfileSecret(keyUID, password string, kdfIterati
 	if c.keyUID == keyUID && c.dekHex != "" {
 		fingerprint := sha256.Sum256([]byte(password))
 		if subtle.ConstantTimeCompare(fingerprint[:], c.kekFingerprint) == 1 ||
-			subtle.ConstantTimeCompare([]byte(password), []byte(c.dekHex)) == 1 {
+			subtle.ConstantTimeCompare([]byte(password), []byte(c.dekHex)) == 1 ||
+			(c.dekClientHash != "" && subtle.ConstantTimeCompare([]byte(password), []byte(c.dekClientHash)) == 1) {
 			resolved := resolvedProfileSecret{
 				secret:             c.dekHex,
 				dbKdfIter:          c.dbKdfIter,
@@ -101,6 +110,7 @@ func (b *StatusBackend) resolveProfileSecret(keyUID, password string, kdfIterati
 	c.keyUID = keyUID
 	c.kekFingerprint = fingerprint[:]
 	c.dekHex = primary
+	c.dekClientHash = clientHashOf(primary)
 	c.dbKdfIter = primaryIter
 	c.primaryFromPending = primaryFromPending
 	c.pendingDekHex = pendingDek
@@ -128,6 +138,7 @@ func (b *StatusBackend) clearProfileSecretCache() {
 	c.keyUID = ""
 	c.kekFingerprint = nil
 	c.dekHex = ""
+	c.dekClientHash = ""
 	c.dbKdfIter = 0
 	c.primaryFromPending = false
 	c.pendingDekHex = ""
@@ -135,6 +146,55 @@ func (b *StatusBackend) clearProfileSecretCache() {
 	c.dbAppOpenedWith = ""
 	c.dbWalletOpenedWith = ""
 	c.mu.Unlock()
+}
+
+// clientHashOf returns the client hashing convention of a secret: "0x" + lowercase hex keccak256.
+func clientHashOf(secret string) string {
+	return "0x" + hex.EncodeToString(ethcrypto.Keccak256([]byte(secret)))
+}
+
+// primeSecretCacheWithDEK caches the DEK directly from a client-supplied DEK (biometric login).
+func (b *StatusBackend) primeSecretCacheWithDEK(keyUID, dekHex string, dbKdfIter int) {
+	c := &b.secretCache
+	c.mu.Lock()
+	c.keyUID = keyUID
+	c.kekFingerprint = nil
+	c.dekHex = dekHex
+	c.dekClientHash = clientHashOf(dekHex)
+	c.dbKdfIter = dbKdfIter
+	c.primaryFromPending = false
+	c.pendingDekHex = ""
+	c.pendingDbKdfIter = 0
+	c.mu.Unlock()
+}
+
+// prepareDEKLogin prepares a DEK login request by caching the DEK and setting the password to the DEK.
+func (b *StatusBackend) prepareDEKLogin(request *requests.Login) error {
+	if !envelope.Exists(b.rootDataDir, request.KeyUID) {
+		return errors.New("dek login: profile is not on the DEK encryption scheme")
+	}
+	if envelope.PendingExists(b.rootDataDir, request.KeyUID) {
+		return errors.New("dek login: interrupted rekey pending, a password login is required")
+	}
+	iter, err := envelope.ReadDBKdfIterations(b.rootDataDir, request.KeyUID)
+	if err != nil {
+		return err
+	}
+	b.primeSecretCacheWithDEK(request.KeyUID, request.DEK, iter)
+	request.Password = request.DEK
+	return nil
+}
+
+// ExportProfileDEK returns the profile's DEK given a valid credential (the client-hashed password KEK, or the raw DEK or its client hash).
+func (b *StatusBackend) ExportProfileDEK(keyUID, password string) (string, error) {
+	resolved, err := b.resolveProfileSecret(keyUID, password, 0)
+	if err != nil {
+		return "", asKeystoreResolutionError(err)
+	}
+	if !resolved.migrated {
+		return "", ErrProfileNotMigratedToDEK
+	}
+	return resolved.secret, nil
 }
 
 // refreshSecretCacheKEK updates the cached KEK fingerprint after the envelope was re-wrapped with

--- a/pkg/backend/profile_secret_test.go
+++ b/pkg/backend/profile_secret_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 
+	"github.com/status-im/status-go/internal/accounts-management/keystore"
 	"github.com/status-im/status-go/internal/accounts-management/keystore/envelope"
 )
 
@@ -115,6 +116,89 @@ func TestResolveProfileSecretCacheIsPerProfile(t *testing.T) {
 	require.NoError(t, err)
 	require.False(t, resolved.migrated)
 	require.Equal(t, secretTestPassword, resolved.secret)
+}
+
+func TestResolveProfileSecretAcceptsClientHashedDEKWhenWarm(t *testing.T) {
+	b := newSecretTestBackend(t)
+
+	dek, err := envelope.Generate()
+	require.NoError(t, err)
+	require.NoError(t, envelope.Write(b.rootDataDir, secretTestKeyUID, dek, secretTestPassword, 3200))
+
+	// Cold: the client-hashed DEK is not a valid KEK.
+	_, err = b.resolveProfileSecret(secretTestKeyUID, clientHashOf(dek), 0)
+	require.ErrorIs(t, err, envelope.ErrInvalidKEK)
+
+	// Warm the cache with the real password; the client-hashed DEK then resolves.
+	_, err = b.resolveProfileSecret(secretTestKeyUID, secretTestPassword, 0)
+	require.NoError(t, err)
+	resolved, err := b.resolveProfileSecret(secretTestKeyUID, clientHashOf(dek), 0)
+	require.NoError(t, err)
+	require.True(t, resolved.migrated)
+	require.Equal(t, dek, resolved.secret)
+
+	// Cleared again: rejected again.
+	b.clearProfileSecretCache()
+	_, err = b.resolveProfileSecret(secretTestKeyUID, clientHashOf(dek), 0)
+	require.ErrorIs(t, err, envelope.ErrInvalidKEK)
+}
+
+func TestPrimeSecretCacheWithDEK(t *testing.T) {
+	b := newSecretTestBackend(t)
+
+	dek, err := envelope.Generate()
+	require.NoError(t, err)
+	require.NoError(t, envelope.Write(b.rootDataDir, secretTestKeyUID, dek, secretTestPassword, 3200))
+
+	b.primeSecretCacheWithDEK(secretTestKeyUID, dek, 3200)
+
+	// The raw DEK and its client hash both resolve from the primed cache.
+	resolved, err := b.resolveProfileSecret(secretTestKeyUID, dek, 0)
+	require.NoError(t, err)
+	require.True(t, resolved.migrated)
+	require.Equal(t, dek, resolved.secret)
+	require.Equal(t, 3200, resolved.dbKdfIter)
+
+	resolved, err = b.resolveProfileSecret(secretTestKeyUID, clientHashOf(dek), 0)
+	require.NoError(t, err)
+	require.Equal(t, dek, resolved.secret)
+
+	// No KEK is known for a primed session, so the real password takes the cold path,
+	// re-verifies against the envelope and restores the KEK fingerprint.
+	resolved, err = b.resolveProfileSecret(secretTestKeyUID, secretTestPassword, 0)
+	require.NoError(t, err)
+	require.Equal(t, dek, resolved.secret)
+
+	// Wrong values still fail.
+	_, err = b.resolveProfileSecret(secretTestKeyUID, "0xwrong", 0)
+	require.ErrorIs(t, err, envelope.ErrInvalidKEK)
+}
+
+func TestExportProfileDEK(t *testing.T) {
+	b := newSecretTestBackend(t)
+
+	// Legacy profile: the password must never be echoed back as a "DEK".
+	_, err := b.ExportProfileDEK(secretTestKeyUID, secretTestPassword)
+	require.ErrorIs(t, err, ErrProfileNotMigratedToDEK)
+
+	dek, err := envelope.Generate()
+	require.NoError(t, err)
+	require.NoError(t, envelope.Write(b.rootDataDir, secretTestKeyUID, dek, secretTestPassword, 3200))
+
+	// Correct KEK, cold.
+	exported, err := b.ExportProfileDEK(secretTestKeyUID, secretTestPassword)
+	require.NoError(t, err)
+	require.Equal(t, dek, exported)
+
+	// Session credential (client-hashed DEK), warm.
+	exported, err = b.ExportProfileDEK(secretTestKeyUID, clientHashOf(dek))
+	require.NoError(t, err)
+	require.Equal(t, dek, exported)
+
+	// Wrong KEK, cold: reported as an incorrect password.
+	b.clearProfileSecretCache()
+	_, err = b.ExportProfileDEK(secretTestKeyUID, "0xwrong")
+	require.ErrorIs(t, err, keystore.ErrIncorrectPasswordProvided)
 }
 
 func TestOpenDBWithCredsFallback(t *testing.T) {

--- a/pkg/services/pairing/common.go
+++ b/pkg/services/pairing/common.go
@@ -151,6 +151,7 @@ func validateAndVerifyPassword(s interface{}, senderConfig *SenderConfig) error 
 	secret := senderConfig.Password
 	rootDataDir := rootDataDirFromKeystorePath(senderConfig.KeystorePath, senderConfig.KeyUID)
 	if envelope.Exists(rootDataDir, senderConfig.KeyUID) {
+		// The KEK (client-hashed password) is required here, credentials like DEK or its client hash should not be used here.
 		secret, _, err = envelope.Unwrap(rootDataDir, senderConfig.KeyUID, senderConfig.Password)
 		if err != nil {
 			return err


### PR DESCRIPTION
Allow clients to use the profile's data-encryption key as the biometric login credential instead of the raw password:

- LoginAccount: new `dek` request field (32 hex bytes, validated and normalized to lowercase, mutually exclusive with password/mnemonic/keycard keys)
- resolveProfileSecret: accepts the client-hashed DEK ("0x" + keccak256), so a stored DEK credential works through the existing hashed-password paths on the client side
- New ExportProfileDEK endpoint: returns the DEK for a valid credential