### PR TITLE
test: cut KEK derivation cost in unit test builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -562,7 +562,7 @@ test-unit: ##@tests Run unit and integration tests
 
 test-single: test-unit-prep
 	LD_LIBRARY_PATH="$(RUNTIME_LIB_DIRS)" CGO_LDFLAGS="$(CGO_LDFLAGS)" CGO_CFLAGS="$(CGO_CFLAGS)" \
-	go test -v -tags '$(BUILD_TAGS)' $(PKG) -run '$(TEST)' $(if $(TESTIFY_M),-testify.m '$(TESTIFY_M)')
+	go test -v -tags '$(strip $(BUILD_TAGS) test_fast_kdf)' $(PKG) -run '$(TEST)' $(if $(TESTIFY_M),-testify.m '$(TESTIFY_M)')
 
 test-unit-network: test-unit-prep
 test-unit-network: export UNIT_TEST_RERUN_FAILS ?= false

--- a/internal/accounts-management/keystore/envelope/envelope.go
+++ b/internal/accounts-management/keystore/envelope/envelope.go
@@ -22,9 +22,6 @@ const (
 	pendingSuffix = ".pending" // used for deep rekey (when a new DEK is generated)
 
 	DekLength = 32 // DEK size in bytes
-
-	scryptN = 1 << 18
-	scryptP = 1
 )
 
 var ErrInvalidKEK = errors.New("envelope: invalid key-encryption key")

--- a/internal/accounts-management/keystore/envelope/scrypt_params.go
+++ b/internal/accounts-management/keystore/envelope/scrypt_params.go
@@ -1,0 +1,10 @@
+//go:build !test_fast_kdf
+
+package envelope
+
+// KEK derivation cost, matching go-ethereum's StandardScryptN/P. The parameters are
+// stored in the wrapped-DEK file, so a file written with any cost stays readable.
+const (
+	scryptN = 1 << 18
+	scryptP = 1
+)

--- a/internal/accounts-management/keystore/envelope/scrypt_params_fast.go
+++ b/internal/accounts-management/keystore/envelope/scrypt_params_fast.go
@@ -2,8 +2,9 @@
 
 package envelope
 
-// Reduced KEK derivation cost for unit test builds. Never set this tag for a shipped binary.
+// Minimum KEK derivation cost for unit test builds, matching go-ethereum's own
+// veryLightScryptN. Never set this tag for a shipped binary.
 const (
-	scryptN = 1 << 12
+	scryptN = 2
 	scryptP = 1
 )

--- a/internal/accounts-management/keystore/envelope/scrypt_params_fast.go
+++ b/internal/accounts-management/keystore/envelope/scrypt_params_fast.go
@@ -1,0 +1,9 @@
+//go:build test_fast_kdf
+
+package envelope
+
+// Reduced KEK derivation cost for unit test builds. Never set this tag for a shipped binary.
+const (
+	scryptN = 1 << 12
+	scryptP = 1
+)

--- a/scripts/run_unit_tests.sh
+++ b/scripts/run_unit_tests.sh
@@ -19,6 +19,12 @@ if [[ $UNIT_TEST_USE_DEVELOPMENT_LOGGER == 'false' ]]; then
   fi
 fi
 
+if [[ -z $BUILD_TAGS ]]; then
+  BUILD_TAGS="test_fast_kdf"
+else
+  BUILD_TAGS="${BUILD_TAGS} test_fast_kdf"
+fi
+
 if [[ -z "${UNIT_TEST_COUNT}" ]]; then
   UNIT_TEST_COUNT=1
 fi


### PR DESCRIPTION
# Description

1. Moved the `keystore/envelope` scrypt parameters behind a `test_fast_kdf` build tag and dropped them to scrypt's minimum (`N=2`, what go-ethereum uses in its own keystore tests) for unit test builds. Shipped binaries keep `StandardScryptN` (`1<<18`).
2. Set the tag in `scripts/run_unit_tests.sh` and in the `test-single` make target.

The DEK work landed on `develop` on 2026-08-21 and #7762 on 2026-08-27, together adding 29 tests to `pkg/backend`. Measured on one machine, the package went from **1m33s** with those skipped to **4m56s** with them — against the flat `-timeout 5m` that `run_unit_tests.sh` gives every non-`protocol` package.

Go's timeout panic aborts the whole test binary, so gotestsum blamed whichever test was in flight. That is why it looked like a different flaky test each run instead of one package over budget.

`pkg/backend` spends **135s across 267 KEK derivations**, ~540ms each. The envelope sits on the login and account-creation path, so this hit pre-existing tests too, not just the new ones.

# Benefits

`pkg/backend`: **4m56s → 2m27s**, same 85 tests. Headroom against the 5m ceiling goes from 1.01x to ~1.9x.

<details>
<summary>AI-made decisions</summary>

- Build tag rather than a variable or env var: a compile-time switch cannot be flipped in a shipped binary, which matters for a KDF that guards profile databases at rest.
- Left `DEFAULT_TIMEOUT_MINUTES` and the runner's shard parallelism alone. Both predate the regression; raising the ceiling would only defer the next occurrence.
- Kept `make lint` on the untagged variant, so linting sees the code that ships.
- Ruled out two other explanations by measurement: there is no stall (largest gap between log lines over a 285s run is 3.17s, and it is scrypt), and nothing degrades as the run proceeds (crash-injection subtests take 0.74x as long at the end of a full run as in isolation).
- Checked for redundant KEK work and found none: the second unwrap on the login path only fires when a `.pending` envelope exists after an interrupted rekey.
- Not fixed here: the suite leaks ~320 goroutines per `pkg/backend` binary (44 `Waku.SubscribeEnvelopeEvents` proxies whose channel is never closed, 65 geth keystore watchers, a `sql.Register` per `openDB`). Real, but measurably not what trips the timeout.
- Also not fixed, unrelated: `TestController_FetchImmediatelyWithConfig` gives an event 500ms to cross a wallet feed and fetch on two chains, too tight under the runner's parallelism. It fails in the same CI log for its own reasons.

</details>
