### PR TITLE
build: upgrade protobuf to v36 and run protoc-gen-go as a go tool

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Setup Protocol Buffer Compiler
         uses: arduino/setup-protoc@v3
         with:
-          version: '29.3'
+          version: '36.0'
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Cache go-generate-fast

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -19,20 +19,6 @@ jobs:
       - name: Get dependencies
         run: go mod download
 
-      - name: Cache Go dependencies
-        uses: actions/cache@v4
-        id: cache-go-deps
-        with:
-          path: ~/go/bin
-          key: go-deps-${{ runner.os }}-v4.0.2-protoc-gen-go-v1.34.1
-          restore-keys: |
-            go-deps-${{ runner.os }}-
-
-      - name: Install Go dependencies
-        if: steps.cache-go-deps.outputs.cache-hit != 'true'
-        run: |
-          go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.34.1
-
       - name: Setup Protocol Buffer Compiler
         uses: arduino/setup-protoc@v3
         with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -58,7 +58,6 @@ WORKDIR /go/src/github.com/status-im/status-go
 
 ADD go.mod go.sum ./
 RUN go mod download
-RUN go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.34.1
 
 ADD . .
 ARG cache_id='local'

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,9 +6,23 @@ ENV CC=clang
 ENV CXX=clang++
 
 RUN apt-get update \
-    && apt-get install -y git bash make cmake llvm clang protobuf-compiler build-essential pkg-config curl xz-utils jq unzip \
+    && apt-get install -y git bash make cmake llvm clang build-essential pkg-config curl xz-utils jq unzip \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
+
+# Install protoc from pre-built binaries
+ARG PROTOC_VERSION=36.0
+RUN set -eu && \
+    DPKG_ARCH="$(dpkg --print-architecture)" && \
+    case "$DPKG_ARCH" in \
+    amd64) PROTOC_ARCH="x86_64" ;; \
+    arm64) PROTOC_ARCH="aarch_64" ;; \
+    *) echo "Unsupported architecture: $DPKG_ARCH" >&2; exit 1 ;; \
+    esac && \
+    curl -sSfL "https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VERSION}/protoc-${PROTOC_VERSION}-linux-${PROTOC_ARCH}.zip" -o /tmp/protoc.zip && \
+    unzip -q /tmp/protoc.zip -d /usr/local bin/protoc 'include/*' && \
+    rm /tmp/protoc.zip && \
+    protoc --version
 
 # Install Nim from pre-built binaries
 ARG NIM_VERSION=2.2.4

--- a/Makefile
+++ b/Makefile
@@ -401,7 +401,6 @@ cmd: status-backend push-notification-server
 status-go-deps:
 	go clean -cache || true
 	go clean -modcache || true
-	go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.34.1
 
 # GOOS and GOARCH are essential to generate cbindings when cross compiling on macos
 GO_HOST_ENV = GOOS=$(shell go env GOHOSTOS) GOARCH=$(shell go env GOHOSTARCH)

--- a/_assets/ci/Jenkinsfile.desktop
+++ b/_assets/ci/Jenkinsfile.desktop
@@ -138,7 +138,7 @@ def assembePath(List<String> extraPaths) {
       'C:/ProgramData/scoop/apps/msys2/current/mingw64/lib',
       'C:/ProgramData/scoop/apps/vcredist2022/14.44.35211.0',
       'C:/ProgramData/scoop/apps/openssl-lts/3.0.19/bin',
-      'C:/ProgramData/scoop/apps/protobuf/3.20.1/bin',
+      'C:/ProgramData/scoop/apps/protobuf/36.0/bin',
       'C:/ProgramData/scoop/apps/inno-setup/6.7.0',
       'C:/ProgramData/scoop/apps/git/current/bin',
       'C:/ProgramData/scoop/shims',

--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ replace github.com/mutecomm/go-sqlcipher/v4 v4.4.2 => github.com/status-im/go-sq
 
 replace github.com/libp2p/go-libp2p-pubsub v0.13.1 => github.com/waku-org/go-libp2p-pubsub v0.13.1-gowaku
 
-replace github.com/oNaiPs/go-generate-fast v0.3.0 => github.com/status-im/go-generate-fast v0.0.0-20250916164518-c78009bcfa9e
+replace github.com/oNaiPs/go-generate-fast v0.3.0 => github.com/status-im/go-generate-fast v0.0.0-20260821115326-e0f0915e0942
 
 require (
 	github.com/anacrolix/torrent v1.41.0

--- a/go.mod
+++ b/go.mod
@@ -65,7 +65,7 @@ require (
 	go.uber.org/zap v1.27.0
 	golang.org/x/crypto v0.43.0
 	golang.org/x/image v0.24.0
-	google.golang.org/protobuf v1.36.4
+	google.golang.org/protobuf v1.36.12
 	gopkg.in/go-playground/assert.v1 v1.2.1 // indirect
 	gopkg.in/go-playground/validator.v9 v9.31.0
 	gopkg.in/natefinch/lumberjack.v2 v2.2.1

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ tool (
 	github.com/status-im/goroutine-defer-guard/cmd/goroutine-defer-guard
 	github.com/wadey/gocovmerge
 	go.uber.org/mock/mockgen
+	google.golang.org/protobuf/cmd/protoc-gen-go
 )
 
 replace github.com/rjeczalik/notify => github.com/status-im/notify v1.0.2-status
@@ -259,7 +260,7 @@ require (
 	github.com/golangci/revgrep v0.5.2 // indirect
 	github.com/golangci/unconvert v0.0.0-20180507085042-28b1c447d1f4 // indirect
 	github.com/google/btree v1.0.1 // indirect
-	github.com/google/go-cmp v0.6.0 // indirect
+	github.com/google/go-cmp v0.7.0 // indirect
 	github.com/google/gofuzz v1.2.0 // indirect
 	github.com/google/gopacket v1.1.19 // indirect
 	github.com/google/pprof v0.0.0-20250317173921-a4b03ec1a45e // indirect

--- a/go.sum
+++ b/go.sum
@@ -2275,8 +2275,8 @@ github.com/status-im/doubleratchet v3.0.0+incompatible h1:aJ1ejcSERpSzmWZBgtfYti
 github.com/status-im/doubleratchet v3.0.0+incompatible/go.mod h1:1sqR0+yhiM/bd+wrdX79AOt2csZuJOni0nUDzKNuqOU=
 github.com/status-im/extkeys v1.4.0 h1:HiB/vQXZrGveZbGy3W6hI4T0CfCt0uP4xvGwjXL4cAQ=
 github.com/status-im/extkeys v1.4.0/go.mod h1:AZGS9vJKbME5tovNqYH/LrfHu8t9ad9nxl76fbLG5PY=
-github.com/status-im/go-generate-fast v0.0.0-20250916164518-c78009bcfa9e h1:GV7a03166mVZLUlfMBDbJOjfEB4A+iJ8rYvKlDUvOLA=
-github.com/status-im/go-generate-fast v0.0.0-20250916164518-c78009bcfa9e/go.mod h1:iktiTcPdK+nuL47hn+7UL12uIkgJYyOAh99jdA6ruGw=
+github.com/status-im/go-generate-fast v0.0.0-20260821115326-e0f0915e0942 h1:rEX4iH8jNbuwpyLDrRddVjC35Bcc/Ts6PG/ozSw+OyM=
+github.com/status-im/go-generate-fast v0.0.0-20260821115326-e0f0915e0942/go.mod h1:iktiTcPdK+nuL47hn+7UL12uIkgJYyOAh99jdA6ruGw=
 github.com/status-im/go-sqlcipher/v4 v4.5.4-status.3 h1:/73h1w1hUfb3wVyTlNrUIwahZxatgesCHa6lwO57C2M=
 github.com/status-im/go-sqlcipher/v4 v4.5.4-status.3/go.mod h1:mF2UmIpBnzFeBdu/ypTDb/LdbS0nk0dfSN1WUsWTjMA=
 github.com/status-im/go-wallet-sdk v0.0.0-20260728092705-f70963a74b0e h1:EV0EVv9S/F1lRPcDhbw42X2m918FmPwO2GbWZhg1G/Y=

--- a/go.sum
+++ b/go.sum
@@ -1138,8 +1138,8 @@ github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.8/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
-github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
-github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
+github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
 github.com/google/go-containerregistry v0.5.1/go.mod h1:Ct15B4yir3PLOP5jsy0GNeYVaIZs/MK/Jz5any1wFW0=
 github.com/google/go-github v17.0.0+incompatible/go.mod h1:zLgOLi98H3fifZn+44m+umXrS52loVEgC2AApnigrVQ=
 github.com/google/go-github/v39 v39.2.0/go.mod h1:C1s8C5aCC9L+JXIYpJM5GYytdX52vC1bLvHEF1IhBrE=

--- a/go.sum
+++ b/go.sum
@@ -3376,8 +3376,8 @@ google.golang.org/protobuf v1.25.0/go.mod h1:9JNX74DMeImyA3h4bdi1ymwjUzf21/xIlba
 google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
 google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
 google.golang.org/protobuf v1.27.1/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
-google.golang.org/protobuf v1.36.4 h1:6A3ZDJHn/eNqc1i+IdefRzy/9PokBTPvcqMySR7NNIM=
-google.golang.org/protobuf v1.36.4/go.mod h1:9fA7Ob0pmnwhb644+1+CVWFRbNajQ6iRojtC/QF5bRE=
+google.golang.org/protobuf v1.36.12 h1:pJOKDDOyeXErUroCihFAd5LQuwXBSpVnKGrj5o/fwxc=
+google.golang.org/protobuf v1.36.12/go.mod h1:HTf+CrKn2C3g5S8VImy6tdcUvCska2kB7j23XfzDpco=
 gopkg.in/airbrake/gobrake.v2 v2.0.9/go.mod h1:/h5ZAUhDkGaJfjzjKLSjv6zCL6O0LLBxU4K+aSYdM/U=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/internal/protocol/protobuf/service.go
+++ b/internal/protocol/protobuf/service.go
@@ -4,7 +4,7 @@ import (
 	"github.com/golang/protobuf/proto"
 )
 
-//go:generate protoc --go_out=. ./chat_message.proto ./application_metadata_message.proto ./membership_update_message.proto ./command.proto ./contact.proto ./pairing.proto ./push_notifications.proto ./emoji_reaction.proto ./enums.proto ./group_chat_invitation.proto ./chat_identity.proto ./communities.proto ./pin_message.proto ./anon_metrics.proto ./status_update.proto ./sync_settings.proto ./contact_verification.proto ./community_update.proto ./url_data.proto ./community_privileged_user_sync_message.proto ./profile_showcase.proto ./messenger_local_backup.proto ./wallet_local_backup.proto ./accounts_local_backup.proto
+//go:generate protoc "--go_prefix=go tool" --go_out=. ./chat_message.proto ./application_metadata_message.proto ./membership_update_message.proto ./command.proto ./contact.proto ./pairing.proto ./push_notifications.proto ./emoji_reaction.proto ./enums.proto ./group_chat_invitation.proto ./chat_identity.proto ./communities.proto ./pin_message.proto ./anon_metrics.proto ./status_update.proto ./sync_settings.proto ./contact_verification.proto ./community_update.proto ./url_data.proto ./community_privileged_user_sync_message.proto ./profile_showcase.proto ./messenger_local_backup.proto ./wallet_local_backup.proto ./accounts_local_backup.proto
 
 func Unmarshal(payload []byte) (*ApplicationMetadataMessage, error) {
 	var message ApplicationMetadataMessage

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -55,4 +55,10 @@ in rec {
 
   # Custom packages
   codecov-cli = callPackage ./pkgs/codecov-cli { };
+
+  # Not yet packaged in the pinned nixpkgs.
+  protobuf_36 = callPackage "${prev.path}/pkgs/development/libraries/protobuf/generic.nix" {
+    version = "36.0";
+    hash = "sha256-VGXFfqLm7IEJ9MQpMYhdVW5qPZbrYZ6q+0Y1TqQkjks=";
+  };
 }

--- a/nix/pkgs/status-go/library/default.nix
+++ b/nix/pkgs/status-go/library/default.nix
@@ -16,14 +16,14 @@ in pkgs.buildGoModule {
   src = builtins.path { path = ./../../../..; name = "status-go-library"; };
 
   # WARNING: Needs to be updated when go.mod is changed.
-  vendorHash = "sha256-hBC3727sAePd8STXyHgPKtgfcJEbr+zz9597KENAagc=";
+  vendorHash = "sha256-JlN0oiZANaF95hZOYFEKSHtmu5CHtWLE3uKDSTnMpI4=";
 
   inherit meta version;
 
   nativeBuildInputs = with pkgs; [
     mockgen
     protoc-gen-go
-    protobuf_29
+    protobuf_36
   ];
 
   phases = ["unpackPhase" "configurePhase" "buildPhase"];

--- a/nix/pkgs/status-go/library/default.nix
+++ b/nix/pkgs/status-go/library/default.nix
@@ -16,13 +16,12 @@ in pkgs.buildGoModule {
   src = builtins.path { path = ./../../../..; name = "status-go-library"; };
 
   # WARNING: Needs to be updated when go.mod is changed.
-  vendorHash = "sha256-JlN0oiZANaF95hZOYFEKSHtmu5CHtWLE3uKDSTnMpI4=";
+  vendorHash = "sha256-KTdd//keDwVjw1Jb9+Vt4zLoNx8Us4aHxP449HuROyM=";
 
   inherit meta version;
 
   nativeBuildInputs = with pkgs; [
     mockgen
-    protoc-gen-go
     protobuf_36
   ];
 

--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -10,7 +10,7 @@ in pkgs.mkShell {
   buildInputs = with pkgs; [
     git jq which gcc rustc cargo openjdk openssl nim go
     golangci-lint go-junit-report gopls
-    protobuf_29 protoc-gen-go gotestsum
+    protobuf_36 protoc-gen-go gotestsum
     libsds libstorage
   ] ++ lib.optionals (isDarwin) [
     pkgs.xcodeWrapper

--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -10,7 +10,7 @@ in pkgs.mkShell {
   buildInputs = with pkgs; [
     git jq which gcc rustc cargo openjdk openssl nim go
     golangci-lint go-junit-report gopls
-    protobuf_36 protoc-gen-go gotestsum
+    protobuf_36 gotestsum
     libsds libstorage
   ] ++ lib.optionals (isDarwin) [
     pkgs.xcodeWrapper

--- a/pkg/messaging/layers/encryption/protocol.go
+++ b/pkg/messaging/layers/encryption/protocol.go
@@ -21,7 +21,7 @@ import (
 	"github.com/status-im/status-go/pkg/messaging/layers/encryption/sharedsecret"
 )
 
-//go:generate protoc --go_out=. ./protocol_message.proto
+//go:generate protoc "--go_prefix=go tool" --go_out=. ./protocol_message.proto
 
 const (
 	protocolVersion                = 1

--- a/pkg/messaging/layers/reliability/protobuf/generate.go
+++ b/pkg/messaging/layers/reliability/protobuf/generate.go
@@ -1,3 +1,3 @@
 package protobuf
 
-//go:generate protoc --go_out=. ./retrieval_hint.proto
+//go:generate protoc "--go_prefix=go tool" --go_out=. ./retrieval_hint.proto

--- a/pkg/messaging/layers/segmentation/protobuf/generate.go
+++ b/pkg/messaging/layers/segmentation/protobuf/generate.go
@@ -1,3 +1,3 @@
 package protobuf
 
-//go:generate protoc --go_out=. ./segment_message.proto
+//go:generate protoc "--go_prefix=go tool" --go_out=. ./segment_message.proto


### PR DESCRIPTION
Backports #7738 and #7739 to `release/10.35.x`.

# Description

1. Cherry-picked #7738 — protoc v36 in the Nix dev shell, the `status-go-library` derivation, GitHub Actions and the `Dockerfile`, plus `google.golang.org/protobuf` v1.36.12.
2. Moved the pinned `go-generate-fast` fork from `c78009b` to `e0f0915` — the same commit plus the one-line `--go_prefix` flag declaration, without which the directives in the next commit make it panic.
3. Cherry-picked #7739 — `protoc-gen-go` declared in the `go.mod` `tool` block and invoked as `go tool` via `"--go_prefix=go tool"`, with every hand-rolled install of it removed.

<details>
<summary>AI-made decisions</summary>

- `develop` gets the `--go_prefix` support by tracking upstream go-generate-fast v0.5.0 (#7746). That release carries a ~190-module dependency refresh, so this branch takes the one-line fork bump instead — same behaviour, no dependency churn on a release branch.
- As a side effect this branch parses the directive better than `develop` does: v0.5.0 splits directives with `strings.Fields` and stops tracking `.proto` files as cache inputs, while the fork keeps the quote-aware splitter.
- `go.mod` needed `go mod tidy` after the cherry-picks; without it `go list ./...` returned nothing and `make generate` failed with `no Go files`.
- `vendorHash` recomputed; it matches the value this same combination produced on `develop`.

</details>
