### PR TITLE
test(functional): let light clients settle before driving the compat chat flow

### DIFF
--- a/test/functional/tests/test_chat_compatibility.py
+++ b/test/functional/tests/test_chat_compatibility.py
@@ -1,7 +1,21 @@
+import time
+
 import pytest
 
 from steps import messenger
 from utils.config import Config
+
+# A light client keeps topping up its filter subscription towards MaxPeersForFilter (3)
+# while the test fleet offers fewer servers, so it re-subscribes every ~5s. Let that
+# settle before the app starts creating filters, or the two collide inside one second
+# and the server's 1/s filter limit answers 429.
+LIGHT_SETTLE_SECONDS = 8
+
+
+def _settle(backend, is_light):
+    if is_light:
+        time.sleep(LIGHT_SETTLE_SECONDS)
+    return backend
 
 
 def pytest_generate_tests(metafunc):
@@ -30,15 +44,15 @@ class TestChatCompatibility:
 
     @pytest.fixture()
     def vut(self, backend_new_profile, vut_light):
-        return backend_new_profile("vut", waku_light_client=vut_light)
+        return _settle(backend_new_profile("vut", waku_light_client=vut_light), vut_light)
 
     @pytest.fixture()
     def peer(self, backend_new_profile, peer_image, peer_light):
-        return backend_new_profile("peer", image=peer_image, waku_light_client=peer_light)
+        return _settle(backend_new_profile("peer", image=peer_image, waku_light_client=peer_light), peer_light)
 
     @pytest.fixture()
     def third(self, backend_new_profile, peer_image, peer_light):
-        return backend_new_profile("third", image=peer_image, waku_light_client=peer_light)
+        return _settle(backend_new_profile("third", image=peer_image, waku_light_client=peer_light), peer_light)
 
     def test_one_to_one_compatibility(self, vut, peer):
         messenger.make_contacts(vut, peer)


### PR DESCRIPTION
Iterates #7513

Alternative to #7780, which raises the limit on the serving side instead.

# Description

1. Let a light client settle for 8s after login before the compat test drives the chat flow.

The light client keeps topping up its filter subscription towards `MaxPeersForFilter` (3) while the test fleet offers fewer filter servers, so it re-subscribes every ~5s indefinitely. Without a settle, one of those top-ups lands within a second of the app's first filter batch, and the peer's filter server — go-waku's default `1 request/sec, burst 1, per peer`, which status-go never overrides — answers 429. That parks the whole aggregated subscription for 60s, longer than the test's 60s `expect_signal` timeout.

Measured on `v10.35.0-full-light` against an unfixed backend: the smallest gap between two consecutive subscribes to the same server moves from 0.987s to 1.493s, the 429s go from 2 to 0, and the suite goes 12/12.

<details>
<summary>AI-made decisions</summary>

- 8s is empirical, not derived. It clears the ~5s top-up cadence with margin; the surviving gap is 1.493s against a 1s refill, so there is roughly half a second of headroom. If the app flow speeds up again this needs re-tuning — the same 13ms margin that made `v10.35.0` fail where `v10.34.1` passed at 1.499s.
- Settle in the fixtures rather than between test steps: the collision is between a discovery-driven top-up and the app's first filter batch, so a sleep between `make_contacts` and `join_private_group` would not touch the discovery half.
- This does not fix `test_community_compatibility`. Joining a community fans out many subscribes to the same server inside one operation — measured gap 0.0ms — so no test-level delay can separate them. That cell still takes 4 rate-limit parks per run and passes only because the parked subscription is not the one under assertion. It behaves the same against `v10.34.1`, so it predates the release cut.
- Considered adding a third filter-capable node to the test fleet so `MaxPeersForFilter` is satisfiable and the top-up loop stops. It fixes the same cell but not the community fan-out either, and costs another container.

</details>
