### PR TITLE
test: exclude our own release from compat peer refs

### DIFF
--- a/scripts/run_functional_tests.sh
+++ b/scripts/run_functional_tests.sh
@@ -138,7 +138,10 @@ if [[ "${FUNCTIONAL_TESTS_MARKER}" == "compatibility" ]]; then
    if [[ -z "${PEER_REFS}" ]]; then
       echo "${GRN}Fetching git tags to determine peer refs${RST}"
       git fetch --tags --quiet || true
-      PEER_REFS="$(git tag --sort=-v:refname 2>/dev/null | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | awk -F. '!seen[$1"."$2]++' | head -2 | paste -sd' ' -)"
+      # Only a release branch shares a line with its peers; develop is always ahead of all of them.
+      target_branch="${CHANGE_TARGET:-${BRANCH_NAME:-$(git rev-parse --abbrev-ref HEAD 2>/dev/null)}}"
+      own_minor="$(printf '%s' "${target_branch}" | sed -nE 's|^release/([0-9]+)\.([0-9]+)\..*|v\1.\2|p')"
+      PEER_REFS="$(git tag --sort=-v:refname 2>/dev/null | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | awk -F. -v own="${own_minor}" '$1"."$2 != own && !seen[$1"."$2]++' | head -2 | paste -sd' ' -)"
     fi
     if [[ -z "${PEER_REFS}" ]]; then
       echo -e "${RED}No peer refs available. Set PEER_REFS or PEER_IMAGES.${RST}"


### PR DESCRIPTION
# Description

1. Excluded the build's own minor line when resolving compatibility peer refs, keyed on the target branch. On `release/10.35.x` the newest release tag is `v10.35.0`, so the suite paired the build under test against itself; peers there are now `v10.34.1 v10.33.2`.

Only a release branch shares a line with its peers — `develop` is always ahead of every release, so it keeps pairing against `v10.35.0 v10.34.1` as before. The branch comes from `CHANGE_TARGET`, then `BRANCH_NAME`, then the local checkout, and anything that is not `release/X.Y.*` resolves to no exclusion.

| target branch | peers |
| --- | --- |
| `release/10.35.x` | `v10.34.1 v10.33.2` |
| `release/10.36.x` | `v10.35.0 v10.34.1` |
| `develop`, `PR-1234`, unset | `v10.35.0 v10.34.1` |

<details>
<summary>AI-made decisions</summary>

- Keyed on the branch rather than on `git describe`. Deriving the own line from the newest reachable tag looks equivalent but is wrong on `develop`: `v10.35.0` is reachable from `develop`, so it would exclude 10.35 there too.
- Also rejected `git merge-base --is-ancestor`: `v10.35.0` is an ancestor of `develop` while `v10.34.0` is not, because the two tags were placed at different points relative to their release cuts.
- `CHANGE_TARGET` before `BRANCH_NAME` so a PR is judged by what it targets, not by its own name. Did not use the Jenkinsfile's `BRANCH` param — it defaults to `develop` and would mask the others.
- Left `PEER_REFS` / `PEER_IMAGES` overrides untouched; they still bypass resolution entirely.

</details>
