### PR TITLE
feat(threads): support 1-1 and group chat threads

### DIFF
--- a/internal/protocol/chat.go
+++ b/internal/protocol/chat.go
@@ -35,6 +35,15 @@ type ChatType int
 
 type ChatContext string
 
+func (c *Chat) SupportsThreads() bool {
+	switch c.ChatType {
+	case ChatTypeOneToOne, ChatTypePrivateGroupChat, ChatTypeCommunityChat:
+		return true
+	default:
+		return false
+	}
+}
+
 const (
 	ChatTypeOneToOne ChatType = iota + 1
 	ChatTypePublic

--- a/internal/protocol/messenger.go
+++ b/internal/protocol/messenger.go
@@ -79,6 +79,7 @@ const (
 var (
 	ErrChatNotFoundError     = errors.New("Chat not found")
 	ErrThreadFeatureDisabled = errors.New("threads feature is disabled")
+	ErrThreadsNotSupportedForChatType = errors.New("threads are not supported for this chat type")
 )
 
 const communityAdvertiseIntervalSecond int64 = 24 * 60 * 60
@@ -2150,7 +2151,7 @@ func (m *Messenger) sendChatMessage(ctx context.Context, message *common.Message
 
 	if !m.featureFlags.Threads {
 		message.ThreadId = nil
-	} else if message.GetThreadId() != "" && chat.ChatType == ChatTypeCommunityChat {
+	} else if message.GetThreadId() != "" {
 		threadExists := true
 		_, err = m.persistence.ThreadByID(chat.ID, message.GetThreadId())
 		if errors.Is(err, common.ErrRecordNotFound) {
@@ -2160,13 +2161,8 @@ func (m *Messenger) sendChatMessage(ctx context.Context, message *common.Message
 		}
 
 		if !threadExists {
-			community, err := m.communitiesManager.GetByIDString(chat.CommunityID)
-			if err != nil {
+			if err := m.canCreateThread(chat); err != nil {
 				return nil, err
-			}
-
-			if !community.AllowsAllMembersToCreateThread() && !community.IsPrivilegedMember(&m.identity.PublicKey) {
-				return nil, errors.New("only admins can create threads in this community")
 			}
 		}
 	}

--- a/internal/protocol/messenger_threads.go
+++ b/internal/protocol/messenger_threads.go
@@ -14,6 +14,27 @@ func (m *Messenger) ThreadsByChatID(chatID string) ([]*Thread, error) {
 	return m.persistence.ThreadsByChatID(chatID)
 }
 
+func (m *Messenger) canCreateThread(chat *Chat) error {
+	if !chat.SupportsThreads() {
+		return ErrThreadsNotSupportedForChatType
+	}
+
+	if chat.ChatType != ChatTypeCommunityChat {
+		return nil
+	}
+
+	community, err := m.communitiesManager.GetByIDString(chat.CommunityID)
+	if err != nil {
+		return err
+	}
+
+	if !community.AllowsAllMembersToCreateThread() && !community.IsPrivilegedMember(&m.identity.PublicKey) {
+		return errors.New("only admins can create threads in this community")
+	}
+
+	return nil
+}
+
 // CreateThread creates thread metadata for an existing parent message in a chat.
 // The parent message must already be stored locally. Permission rules (admin-only
 // vs all-members) are enforced for community chats.
@@ -40,16 +61,8 @@ func (m *Messenger) CreateThread(chatID string, parentMessageID string) (*Messen
 		return nil, threadErr
 	}
 
-	// Enforce community permission: only check on new thread creation
-	if chat.ChatType == ChatTypeCommunityChat {
-		community, err := m.communitiesManager.GetByIDString(chat.CommunityID)
-		if err != nil {
-			return nil, err
-		}
-
-		if !community.AllowsAllMembersToCreateThread() && !community.IsPrivilegedMember(&m.identity.PublicKey) {
-			return nil, errors.New("only admins can create threads in this community")
-		}
+	if err := m.canCreateThread(chat); err != nil {
+		return nil, err
 	}
 
 	parentMsg, msgErr := m.persistence.MessageByID(parentMessageID)
@@ -94,7 +107,7 @@ func (m *Messenger) addThreadsToResponse(response *MessengerResponse, messages [
 			continue
 		}
 
-		chatID := message.GetChatId()
+		chatID := message.LocalChatID
 		if chatID == "" {
 			continue
 		}

--- a/internal/protocol/messenger_threads_test.go
+++ b/internal/protocol/messenger_threads_test.go
@@ -184,6 +184,38 @@ func (s *MessengerThreadsSuite) TestThreadsIncludeUnreadCounts() {
 	s.Require().Equal(uint(1), thread.UnviewedMentionsCount)
 }
 
+func (s *MessengerThreadsSuite) TestAddThreadsToResponseUsesLocalChatIDForOneToOneChats() {
+	receiver := s.m
+	sender := s.newMessenger()
+	receiver.featureFlags.Threads = true
+	sender.featureFlags.Threads = true
+
+	receiverChat := CreateOneToOneChat("sender", &sender.identity.PublicKey, receiver.getTimesource())
+	senderChat := CreateOneToOneChat("receiver", &receiver.identity.PublicKey, sender.getTimesource())
+	s.Require().NotEqual(receiverChat.ID, senderChat.ID)
+
+	threadID := "parent-id"
+	receivedReply := buildTestMessage(*senderChat)
+	receivedReply.ID = "reply-id"
+	receivedReply.Text = "Unread reply"
+	receivedReply.ChatMessage.Text = "Unread reply"
+	receivedReply.ChatMessage.ThreadId = &threadID
+	receivedReply.ResponseTo = threadID
+	receivedReply.LocalChatID = receiverChat.ID
+	receivedReply.Mentioned = true
+	receivedReply.Seen = false
+
+	s.Require().NoError(receiver.persistence.SaveMessages([]*common.Message{receivedReply}))
+
+	response := &MessengerResponse{}
+	s.Require().NoError(receiver.addThreadsToResponse(response, []*common.Message{receivedReply}))
+	s.Require().Len(response.Threads(), 1)
+	s.Require().Equal(receiverChat.ID, response.Threads()[0].ChatID)
+	s.Require().Equal(threadID, response.Threads()[0].ThreadID)
+	s.Require().Equal(uint(1), response.Threads()[0].UnviewedMessagesCount)
+	s.Require().Equal(uint(1), response.Threads()[0].UnviewedMentionsCount)
+}
+
 func (s *MessengerThreadsSuite) TestMessagesByThreadID() {
 	chat := CreateOneToOneChat("test-user", &s.m.identity.PublicKey, s.m.getTimesource())
 	s.Require().NoError(s.m.SaveChat(chat))
@@ -307,14 +339,14 @@ func (s *MessengerThreadsSuite) TestReceivedThreadReplyDoesNotIncrementParentUnr
 
 	sender := s.newMessenger()
 	sender.featureFlags.Threads = true
-	chatID := "thread-unread-public-chat"
+	chatID := "thread-unread-one-to-one-chat"
 
-	receiverChat := CreatePublicChat(chatID, receiver.getTimesource())
+	receiverChat := CreateOneToOneChat(chatID, &sender.identity.PublicKey, receiver.getTimesource())
 	s.Require().NoError(receiver.SaveChat(receiverChat))
 	_, err := receiver.Join(receiverChat)
 	s.Require().NoError(err)
 
-	senderChat := CreatePublicChat(chatID, sender.getTimesource())
+	senderChat := CreateOneToOneChat(chatID, &receiver.identity.PublicKey, sender.getTimesource())
 	s.Require().NoError(sender.SaveChat(senderChat))
 	_, err = sender.Join(senderChat)
 	s.Require().NoError(err)
@@ -522,14 +554,14 @@ func (s *MessengerThreadsSuite) TestThreadMessagesAreReceivedAndListedWhenThread
 
 	sender := s.newMessenger()
 	sender.featureFlags.Threads = true
-	chatID := "threads-disabled-public-chat"
+	chatID := "threads-disabled-one-to-one-chat"
 
-	receiverChat := CreatePublicChat(chatID, receiver.getTimesource())
+	receiverChat := CreateOneToOneChat(chatID, &sender.identity.PublicKey, receiver.getTimesource())
 	s.Require().NoError(receiver.SaveChat(receiverChat))
 	_, err := receiver.Join(receiverChat)
 	s.Require().NoError(err)
 
-	senderChat := CreatePublicChat(chatID, sender.getTimesource())
+	senderChat := CreateOneToOneChat(chatID, &receiver.identity.PublicKey, sender.getTimesource())
 	s.Require().NoError(sender.SaveChat(senderChat))
 	_, err = sender.Join(senderChat)
 	s.Require().NoError(err)


### PR DESCRIPTION
Part of https://github.com/status-im/status-app/issues/21895

Enable thread creation and messaging for one-to-one and private group chats. Expose thread metadata, unread counts, and mention counts with messenger responses, and support marking individual threads as read.
