### PR TITLE
fix(walletconnect): stop deadlocking readLoop on re-subscribe [2.39]

### DIFF
--- a/pkg/services/connector/walletconnect/relay.go
+++ b/pkg/services/connector/walletconnect/relay.go
@@ -579,7 +579,10 @@ func (r *RelayClient) reconnect() error {
 		// and deadlock again, forever. Hand it to its own goroutine so readLoop
 		// can resume immediately.
 		if handler != nil {
-			go handler()
+			go func() {
+				defer panics.LogOnPanic()
+				handler()
+			}()
 		}
 
 		return nil

--- a/pkg/services/connector/walletconnect/relay.go
+++ b/pkg/services/connector/walletconnect/relay.go
@@ -571,8 +571,15 @@ func (r *RelayClient) reconnect() error {
 
 		r.logger.Info("successfully reconnected to relay")
 
+		// The handler re-subscribes to the active topics, and Subscribe blocks
+		// until readLoop delivers the relay's response. reconnect() itself runs
+		// on the readLoop goroutine, so calling the handler inline would leave
+		// nobody reading the socket: every re-subscribe would time out, the
+		// connection would be treated as broken, and the client would reconnect
+		// and deadlock again, forever. Hand it to its own goroutine so readLoop
+		// can resume immediately.
 		if handler != nil {
-			handler()
+			go handler()
 		}
 
 		return nil

--- a/pkg/services/connector/walletconnect/relay.go
+++ b/pkg/services/connector/walletconnect/relay.go
@@ -4,8 +4,10 @@ import (
 	cryptorand "crypto/rand"
 	"encoding/json"
 	"fmt"
+	"io"
 	"math/big"
 	"net/url"
+	"strings"
 	"sync"
 	"time"
 
@@ -207,8 +209,19 @@ func (r *RelayClient) dialRelay() (*websocket.Conn, error) {
 	q.Set("projectId", r.projectID)
 	u.RawQuery = q.Encode()
 
-	conn, _, err := websocket.DefaultDialer.Dial(u.String(), nil)
+	conn, resp, err := websocket.DefaultDialer.Dial(u.String(), nil)
 	if err != nil {
+		// gorilla collapses every non-101 upgrade response into the same opaque
+		// "bad handshake", which cannot distinguish a rejected token from a bad
+		// project id or a rate limit. Carry the status and a short body snippet
+		// instead. The URL itself must never be logged: it carries the auth JWT
+		// and the project id.
+		if resp != nil {
+			defer resp.Body.Close()
+			body, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
+			return nil, fmt.Errorf("dial relay: %w (relay responded %s: %s)",
+				err, resp.Status, truncate(strings.TrimSpace(string(body)), 200))
+		}
 		return nil, fmt.Errorf("dial relay: %w", err)
 	}
 	return conn, nil

--- a/pkg/services/connector/walletconnect/relay_reconnect_test.go
+++ b/pkg/services/connector/walletconnect/relay_reconnect_test.go
@@ -127,3 +127,18 @@ func TestReconnectedHandler_ResubscribeDoesNotDeadlockReadLoop(t *testing.T) {
 	}
 	_ = r.Close()
 }
+
+// gorilla reports every non-101 upgrade response as the same opaque
+// "websocket: bad handshake". The dial URL carries the auth JWT and the project
+// id, so it must never be logged, but the status code tells an operator whether
+// the relay rejected the credentials, the project, or rate-limited the client.
+func TestDialRelay_ReportsRejectedUpgradeStatus(t *testing.T) {
+	fr := newFakeRelay(t, fakeRelayOpts{rejectStatus: 401, rejectBody: "invalid jwt"})
+	r := newTestRelayClient(t, fr)
+
+	err := r.Connect()
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "401", "dial error must carry the relay's HTTP status")
+	require.NotContains(t, err.Error(), "auth=", "dial error must not leak the auth JWT")
+	require.NotContains(t, err.Error(), "projectId", "dial error must not leak the project id")
+}

--- a/pkg/services/connector/walletconnect/relay_reconnect_test.go
+++ b/pkg/services/connector/walletconnect/relay_reconnect_test.go
@@ -99,3 +99,31 @@ func TestConnect_IsIdempotentWhenLive(t *testing.T) {
 	waitAccepted(t, fr, 1)
 	_ = r.Close()
 }
+
+// The reconnected handler mirrors Client.onReconnected: it re-subscribes to the
+// active topics over the freshly established connection. Subscribe is a
+// request/response call whose reply can only be delivered by readLoop, so the
+// handler must not be invoked on the readLoop goroutine itself.
+func TestReconnectedHandler_ResubscribeDoesNotDeadlockReadLoop(t *testing.T) {
+	fr := newFakeRelay(t, fakeRelayOpts{echoSubscribe: true})
+	r := newTestRelayClient(t, fr)
+
+	subscribed := make(chan error, 1)
+	r.SetReconnectedHandler(func() {
+		_, err := r.Subscribe("session-topic")
+		subscribed <- err
+	})
+
+	require.NoError(t, r.Connect())
+	waitAccepted(t, fr, 1)
+
+	fr.DropNow()
+
+	select {
+	case err := <-subscribed:
+		require.NoError(t, err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("re-subscribe after reconnect never completed: readLoop cannot deliver the response while it is blocked inside the reconnected handler")
+	}
+	_ = r.Close()
+}

--- a/pkg/services/connector/walletconnect/relay_test_helpers_test.go
+++ b/pkg/services/connector/walletconnect/relay_test_helpers_test.go
@@ -20,6 +20,8 @@ type fakeRelayOpts struct {
 	forceDropAt   int32 // >0: close the N-th accepted connection immediately after upgrade
 	echoSubscribe bool  // reply to irn_subscribe with a fake "sub-id"
 	silentOnPing  bool  // do not respond to ping (used by heartbeat tests)
+	rejectStatus  int   // >0: refuse the upgrade with this HTTP status instead
+	rejectBody    string
 }
 
 // fakeRelay is an in-process WalletConnect IRN-like WebSocket server for relay tests.
@@ -40,6 +42,12 @@ func newFakeRelay(t *testing.T, opts fakeRelayOpts) *fakeRelay {
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		if fr.opts.rejectStatus > 0 {
+			atomic.AddInt32(&fr.accepted, 1)
+			w.WriteHeader(fr.opts.rejectStatus)
+			_, _ = w.Write([]byte(fr.opts.rejectBody))
+			return
+		}
 		conn, err := upgrader.Upgrade(w, r, nil)
 		if err != nil {
 			return


### PR DESCRIPTION
Cherry-pick of #7771 onto the 2.39 line.

- Relay re-subscribed on the readLoop goroutine, inline.
- Subscribe waited for a reply readLoop could not deliver.
- Timed out after 30s, reconnected, deadlocked again, forever.
- Session topic never subscribed; dApp requests silently dropped.
- OpenSea purchases never arrived; Logout() hung on teardown.
- Handler now runs on its own goroutine.
- Red test added first; it timed out at 5s.
- Package suite passes with `-race`.


Closes https://github.com/status-im/status-app/issues/22119


https://github.com/user-attachments/assets/081ec1d3-9093-4b1e-8054-d5d69bfc8bde

