### PR TITLE
feat(messaging): advertise WakuMessage version=0 on send (#7499 phase 2)

### DIFF
--- a/pkg/messaging/waku/api.go
+++ b/pkg/messaging/waku/api.go
@@ -32,14 +32,15 @@ import (
 // (EventEnvelopeAvailable) and no longer decodes/polls — status-im/status-go#7464.)
 
 // Send publishes a pre-encoded payload to the messaging network. The payload
-// is expected to be already encoded for WakuMessage version=1 (see
-// transport/rfc26.Encode); this method just wraps it in a WakuMessage
-// envelope and hands it to the publish path. Returns the wire hash.
+// is expected to be already RFC26-encoded (see transport/rfc26.Encode); this
+// method just wraps it in a WakuMessage envelope and hands it to the publish
+// path. The `version` field is a wire label independent of that encoding, and
+// is advertised as 0. Returns the wire hash.
 //
 // ctx is accepted for symmetry with transport.MessagingAPI; the send queue
 // uses the waku instance's own lifecycle context.
 func (w *Waku) Send(ctx context.Context, pubsubTopic, contentTopic string, payload []byte, ephemeral bool, priority *int) ([]byte, error) {
-	var version uint32 = 1 // wire-format discriminator; v1 encryption is applied by the caller
+	var version uint32 = 0 // wire label only; the payload is RFC26-encoded by the caller
 	msg := &pb.WakuMessage{
 		Payload:      payload,
 		Version:      &version,


### PR DESCRIPTION
Iterates #7499

Replaces #7539, which was closed after phase 1 (#7537, 2.38) to leave a two-release gap — 2.40 satisfies it. Re-applied on latest `develop`; GitHub would not reopen #7539 after the rewrite.

# Description

1. `Waku.Send` now advertises `version=0` on the wire. The payload is unchanged — still RFC26-encoded by the transport, which is what lets us adopt the logos-delivery Messaging API (defaults to `version=0`) without a wire-format break.

| Phase | App version | Receiving v0 | Receiving v1 | Sending |
|-|-|-|-|-|
| 1 | 2.38 | Decrypt | Decrypt | v1 (#7537) |
| **2** | **2.40** | Decrypt | Decrypt | **v0 ← this PR** |

Receivers since phase 1 decrypt regardless of the label, so a 2.38/2.39 peer still reads these, and this build still reads their `version=1`. No phase 3 — `logos-delivery` ignores the field.

<details>
<summary>AI-made decisions</summary>

- Kept the doc comment on `Send` accurate about the payload still being RFC26-encoded, since the wire label no longer implies the encoding.
- Dropped the explanatory block comment the earlier draft put at the assignment; the migration rationale lives in #7499 and in `transport.decode`.

</details>
