### PR TITLE
feat: accept unicode display names

### DIFF
--- a/internal/protocol/common/display_name.go
+++ b/internal/protocol/common/display_name.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"regexp"
 	"strings"
+	"unicode/utf8"
 
 	"github.com/status-im/status-go/internal/protocol/identity/alias"
 )
@@ -22,7 +23,7 @@ const (
 )
 
 // Compiled regex pattern for validating display names
-var displayNameRegex = regexp.MustCompile(fmt.Sprintf("^[\\w-\\s]{%d,%d}$", MinDisplayNameLength, MaxDisplayNameLength))
+var displayNameRegex = regexp.MustCompile(`^[\p{L}\p{M}\p{N}_\-\s]+$`)
 
 func ValidateDisplayName(displayName *string) error {
 	name := strings.TrimSpace(*displayName)
@@ -32,11 +33,10 @@ func ValidateDisplayName(displayName *string) error {
 		return nil
 	}
 
-	if len(name) < MinDisplayNameLength || len(name) > MaxDisplayNameLength {
+	if l := utf8.RuneCountInString(name); l < MinDisplayNameLength || l > MaxDisplayNameLength {
 		return ErrInvalidDisplayNameLength
 	}
 
-	// Use pre-compiled regex to validate name format
 	if !displayNameRegex.MatchString(name) {
 		return ErrInvalidDisplayNameRegExp
 	}

--- a/internal/protocol/common/display_name_test.go
+++ b/internal/protocol/common/display_name_test.go
@@ -1,0 +1,61 @@
+package common
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateDisplayName_AcceptsAnyScript(t *testing.T) {
+	names := []string{
+		"John Doe",
+		"john_doe-1",
+		"Ђорђе Ћурчић",                            // Serbian Cyrillic
+		"Đorđe Čurčić",                            // Serbian Latin
+		"Ґудзик Їжак",                             // Ukrainian
+		"Straße Ärger",                            // German
+		"Élodie Noël",                             // French
+		"Αλέξανδρος",                              // Greek
+		"我的名字很长",                                  // Chinese
+		"財布 ワレット",                                 // Japanese
+		"내 이름은 김",                                 // Korean
+		"محفظتي هنا",                              // Arabic
+		"הארנק שלי",                               // Hebrew
+		"मेरा बटुआ",                               // Hindi, with combining marks
+		"กระเป๋าของฉัน",                           // Thai, with combining marks
+		"Ví của tôi",                              // Vietnamese
+		"Ђорђе ٣٤٥",                               // non-ASCII digits
+		strings.Repeat("Ж", MaxDisplayNameLength), // 24 runes but 48 bytes
+	}
+	for _, name := range names {
+		n := name
+		require.NoError(t, ValidateDisplayName(&n), name)
+		require.Equal(t, strings.TrimSpace(name), n)
+	}
+}
+
+func TestValidateDisplayName_Rejects(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+	}{
+		{"Ђорђе!", ErrInvalidDisplayNameRegExp},
+		{"john.doe", ErrInvalidDisplayNameRegExp},
+		{"我的名字。", ErrInvalidDisplayNameRegExp},
+		{"Ђорђе 🙂", ErrInvalidDisplayNameRegExp},
+		{"Ђорђ", ErrInvalidDisplayNameLength},                                      // 4 runes (8 bytes)
+		{strings.Repeat("Ж", MaxDisplayNameLength+1), ErrInvalidDisplayNameLength}, // 25 runes
+		{"Ђорђе-eth", ErrInvalidDisplayNameEthSuffix},
+	}
+	for _, c := range cases {
+		n := c.name
+		require.ErrorIs(t, ValidateDisplayName(&n), c.err, c.name)
+	}
+}
+
+func TestValidateDisplayName_EmptyIsAccepted(t *testing.T) {
+	n := "   "
+	require.NoError(t, ValidateDisplayName(&n))
+	require.Equal(t, "", n)
+}

--- a/internal/protocol/messenger_identity_display_name_test.go
+++ b/internal/protocol/messenger_identity_display_name_test.go
@@ -223,6 +223,13 @@ func (s *MessengerProfileDisplayNameHandlerSuite) TestDisplayNameRestrictions() 
 	displayName, err = s.m.settings.DisplayName()
 	s.Require().NoError(err)
 	s.Require().Equal("name with space", displayName)
+
+	// letters/digits of any script are accepted, length is counted in runes
+	err = s.m.SetDisplayName("Ђорђе Ћурчић 我的名字")
+	s.Require().NoError(err)
+	displayName, err = s.m.settings.DisplayName()
+	s.Require().NoError(err)
+	s.Require().Equal("Ђорђе Ћурчић 我的名字", displayName)
 }
 
 func (s *MessengerProfileDisplayNameHandlerSuite) TestSetEmptyDisplayNameSkipsDupeCheck() {


### PR DESCRIPTION
- match letters, combining marks and digits of any script: `^[\p{L}\p{M}\p{N}_\-\s]+$`
- count the 5-24 length limit in runes (utf8.RuneCountInString), not bytes
- keep the `.eth` suffix and alias checks unchanged
- add unit tests covering 15 scripts, rejections, rune vs byte length, and a SetDisplayName success case in the identity suite

Note: peers running builds without this change still validate received names with the old ASCII rule and will drop messages from users with non-ASCII display names until they upgrade.