### PR TITLE
fix(wallet/collectibles): disable collectibles on Robinhood chains

### DIFF
--- a/pkg/services/wallet/collectibles/unsupported_chains.go
+++ b/pkg/services/wallet/collectibles/unsupported_chains.go
@@ -11,6 +11,8 @@ import (
 var UnsupportedCollectibleChains = []uint64{
 	walletCommon.BSCMainnet,
 	walletCommon.BSCTestnet,
+	walletCommon.RobinhoodMainnet,
+	walletCommon.RobinhoodTestnet,
 	walletCommon.InkMainnet,
 	walletCommon.EthereumHoodi,
 	walletCommon.KatanaBokuto,

--- a/pkg/services/wallet/collectibles/unsupported_chains_test.go
+++ b/pkg/services/wallet/collectibles/unsupported_chains_test.go
@@ -17,5 +17,7 @@ func TestUnsupportedCollectibleChains_sorted(t *testing.T) {
 func TestIsUnsupportedCollectibleChain(t *testing.T) {
 	require.True(t, IsUnsupportedCollectibleChain(walletCommon.InkMainnet))
 	require.True(t, IsUnsupportedCollectibleChain(walletCommon.BSCMainnet))
+	require.True(t, IsUnsupportedCollectibleChain(walletCommon.RobinhoodMainnet))
+	require.True(t, IsUnsupportedCollectibleChain(walletCommon.RobinhoodTestnet))
 	require.False(t, IsUnsupportedCollectibleChain(walletCommon.EthereumMainnet))
 }

--- a/pkg/services/wallet/thirdparty/collectibles/alchemy/url_resolver.go
+++ b/pkg/services/wallet/thirdparty/collectibles/alchemy/url_resolver.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/status-im/status-go/pkg/security"
+	walletcollectibles "github.com/status-im/status-go/pkg/services/wallet/collectibles"
 	walletCommon "github.com/status-im/status-go/pkg/services/wallet/common"
 	"github.com/status-im/status-go/pkg/services/wallet/thirdparty"
 )
@@ -79,6 +80,9 @@ func (r *proxyURLResolver) IsChainSupported(chainID walletCommon.ChainID) bool {
 
 func getBaseURL(chainID walletCommon.ChainID) (string, error) {
 	id := uint64(chainID)
+	if walletcollectibles.IsUnsupportedCollectibleChain(id) {
+		return "", thirdparty.ErrChainIDNotSupported
+	}
 	host, ok := alchemyNFTDirectHosts[id]
 	if !ok {
 		return "", thirdparty.ErrChainIDNotSupported

--- a/pkg/services/wallet/thirdparty/collectibles/alchemy/url_resolver_test.go
+++ b/pkg/services/wallet/thirdparty/collectibles/alchemy/url_resolver_test.go
@@ -95,6 +95,8 @@ func TestDirectURLResolver_IsChainSupported(t *testing.T) {
 	require.False(t, resolver.IsChainSupported(walletCommon.ChainID(walletCommon.InkSepolia)))
 	require.False(t, resolver.IsChainSupported(walletCommon.ChainID(walletCommon.KatanaMainnet)))
 	require.False(t, resolver.IsChainSupported(walletCommon.ChainID(walletCommon.KatanaBokuto)))
+	require.False(t, resolver.IsChainSupported(walletCommon.ChainID(walletCommon.RobinhoodMainnet)))
+	require.False(t, resolver.IsChainSupported(walletCommon.ChainID(walletCommon.RobinhoodTestnet)))
 	require.False(t, resolver.IsChainSupported(walletCommon.ChainID(999999)))
 }
 
@@ -108,5 +110,7 @@ func TestProxyURLResolver_IsChainSupported(t *testing.T) {
 	require.False(t, resolver.IsChainSupported(walletCommon.ChainID(walletCommon.InkSepolia)))
 	require.False(t, resolver.IsChainSupported(walletCommon.ChainID(walletCommon.KatanaMainnet)))
 	require.False(t, resolver.IsChainSupported(walletCommon.ChainID(walletCommon.KatanaBokuto)))
+	require.False(t, resolver.IsChainSupported(walletCommon.ChainID(walletCommon.RobinhoodMainnet)))
+	require.False(t, resolver.IsChainSupported(walletCommon.ChainID(walletCommon.RobinhoodTestnet)))
 	require.False(t, resolver.IsChainSupported(walletCommon.ChainID(999999)))
 }


### PR DESCRIPTION
- Robinhood NFT fetches fail: proxy 502, Alchemy 403.
- Only chain 4663 fails; other chains are healthy.
- Failures marked the chain down, triggering red banner.
- Blacklist Robinhood mainnet and testnet for collectibles.
- Direct Alchemy resolver now honours the same blacklist.
- Result: calm "not supported" tag, like BNB.

Closes https://github.com/status-im/status-app/issues/22107
