### PR TITLE
test: cut KEK derivation cost in unit test builds [cherry-pick 10.35.x]

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -562,7 +562,7 @@ test-unit: ##@tests Run unit and integration tests
 
 test-single: test-unit-prep
 	LD_LIBRARY_PATH="$(RUNTIME_LIB_DIRS)" CGO_LDFLAGS="$(CGO_LDFLAGS)" CGO_CFLAGS="$(CGO_CFLAGS)" \
-	go test -v -tags '$(BUILD_TAGS)' $(PKG) -run '$(TEST)' $(if $(TESTIFY_M),-testify.m '$(TESTIFY_M)')
+	go test -v -tags '$(strip $(BUILD_TAGS) test_fast_kdf)' $(PKG) -run '$(TEST)' $(if $(TESTIFY_M),-testify.m '$(TESTIFY_M)')
 
 test-unit-network: test-unit-prep
 test-unit-network: export UNIT_TEST_RERUN_FAILS ?= false

--- a/internal/accounts-management/keystore/envelope/envelope.go
+++ b/internal/accounts-management/keystore/envelope/envelope.go
@@ -22,9 +22,6 @@ const (
 	pendingSuffix = ".pending" // used for deep rekey (when a new DEK is generated)
 
 	dekLength = 32 // DEK size in bytes
-
-	scryptN = 1 << 18
-	scryptP = 1
 )
 
 var ErrInvalidKEK = errors.New("envelope: invalid key-encryption key")

--- a/internal/accounts-management/keystore/envelope/scrypt_params.go
+++ b/internal/accounts-management/keystore/envelope/scrypt_params.go
@@ -1,0 +1,10 @@
+//go:build !test_fast_kdf
+
+package envelope
+
+// KEK derivation cost, matching go-ethereum's StandardScryptN/P. The parameters are
+// stored in the wrapped-DEK file, so a file written with any cost stays readable.
+const (
+	scryptN = 1 << 18
+	scryptP = 1
+)

--- a/internal/accounts-management/keystore/envelope/scrypt_params_fast.go
+++ b/internal/accounts-management/keystore/envelope/scrypt_params_fast.go
@@ -1,0 +1,10 @@
+//go:build test_fast_kdf
+
+package envelope
+
+// Minimum KEK derivation cost for unit test builds, matching go-ethereum's own
+// veryLightScryptN. Never set this tag for a shipped binary.
+const (
+	scryptN = 2
+	scryptP = 1
+)

--- a/scripts/run_unit_tests.sh
+++ b/scripts/run_unit_tests.sh
@@ -19,6 +19,12 @@ if [[ $UNIT_TEST_USE_DEVELOPMENT_LOGGER == 'false' ]]; then
   fi
 fi
 
+if [[ -z $BUILD_TAGS ]]; then
+  BUILD_TAGS="test_fast_kdf"
+else
+  BUILD_TAGS="${BUILD_TAGS} test_fast_kdf"
+fi
+
 if [[ -z "${UNIT_TEST_COUNT}" ]]; then
   UNIT_TEST_COUNT=1
 fi


### PR DESCRIPTION
Cherry-pick of https://github.com/status-im/status-go/pull/7790 (@igor-sirotin) onto `release/10.35.x`.

This branch has the DEK envelope work and the crash-injection tests but not the fix, so `pkg/backend` still
runs against the flat `-timeout 5m` in `scripts/run_unit_tests.sh` with no headroom. When it goes over, Go's
timeout panic aborts the whole test binary and gotestsum blames whichever test was in flight — which is why
the branch keeps reporting a different "flaky" backend test each run, plus a synthetic `TestMain` and
tests marked `Skipped` that never got to run.

Needed by https://github.com/status-im/status-go/pull/7793, whose CI reports are otherwise noisy for this reason.

## Conflict

One, in `envelope.go`, and only in the const block the change touches: this branch has `dekLength`, develop
has it renamed to `DekLength` from an unrelated commit. Kept `dekLength` and applied what this commit is
actually about — moving `scryptN`/`scryptP` out to the build-tagged `scrypt_params` files.

## Testing

macOS/arm64, 16 cores, on this branch — same 85 tests pass either way:

| Build | `pkg/backend` |
| --- | --- |
| without the tag | 171s |
| with `test_fast_kdf` | 99s |

`go vet` clean in both variants, and the `envelope` package's own tests pass with the tag set.

The gap is smaller here than the 4m56s → 2m27s the original PR measured, since this machine is faster than
the CI agent; the point is the headroom against the 5m ceiling.
