### PR TITLE
fix(ci): pin status-app e2e to the package build it triggered

### DIFF
--- a/_assets/ci/Jenkinsfile.status-app
+++ b/_assets/ci/Jenkinsfile.status-app
@@ -58,7 +58,7 @@ pipeline {
             }
             stage('E2E') {
               steps { script {
-                triggerE2E('linux', 'x86_64', linux_x86_64.fullProjectName)
+                triggerE2E('linux', 'x86_64', linux_x86_64)
               } }
             }
           }
@@ -72,7 +72,7 @@ pipeline {
             }
             stage('E2E') {
               steps { script {
-                triggerE2E('windows', 'x86_64', windows_x86_64.fullProjectName)
+                triggerE2E('windows', 'x86_64', windows_x86_64)
               } }
             }
           }
@@ -118,13 +118,14 @@ def triggerJob(String platform, String arch) {
   )
 }
 
-def triggerE2E(String platform, String arch, String buildSource) {
+def triggerE2E(String platform, String arch, def packageBuild) {
   return build(
     job:        "status-app/systems/${platform}/${arch}/tests-e2e",
     parameters: jenkins.mapToParams([
-      BRANCH:          env.STATUS_APP_BRANCH,
-      BUILD_SOURCE:    buildSource,
-      TEST_SCOPE_FLAG: '-m=critical',
+      BRANCH:              env.STATUS_APP_BRANCH,
+      BUILD_SOURCE:        packageBuild.fullProjectName,
+      SOURCE_BUILD_NUMBER: packageBuild.number.toString(),
+      TEST_SCOPE_FLAG:     '-m=critical',
     ]),
     wait:       true,
     propagate:  true,


### PR DESCRIPTION
Iterates status-im/status-app#22109

# Description

1. `triggerE2E` now takes the package build itself instead of its `fullProjectName`, and passes `SOURCE_BUILD_NUMBER` alongside `BUILD_SOURCE` so the downstream e2e job copies the artifact from that exact build rather than the latest one that happens to have artifacts.

Needs the parameter added in status-im/status-app#22110. Jenkins ignores unknown parameters, so merge order is free — until that lands this is a no-op.

<details>
<summary>AI-made decisions</summary>

- `packageBuild.number.toString()` rather than `.number`: `jenkins.mapToParams` switches on `value.getClass()`, maps only `String` and `Boolean`, and drops the rest via `findResults`. An int — and a GString too — would silently vanish and leave the e2e job on the old selector.
- Passed the `RunWrapper` into `triggerE2E` instead of adding a fourth argument, so the path and the number cannot drift apart at the call sites.
- The macos/ios/android stages were left alone; they call `triggerJob` only and never trigger an e2e job.

</details>
