### PR TITLE
fix(wallet): handle zkSync native-token alias as a canonical native token

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -101,7 +101,7 @@ require (
 	github.com/prometheus/client_model v0.6.1
 	github.com/schollz/peerdiscovery v1.7.0
 	github.com/status-im/extkeys v1.4.0
-	github.com/status-im/go-wallet-sdk v0.0.0-20260728092705-f70963a74b0e
+	github.com/status-im/go-wallet-sdk v0.0.0-20260831150359-0d553d87d783
 	github.com/waku-org/go-waku v0.10.3
 	github.com/waku-org/sds-go-bindings v0.3.1
 	github.com/wk8/go-ordered-map/v2 v2.1.7

--- a/go.sum
+++ b/go.sum
@@ -2279,8 +2279,8 @@ github.com/status-im/go-generate-fast v0.0.0-20260821115326-e0f0915e0942 h1:rEX4
 github.com/status-im/go-generate-fast v0.0.0-20260821115326-e0f0915e0942/go.mod h1:iktiTcPdK+nuL47hn+7UL12uIkgJYyOAh99jdA6ruGw=
 github.com/status-im/go-sqlcipher/v4 v4.5.4-status.3 h1:/73h1w1hUfb3wVyTlNrUIwahZxatgesCHa6lwO57C2M=
 github.com/status-im/go-sqlcipher/v4 v4.5.4-status.3/go.mod h1:mF2UmIpBnzFeBdu/ypTDb/LdbS0nk0dfSN1WUsWTjMA=
-github.com/status-im/go-wallet-sdk v0.0.0-20260728092705-f70963a74b0e h1:EV0EVv9S/F1lRPcDhbw42X2m918FmPwO2GbWZhg1G/Y=
-github.com/status-im/go-wallet-sdk v0.0.0-20260728092705-f70963a74b0e/go.mod h1:E4E1D0mflc2pcjsutZpvMYSjI+a231uBHQf8UjdT1Ug=
+github.com/status-im/go-wallet-sdk v0.0.0-20260831150359-0d553d87d783 h1:KDtp7pE9KwDxbepy8Hp2w/i07rAtZLMeFka4jTwHnM4=
+github.com/status-im/go-wallet-sdk v0.0.0-20260831150359-0d553d87d783/go.mod h1:E4E1D0mflc2pcjsutZpvMYSjI+a231uBHQf8UjdT1Ug=
 github.com/status-im/gomoji v1.1.3-0.20220213022530-e5ac4a8732d4 h1:CtobZoiNdHpx+xurFxnuJ1xsGm3oKMfcZkB3vmomJmA=
 github.com/status-im/gomoji v1.1.3-0.20220213022530-e5ac4a8732d4/go.mod h1:hmpnZzkzSZJbFYWAUkrPV8I36x7mdYiPhPqnALP4fKA=
 github.com/status-im/goroutine-defer-guard v0.3.1 h1:cZhcJ3gO6OgMYBOfEaAAUZaZgKZeSzMlGNEjMyejuRo=

--- a/pkg/services/wallet/common/const.go
+++ b/pkg/services/wallet/common/const.go
@@ -141,6 +141,33 @@ func ZkSyncETHTokenAddress() common.Address {
 	return common.HexToAddress("0x000000000000000000000000000000000000800a")
 }
 
+// AdditionalNativeTokenAddresses maps chains to addresses of the chain's native token.
+// The canonical native token address is always the zero address.
+func AdditionalNativeTokenAddresses() map[uint64][]common.Address {
+	return map[uint64][]common.Address{
+		ZkSyncMainnet: {ZkSyncETHTokenAddress()},
+		ZkSyncSepolia: {ZkSyncETHTokenAddress()},
+	}
+}
+
+// IsNativeTokenAlias reports whether addr is a registered native-token alias on chainID
+func IsNativeTokenAlias(chainID uint64, addr common.Address) bool {
+	for _, alias := range AdditionalNativeTokenAddresses()[chainID] {
+		if alias == addr {
+			return true
+		}
+	}
+	return false
+}
+
+// NormalizeNativeTokenAddress maps a native-token alias to the canonical zero address.
+func NormalizeNativeTokenAddress(chainID uint64, addr common.Address) common.Address {
+	if IsNativeTokenAlias(chainID, addr) {
+		return ZeroAddress()
+	}
+	return addr
+}
+
 func ZeroAddress() common.Address {
 	return common.Address{}
 }

--- a/pkg/services/wallet/token/token.go
+++ b/pkg/services/wallet/token/token.go
@@ -241,10 +241,7 @@ func setUpTokenListsManager(mng *Manager, walletDB *sql.DB, enabledChains []uint
 
 		SkippedTokenKeys: walletcommon.SkippedTokenKeys(),
 
-		AdditionalAddressesForNativeToken: map[uint64][]common.Address{
-			walletcommon.ZkSyncMainnet: {walletcommon.ZkSyncETHTokenAddress()},
-			walletcommon.ZkSyncSepolia: {walletcommon.ZkSyncETHTokenAddress()},
-		},
+		AdditionalAddressesForNativeToken: walletcommon.AdditionalNativeTokenAddresses(),
 	}
 
 	return manager.New(config, wsdkFetcher, contentStore, customTokenStore)
@@ -381,6 +378,7 @@ func (tm *Manager) Stop() {
 }
 
 func (tm *Manager) GetTokenByChainAddress(chainID uint64, address common.Address) (*tokentypes.Token, error) {
+	// Native-token aliases resolve to the canonical zero-address native token
 	if token, ok := tm.tokensManager.GetTokenByChainAddress(chainID, address); ok {
 		return &tokentypes.Token{Token: token}, nil
 	}

--- a/pkg/services/wallet/tokenbalances/fetcher.go
+++ b/pkg/services/wallet/tokenbalances/fetcher.go
@@ -11,6 +11,7 @@ import (
 	"github.com/status-im/go-wallet-sdk/pkg/balance/multistandardfetcher"
 
 	"github.com/status-im/status-go/internal/logutils"
+	walletCommon "github.com/status-im/status-go/pkg/services/wallet/common"
 )
 
 type MultiStandardBalanceFetcher interface {
@@ -38,10 +39,19 @@ func (f *Fetcher) Fetch(ctx context.Context, chainID uint64, tokenAddresses []Co
 		ERC20:  make(map[AccountAddress][]ContractAddress),
 	}
 
+	nativeRequested := false
+	requestedNativeAliases := make([]ContractAddress, 0)
 	for _, tokenAddress := range tokenAddresses {
-		if tokenAddress == NativeTokenAddress {
-			// Native token represented by zero address
-			config.Native = append(config.Native, accountAddresses...)
+		// Native-token aliases (e.g. ETH at 0x…800a on ZKsync Era) are not ERC20 contracts,
+		// fetch them via the native path and mirror the result under the requested alias below.
+		if walletCommon.NormalizeNativeTokenAddress(chainID, tokenAddress) == NativeTokenAddress {
+			if tokenAddress != NativeTokenAddress {
+				requestedNativeAliases = append(requestedNativeAliases, tokenAddress)
+			}
+			if !nativeRequested {
+				nativeRequested = true
+				config.Native = append(config.Native, accountAddresses...)
+			}
 		} else {
 			for _, accountAddress := range accountAddresses {
 				config.ERC20[accountAddress] = append(config.ERC20[accountAddress], tokenAddress)
@@ -82,6 +92,18 @@ func (f *Fetcher) Fetch(ctx context.Context, chainID uint64, tokenAddresses []Co
 				ret[result.Account] = make(map[ContractAddress]*big.Int)
 			}
 			maps.Copy(ret[result.Account], result.Results)
+		}
+	}
+
+	// Mirror the native balance under any requested alias addresses so callers that
+	// looked the token up by its alias still find the balance.
+	if len(requestedNativeAliases) > 0 {
+		for _, balances := range ret {
+			if nativeBalance, ok := balances[NativeTokenAddress]; ok {
+				for _, alias := range requestedNativeAliases {
+					balances[alias] = nativeBalance
+				}
+			}
 		}
 	}
 

--- a/pkg/services/wallet/tokenbalances/fetcher_test.go
+++ b/pkg/services/wallet/tokenbalances/fetcher_test.go
@@ -1,0 +1,112 @@
+package tokenbalances
+
+import (
+	"context"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/status-im/go-wallet-sdk/pkg/balance/multistandardfetcher"
+
+	wCommon "github.com/status-im/status-go/pkg/services/wallet/common"
+)
+
+type fakeMultiStandardBalanceFetcher struct {
+	fetchBalances func(ctx context.Context, chainID uint64, config multistandardfetcher.FetchConfig) (<-chan multistandardfetcher.FetchResult, error)
+}
+
+func (f *fakeMultiStandardBalanceFetcher) FetchBalances(ctx context.Context, chainID uint64, config multistandardfetcher.FetchConfig) (<-chan multistandardfetcher.FetchResult, error) {
+	return f.fetchBalances(ctx, chainID, config)
+}
+
+func resultsChannel(results ...multistandardfetcher.FetchResult) <-chan multistandardfetcher.FetchResult {
+	ch := make(chan multistandardfetcher.FetchResult, len(results))
+	for _, r := range results {
+		ch <- r
+	}
+	close(ch)
+	return ch
+}
+
+func nativeResult(account AccountAddress, balance *big.Int) multistandardfetcher.FetchResult {
+	return multistandardfetcher.FetchResult{
+		ResultType: multistandardfetcher.ResultTypeNative,
+		Result: multistandardfetcher.NativeResult{
+			Account: account,
+			Result:  balance,
+		},
+	}
+}
+
+// ETH on ZKsync Era is exposed by token lists at the 0x…800a system-contract alias, which is
+// not a standard ERC20. FetchSingle must resolve such aliases through the native path and
+// still key the result under the requested alias address.
+func TestFetchSingleNativeTokenAlias(t *testing.T) {
+	account := AccountAddress{0x11}
+	balance := big.NewInt(42)
+
+	fake := &fakeMultiStandardBalanceFetcher{
+		fetchBalances: func(_ context.Context, chainID uint64, config multistandardfetcher.FetchConfig) (<-chan multistandardfetcher.FetchResult, error) {
+			require.Equal(t, wCommon.ZkSyncMainnet, chainID)
+			// The alias must be fetched natively, never as an ERC20 contract call.
+			require.Equal(t, []AccountAddress{account}, config.Native)
+			require.Empty(t, config.ERC20)
+			return resultsChannel(nativeResult(account, balance)), nil
+		},
+	}
+
+	fetcher := NewFetcher(fake)
+	got, err := fetcher.FetchSingle(context.Background(), wCommon.ZkSyncMainnet, wCommon.ZkSyncETHTokenAddress(), account)
+	require.NoError(t, err)
+	require.Equal(t, balance, got)
+}
+
+// Requesting the canonical zero address and an alias together must produce a single native
+// fetch, with the balance mirrored under both requested addresses.
+func TestFetchNativeTokenAliasDeduplicated(t *testing.T) {
+	account := AccountAddress{0x11}
+	balance := big.NewInt(7)
+
+	fake := &fakeMultiStandardBalanceFetcher{
+		fetchBalances: func(_ context.Context, _ uint64, config multistandardfetcher.FetchConfig) (<-chan multistandardfetcher.FetchResult, error) {
+			require.Equal(t, []AccountAddress{account}, config.Native) // accounts added once, not per address
+			require.Empty(t, config.ERC20)
+			return resultsChannel(nativeResult(account, balance)), nil
+		},
+	}
+
+	fetcher := NewFetcher(fake)
+	balances, err := fetcher.Fetch(context.Background(), wCommon.ZkSyncMainnet,
+		[]ContractAddress{NativeTokenAddress, wCommon.ZkSyncETHTokenAddress()}, []AccountAddress{account})
+	require.NoError(t, err)
+	require.Equal(t, balance, balances[account][NativeTokenAddress])
+	require.Equal(t, balance, balances[account][wCommon.ZkSyncETHTokenAddress()])
+}
+
+// On chains without a registered alias, a non-zero token address keeps going down the ERC20 path.
+func TestFetchSingleERC20Unaffected(t *testing.T) {
+	account := AccountAddress{0x11}
+	tokenAddress := ContractAddress{0x22}
+	balance := big.NewInt(1000)
+
+	fake := &fakeMultiStandardBalanceFetcher{
+		fetchBalances: func(_ context.Context, chainID uint64, config multistandardfetcher.FetchConfig) (<-chan multistandardfetcher.FetchResult, error) {
+			require.Equal(t, wCommon.EthereumMainnet, chainID)
+			require.Empty(t, config.Native)
+			require.Equal(t, []ContractAddress{tokenAddress}, config.ERC20[account])
+			return resultsChannel(multistandardfetcher.FetchResult{
+				ResultType: multistandardfetcher.ResultTypeERC20,
+				Result: multistandardfetcher.ERC20Result{
+					Account: account,
+					Results: map[ContractAddress]*big.Int{tokenAddress: balance},
+				},
+			}), nil
+		},
+	}
+
+	fetcher := NewFetcher(fake)
+	got, err := fetcher.FetchSingle(context.Background(), wCommon.EthereumMainnet, tokenAddress, account)
+	require.NoError(t, err)
+	require.Equal(t, balance, got)
+}


### PR DESCRIPTION
Corresponding `go-wallet-sdk` PR:
- https://github.com/status-im/go-wallet-sdk/pull/46

Sending ETH on zkSync intermittently failed with "no balance found". Token lists expose native ETH at the 0x…800a system-contract alias, which isn't a standard ERC20 (balanceOf reverts), and the duplicate alias entry made symbol/group lookups a map-iteration-order lottery.

Fixes https://github.com/status-im/status-app/issues/22182