### PR TITLE
test(functional): run the compatibility matrix against the build under test

### DIFF
--- a/test/functional/tests/test_chat_compatibility.py
+++ b/test/functional/tests/test_chat_compatibility.py
@@ -6,8 +6,13 @@ from utils.config import Config
 
 def pytest_generate_tests(metafunc):
     if "peer_image" in metafunc.fixturenames:
-        images = Config.peer_docker_images or ([Config.docker_image] if Config.docker_image else [])
-        ids = [(image.split(":")[-1] or "self") for image in images]
+        images, ids = [], []
+        for image in Config.peer_docker_images or []:
+            images.append(image)
+            ids.append(image.split(":")[-1] or "peer")
+        if Config.docker_image and Config.docker_image not in images:
+            images.append(Config.docker_image)
+            ids.append("self")
         metafunc.parametrize("peer_image", images, ids=ids)
 
 
@@ -23,6 +28,11 @@ def pytest_generate_tests(metafunc):
 )
 class TestChatCompatibility:
     """Cross-version chat smoke: vut (build under test) talks to peer (a released backend).
+
+    The peer set always includes the build under test itself (the "self" id), so the
+    mode matrix below is exercised same-version as well as cross-version. Nothing else
+    in the suite pairs a full node with a light one: the rpc tests parametrize a single
+    waku_light_client value across both sides.
 
     Each test runs in a full/light waku mode matrix: vut runs in the first mode,
     peer and third run in the second.


### PR DESCRIPTION
Blocked by #7780

# Description

1. Added the build under test to the compatibility suite's peer set, under the `self` id, so the full/light mode matrix runs same-version as well as cross-version.

Nothing else in the functional suite pairs a full node with a light one — `TestFetchingChatMessages` parametrizes a single `waku_light_client` value and applies it to both sides, so it only ever runs full-full and light-light. That gap is why the filter rate-limit bug in #7780 reached a release: it reproduces on develop against develop in the `full-light` cell, and the suite only caught it once `release/10.35.x` was cut and `v10.35.0` became recent enough to stand in for the vut.

This adds 12 cases (3 tests × 4 modes) and the suite runs serially, so the job gets meaningfully longer.

<details>
<summary>AI-made decisions</summary>

- The vut image goes last in the peer list, so an existing failure keeps the parametrization id it had before this change.
- Kept the fallback that used the vut image when no peers are resolved, rather than making `self` conditional on there being no peer refs — the point is for it to always run.
- Ids for resolved peer images now fall back to `peer` rather than `self` when an image has no tag, so `self` unambiguously means the build under test.

</details>
