### PR TITLE
fix(wallet): market tab currency conversion for 2.39 [cherry-pick]

### DIFF
--- a/internal/db/walletdb/migrations/sql/1787616000_add_currency_to_market_data.up.sql
+++ b/internal/db/walletdb/migrations/sql/1787616000_add_currency_to_market_data.up.sql
@@ -1,0 +1,4 @@
+-- Leaderboard market data is stored in the currency it was fetched in.
+-- Rows written before this migration are USD, because the proxy was always
+-- queried without a conversion currency.
+ALTER TABLE market_data ADD COLUMN currency TEXT NOT NULL DEFAULT 'usd';

--- a/pkg/services/wallet/leaderboard/cache.go
+++ b/pkg/services/wallet/leaderboard/cache.go
@@ -27,6 +27,15 @@ func (c *PageCache) GetLastPage() LeaderboardPage {
 	return c.lastPage
 }
 
+// SetCurrency relabels the cached page, so updates pushed after a currency
+// change are tagged with the currency their values are actually in.
+func (c *PageCache) SetCurrency(currency string) {
+	c.dataMutex.Lock()
+	defer c.dataMutex.Unlock()
+
+	c.lastPage.Currency = currency
+}
+
 func (c *PageCache) UpdateLastPage(page *LeaderboardPage) {
 	c.dataMutex.Lock()
 	defer c.dataMutex.Unlock()

--- a/pkg/services/wallet/leaderboard/currency_change_test.go
+++ b/pkg/services/wallet/leaderboard/currency_change_test.go
@@ -1,0 +1,361 @@
+package leaderboard
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/ethereum/go-ethereum/event"
+	"github.com/stretchr/testify/require"
+
+	"github.com/status-im/status-go/internal/db/multiaccounts/settings"
+	"github.com/status-im/status-go/pkg/pubsub"
+	"github.com/status-im/status-go/pkg/security"
+	"github.com/status-im/status-go/pkg/services/wallet/async"
+	"github.com/status-im/status-go/pkg/services/wallet/walletevent"
+)
+
+const (
+	priceInUSD = 78281.0
+	priceInEUR = 67000.0
+)
+
+// stubCurrencySource stands in for the settings DB.
+type stubCurrencySource struct{ currency string }
+
+func (s *stubCurrencySource) GetCurrency() (string, error) { return s.currency, nil }
+
+// currencyAwareFetcher produces a price that depends on the currency the
+// storage is set to, so USD data can be told apart from EUR data. It stands in
+// for the refresh loops: a trigger fetches and reports, but only while the
+// loops are meant to be running.
+type currencyAwareFetcher struct {
+	storage *DataStorage
+	subs    *SubscriptionManager
+
+	mu      sync.Mutex
+	running bool
+}
+
+func priceFor(currency string) float64 {
+	if currency == "eur" {
+		return priceInEUR
+	}
+	return priceInUSD
+}
+
+func (f *currencyAwareFetcher) FetchMarkets(ctx context.Context) error {
+	currency := f.storage.GetCurrency()
+	f.storage.UpdateCryptoDataWithEtag([]Cryptocurrency{
+		{ID: "bitcoin", Symbol: "btc", CurrentPrice: priceFor(currency)},
+	}, "etag-"+currency, currency)
+	return nil
+}
+
+func (f *currencyAwareFetcher) FetchPrices(ctx context.Context) error {
+	currency := f.storage.GetCurrency()
+	f.storage.UpdatePriceDataWithEtag(PriceMap{
+		"bitcoin": {ID: "bitcoin", Price: priceFor(currency)},
+	}, "price-etag-"+currency, currency)
+	return nil
+}
+
+func (f *currencyAwareFetcher) Start(ctx context.Context) {}
+
+func (f *currencyAwareFetcher) StartRefreshLoops() { f.setRunning(true) }
+
+func (f *currencyAwareFetcher) Stop() { f.setRunning(false) }
+
+func (f *currencyAwareFetcher) RefreshNow() {
+	if !f.isRunning() {
+		return
+	}
+	ctx := context.Background()
+	if err := f.FetchMarkets(ctx); err == nil {
+		f.subs.Emit(ctx, TickerFullDataUpdateSource)
+	}
+	if err := f.FetchPrices(ctx); err == nil {
+		f.subs.Emit(ctx, TickerPriceUpdateSource)
+	}
+}
+
+func (f *currencyAwareFetcher) setRunning(running bool) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.running = running
+}
+
+func (f *currencyAwareFetcher) isRunning() bool {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.running
+}
+
+type pushTestService struct {
+	service   *MarketDataService
+	events    chan walletevent.Event
+	publisher *pubsub.Publisher
+}
+
+func newPushTestService(t *testing.T, db *sql.DB, currency string) *pushTestService {
+	t.Helper()
+
+	feed := &event.Feed{}
+	events := make(chan walletevent.Event, 64)
+	sub := feed.Subscribe(events)
+	t.Cleanup(sub.Unsubscribe)
+
+	publisher := pubsub.NewPublisher()
+	t.Cleanup(publisher.Close)
+
+	storage := NewDataStorage(db)
+	subs := NewSubscriptionManager()
+	service := &MarketDataService{
+		feed:                feed,
+		storage:             storage,
+		subscriptionManager: subs,
+		scheduler:           async.NewScheduler(),
+		cache:               NewPageCache(),
+		currencySource:      &stubCurrencySource{currency: currency},
+		accountsPublisher:   publisher,
+	}
+	service.fetcher = &currencyAwareFetcher{storage: storage, subs: subs}
+	service.Start(context.Background())
+
+	return &pushTestService{service: service, events: events, publisher: publisher}
+}
+
+func (s *pushTestService) publishCurrency(currency string) {
+	pubsub.Publish(s.publisher, settings.EventSettingChanged{
+		Setting: settings.Currency,
+		Value:   currency,
+	})
+}
+
+func waitForEventType(t *testing.T, events chan walletevent.Event, want walletevent.EventType) string {
+	t.Helper()
+	deadline := time.After(5 * time.Second)
+	for {
+		select {
+		case ev := <-events:
+			if ev.Type == want {
+				return ev.Message
+			}
+		case <-deadline:
+			t.Fatalf("timed out waiting for %s", want)
+		}
+	}
+}
+
+// TestCurrencyChangePushesConvertedPage covers a client that is listening when
+// the setting changes: the new page has to reach it, or the tab keeps showing
+// the old currency's figures.
+func TestCurrencyChangePushesConvertedPage(t *testing.T) {
+	db, cleanup := setupTestWalletDB(t)
+	defer cleanup()
+
+	svc := newPushTestService(t, db, "usd")
+	defer svc.service.Stop()
+
+	svc.service.FetchLeaderboardPageAsync(1, 10, 0, "USD")
+	waitForEventType(t, svc.events, EventFetchLeaderboardPageDone)
+	require.Equal(t, priceInUSD, svc.service.storage.GetCryptoData()[0].CurrentPrice)
+
+	svc.publishCurrency("EUR")
+
+	msg := waitForEventType(t, svc.events, EventLeaderboardPageDataUpdated)
+	var page LeaderboardPage
+	require.NoError(t, json.Unmarshal([]byte(msg), &page))
+	require.Equal(t, "EUR", page.Currency)
+	require.Len(t, page.Data, 1)
+	require.Equal(t, priceInEUR, page.Data[0].CurrentPrice)
+}
+
+// TestCurrencyChangeWhileTabClosed covers the path the desktop takes: the
+// Market tab is torn down when the user opens Settings, so the change lands
+// with nothing subscribed and the tab re-requests on its way back in.
+func TestCurrencyChangeWhileTabClosed(t *testing.T) {
+	db, cleanup := setupTestWalletDB(t)
+	defer cleanup()
+
+	svc := newPushTestService(t, db, "usd")
+	defer svc.service.Stop()
+
+	svc.service.FetchLeaderboardPageAsync(1, 10, 0, "USD")
+	waitForEventType(t, svc.events, EventFetchLeaderboardPageDone)
+
+	// User leaves the Market tab for Settings.
+	require.NoError(t, svc.service.UnsubscribeFromLeaderboard())
+
+	svc.publishCurrency("EUR")
+	require.Eventually(t, func() bool { return svc.service.storage.GetCurrency() == "eur" },
+		2*time.Second, 10*time.Millisecond)
+
+	// User returns to the Market tab.
+	svc.service.FetchLeaderboardPageAsync(1, 10, 0, "EUR")
+	msg := waitForEventType(t, svc.events, EventFetchLeaderboardPageDone)
+
+	var res GetLeaderboardPageResponse
+	require.NoError(t, json.Unmarshal([]byte(msg), &res))
+	require.Len(t, res.Data, 1)
+	require.Equal(t, priceInEUR, res.Data[0].CurrentPrice)
+}
+
+// TestFetchInFlightDuringCurrencyChangeIsDropped guards the case where a
+// refresh issued in USD lands after the user has switched to EUR. Storing those
+// dollar figures as EUR data would also refresh the timestamp and keep the USD
+// ETag, leaving nothing to refetch and the tab showing dollar amounts behind a
+// euro sign until the data went stale.
+func TestFetchInFlightDuringCurrencyChangeIsDropped(t *testing.T) {
+	db, cleanup := setupTestWalletDB(t)
+	defer cleanup()
+
+	storage := NewDataStorage(db)
+
+	released := make(chan struct{})
+	inFlight := make(chan struct{})
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// No convert_currency: the request goes out while USD is selected.
+		require.Empty(t, r.URL.Query().Get(convertCurrencyParam))
+		close(inFlight)
+		<-released
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("Etag", "usd-etag")
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"data": []map[string]interface{}{
+				{"id": "bitcoin", "symbol": "btc", "current_price": priceInUSD},
+			},
+		})
+	}))
+	defer server.Close()
+
+	fetcher := NewProxyFetcher(ServiceConfig{
+		User:        security.NewSensitiveString("test"),
+		Password:    security.NewSensitiveString("password"),
+		UrlOverride: security.NewSensitiveString(server.URL),
+		AllowETag:   true,
+	}, storage, NewSubscriptionManager()).(*ProxyFetcher)
+
+	done := make(chan error, 1)
+	go func() { done <- fetcher.FetchMarkets(context.Background()) }()
+
+	<-inFlight
+	require.True(t, storage.SetCurrency("EUR"))
+	close(released)
+	require.NoError(t, <-done)
+
+	require.Equal(t, "eur", storage.GetCurrency())
+	require.Empty(t, storage.GetCryptoData(), "USD payload was stored as EUR data")
+	require.Empty(t, storage.GetCryptoEtag(), "USD ETag was kept for the EUR currency")
+	require.True(t, storage.IsDataStale(), "stale flag cleared, so nothing would refetch in EUR")
+}
+
+// TestPricesInFlightDuringCurrencyChangeIsDropped covers the same race on the
+// price refresh loop, which pushes straight to the client with no staleness
+// check to catch a stale value later.
+func TestPricesInFlightDuringCurrencyChangeIsDropped(t *testing.T) {
+	db, cleanup := setupTestWalletDB(t)
+	defer cleanup()
+
+	storage := NewDataStorage(db)
+
+	released := make(chan struct{})
+	inFlight := make(chan struct{})
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		close(inFlight)
+		<-released
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"bitcoin": map[string]interface{}{"price": priceInUSD},
+		})
+	}))
+	defer server.Close()
+
+	fetcher := NewProxyFetcher(ServiceConfig{
+		User:        security.NewSensitiveString("test"),
+		Password:    security.NewSensitiveString("password"),
+		UrlOverride: security.NewSensitiveString(server.URL),
+	}, storage, NewSubscriptionManager()).(*ProxyFetcher)
+
+	done := make(chan error, 1)
+	go func() { done <- fetcher.FetchPrices(context.Background()) }()
+
+	<-inFlight
+	require.True(t, storage.SetCurrency("EUR"))
+	close(released)
+	require.NoError(t, <-done)
+
+	require.Empty(t, storage.GetPriceData(), "USD prices were stored as EUR prices")
+}
+
+// TestRefreshNowDrivesTheRunningLoops pins the mechanism a currency change
+// relies on: the refetch travels through the same loops as every periodic
+// refresh, and does nothing while they are stopped.
+func TestRefreshNowDrivesTheRunningLoops(t *testing.T) {
+	db, cleanup := setupTestWalletDB(t)
+	defer cleanup()
+
+	requests := make(chan string, 8)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests <- r.URL.Path
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Path == PRICES_ENDPOINT {
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{})
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{"data": []interface{}{}})
+	}))
+	defer server.Close()
+
+	storage := NewDataStorage(db)
+	subs := NewSubscriptionManager()
+	signals := subs.Subscribe()
+
+	// Intervals long enough that nothing here can be a tick.
+	fetcher := NewProxyFetcher(ServiceConfig{
+		UrlOverride:         security.NewSensitiveString(server.URL),
+		FullDataInterval:    time.Hour,
+		PriceUpdateInterval: time.Hour,
+	}, storage, subs)
+
+	// While the loops are stopped a trigger has to do nothing, which is what
+	// leaves the tab-closed case to the next page request.
+	fetcher.RefreshNow()
+	select {
+	case path := <-requests:
+		t.Fatalf("stopped loops fetched %s", path)
+	case <-time.After(200 * time.Millisecond):
+	}
+
+	fetcher.StartRefreshLoops()
+	defer fetcher.Stop()
+
+	fetcher.RefreshNow()
+
+	seen := map[string]bool{}
+	for len(seen) < 2 {
+		select {
+		case path := <-requests:
+			seen[path] = true
+		case <-time.After(5 * time.Second):
+			t.Fatalf("triggered loops did not fetch, saw %v", seen)
+		}
+	}
+	require.True(t, seen[MARKETS_ENDPOINT])
+	require.True(t, seen[PRICES_ENDPOINT])
+
+	// Each completed refresh reports itself, which is what carries the new
+	// values out to the client.
+	select {
+	case <-signals:
+	case <-time.After(5 * time.Second):
+		t.Fatal("a triggered refresh reported nothing to the subscribers")
+	}
+}

--- a/pkg/services/wallet/leaderboard/currency_test.go
+++ b/pkg/services/wallet/leaderboard/currency_test.go
@@ -1,0 +1,238 @@
+package leaderboard
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/status-im/status-go/pkg/security"
+)
+
+func testFetcherConfig(url string) ServiceConfig {
+	return ServiceConfig{
+		User:        security.NewSensitiveString("test"),
+		Password:    security.NewSensitiveString("password"),
+		UrlOverride: security.NewSensitiveString(url),
+		AllowETag:   true,
+	}
+}
+
+func writeMarketsResponse(w http.ResponseWriter) {
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(map[string]interface{}{
+		"data": []map[string]interface{}{
+			{"id": "bitcoin", "symbol": "btc", "current_price": 80000.0},
+		},
+	})
+}
+
+// recordingServer collects the convert_currency values the fetcher sent.
+type recordingServer struct {
+	mu       sync.Mutex
+	queries  []string
+	reject   map[string]bool
+	server   *httptest.Server
+	requests int
+}
+
+func newRecordingServer(reject ...string) *recordingServer {
+	rs := &recordingServer{reject: make(map[string]bool)}
+	for _, currency := range reject {
+		rs.reject[currency] = true
+	}
+	rs.server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		convert := r.URL.Query().Get(convertCurrencyParam)
+
+		rs.mu.Lock()
+		rs.queries = append(rs.queries, convert)
+		rs.requests++
+		reject := rs.reject[convert]
+		rs.mu.Unlock()
+
+		if reject {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusBadRequest)
+			_, _ = w.Write([]byte(`{"error":"unsupported convert_currency: ` + convert + `"}`))
+			return
+		}
+		writeMarketsResponse(w)
+	}))
+	return rs
+}
+
+func (rs *recordingServer) sentQueries() []string {
+	rs.mu.Lock()
+	defer rs.mu.Unlock()
+	return append([]string{}, rs.queries...)
+}
+
+func TestFetcherSendsConvertCurrency(t *testing.T) {
+	db, cleanup := setupTestWalletDB(t)
+	defer cleanup()
+
+	t.Run("non-USD currency is converted by the proxy", func(t *testing.T) {
+		rs := newRecordingServer()
+		defer rs.server.Close()
+
+		storage := NewDataStorage(db)
+		require.True(t, storage.SetCurrency("EUR"))
+
+		fetcher := NewProxyFetcher(testFetcherConfig(rs.server.URL), storage, NewSubscriptionManager()).(*ProxyFetcher)
+		require.NoError(t, fetcher.FetchMarkets(context.Background()))
+
+		require.Equal(t, []string{"eur"}, rs.sentQueries())
+	})
+
+	t.Run("USD needs no conversion", func(t *testing.T) {
+		rs := newRecordingServer()
+		defer rs.server.Close()
+
+		storage := NewDataStorage(db)
+		fetcher := NewProxyFetcher(testFetcherConfig(rs.server.URL), storage, NewSubscriptionManager()).(*ProxyFetcher)
+		require.NoError(t, fetcher.FetchMarkets(context.Background()))
+
+		require.Equal(t, []string{""}, rs.sentQueries())
+	})
+}
+
+func TestFetcherFallsBackWhenCurrencyIsRejected(t *testing.T) {
+	db, cleanup := setupTestWalletDB(t)
+	defer cleanup()
+
+	rs := newRecordingServer("xyz")
+	defer rs.server.Close()
+
+	storage := NewDataStorage(db)
+	require.True(t, storage.SetCurrency("xyz"))
+
+	fetcher := NewProxyFetcher(testFetcherConfig(rs.server.URL), storage, NewSubscriptionManager()).(*ProxyFetcher)
+
+	// The rejected request is retried once without the conversion, so the tab
+	// gets data at all, in USD.
+	require.NoError(t, fetcher.FetchMarkets(context.Background()))
+	require.Equal(t, []string{"xyz", ""}, rs.sentQueries())
+	require.Equal(t, 1, storage.GetCryptoDataSize())
+
+	// Later fetches do not ask for the rejected currency again.
+	require.NoError(t, fetcher.FetchMarkets(context.Background()))
+	require.Equal(t, []string{"xyz", "", ""}, rs.sentQueries())
+}
+
+func TestFetcherKeepsRetryingOnUnrelatedErrors(t *testing.T) {
+	db, cleanup := setupTestWalletDB(t)
+	defer cleanup()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte("boom"))
+	}))
+	defer server.Close()
+
+	storage := NewDataStorage(db)
+	require.True(t, storage.SetCurrency("eur"))
+
+	fetcher := NewProxyFetcher(testFetcherConfig(server.URL), storage, NewSubscriptionManager()).(*ProxyFetcher)
+	require.NoError(t, fetcher.FetchMarkets(context.Background()))
+
+	// A server error must not disable the currency.
+	require.Equal(t, "eur", fetcher.convertCurrencyFor("eur"))
+}
+
+func TestSetCurrencyInvalidatesCachedData(t *testing.T) {
+	db, cleanup := setupTestWalletDB(t)
+	defer cleanup()
+
+	storage := NewDataStorage(db)
+	storage.UpdateCryptoDataWithEtag(mockCrypto, "crypto-etag", DefaultCurrency)
+	storage.UpdatePriceDataWithEtag(mockPriceData, "price-etag", DefaultCurrency)
+
+	require.False(t, storage.IsDataStale())
+
+	require.True(t, storage.SetCurrency("eur"))
+
+	require.Equal(t, "eur", storage.GetCurrency())
+	require.Empty(t, storage.GetCryptoEtag())
+	require.Empty(t, storage.GetPriceEtag())
+	require.Equal(t, 0, storage.GetCryptoDataSize())
+	require.Empty(t, storage.GetPriceData())
+	require.True(t, storage.IsDataStale())
+
+	// The persisted snapshot of the previous currency is gone too.
+	persisted, err := NewPersistance(db).GetCryptocurrencies(DefaultCurrency)
+	require.NoError(t, err)
+	require.Empty(t, persisted)
+}
+
+func TestSetCurrencyIsCaseInsensitive(t *testing.T) {
+	db, cleanup := setupTestWalletDB(t)
+	defer cleanup()
+
+	storage := NewDataStorage(db)
+	require.True(t, storage.SetCurrency("EUR"))
+	storage.UpdateCryptoDataWithEtag(mockCrypto, "crypto-etag", "eur")
+
+	// status-desktop sends the code uppercased, the settings DB stores it
+	// lowercased - that must not count as a change.
+	require.False(t, storage.SetCurrency("eur"))
+	require.Equal(t, "crypto-etag", storage.GetCryptoEtag())
+}
+
+func TestStartRestoresOnlyMatchingCurrency(t *testing.T) {
+	db, cleanup := setupTestWalletDB(t)
+	defer cleanup()
+
+	require.NoError(t, NewPersistance(db).UpsertCryptocurrencies(mockCrypto, DefaultCurrency))
+
+	t.Run("same currency is restored", func(t *testing.T) {
+		storage := NewDataStorage(db)
+		storage.Start()
+		require.Equal(t, len(mockCrypto), storage.GetCryptoDataSize())
+	})
+
+	t.Run("other currency is a cache miss", func(t *testing.T) {
+		storage := NewDataStorage(db)
+		storage.currency = "eur"
+		storage.Start()
+		require.Equal(t, 0, storage.GetCryptoDataSize())
+	})
+}
+
+func TestPersistenceIsScopedToCurrency(t *testing.T) {
+	db, cleanup := setupTestWalletDB(t)
+	defer cleanup()
+
+	persistence := NewPersistance(db)
+	require.NoError(t, persistence.UpsertCryptocurrencies(mockCrypto, "eur"))
+
+	stored, err := persistence.GetCryptocurrencies("eur")
+	require.NoError(t, err)
+	require.Equal(t, len(mockCrypto), len(stored))
+
+	stored, err = persistence.GetCryptocurrencies(DefaultCurrency)
+	require.NoError(t, err)
+	require.Empty(t, stored)
+
+	require.NoError(t, persistence.DeleteCryptocurrenciesNotIn(DefaultCurrency))
+	stored, err = persistence.GetCryptocurrencies("eur")
+	require.NoError(t, err)
+	require.Empty(t, stored)
+}
+
+func TestFetchLeaderboardPageAppliesRequestedCurrency(t *testing.T) {
+	db, cleanup := setupTestWalletDB(t)
+	defer cleanup()
+
+	service := setupMarketDatadService(t, ServiceConfig{}, db)
+	service.storage.UpdateCryptoDataWithEtag(mockCrypto, "crypto-etag", DefaultCurrency)
+
+	service.setCurrency("EUR", false)
+
+	require.Equal(t, "eur", service.storage.GetCurrency())
+	require.Empty(t, service.storage.GetCryptoEtag())
+	require.True(t, service.storage.IsDataStale())
+}

--- a/pkg/services/wallet/leaderboard/fetcher.go
+++ b/pkg/services/wallet/leaderboard/fetcher.go
@@ -3,7 +3,11 @@ package leaderboard
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"net/http"
+	netUrl "net/url"
+	"strings"
 	"sync"
 	"time"
 
@@ -17,6 +21,10 @@ import (
 const (
 	MARKETS_ENDPOINT = "/v1/leaderboard/markets"
 	PRICES_ENDPOINT  = "/v1/leaderboard/prices"
+
+	// convertCurrencyParam asks the market proxy to convert the values it
+	// serves (which are cached in USD) to another currency at request time.
+	convertCurrencyParam = "convert_currency"
 )
 
 // DataFetcher defines the interface for fetching market and price data
@@ -27,6 +35,9 @@ type DataFetcher interface {
 	FetchPrices(ctx context.Context) error
 	// StartRefreshLoops starts the data refresh loops
 	StartRefreshLoops()
+	// RefreshNow makes the running refresh loops fetch at once rather than at
+	// their next tick. It is a no-op while they are stopped.
+	RefreshNow()
 	// Start begins the data refresh loops
 	Start(ctx context.Context)
 	// Stop halts all data refresh operations
@@ -40,9 +51,17 @@ type ProxyFetcher struct {
 	subscriptionManager *SubscriptionManager
 	config              ServiceConfig
 
-	// Background polling state
-	contextMutex sync.Mutex
-	cancelFunc   context.CancelFunc
+	// mu guards every piece of mutable fetcher state below it.
+	mu sync.Mutex
+	// cancelFunc stops the refresh loops; nil while they are not running.
+	cancelFunc context.CancelFunc
+	// refreshMarkets/refreshPrices carry the "fetch now" trigger to the running
+	// loops. They are nil while the loops are stopped.
+	refreshMarkets chan struct{}
+	refreshPrices  chan struct{}
+	// unsupportedCurrencies remembers the currencies the proxy rejected with a
+	// 400, so a rejected currency costs one failed request, not one per refresh.
+	unsupportedCurrencies map[string]struct{}
 }
 
 // NewProxyFetcher creates a new proxy data fetcher
@@ -53,10 +72,11 @@ func NewProxyFetcher(config ServiceConfig, storage *DataStorage, subscriptionMan
 		thirdparty.WithMaxRetries(1),
 	)
 	return &ProxyFetcher{
-		client:              httpClient,
-		storage:             storage,
-		subscriptionManager: subscriptionManager,
-		config:              config,
+		client:                httpClient,
+		storage:               storage,
+		subscriptionManager:   subscriptionManager,
+		config:                config,
+		unsupportedCurrencies: make(map[string]struct{}),
 	}
 }
 
@@ -71,87 +91,126 @@ func (f *ProxyFetcher) Start(ctx context.Context) {
 
 // Stop halts all data refresh operations
 func (f *ProxyFetcher) Stop() {
-	f.contextMutex.Lock()
-	defer f.contextMutex.Unlock()
-
-	// Cancel the context to stop all loops
-	if f.cancelFunc != nil {
-		f.cancelFunc()
-		f.cancelFunc = nil
-	}
+	f.releaseLoops()
 }
 
 func (f *ProxyFetcher) StartRefreshLoops() {
-	f.contextMutex.Lock()
-	defer f.contextMutex.Unlock()
-
-	if f.cancelFunc != nil {
+	ctx, markets, prices, ok := f.claimLoops()
+	if !ok {
 		return
 	}
-	ctx, cancelFunc := context.WithCancel(context.Background())
-	f.cancelFunc = cancelFunc
 
-	// Start crypto data refresh loop
 	go func() {
 		defer panics.LogOnPanic()
-		f.cryptoRefreshLoop(ctx)
+		f.refreshLoop(ctx, f.config.FullDataInterval, 0, markets, f.FetchMarkets, TickerFullDataUpdateSource)
 	}()
 
-	// Start price data refresh loop
 	go func() {
 		defer panics.LogOnPanic()
-		f.priceRefreshLoop(ctx)
+		// Prices wait a moment before their first tick, so that a fresh
+		// subscription fetches the markets page first.
+		f.refreshLoop(ctx, f.config.PriceUpdateInterval, time.Second, prices, f.FetchPrices, TickerPriceUpdateSource)
 	}()
 }
 
-// cryptoRefreshLoop periodically fetches the full cryptocurrency data
-func (f *ProxyFetcher) cryptoRefreshLoop(ctx context.Context) {
-	// Set up ticker for periodic updates
-	ticker := time.NewTicker(f.config.FullDataInterval)
+// RefreshNow makes both loops fetch as soon as they come round, rather than at
+// their next tick. The sends are non-blocking against buffered channels, so
+// triggers arriving faster than the loops can serve them collapse into one.
+func (f *ProxyFetcher) RefreshNow() {
+	markets, prices := f.triggers()
+	for _, trigger := range []chan struct{}{markets, prices} {
+		select {
+		case trigger <- struct{}{}:
+		default:
+		}
+	}
+}
+
+// claimLoops reserves the refresh loops and hands back what they need to run.
+// ok is false when they are already running.
+func (f *ProxyFetcher) claimLoops() (ctx context.Context, markets, prices chan struct{}, ok bool) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	if f.cancelFunc != nil {
+		return nil, nil, nil, false
+	}
+
+	ctx, f.cancelFunc = context.WithCancel(context.Background())
+	f.refreshMarkets = make(chan struct{}, 1)
+	f.refreshPrices = make(chan struct{}, 1)
+
+	return ctx, f.refreshMarkets, f.refreshPrices, true
+}
+
+// releaseLoops cancels the refresh loops and drops their triggers, so that a
+// trigger fired while they are stopped cannot queue a fetch for the next start.
+func (f *ProxyFetcher) releaseLoops() {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	if f.cancelFunc == nil {
+		return
+	}
+	f.cancelFunc()
+	f.cancelFunc = nil
+	f.refreshMarkets = nil
+	f.refreshPrices = nil
+}
+
+// triggers returns the loop triggers, or nils while the loops are stopped.
+// A send on a nil channel never proceeds, so the non-blocking selects in
+// RefreshNow fall through and the trigger is dropped.
+func (f *ProxyFetcher) triggers() (markets, prices chan struct{}) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.refreshMarkets, f.refreshPrices
+}
+
+// refreshLoop drives one endpoint: it fetches on its own tick and whenever it
+// is triggered, and reports each success to the subscribers, which is what
+// carries the new values out to the client.
+func (f *ProxyFetcher) refreshLoop(ctx context.Context, interval, startDelay time.Duration, trigger <-chan struct{}, fetch func(context.Context) error, source int) {
+	if startDelay > 0 {
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(startDelay):
+		}
+	}
+
+	ticker := time.NewTicker(interval)
 	defer ticker.Stop()
 
 	for {
 		select {
 		case <-ctx.Done():
-			return // Context cancelled, stop the loop
+			return
 		case <-ticker.C:
-			if err := f.FetchMarkets(ctx); err != nil {
-				logutils.ZapLogger().Error("Error fetching crypto data", zap.Error(err))
-			} else {
-				f.subscriptionManager.Emit(ctx, TickerFullDataUpdateSource)
-			}
+			f.refresh(ctx, fetch, source)
+		case <-trigger:
+			f.refresh(ctx, fetch, source)
 		}
 	}
 }
 
-// priceRefreshLoop periodically fetches price updates
-func (f *ProxyFetcher) priceRefreshLoop(ctx context.Context) {
-	// Wait a short time before starting price updates
-	time.Sleep(1 * time.Second)
-
-	// Set up ticker for periodic updates
-	ticker := time.NewTicker(f.config.PriceUpdateInterval)
-	defer ticker.Stop()
-
-	for {
-		select {
-		case <-ctx.Done():
-			return // Context cancelled, stop the loop
-		case <-ticker.C:
-			if err := f.FetchPrices(ctx); err != nil {
-				logutils.ZapLogger().Error("Error fetching price data", zap.Error(err))
-			} else {
-				f.subscriptionManager.Emit(ctx, TickerPriceUpdateSource)
-			}
-		}
+func (f *ProxyFetcher) refresh(ctx context.Context, fetch func(context.Context) error, source int) {
+	if err := fetch(ctx); err != nil {
+		logutils.ZapLogger().Error("Market - error fetching data",
+			zap.Int("source", source), zap.Error(err))
+		return
 	}
+	f.subscriptionManager.Emit(ctx, source)
 }
 
 // FetchMarkets fetches the full market data
 func (f *ProxyFetcher) FetchMarkets(ctx context.Context) error {
 	etag := f.storage.GetCryptoEtag()
+	// The currency this response is requested in has to travel with it: by the
+	// time it lands the user may have selected another one.
+	currency := f.storage.GetCurrency()
 
-	body, newEtag, updated := f.fetchData(ctx, MARKETS_ENDPOINT, etag)
+	body, newEtag, updated := f.fetchData(ctx, MARKETS_ENDPOINT, etag, currency)
 	if !updated {
 		return nil
 	}
@@ -162,7 +221,7 @@ func (f *ProxyFetcher) FetchMarkets(ctx context.Context) error {
 	}
 
 	// Store data and etag atomically
-	f.storage.UpdateCryptoDataWithEtag(data.Data, newEtag)
+	f.storage.UpdateCryptoDataWithEtag(data.Data, newEtag, currency)
 
 	return nil
 }
@@ -170,8 +229,9 @@ func (f *ProxyFetcher) FetchMarkets(ctx context.Context) error {
 // FetchPrices fetches the latest price data
 func (f *ProxyFetcher) FetchPrices(ctx context.Context) error {
 	etag := f.storage.GetPriceEtag()
+	currency := f.storage.GetCurrency()
 
-	body, newEtag, updated := f.fetchData(ctx, PRICES_ENDPOINT, etag)
+	body, newEtag, updated := f.fetchData(ctx, PRICES_ENDPOINT, etag, currency)
 	if !updated {
 		return nil
 	}
@@ -201,14 +261,41 @@ func (f *ProxyFetcher) FetchPrices(ctx context.Context) error {
 	}
 
 	// Store data and etag atomically
-	f.storage.UpdatePriceDataWithEtag(priceData, newEtag)
+	f.storage.UpdatePriceDataWithEtag(priceData, newEtag, currency)
 
 	return nil
 }
 
-func (f *ProxyFetcher) fetchData(ctx context.Context, endpoint string, etag string) ([]byte, string, bool) {
+// fetchData requests an endpoint converted to the given display currency.
+// If the proxy rejects the currency it retries once without the conversion, so
+// an unsupported currency degrades to USD values instead of an empty tab.
+func (f *ProxyFetcher) fetchData(ctx context.Context, endpoint string, etag string, currency string) ([]byte, string, bool) {
+	convertCurrency := f.convertCurrencyFor(currency)
+
+	body, newEtag, err := f.doFetch(ctx, endpoint, etag, convertCurrency)
+	if err != nil && isUnsupportedCurrencyError(err) {
+		logutils.ZapLogger().Error("Market - proxy rejected the display currency, falling back to USD values",
+			zap.String("endpoint", endpoint),
+			zap.String("currency", convertCurrency),
+			zap.Error(err))
+		f.markCurrencyUnsupported(convertCurrency)
+		body, newEtag, err = f.doFetch(ctx, endpoint, etag, "")
+	}
+
+	if err != nil || body == nil {
+		return nil, newEtag, false
+	}
+	return body, newEtag, true
+}
+
+func (f *ProxyFetcher) doFetch(ctx context.Context, endpoint string, etag string, convertCurrency string) ([]byte, string, error) {
 	baseUrl := GetMarketProxyHost(f.config.UrlOverride.Reveal(), f.config.StageName)
 	url := f.client.BuildURL(baseUrl, endpoint)
+
+	var params netUrl.Values
+	if convertCurrency != "" {
+		params = netUrl.Values{convertCurrencyParam: []string{convertCurrency}}
+	}
 
 	options := []thirdparty.RequestOption{}
 
@@ -224,9 +311,47 @@ func (f *ProxyFetcher) fetchData(ctx context.Context, endpoint string, etag stri
 		Password: f.config.Password,
 	}))
 
-	body, newEtag, err := f.client.DoGetRequestWithEtag(ctx, url, nil, etag, options...)
-	if err != nil || body == nil {
-		return nil, newEtag, false
+	return f.client.DoGetRequestWithEtag(ctx, url, params, etag, options...)
+}
+
+// convertCurrencyFor returns the value to send as convert_currency, or an
+// empty string when no conversion is needed or possible: USD is what the proxy
+// already caches, and a currency it rejected once is not asked for again.
+func (f *ProxyFetcher) convertCurrencyFor(currency string) string {
+	currency = normalizeCurrency(currency)
+	if currency == DefaultCurrency {
+		return ""
 	}
-	return body, newEtag, true
+
+	if f.isCurrencyUnsupported(currency) {
+		return ""
+	}
+	return currency
+}
+
+func (f *ProxyFetcher) isCurrencyUnsupported(currency string) bool {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	_, unsupported := f.unsupportedCurrencies[currency]
+	return unsupported
+}
+
+func (f *ProxyFetcher) markCurrencyUnsupported(currency string) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.unsupportedCurrencies == nil {
+		f.unsupportedCurrencies = make(map[string]struct{})
+	}
+	f.unsupportedCurrencies[currency] = struct{}{}
+}
+
+// isUnsupportedCurrencyError reports whether the proxy answered
+// `400 {"error":"unsupported convert_currency: xyz"}`.
+func isUnsupportedCurrencyError(err error) bool {
+	var statusErr *thirdparty.HTTPStatusError
+	if !errors.As(err, &statusErr) {
+		return false
+	}
+	return statusErr.StatusCode == http.StatusBadRequest &&
+		strings.Contains(strings.ToLower(statusErr.Body), convertCurrencyParam)
 }

--- a/pkg/services/wallet/leaderboard/fetcher_test.go
+++ b/pkg/services/wallet/leaderboard/fetcher_test.go
@@ -97,7 +97,7 @@ func TestProxyFetcherFetchPrices(t *testing.T) {
 	})
 
 	t.Run("ETag not modified", func(t *testing.T) {
-		storage.UpdatePriceDataWithEtag(mockPriceData, "existing-etag")
+		storage.UpdatePriceDataWithEtag(mockPriceData, "existing-etag", DefaultCurrency)
 		oldPriceData := storage.GetPriceData()
 
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/pkg/services/wallet/leaderboard/persistence.go
+++ b/pkg/services/wallet/leaderboard/persistence.go
@@ -9,9 +9,16 @@ import (
 )
 
 type MarketDataPersistenceInterface interface {
-	UpsertCryptocurrencies(data []Cryptocurrency) error
-	GetCryptocurrencies() ([]Cryptocurrency, error)
+	// UpsertCryptocurrencies stores the rows together with the currency their
+	// values are expressed in.
+	UpsertCryptocurrencies(data []Cryptocurrency, currency string) error
+	// GetCryptocurrencies returns only the rows stored for the given currency;
+	// rows left over from another currency are a cache miss, not data.
+	GetCryptocurrencies(currency string) ([]Cryptocurrency, error)
 	DeleteCryptocurrencies(ids []string) error
+	// DeleteCryptocurrenciesNotIn drops every row that is not expressed in the
+	// given currency, so a currency switch cannot leave stale values behind.
+	DeleteCryptocurrenciesNotIn(currency string) error
 }
 
 type Persistence struct {
@@ -25,7 +32,7 @@ func NewPersistance(db *sql.DB) *Persistence {
 	}
 }
 
-func (p *Persistence) UpsertCryptocurrencies(cryptos []Cryptocurrency) error {
+func (p *Persistence) UpsertCryptocurrencies(cryptos []Cryptocurrency, currency string) error {
 	p.dataMutex.Lock()
 	defer p.dataMutex.Unlock()
 	tx, err := p.db.Begin()
@@ -41,13 +48,14 @@ func (p *Persistence) UpsertCryptocurrencies(cryptos []Cryptocurrency) error {
 	}()
 
 	query := sq.Insert("market_data").
-		Columns("id", "symbol", "current_price", "market_cap", "total_volume", "price_change_percentage_24h").
+		Columns("id", "symbol", "current_price", "market_cap", "total_volume", "price_change_percentage_24h", "currency").
 		Suffix(`ON CONFLICT (id) DO UPDATE SET
 	        symbol = excluded.symbol,
 	        current_price = excluded.current_price,
 	        market_cap = excluded.market_cap,
 	        total_volume = excluded.total_volume,
-	        price_change_percentage_24h = excluded.price_change_percentage_24h`).
+	        price_change_percentage_24h = excluded.price_change_percentage_24h,
+	        currency = excluded.currency`).
 		RunWith(tx)
 
 	for _, crypto := range cryptos {
@@ -58,6 +66,7 @@ func (p *Persistence) UpsertCryptocurrencies(cryptos []Cryptocurrency) error {
 			crypto.MarketCap,
 			crypto.TotalVolume,
 			crypto.PriceChangePercentage24h,
+			normalizeCurrency(currency),
 		)
 	}
 
@@ -86,11 +95,25 @@ func (p *Persistence) DeleteCryptocurrencies(ids []string) error {
 	return nil
 }
 
-func (p *Persistence) GetCryptocurrencies() ([]Cryptocurrency, error) {
+func (p *Persistence) DeleteCryptocurrenciesNotIn(currency string) error {
+	p.dataMutex.Lock()
+	defer p.dataMutex.Unlock()
+	queryDelete := sq.Delete("market_data").
+		Where(sq.NotEq{"currency": normalizeCurrency(currency)}).
+		RunWith(p.db)
+	_, err := queryDelete.Exec()
+	if err != nil {
+		return fmt.Errorf("failed to delete records of other currencies: %w", err)
+	}
+	return nil
+}
+
+func (p *Persistence) GetCryptocurrencies(currency string) ([]Cryptocurrency, error) {
 	p.dataMutex.Lock()
 	defer p.dataMutex.Unlock()
 	query := sq.Select("id", "symbol", "current_price", "market_cap", "total_volume", "price_change_percentage_24h").
-		From("market_data")
+		From("market_data").
+		Where(sq.Eq{"currency": normalizeCurrency(currency)})
 
 	rows, err := query.RunWith(p.db).Query()
 	if err != nil {

--- a/pkg/services/wallet/leaderboard/persistence_test.go
+++ b/pkg/services/wallet/leaderboard/persistence_test.go
@@ -38,13 +38,13 @@ func TestMarketDataPersistenceTestSuite(t *testing.T) {
 }
 
 func (s *MarketDataPersistenceTestSuite) TestUpsertAndGetCryptocurrencies() {
-	cryptos, err := s.marketDataPersistence.GetCryptocurrencies()
+	cryptos, err := s.marketDataPersistence.GetCryptocurrencies(DefaultCurrency)
 	s.Require().NoError(err)
 	s.Require().Equal(0, len(cryptos))
 
-	err = s.marketDataPersistence.UpsertCryptocurrencies(mockCrypto)
+	err = s.marketDataPersistence.UpsertCryptocurrencies(mockCrypto, DefaultCurrency)
 	s.Require().NoError(err)
-	cryptos, err = s.marketDataPersistence.GetCryptocurrencies()
+	cryptos, err = s.marketDataPersistence.GetCryptocurrencies(DefaultCurrency)
 	s.Require().NoError(err)
 	s.Require().Equal(len(mockCrypto), len(cryptos))
 	for i, crypto := range cryptos {
@@ -53,16 +53,16 @@ func (s *MarketDataPersistenceTestSuite) TestUpsertAndGetCryptocurrencies() {
 }
 
 func (s *MarketDataPersistenceTestSuite) TestDeleteCryptocurrencies() {
-	err := s.marketDataPersistence.UpsertCryptocurrencies(mockCrypto)
+	err := s.marketDataPersistence.UpsertCryptocurrencies(mockCrypto, DefaultCurrency)
 	s.Require().NoError(err)
-	cryptos, err := s.marketDataPersistence.GetCryptocurrencies()
+	cryptos, err := s.marketDataPersistence.GetCryptocurrencies(DefaultCurrency)
 	s.Require().NoError(err)
 	s.Require().Equal(len(mockCrypto), len(cryptos))
 
 	err = s.marketDataPersistence.DeleteCryptocurrencies([]string{mockCrypto[0].ID})
 	s.Require().NoError(err)
 
-	cryptos, err = s.marketDataPersistence.GetCryptocurrencies()
+	cryptos, err = s.marketDataPersistence.GetCryptocurrencies(DefaultCurrency)
 	s.Require().NoError(err)
 	s.Require().Equal(len(mockCrypto)-1, len(cryptos))
 	for i, crypto := range cryptos {

--- a/pkg/services/wallet/leaderboard/service.go
+++ b/pkg/services/wallet/leaderboard/service.go
@@ -6,13 +6,16 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"sync"
 
 	"go.uber.org/zap"
 
 	"github.com/ethereum/go-ethereum/event"
 
+	"github.com/status-im/status-go/internal/db/multiaccounts/settings"
 	"github.com/status-im/status-go/internal/logutils"
 	"github.com/status-im/status-go/internal/panics"
+	"github.com/status-im/status-go/pkg/pubsub"
 	"github.com/status-im/status-go/pkg/services/wallet/async"
 	"github.com/status-im/status-go/pkg/services/wallet/walletevent"
 )
@@ -44,6 +47,13 @@ var (
 	}
 )
 
+// CurrencySource provides the user's selected display currency. It is
+// satisfied by accounts.Database (which embeds the settings manager), the
+// source of truth for the `currency` setting.
+type CurrencySource interface {
+	GetCurrency() (string, error)
+}
+
 // MarketDataService manages market data fetching and provides access to the latest data
 type MarketDataService struct {
 	config    ServiceConfig
@@ -55,8 +65,19 @@ type MarketDataService struct {
 	storage *DataStorage
 	cache   *PageCache
 
-	// Subscription management
-	subscriptionManager    *SubscriptionManager
+	// Display currency
+	currencySource      CurrencySource
+	accountsPublisher   *pubsub.Publisher
+	subscriptionManager *SubscriptionManager
+
+	// mu guards the two pieces of lifecycle state below. Both are reached from
+	// the RPC handler, the scheduler callback and the settings watcher.
+	mu sync.Mutex
+	// currencyWatchStop closes to stop the settings watcher; nil while it is
+	// not running.
+	currencyWatchStop chan struct{}
+	// pageUpdateSubscription is the channel feeding the client push events;
+	// nil while no client is listening.
 	pageUpdateSubscription chan Signal
 }
 
@@ -65,8 +86,10 @@ type GetLeaderboardPageResponse struct {
 	ErrorCode ErrorCode `json:"error_code"`
 }
 
-// NewMarketDataService creates a new market data service with the given configuration
-func NewMarketDataService(config ServiceConfig, walletDB *sql.DB, feed *event.Feed) *MarketDataService {
+// NewMarketDataService creates a new market data service with the given configuration.
+// currencySource and accountsPublisher may be nil, in which case the display
+// currency is only taken from the client's page requests.
+func NewMarketDataService(config ServiceConfig, walletDB *sql.DB, feed *event.Feed, currencySource CurrencySource, accountsPublisher *pubsub.Publisher) *MarketDataService {
 	storage := NewDataStorage(walletDB)
 	subscriptionManager := NewSubscriptionManager()
 	return &MarketDataService{
@@ -77,20 +100,129 @@ func NewMarketDataService(config ServiceConfig, walletDB *sql.DB, feed *event.Fe
 		subscriptionManager: subscriptionManager,
 		scheduler:           async.NewScheduler(),
 		cache:               NewPageCache(),
+		currencySource:      currencySource,
+		accountsPublisher:   accountsPublisher,
 	}
 }
 
 // Start begins the data refresh loops
 func (s *MarketDataService) Start(ctx context.Context) {
+	// The currency has to be known before the persisted snapshot is read, so
+	// that a snapshot left over from another currency is not restored.
+	s.applyStoredCurrency()
 	s.storage.StartAsync()
+	s.startCurrencyWatch()
 	s.fetcher.Start(ctx)
 }
 
 // Stop halts all data refresh operations
 func (s *MarketDataService) Stop() {
+	s.releaseCurrencyWatch()
 	s.fetcher.Stop()
 	s.storage.WaitForStart()
 	s.UnsubscribeFromLeaderboard() //nolint:errcheck
+}
+
+// applyStoredCurrency seeds the display currency from the settings DB
+func (s *MarketDataService) applyStoredCurrency() {
+	if s.currencySource == nil {
+		return
+	}
+	currency, err := s.currencySource.GetCurrency()
+	if err != nil {
+		logutils.ZapLogger().Warn("Market - could not read the display currency setting", zap.Error(err))
+		return
+	}
+	s.setCurrency(currency, false)
+}
+
+// startCurrencyWatch follows the display currency setting. Cached leaderboard
+// values, the persisted snapshot and the ETags all belong to the currency they
+// were fetched in, so a change to it invalidates every one of them and calls
+// for fresh data.
+func (s *MarketDataService) startCurrencyWatch() {
+	if s.accountsPublisher == nil {
+		return
+	}
+
+	stop, ok := s.claimCurrencyWatch()
+	if !ok {
+		return
+	}
+
+	events, unsub := pubsub.Subscribe[settings.EventSettingChanged](s.accountsPublisher, 1)
+	go func() {
+		defer panics.LogOnPanic()
+		defer unsub()
+		s.watchCurrency(stop, events)
+	}()
+}
+
+// watchCurrency applies every currency the settings DB reports until stopped.
+func (s *MarketDataService) watchCurrency(stop <-chan struct{}, events <-chan settings.EventSettingChanged) {
+	for {
+		select {
+		case <-stop:
+			return
+		case ev, ok := <-events:
+			if !ok {
+				return
+			}
+			if !ev.Setting.Equals(settings.Currency) {
+				continue
+			}
+			currency, ok := ev.Value.(string)
+			if !ok {
+				continue
+			}
+			s.setCurrency(currency, true)
+		}
+	}
+}
+
+// claimCurrencyWatch reserves the settings watch and returns the channel it
+// should stop on. ok is false when a watch is already running.
+func (s *MarketDataService) claimCurrencyWatch() (<-chan struct{}, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.currencyWatchStop != nil {
+		return nil, false
+	}
+	s.currencyWatchStop = make(chan struct{})
+	return s.currencyWatchStop, true
+}
+
+// releaseCurrencyWatch stops a running settings watch, if there is one.
+func (s *MarketDataService) releaseCurrencyWatch() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.currencyWatchStop == nil {
+		return
+	}
+	close(s.currencyWatchStop)
+	s.currencyWatchStop = nil
+}
+
+// setCurrency switches the display currency, dropping everything cached for the
+// previous one.
+//
+// When refetch is set the running refresh loops are triggered, so the
+// replacement data travels the same path as any other refresh and reaches the
+// client as the usual update events. While no client is listening the loops are
+// stopped and the trigger is dropped; the cache stays invalidated, which leaves
+// the empty data reading as stale for the next page request to fill.
+func (s *MarketDataService) setCurrency(currency string, refetch bool) {
+	if !s.storage.SetCurrency(currency) {
+		return
+	}
+
+	s.cache.SetCurrency(currency)
+
+	if refetch {
+		s.fetcher.RefreshNow()
+	}
 }
 
 // GetCombinedData returns cryptocurrency data with updated price information
@@ -100,6 +232,8 @@ func (s *MarketDataService) GetCombinedData() []Cryptocurrency {
 }
 
 func (s *MarketDataService) isSubscribed() bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	return s.pageUpdateSubscription != nil
 }
 
@@ -159,6 +293,9 @@ func (s *MarketDataService) sendLeaderboardPageUpdate() {
 func (s *MarketDataService) FetchLeaderboardPageAsync(page, pageSize, sortOrder int, currency string) {
 	s.scheduler.Enqueue(fetchLeaderboardPageTask, func(ctx context.Context) (interface{}, error) {
 		s.storage.WaitForStart()
+		// The requested currency is the client's display currency. Switching it
+		// invalidates the cached data and ETags, so the fetch below is a full one.
+		s.setCurrency(currency, false)
 		if s.storage.IsDataStale() {
 			s.fetcher.FetchMarkets(ctx) //nolint:errcheck
 		}
@@ -194,33 +331,65 @@ func (s *MarketDataService) FetchLeaderboardPageAsync(page, pageSize, sortOrder 
 }
 
 func (s *MarketDataService) subscribeToLeaderboard() {
-	if s.isSubscribed() {
+	subscription, ok := s.claimSubscription()
+	if !ok {
 		return
 	}
 
-	s.fetcher.StartRefreshLoops()
-
-	s.pageUpdateSubscription = s.subscriptionManager.Subscribe()
 	go func() {
 		defer panics.LogOnPanic()
-		for sig := range s.pageUpdateSubscription {
-			switch sig.Source() {
-			case TickerFullDataUpdateSource:
-				s.sendLeaderboardPageUpdate()
-			case TickerPriceUpdateSource:
-				s.sendLeaderboardPagePricesUpdate()
-			}
-		}
+		s.pushRefreshes(subscription)
 	}()
+}
+
+// pushRefreshes turns every completed refresh into the matching client event.
+func (s *MarketDataService) pushRefreshes(subscription <-chan Signal) {
+	for sig := range subscription {
+		switch sig.Source() {
+		case TickerFullDataUpdateSource:
+			s.sendLeaderboardPageUpdate()
+		case TickerPriceUpdateSource:
+			s.sendLeaderboardPagePricesUpdate()
+		}
+	}
 }
 
 func (s *MarketDataService) UnsubscribeFromLeaderboard() error {
 	s.fetcher.Stop()
-	if !s.isSubscribed() {
+
+	subscription := s.releaseSubscription()
+	if subscription == nil {
 		return fmt.Errorf("No subscription found")
 	}
-	s.subscriptionManager.Unsubscribe(s.pageUpdateSubscription)
-	s.pageUpdateSubscription = nil
+	s.subscriptionManager.Unsubscribe(subscription)
 	s.cache.Clear()
 	return nil
+}
+
+// claimSubscription starts the refresh loops and installs the subscription that
+// carries their results to the client. ok is false when one is already
+// installed.
+func (s *MarketDataService) claimSubscription() (chan Signal, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.pageUpdateSubscription != nil {
+		return nil, false
+	}
+	s.fetcher.StartRefreshLoops()
+	s.pageUpdateSubscription = s.subscriptionManager.Subscribe()
+
+	return s.pageUpdateSubscription, true
+}
+
+// releaseSubscription clears the client subscription and hands back the channel
+// it was using, or nil when no client was listening.
+func (s *MarketDataService) releaseSubscription() chan Signal {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	subscription := s.pageUpdateSubscription
+	s.pageUpdateSubscription = nil
+
+	return subscription
 }

--- a/pkg/services/wallet/leaderboard/service_test.go
+++ b/pkg/services/wallet/leaderboard/service_test.go
@@ -36,11 +36,11 @@ type restartableMarketDataPersistence struct {
 	data     []Cryptocurrency
 }
 
-func (p *blockingMarketDataPersistence) UpsertCryptocurrencies([]Cryptocurrency) error {
+func (p *blockingMarketDataPersistence) UpsertCryptocurrencies([]Cryptocurrency, string) error {
 	return nil
 }
 
-func (p *blockingMarketDataPersistence) GetCryptocurrencies() ([]Cryptocurrency, error) {
+func (p *blockingMarketDataPersistence) GetCryptocurrencies(string) ([]Cryptocurrency, error) {
 	close(p.started)
 	<-p.release
 	return p.data, nil
@@ -50,11 +50,15 @@ func (p *blockingMarketDataPersistence) DeleteCryptocurrencies([]string) error {
 	return nil
 }
 
-func (p *restartableMarketDataPersistence) UpsertCryptocurrencies([]Cryptocurrency) error {
+func (p *blockingMarketDataPersistence) DeleteCryptocurrenciesNotIn(string) error {
 	return nil
 }
 
-func (p *restartableMarketDataPersistence) GetCryptocurrencies() ([]Cryptocurrency, error) {
+func (p *restartableMarketDataPersistence) UpsertCryptocurrencies([]Cryptocurrency, string) error {
+	return nil
+}
+
+func (p *restartableMarketDataPersistence) GetCryptocurrencies(string) ([]Cryptocurrency, error) {
 	attempt := <-p.attempts
 	close(attempt.started)
 	<-attempt.release
@@ -65,29 +69,34 @@ func (p *restartableMarketDataPersistence) DeleteCryptocurrencies([]string) erro
 	return nil
 }
 
+func (p *restartableMarketDataPersistence) DeleteCryptocurrenciesNotIn(string) error {
+	return nil
+}
+
 func NewMockFetcher(storage *DataStorage) *MockFetcher {
 	f := &MockFetcher{
 		storage: storage,
 	}
 	// Initialize data
-	f.storage.UpdateCryptoDataWithEtag(mockCrypto, "test-etag")
-	f.storage.UpdatePriceDataWithEtag(mockPriceData, "test-etag")
+	f.storage.UpdateCryptoDataWithEtag(mockCrypto, "test-etag", DefaultCurrency)
+	f.storage.UpdatePriceDataWithEtag(mockPriceData, "test-etag", DefaultCurrency)
 	return f
 }
 
 func (f *MockFetcher) FetchMarkets(ctx context.Context) error {
-	f.storage.UpdateCryptoDataWithEtag(mockCrypto, "test-etag")
+	f.storage.UpdateCryptoDataWithEtag(mockCrypto, "test-etag", DefaultCurrency)
 	return nil
 }
 
 func (f *MockFetcher) FetchPrices(ctx context.Context) error {
-	f.storage.UpdatePriceDataWithEtag(mockPriceData, "test-etag")
+	f.storage.UpdatePriceDataWithEtag(mockPriceData, "test-etag", DefaultCurrency)
 	return nil
 }
 
 func (f *MockFetcher) Start(ctx context.Context) {}
 func (f *MockFetcher) Stop()                     {}
 func (f *MockFetcher) StartRefreshLoops()        {}
+func (f *MockFetcher) RefreshNow()               {}
 
 func setupTestWalletDB(t *testing.T) (*sql.DB, func()) {
 	db, cleanup, err := testutils.SetupTestSQLDB(walletdb.DbInitializer{}, "wallet-tests")
@@ -180,7 +189,7 @@ func TestDataStorageStartDoesNotOverwriteFetchedData(t *testing.T) {
 
 	storage.StartAsync()
 	<-persistence.started
-	require.True(t, storage.UpdateCryptoDataWithEtag(fetchedData, "fresh-etag"))
+	require.True(t, storage.UpdateCryptoDataWithEtag(fetchedData, "fresh-etag", DefaultCurrency))
 
 	close(persistence.release)
 	storage.WaitForStart()

--- a/pkg/services/wallet/leaderboard/storage.go
+++ b/pkg/services/wallet/leaderboard/storage.go
@@ -15,20 +15,32 @@ import (
 
 const DATA_STALE_THRESHOLD = 10 * time.Minute
 
-// DataStorage manages the storage and retrieval of market data
+// DataStorage manages the storage and retrieval of market data.
+//
+// It is the one owner of the invariant that the cached values, their ETags and
+// the persisted snapshot are all expressed in `currency`: only SetCurrency
+// changes it, and every write is checked against it first.
 type DataStorage struct {
-	// Data and synchronization
+	marketDataPersistence MarketDataPersistenceInterface
+
+	// dataMutex guards everything below it.
+	dataMutex             sync.RWMutex
 	cryptoData            []Cryptocurrency
 	cryptoDataInitialized bool
-	startMu               sync.Mutex
-	startDone             chan struct{}
-
-	marketDataPersistence MarketDataPersistenceInterface
 	priceData             PriceMap
-	dataMutex             sync.RWMutex
 	cryptoEtag            string
 	priceEtag             string
 	lastUpdateTime        time.Time
+	// currency is the display currency the cached values are expressed in.
+	// Everything held here - data, etags and the persisted snapshot - is only
+	// valid for this currency.
+	currency string
+
+	// startMu guards startDone. It stays separate from dataMutex because
+	// WaitForStart blocks on startDone until Start finishes, and Start needs
+	// dataMutex to do so.
+	startMu   sync.Mutex
+	startDone chan struct{}
 }
 
 type FingerprintData map[string]string // map[crypto_id]fingerprint
@@ -38,6 +50,7 @@ func NewDataStorage(walletDB *sql.DB) *DataStorage {
 	return &DataStorage{
 		priceData:             make(PriceMap),
 		marketDataPersistence: NewPersistance(walletDB),
+		currency:              DefaultCurrency,
 	}
 }
 
@@ -47,16 +60,56 @@ func (s *DataStorage) Start() {
 		s.dataMutex.RUnlock()
 		return
 	}
+	currency := normalizeCurrency(s.currency)
 	s.dataMutex.RUnlock()
 
-	cryptoData, _ := s.marketDataPersistence.GetCryptocurrencies()
+	// Only the snapshot persisted for the currently selected currency may be
+	// restored; a snapshot left over from another currency is a cache miss.
+	cryptoData, _ := s.marketDataPersistence.GetCryptocurrencies(currency)
 
 	s.dataMutex.Lock()
 	defer s.dataMutex.Unlock()
-	if !s.cryptoDataInitialized {
+	if !s.cryptoDataInitialized && normalizeCurrency(s.currency) == currency {
 		s.cryptoData = cryptoData
 		s.cryptoDataInitialized = true
 	}
+}
+
+// GetCurrency returns the display currency the cached data is expressed in.
+func (s *DataStorage) GetCurrency() string {
+	s.dataMutex.RLock()
+	defer s.dataMutex.RUnlock()
+	return normalizeCurrency(s.currency)
+}
+
+// SetCurrency switches the display currency. Because the cached values, the
+// persisted snapshot and the ETags are all currency-specific, a switch drops
+// every one of them so the next fetch is a full fetch in the new currency.
+// It reports whether the currency actually changed.
+func (s *DataStorage) SetCurrency(currency string) bool {
+	currency = normalizeCurrency(currency)
+
+	s.dataMutex.Lock()
+	if normalizeCurrency(s.currency) == currency {
+		s.dataMutex.Unlock()
+		return false
+	}
+
+	s.currency = currency
+	s.cryptoData = nil
+	s.cryptoDataInitialized = false
+	s.priceData = make(PriceMap)
+	s.cryptoEtag = ""
+	s.priceEtag = ""
+	s.lastUpdateTime = time.Time{}
+	persistence := s.marketDataPersistence
+	s.dataMutex.Unlock()
+
+	if err := persistence.DeleteCryptocurrenciesNotIn(currency); err != nil {
+		logutils.ZapLogger().Error("Market - error dropping data of the previous currency", zap.Error(err))
+	}
+
+	return true
 }
 
 func (s *DataStorage) StartAsync() {
@@ -81,9 +134,21 @@ func (s *DataStorage) WaitForStart() {
 	}
 }
 
-// UpdateCryptoDataWithEtag updates both cryptocurrency data and etag atomically
-// Returns true if the data was actually updated
-func (s *DataStorage) UpdateCryptoDataWithEtag(data []Cryptocurrency, etag string) bool {
+// matchesCurrency reports whether a response fetched in fetchedIn still belongs
+// here. Fetching and storing are not one atomic step, so the display currency
+// can change while a request is in flight; storing such a response would label
+// one currency's values as another's, and would refresh the timestamp that
+// decides whether anything needs fetching at all.
+// Callers must hold dataMutex.
+func (s *DataStorage) matchesCurrency(fetchedIn string) bool {
+	return normalizeCurrency(fetchedIn) == normalizeCurrency(s.currency)
+}
+
+// UpdateCryptoDataWithEtag updates both cryptocurrency data and etag atomically.
+// fetchedIn is the display currency the response was requested in; an update
+// that no longer matches the selected currency is dropped. It reports whether
+// the data was stored.
+func (s *DataStorage) UpdateCryptoDataWithEtag(data []Cryptocurrency, etag string, fetchedIn string) bool {
 	if data == nil {
 		return false
 	}
@@ -91,12 +156,16 @@ func (s *DataStorage) UpdateCryptoDataWithEtag(data []Cryptocurrency, etag strin
 	s.dataMutex.Lock()
 	defer s.dataMutex.Unlock()
 
+	if !s.matchesCurrency(fetchedIn) {
+		return false
+	}
+
 	s.cryptoDataInitialized = true
 	currentIds := s.extractCryptocurrencyIDs(s.cryptoData)
 	s.cryptoData = data
 	s.cryptoEtag = etag
 	s.lastUpdateTime = time.Now()
-	err := s.marketDataPersistence.UpsertCryptocurrencies(s.cryptoData)
+	err := s.marketDataPersistence.UpsertCryptocurrencies(s.cryptoData, s.currency)
 	if err != nil {
 		logutils.ZapLogger().Error("Market - error creating database snapshot", zap.Error(err))
 	}
@@ -136,15 +205,21 @@ func (s *DataStorage) IsDataStale() bool {
 	return time.Since(s.lastUpdateTime) > DATA_STALE_THRESHOLD
 }
 
-// UpdatePriceDataWithEtag updates both price data and etag atomically
-// Returns true if the data was actually updated
-func (s *DataStorage) UpdatePriceDataWithEtag(data PriceMap, etag string) bool {
+// UpdatePriceDataWithEtag updates both price data and etag atomically.
+// fetchedIn is the display currency the response was requested in; an update
+// that no longer matches the selected currency is dropped. It reports whether
+// the data was stored.
+func (s *DataStorage) UpdatePriceDataWithEtag(data PriceMap, etag string, fetchedIn string) bool {
 	if data == nil {
 		return false
 	}
 
 	s.dataMutex.Lock()
 	defer s.dataMutex.Unlock()
+
+	if !s.matchesCurrency(fetchedIn) {
+		return false
+	}
 
 	s.priceData = data
 	s.priceEtag = etag

--- a/pkg/services/wallet/leaderboard/storage_test.go
+++ b/pkg/services/wallet/leaderboard/storage_test.go
@@ -86,7 +86,7 @@ func insertCryptoDataToDatabase(t *testing.T, db *sql.DB, cryptoData []Cryptocur
 	t.Helper()
 
 	persistence := NewPersistance(db)
-	err := persistence.UpsertCryptocurrencies(cryptoData)
+	err := persistence.UpsertCryptocurrencies(cryptoData, DefaultCurrency)
 	require.NoError(t, err)
 }
 
@@ -104,7 +104,7 @@ func TestGetLeaderboardPageErrors(t *testing.T) {
 	defer cleanup()
 	s := NewDataStorage(db)
 	s.Start()
-	s.UpdateCryptoDataWithEtag(mockCrypto, "test-etag")
+	s.UpdateCryptoDataWithEtag(mockCrypto, "test-etag", DefaultCurrency)
 
 	{
 		_, err := s.GetLeaderboardPage(-1, 10, -1, "usd")
@@ -126,7 +126,7 @@ func TestGetLeaderboardPage(t *testing.T) {
 	db, cleanup := setupTestWalletDB(t)
 	defer cleanup()
 	s := NewDataStorage(db)
-	s.UpdateCryptoDataWithEtag(mockCrypto, "test-etag")
+	s.UpdateCryptoDataWithEtag(mockCrypto, "test-etag", DefaultCurrency)
 
 	{
 		_, err := s.GetLeaderboardPage(0, 3, -1, "usd")
@@ -181,8 +181,8 @@ func TestGetLeaderboardPageWithUpdatedPrices(t *testing.T) {
 	db, cleanup := setupTestWalletDB(t)
 	defer cleanup()
 	s := NewDataStorage(db)
-	s.UpdateCryptoDataWithEtag(mockCrypto, "test-etag")
-	s.UpdatePriceDataWithEtag(mockPriceData, "test-etag")
+	s.UpdateCryptoDataWithEtag(mockCrypto, "test-etag", DefaultCurrency)
+	s.UpdatePriceDataWithEtag(mockPriceData, "test-etag", DefaultCurrency)
 
 	{
 		rst, err := s.GetLeaderboardPage(1, 3, -1, "usd")
@@ -203,8 +203,8 @@ func TestGetLeaderboardPagePrices(t *testing.T) {
 	db, cleanup := setupTestWalletDB(t)
 	defer cleanup()
 	s := NewDataStorage(db)
-	s.UpdateCryptoDataWithEtag(mockCrypto, "test-etag")
-	s.UpdatePriceDataWithEtag(mockPriceData, "test-etag")
+	s.UpdateCryptoDataWithEtag(mockCrypto, "test-etag", DefaultCurrency)
+	s.UpdatePriceDataWithEtag(mockPriceData, "test-etag", DefaultCurrency)
 
 	{
 		rst, err := s.GetLeaderboardPage(2, 3, -1, "usd")
@@ -288,7 +288,7 @@ func TestGetLeaderboardPageDatabase(t *testing.T) {
 		require.Equal(t, 3, rst.TotalCount) // Only from database
 	}
 
-	s.UpdateCryptoDataWithEtag(mockCrypto, "test-etag")
+	s.UpdateCryptoDataWithEtag(mockCrypto, "test-etag", DefaultCurrency)
 
 	{
 		rst, err := s.GetLeaderboardPage(1, 3, -1, "usd")
@@ -330,7 +330,7 @@ func TestGetCombinedDataWithPriceUpdates(t *testing.T) {
 	defer cleanup()
 	s := NewDataStorage(db)
 
-	s.UpdateCryptoDataWithEtag(mockCrypto, "test-etag")
+	s.UpdateCryptoDataWithEtag(mockCrypto, "test-etag", DefaultCurrency)
 	combined := s.GetCombinedData()
 	require.Equal(t, len(mockCrypto), len(combined))
 	require.Equal(t, mockCrypto[0].CurrentPrice, combined[0].CurrentPrice)
@@ -349,7 +349,7 @@ func TestGetCombinedDataWithPriceUpdates(t *testing.T) {
 			PercentChange24h: 10.0,
 		},
 	}
-	s.UpdatePriceDataWithEtag(priceDataWithUpdates, "price-etag")
+	s.UpdatePriceDataWithEtag(priceDataWithUpdates, "price-etag", DefaultCurrency)
 
 	combined = s.GetCombinedData()
 	require.Equal(t, len(mockCrypto), len(combined))
@@ -370,7 +370,7 @@ func TestGetCombinedDataWithPriceUpdates(t *testing.T) {
 	priceDataWithZeros := map[string]PriceData{
 		"ripple": {Price: 2.0},
 	}
-	s.UpdatePriceDataWithEtag(priceDataWithZeros, "price-etag-2")
+	s.UpdatePriceDataWithEtag(priceDataWithZeros, "price-etag-2", DefaultCurrency)
 
 	combined = s.GetCombinedData()
 	require.Equal(t, priceDataWithZeros["ripple"].Price, combined[3].CurrentPrice)
@@ -383,7 +383,7 @@ func TestGetLeaderboardPagePricesWithIDLookup(t *testing.T) {
 	db, cleanup := setupTestWalletDB(t)
 	defer cleanup()
 	s := NewDataStorage(db)
-	s.UpdateCryptoDataWithEtag(mockCrypto, "test-etag")
+	s.UpdateCryptoDataWithEtag(mockCrypto, "test-etag", DefaultCurrency)
 
 	priceDataWithIDs := map[string]PriceData{
 		"bitcoin": {
@@ -399,7 +399,7 @@ func TestGetLeaderboardPagePricesWithIDLookup(t *testing.T) {
 			PercentChange24h: 13.0,
 		},
 	}
-	s.UpdatePriceDataWithEtag(priceDataWithIDs, "price-etag")
+	s.UpdatePriceDataWithEtag(priceDataWithIDs, "price-etag", DefaultCurrency)
 
 	rst := s.GetLeaderboardPagePrices(LeaderboardPage{
 		Page:      1,

--- a/pkg/services/wallet/leaderboard/utils.go
+++ b/pkg/services/wallet/leaderboard/utils.go
@@ -7,7 +7,21 @@ import (
 
 const (
 	MarketProxyHostSuffix = "market.status.im"
+
+	// DefaultCurrency is what the proxy serves when no conversion is requested.
+	DefaultCurrency = "usd"
 )
+
+// normalizeCurrency brings a display currency code into the form the proxy
+// expects (lowercase). Clients send it in whatever case they keep it in:
+// status-desktop uppercases it, the settings DB stores it lowercase.
+func normalizeCurrency(currency string) string {
+	currency = strings.ToLower(strings.TrimSpace(currency))
+	if currency == "" {
+		return DefaultCurrency
+	}
+	return currency
+}
 
 // GetMarketProxyHost creates market proxy base URL based on stage name
 func GetMarketProxyHost(customUrl, stageName string) string {

--- a/pkg/services/wallet/service.go
+++ b/pkg/services/wallet/service.go
@@ -311,7 +311,14 @@ func NewService(
 
 	routeExecutionManager := routeexecution.NewManager(db, feed, router, tokenManager, transactionManager)
 
-	leaderboardService := leaderboard.NewMarketDataService(leaderboardConfig, db, feed)
+	// The settings DB is the source of truth for the display currency the
+	// leaderboard has to be fetched in. Guarded so a nil DB does not end up as
+	// a non-nil interface value.
+	var currencySource leaderboard.CurrencySource
+	if accountsDB != nil {
+		currencySource = accountsDB
+	}
+	leaderboardService := leaderboard.NewMarketDataService(leaderboardConfig, db, feed, currencySource, accountsPublisher)
 
 	alchemyEthClientGetter := rpc.NewProviderChainClientGetter(common.SmartProxyAlchemy, rpcClient)
 	alchemyFetcherDb := activityfetcher_alchemy.NewPersistence(db)

--- a/pkg/services/wallet/service.go
+++ b/pkg/services/wallet/service.go
@@ -72,9 +72,10 @@ func createCoingeckoProxyClient(config params.MarketDataProxyConfig) *coingecko.
 	baseURL := leaderboard.GetMarketProxyUrl(config.UrlOverride.Reveal(), config.StageName)
 
 	return coingecko.NewClientWithParams(coingecko.Params{
-		URL:      baseURL,
-		User:     config.User,
-		Password: config.Password,
+		URL:           baseURL,
+		User:          config.User,
+		Password:      config.Password,
+		IsMarketProxy: true,
 	})
 }
 

--- a/pkg/services/wallet/thirdparty/http_client.go
+++ b/pkg/services/wallet/thirdparty/http_client.go
@@ -32,6 +32,22 @@ type BasicCreds struct {
 	Password security.SensitiveString
 }
 
+// HTTPStatusError is returned when a request completed but the server answered
+// with a non-2xx status code. Use errors.As to reach it when a specific status
+// has to be handled - a 400 rejecting a query parameter, say - so that the
+// decision does not rest on the error message.
+type HTTPStatusError struct {
+	StatusCode int
+	Body       string
+}
+
+func (e *HTTPStatusError) Error() string {
+	if e.Body != "" {
+		return fmt.Sprintf("Status code: %d - %s", e.StatusCode, e.Body)
+	}
+	return fmt.Sprintf("HTTP request failed with status code: %d", e.StatusCode)
+}
+
 // HTTPClient represents an HTTP client with configurable options
 type HTTPClient struct {
 	client     *http.Client
@@ -196,11 +212,7 @@ func (c *HTTPClient) doGetRequest(ctx context.Context, url string, params netUrl
 
 	// A non-2xx status code doesn't cause an error
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		if len(body) > 0 {
-			err = fmt.Errorf("Status code: %d - %s", resp.StatusCode, string(body))
-		} else {
-			err = fmt.Errorf("HTTP request failed with status code: %d", resp.StatusCode)
-		}
+		err = &HTTPStatusError{StatusCode: resp.StatusCode, Body: string(body)}
 		logutils.ZapLogger().Debug("GET request returned non-2xx status",
 			zap.String("url", url),
 			zap.Int("status", resp.StatusCode),

--- a/pkg/services/wallet/thirdparty/market/coingecko/client.go
+++ b/pkg/services/wallet/thirdparty/market/coingecko/client.go
@@ -33,6 +33,10 @@ type Client struct {
 	creds            *thirdparty.BasicCreds
 	coingeckoProKey  security.SensitiveString
 	coingeckoDemoKey security.SensitiveString
+
+	// isMarketProxy marks a client pointed at the Status market proxy, which
+	// understands convert_currency and normalizes vs_currency to usd.
+	isMarketProxy bool
 }
 
 type Params struct {
@@ -41,6 +45,9 @@ type Params struct {
 	Password            security.SensitiveString
 	CoingeckoAPIKey     security.SensitiveString
 	CoingeckoDemoAPIKey security.SensitiveString
+	// IsMarketProxy tells the client it talks to the Status market proxy
+	// rather than api.coingecko.com.
+	IsMarketProxy bool
 }
 
 func NewClientWithParams(params Params) *Client {
@@ -74,6 +81,7 @@ func NewClientWithParams(params Params) *Client {
 		creds:            creds,
 		coingeckoProKey:  params.CoingeckoAPIKey,
 		coingeckoDemoKey: params.CoingeckoDemoAPIKey,
+		isMarketProxy:    params.IsMarketProxy,
 	}
 }
 

--- a/pkg/services/wallet/thirdparty/market/coingecko/currency.go
+++ b/pkg/services/wallet/thirdparty/market/coingecko/currency.go
@@ -1,0 +1,83 @@
+package coingecko
+
+import "strings"
+
+const (
+	// baseCurrency is the currency /simple/price is asked for when the caller
+	// wants something else: `vs_currencies` is a required parameter and must
+	// not name the currency handed to convert_currency.
+	baseCurrency = "usd"
+
+	// convertCurrencyParam asks the market proxy for values in another
+	// currency. The proxy decides where they come from - provider values when
+	// it has them, a conversion otherwise. It is a proxy extension;
+	// api.coingecko.com does not know it.
+	convertCurrencyParam = "convert_currency"
+)
+
+func normalizeCurrency(currency string) string {
+	return strings.ToLower(strings.TrimSpace(currency))
+}
+
+// coinsMarketsCurrency decides how to ask for a currency on /coins/markets.
+// The proxy normalizes vs_currency to usd for cache consistency, so the only
+// parameter that has any effect there is convert_currency.
+func (c *Client) coinsMarketsCurrency(currency string) (vsCurrency string, convertCurrency string) {
+	normalized := normalizeCurrency(currency)
+	if !c.isMarketProxy || normalized == "" || normalized == baseCurrency {
+		return currency, ""
+	}
+	return baseCurrency, normalized
+}
+
+// simplePriceCurrencies decides how to ask for currencies on /simple/price.
+//
+// convert_currency names a single currency, so the first one asked for is
+// answered for certain; any others are passed through as vs_currencies and come
+// back only for those the proxy already holds.
+//
+// The converted currency is never repeated in vs_currencies: one currency
+// cannot be requested both ways.
+func (c *Client) simplePriceCurrencies(currencies []string) (vsCurrencies []string, convertCurrency string) {
+	if !c.isMarketProxy {
+		return currencies, ""
+	}
+
+	seen := make(map[string]struct{}, len(currencies))
+	var normalized []string
+	for _, currency := range currencies {
+		currency = normalizeCurrency(currency)
+		if currency == "" {
+			continue
+		}
+		if _, duplicate := seen[currency]; duplicate {
+			continue
+		}
+		seen[currency] = struct{}{}
+		normalized = append(normalized, currency)
+	}
+
+	for i, currency := range normalized {
+		if currency == baseCurrency {
+			continue
+		}
+		convertCurrency = currency
+		vsCurrencies = append(append([]string{}, normalized[:i]...), normalized[i+1:]...)
+		break
+	}
+
+	if convertCurrency == "" {
+		// Nothing to convert: the caller asked for the base currency, or for
+		// nothing at all - vs_currencies is required, so fill in the base.
+		if len(normalized) == 0 {
+			return []string{baseCurrency}, ""
+		}
+		return normalized, ""
+	}
+
+	if len(vsCurrencies) == 0 {
+		vsCurrencies = []string{baseCurrency}
+	}
+
+	return vsCurrencies, convertCurrency
+}

--- a/pkg/services/wallet/thirdparty/market/coingecko/currency_test.go
+++ b/pkg/services/wallet/thirdparty/market/coingecko/currency_test.go
@@ -1,0 +1,119 @@
+package coingecko
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	netUrl "net/url"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCoinsMarketsCurrency(t *testing.T) {
+	proxy := NewClientWithParams(Params{IsMarketProxy: true})
+	direct := NewClientWithParams(Params{})
+
+	t.Run("proxy converts anything but USD", func(t *testing.T) {
+		// status-desktop sends the code uppercased.
+		vsCurrency, convert := proxy.coinsMarketsCurrency("EUR")
+		require.Equal(t, baseCurrency, vsCurrency)
+		require.Equal(t, "eur", convert)
+	})
+
+	t.Run("proxy needs no conversion for USD", func(t *testing.T) {
+		vsCurrency, convert := proxy.coinsMarketsCurrency("USD")
+		require.Equal(t, "USD", vsCurrency)
+		require.Empty(t, convert)
+	})
+
+	t.Run("direct CoinGecko keeps vs_currency", func(t *testing.T) {
+		vsCurrency, convert := direct.coinsMarketsCurrency("EUR")
+		require.Equal(t, "EUR", vsCurrency)
+		require.Empty(t, convert)
+	})
+}
+
+func TestSimplePriceCurrencies(t *testing.T) {
+	proxy := NewClientWithParams(Params{IsMarketProxy: true})
+	direct := NewClientWithParams(Params{})
+
+	t.Run("the requested currency is asked for as convert_currency", func(t *testing.T) {
+		// Which currencies the proxy holds outright is its own business; the
+		// client asks for what it wants and lets the proxy pick the source.
+		vsCurrencies, convert := proxy.simplePriceCurrencies([]string{"JPY"})
+		require.Equal(t, []string{baseCurrency}, vsCurrencies)
+		require.Equal(t, "jpy", convert)
+
+		vsCurrencies, convert = proxy.simplePriceCurrencies([]string{"EUR"})
+		require.Equal(t, []string{baseCurrency}, vsCurrencies)
+		require.Equal(t, "eur", convert)
+	})
+
+	t.Run("the base currency needs no conversion", func(t *testing.T) {
+		vsCurrencies, convert := proxy.simplePriceCurrencies([]string{"USD"})
+		require.Equal(t, []string{baseCurrency}, vsCurrencies)
+		require.Empty(t, convert)
+	})
+
+	t.Run("the converted currency is never listed in vs_currencies", func(t *testing.T) {
+		vsCurrencies, convert := proxy.simplePriceCurrencies([]string{"USD", "JPY"})
+		require.Equal(t, "jpy", convert)
+		require.NotContains(t, vsCurrencies, convert)
+		require.Equal(t, []string{baseCurrency}, vsCurrencies)
+	})
+
+	t.Run("further currencies are asked for as vs_currencies", func(t *testing.T) {
+		// convert_currency names one currency, so only the first is certain;
+		// the rest are served if the proxy happens to hold them.
+		vsCurrencies, convert := proxy.simplePriceCurrencies([]string{"JPY", "PLN"})
+		require.Equal(t, "jpy", convert)
+		require.Equal(t, []string{"pln"}, vsCurrencies)
+	})
+
+	t.Run("duplicates are collapsed", func(t *testing.T) {
+		vsCurrencies, convert := proxy.simplePriceCurrencies([]string{"JPY", "jpy", "USD"})
+		require.Equal(t, "jpy", convert)
+		require.Equal(t, []string{baseCurrency}, vsCurrencies)
+	})
+
+	t.Run("an empty request still names a currency", func(t *testing.T) {
+		// vs_currencies is a required parameter.
+		vsCurrencies, convert := proxy.simplePriceCurrencies(nil)
+		require.Equal(t, []string{baseCurrency}, vsCurrencies)
+		require.Empty(t, convert)
+	})
+
+	t.Run("direct CoinGecko keeps vs_currencies", func(t *testing.T) {
+		vsCurrencies, convert := direct.simplePriceCurrencies([]string{"JPY"})
+		require.Equal(t, []string{"JPY"}, vsCurrencies)
+		require.Empty(t, convert)
+	})
+}
+
+func TestRequestsCarryConvertCurrency(t *testing.T) {
+	var query netUrl.Values
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		query = r.URL.Query()
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Path == "/simple/price" {
+			_, _ = w.Write([]byte(`{"bitcoin":{"usd":1,"jpy":150}}`))
+			return
+		}
+		_, _ = w.Write([]byte(`[]`))
+	}))
+	defer server.Close()
+
+	client := NewClientWithParams(Params{URL: server.URL, IsMarketProxy: true})
+
+	_, err := client.FetchCoinsMarkets(context.Background(), []string{"bitcoin"}, "JPY")
+	require.NoError(t, err)
+	require.Equal(t, baseCurrency, query.Get("vs_currency"))
+	require.Equal(t, "jpy", query.Get(convertCurrencyParam))
+
+	prices, err := client.FetchSimplePrice(context.Background(), []string{"bitcoin"}, []string{"JPY"})
+	require.NoError(t, err)
+	require.Equal(t, baseCurrency, query.Get("vs_currencies"))
+	require.Equal(t, "jpy", query.Get(convertCurrencyParam))
+	require.Equal(t, 150.0, prices["bitcoin"]["jpy"])
+}

--- a/pkg/services/wallet/thirdparty/market/coingecko/request_coins_markets.go
+++ b/pkg/services/wallet/thirdparty/market/coingecko/request_coins_markets.go
@@ -24,9 +24,14 @@ type GeckoMarketValues struct {
 
 func (c *Client) FetchCoinsMarkets(ctx context.Context, ids []string, currency string) ([]GeckoMarketValues, error) {
 
+	vsCurrency, convertCurrency := c.coinsMarketsCurrency(currency)
+
 	params := netUrl.Values{}
 	params.Add("ids", strings.Join(ids, ","))
-	params.Add("vs_currency", currency)
+	params.Add("vs_currency", vsCurrency)
+	if convertCurrency != "" {
+		params.Add(convertCurrencyParam, convertCurrency)
+	}
 	params.Add("order", "market_cap_desc")
 	params.Add("per_page", "250")
 	params.Add("page", "1")

--- a/pkg/services/wallet/thirdparty/market/coingecko/request_simple_price.go
+++ b/pkg/services/wallet/thirdparty/market/coingecko/request_simple_price.go
@@ -17,9 +17,14 @@ type SymbolPriceMap map[string]CurrencyPriceMap
 
 func (c *Client) FetchSimplePrice(ctx context.Context, ids []string, currencies []string) (SymbolPriceMap, error) {
 
+	vsCurrencies, convertCurrency := c.simplePriceCurrencies(currencies)
+
 	params := netUrl.Values{}
 	params.Add("ids", strings.Join(ids, ","))
-	params.Add("vs_currencies", strings.Join(currencies, ","))
+	params.Add("vs_currencies", strings.Join(vsCurrencies, ","))
+	if convertCurrency != "" {
+		params.Add(convertCurrencyParam, convertCurrency)
+	}
 	url := fmt.Sprintf(simplePriceURL, c.baseURL)
 	response, err := c.doGetRequestWithOptionalAuth(ctx, url, params)
 	if err != nil {


### PR DESCRIPTION
Replaces #7769

Cherry-pick of https://github.com/status-im/status-go/pull/7766 
Client side of status-im/status-app#21273

- Fetches the market tab in the display currency
- Reads the currency from settings, watches changes.
- A currency change clears cached data and ETags.
- Responses that raced a change are dropped.
- Unsupported currency degrades honestly to USD.
- coins/markets and simple/price ask convertible currencies.

Desktop pr: https://github.com/status-im/status-app/pull/22102
market-proxy pr: https://github.com/status-im/market-proxy/pull/81