### PR TITLE
fix(waku): widen the filter full-node rate limit

### DIFF
--- a/pkg/messaging/waku/gowaku.go
+++ b/pkg/messaging/waku/gowaku.go
@@ -343,7 +343,10 @@ func New(nodeKey *ecdsa.PrivateKey, cfg *Config, logger *zap.Logger, ts timesour
 	}
 
 	if !cfg.IsLightClient() {
-		opts = append(opts, node.WithWakuFilterFullNode(filter.WithMaxSubscribers(20)))
+		opts = append(opts, node.WithWakuFilterFullNode(
+			filter.WithMaxSubscribers(20),
+			filter.WithFullNodeRateLimiter(15, 20),
+		))
 		opts = append(opts, node.WithLightPush(lightpush.WithRateLimiter(5, 10)))
 	}
 


### PR DESCRIPTION
Closes https://github.com/status-im/status-go/issues/7783

Iterates:
- #7513

Related to:
-  #7576

# Description

Increased filter full node rate limit to 15 req/sec with burst 20.
This matches `WithLightNodeRateLimiter` — ~~what light client is permitted to send~~ the rate limit light client applies on inbound pushed messages. 

This default is set [here](WithFullNodeRateLimiter)

Only `WithMaxSubscribers` was passed before, so the server kept go-waku's default of **1 request/sec, burst 1, per peer** and rejected a light client's normal subscribe burst with a 429, which parks that whole aggregated subscription for 60s.

## What caused this now?

`rpc-compat` job started consistently failing on `test_group_chat_compatibility[statusgo-peer-v10.35.0-full-light]`.
This happened right after cutting `10.35.x` release branch.

First, we didn't detect it earlier because the test suite misses `vut-vut`. Added it in:
- https://github.com/status-im/status-go/pull/7781

Then, the reason is: Status became 0.5s faster on subscriptions 😄 
In this test, it's measured to be ~1.5s between subscription requests in `vut-1.34` and ~0.97s in  `vut-1.35`. 

# AI details

<details>
<summary>AI-reasoning decisions</summary>

This is the status-go half of the fleet change in #7574. That PR lifted the nwaku fleet nodes to `filter:10000/1s` for exactly this reason — "a light client joining a community fans out many per-content-topic filter subscribe requests at once; nwaku's stock filter limit (30/min) answers with 429, which go-waku turns into a long subscription backoff". Status app nodes serve filter too, and kept the go-waku default.

The 429 against an app node is not new. In the `v10.34.1` community cell the light peer already sends two subscribes to the vut 7ms apart and gets rejected; it survived because the parked subscription did not happen to carry the message under assertion, and reruns absorbed it. What changed with `release/10.35.x` is narrower than it looks: across 7 reruns of `group_chat[v10.35.0-full-light]` the smallest gap between two consecutive subscribes to the vut is 0.987–0.994s, against 1.499s for `v10.34.1` — a **13ms miss** on a 1-token-per-second refill. Nothing in the mechanism differs: go-waku's `api/filter/filter.go` is byte-identical between 0.10.2 and 0.10.3, peer selection makes the same choices in the same order, `MaxPeersForFilter` is 3 in both, and `WithBatchInterval` is 300ms in both. Only app-level pacing moved, and it moved just far enough.

Once parked, the subscription carrying `/waku/1/0xd03992cd/rfc26` is not started when the vut publishes the group invite on that topic 5s later; it recovers 60s after the 429, about 5s after pytest's 60s `expect_signal` timeout. The backoff being ≥ the test timeout is what turns a survivable hiccup into a hard failure.

</details>

<details>
<summary>AI-made decisions</summary>

- Picked 15/20 over mirroring the neighbouring `lightpush.WithRateLimiter(5, 10)`: a server should not reject what the reference client is allowed to send, and the limiter is per-peer so the ceiling is still bounded by `MaxSubscribers`.
- Did not chase which commit shaved the ~500ms off the gap. It is app-flow pacing across 263 commits and would need a bisect; the margin was 13ms either way, so the limiter is the defect, not the pacing.
- First attempt dropped `WithWakuFilterFullNode` from Core nodes entirely, on a wrong reading that light clients were being poached away from the fleet. The peer-selection churn and `no suitable peers found` spam are real but harmless — the fleet subscription stays healthy throughout.
- Left `WithLightPush(5, 10)` alone; nothing in the evidence implicates lightpush.
- Residual 429s remain in the `light-full` cells, where the vut is the light client and the released peer is the server. Nothing on this side can change that — `v10.35.0` shipped with the tight limit — and reruns absorb it.
- Worth a separate go-waku issue: a 429 from one peer parks the entire aggregated subscription rather than just that peer, and 60s is long enough to look like message loss to any caller.

</details>
