### PR TITLE
test(functional): name compat cases by both sides of the pairing

### DIFF
--- a/test/functional/tests/test_chat_compatibility.py
+++ b/test/functional/tests/test_chat_compatibility.py
@@ -4,28 +4,44 @@ from steps import messenger
 from utils.config import Config
 
 
+# vut mode, peer mode. The peer mode applies to both the peer and the third backend.
+CLIENT_MODES = [(False, False), (False, True), (True, False), (True, True)]
+
+
+def _mode(is_light: bool) -> str:
+    return "light" if is_light else "full"
+
+
+def _peer_label(image: str) -> str:
+    return image.split(":")[-1].removeprefix("statusgo-peer-") or "peer"
+
+
 def pytest_generate_tests(metafunc):
-    if "peer_image" in metafunc.fixturenames:
-        images, ids = [], []
-        for image in Config.peer_docker_images or []:
-            images.append(image)
-            ids.append(image.split(":")[-1] or "peer")
-        if Config.docker_image and Config.docker_image not in images:
-            images.append(Config.docker_image)
-            ids.append("self")
-        metafunc.parametrize("peer_image", images, ids=ids)
+    """Expand each test into one case per peer backend, per waku mode pair.
+
+    Peer backends are the released images the test runner resolved, plus the build
+    under test itself ("self"). The image and the two modes are parametrized in a
+    single call so that one id can name both sides of the pairing; separate
+    parametrize calls would leave pytest to join their ids with a "-".
+    """
+    if "peer_image" not in metafunc.fixturenames:
+        return
+
+    peer_images = list(Config.peer_docker_images or [])
+    if Config.docker_image and Config.docker_image not in peer_images:
+        peer_images.append(Config.docker_image)
+
+    cases = []
+    for image in peer_images:
+        peer = "self" if image == Config.docker_image else _peer_label(image)
+        for vut_light, peer_light in CLIENT_MODES:
+            case_id = f"self-{_mode(vut_light)}__{peer}-{_mode(peer_light)}"
+            cases.append(pytest.param(image, vut_light, peer_light, id=case_id))
+
+    metafunc.parametrize(("peer_image", "vut_light", "peer_light"), cases)
 
 
 @pytest.mark.compatibility
-@pytest.mark.parametrize(
-    ("vut_light", "peer_light"),
-    [
-        pytest.param(False, False, id="full-full"),
-        pytest.param(False, True, id="full-light"),
-        pytest.param(True, False, id="light-full"),
-        pytest.param(True, True, id="light-light"),
-    ],
-)
 class TestChatCompatibility:
     """Cross-version chat smoke: vut (build under test) talks to peer (a released backend).
 


### PR DESCRIPTION
Stacked on #7781.

# Description

1. Named compatibility cases by both sides of the pairing: `self-<mode>__<peer>-<mode>`.

```
test_group_chat_compatibility[self-full__v10.34.1-light]
test_group_chat_compatibility[self-full__self-light]
```

Previously `[statusgo-peer-v10.34.1-light-full]` — the version sat next to neither side, and telling which of the two modes belonged to the vut meant knowing the order of the `(vut_light, peer_light)` tuple.

2. Merged the mode matrix into `pytest_generate_tests`. The peer image and the two modes are one parametrization now, because a composed id cannot be built from two independent parametrize sources — pytest joins those with `-`.
3. Dropped the `statusgo-peer-` image-name prefix from the label.

<details>
<summary>AI-made decisions</summary>

- `__` rather than `<->`: the id goes verbatim into container log filenames (`statusgo_container.py:314`), JUnit `report.xml` testcase names, and `-k` expressions. Angle brackets are XML-escaped in the report and need shell quoting everywhere else.
- The peer-side mode labels both the `peer` and the `third` backend. They are always the same mode, so one label per side is accurate.
- Renaming resets test identity in Jenkins and Codecov — flaky history and anything keyed on test name treat these as new tests. Stacked on #7781 so it happens once rather than twice.
- `_peer_label` strips the prefix after splitting on `:`, so a registry-tagged image (`harbor.status.im/status-go:v10.34.1`) still labels as `v10.34.1`.

</details>
