### PR TITLE
fix(ci): pin status-app e2e to the package build it triggered (#7770)

### DIFF
--- a/_assets/ci/Jenkinsfile.status-app
+++ b/_assets/ci/Jenkinsfile.status-app
@@ -58,7 +58,7 @@ pipeline {
             }
             stage('E2E') {
               steps { script {
-                triggerE2E('linux', 'x86_64', linux_x86_64.fullProjectName)
+                triggerE2E('linux', 'x86_64', linux_x86_64)
               } }
             }
           }
@@ -72,7 +72,7 @@ pipeline {
             }
             stage('E2E') {
               steps { script {
-                triggerE2E('windows', 'x86_64', windows_x86_64.fullProjectName)
+                triggerE2E('windows', 'x86_64', windows_x86_64)
               } }
             }
           }
@@ -118,13 +118,14 @@ def triggerJob(String platform, String arch) {
   )
 }
 
-def triggerE2E(String platform, String arch, String buildSource) {
+def triggerE2E(String platform, String arch, def packageBuild) {
   return build(
     job:        "status-app/systems/${platform}/${arch}/tests-e2e",
     parameters: jenkins.mapToParams([
-      BRANCH:          env.STATUS_APP_BRANCH,
-      BUILD_SOURCE:    buildSource,
-      TEST_SCOPE_FLAG: '-m=critical',
+      BRANCH:              env.STATUS_APP_BRANCH,
+      BUILD_SOURCE:        packageBuild.fullProjectName,
+      SOURCE_BUILD_NUMBER: packageBuild.number.toString(),
+      TEST_SCOPE_FLAG:     '-m=critical',
     ]),
     wait:       true,
     propagate:  true,


### PR DESCRIPTION
Cherry-pick of #7770 to `release/10.35.x`.

# Description

1. `triggerE2E` now takes the package build itself instead of its `fullProjectName`, and passes `SOURCE_BUILD_NUMBER` alongside `BUILD_SOURCE` so the downstream e2e job copies the artifact from that exact build rather than the latest one that happens to have artifacts.

Needs the parameter added in status-im/status-app#22110, backported in the matching `release/2.39.x` PR. Jenkins ignores unknown parameters, so merge order is free.
