### PR TITLE
chore: cherry-pick fixes from release/10.35.x

### DIFF
--- a/pkg/messaging/waku/gowaku.go
+++ b/pkg/messaging/waku/gowaku.go
@@ -343,7 +343,10 @@ func New(nodeKey *ecdsa.PrivateKey, cfg *Config, logger *zap.Logger, ts timesour
 	}
 
 	if !cfg.IsLightClient() {
-		opts = append(opts, node.WithWakuFilterFullNode(filter.WithMaxSubscribers(20)))
+		opts = append(opts, node.WithWakuFilterFullNode(
+			filter.WithMaxSubscribers(20),
+			filter.WithFullNodeRateLimiter(15, 20),
+		))
 		opts = append(opts, node.WithLightPush(lightpush.WithRateLimiter(5, 10)))
 	}
 

--- a/scripts/run_functional_tests.sh
+++ b/scripts/run_functional_tests.sh
@@ -138,7 +138,10 @@ if [[ "${FUNCTIONAL_TESTS_MARKER}" == "compatibility" ]]; then
    if [[ -z "${PEER_REFS}" ]]; then
       echo "${GRN}Fetching git tags to determine peer refs${RST}"
       git fetch --tags --quiet || true
-      PEER_REFS="$(git tag --sort=-v:refname 2>/dev/null | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | awk -F. '!seen[$1"."$2]++' | head -2 | paste -sd' ' -)"
+      # Only a release branch shares a line with its peers; develop is always ahead of all of them.
+      target_branch="${CHANGE_TARGET:-${BRANCH_NAME:-$(git rev-parse --abbrev-ref HEAD 2>/dev/null)}}"
+      own_minor="$(printf '%s' "${target_branch}" | sed -nE 's|^release/([0-9]+)\.([0-9]+)\..*|v\1.\2|p')"
+      PEER_REFS="$(git tag --sort=-v:refname 2>/dev/null | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | awk -F. -v own="${own_minor}" '$1"."$2 != own && !seen[$1"."$2]++' | head -2 | paste -sd' ' -)"
     fi
     if [[ -z "${PEER_REFS}" ]]; then
       echo -e "${RED}No peer refs available. Set PEER_REFS or PEER_IMAGES.${RST}"


### PR DESCRIPTION
cherry-pick of #7780 and #7787 from `release/10.35.x`

# Description

1. Widened the filter full-node rate limit to 15/20, so a light client installing several aggregated filters at startup doesn't get 429'd into a 60s subscription stall.
2. Excluded the target branch's own minor line from the compatibility suite's peer refs. On `develop` this is a no-op; it takes effect on the next release branch cut from here.

<details>
<summary>AI-made decisions</summary>

- #7778 (protobuf v36) is the third commit on `release/10.35.x` missing from `develop`, but it is already here via #7738/#7739/#7746 — the only residual difference is the `vendorHash` in `nix/pkgs/status-go/library/default.nix`, which is branch-specific. Not cherry-picked.

</details>
