### PR TITLE
fix(threads): scope emoji reaction queries to the thread

### DIFF
--- a/cmd/status-backend/API_REFERENCE.md
+++ b/cmd/status-backend/API_REFERENCE.md
@@ -363,6 +363,33 @@ Same as `wakuext_chatMessages`, but also can get thread history.
 
 ---
 
+### wakuext_emojiReactionsByChatID (deprecated)
+
+Read emoji reactions for a chat. Equivalent to `wakuext_emojiReactionsByChatIDV2` with an empty `threadId`.
+
+**Params:** `[chatId, cursor, limit]`
+- `chatId`: string (communityId + chatUUID)
+- `cursor`: string (empty string for first page)
+- `limit`: number
+
+---
+
+### wakuext_emojiReactionsByChatIDV2
+
+Same as `wakuext_emojiReactionsByChatID`, but also can get reactions on thread messages.
+
+Reactions are selected from the same window of messages `wakuext_chatMessagesV2` would return for
+the same `chatId`/`threadId`/`cursor`/`limit`, so pass the cursor that was used to fetch the
+messages being rendered.
+
+**Params:** `[chatId, threadId, cursor, limit]`
+- `chatId`: string (communityId + chatUUID)
+- `threadId`: string (leave empty to get the reactions of a chat)
+- `cursor`: string (empty string for first page)
+- `limit`: number
+
+---
+
 ### wakuext_createThread
 
 Explicitly create a thread from an existing parent message. The parent message must already be stored locally (i.e. it was previously received or sent).

--- a/internal/protocol/message_persistence.go
+++ b/internal/protocol/message_persistence.go
@@ -1992,12 +1992,24 @@ func (db sqlitePersistence) OldestMessageWhisperTimestampByChatIDs(chatIDs []str
 
 // EmojiReactionsByChatID returns the emoji reactions for the queried messages, up to a maximum of 100, as it's a potentially unbound number.
 // NOTE: This is not completely accurate, as the messages in the database might have change since the last call to `MessageByChatID`.
-func (db sqlitePersistence) EmojiReactionsByChatID(chatID string, currCursor string, limit int) ([]*EmojiReaction, error) {
+func (db sqlitePersistence) EmojiReactionsByChatID(chatID string, threadID string, currCursor string, limit int, threadsEnabled bool) ([]*EmojiReaction, error) {
 	cursorWhere := ""
 	if currCursor != "" {
 		cursorWhere = fmt.Sprintf("AND %s <= ?", cursor) //nolint: goconst
 	}
 	args := []interface{}{chatID, chatID}
+
+	// Mirrors MessageByChatID: the reaction window has to be drawn from the same set of messages
+	// the caller is paging through, otherwise thread replies crowd the base chat out of the
+	// subquery's LIMIT and their reactions silently stop loading (and vice versa).
+	var threadWhere string
+	if threadID != "" {
+		threadWhere = "AND m1.thread_id = ?"
+		args = append(args, threadID)
+	} else if threadsEnabled {
+		threadWhere = "AND (m1.thread_id IS NULL OR m1.thread_id = '')"
+	}
+
 	if currCursor != "" {
 		args = append(args, currCursor)
 	}
@@ -2030,10 +2042,10 @@ func (db sqlitePersistence) EmojiReactionsByChatID(chatID string, currCursor str
 			e.local_chat_id = ?
 			AND
 			e.message_id IN
-			(SELECT id FROM user_messages m1 WHERE NOT(m1.hide) AND m1.local_chat_id = ? %s
+			(SELECT id FROM user_messages m1 WHERE NOT(m1.hide) AND m1.local_chat_id = ? %s %s
 			ORDER BY %s DESC LIMIT ?)
 			LIMIT 1000
-		`, cursorWhere, cursor)
+		`, threadWhere, cursorWhere, cursor)
 
 	rows, err := db.db.Query(
 		query,

--- a/internal/protocol/messenger_emoji_reactions.go
+++ b/internal/protocol/messenger_emoji_reactions.go
@@ -124,7 +124,7 @@ func (m *Messenger) SendEmojiReaction(ctx context.Context, chatID string, messag
 	return &response, nil
 }
 
-func (m *Messenger) EmojiReactionsByChatID(chatID string, cursor string, limit int) ([]*EmojiReaction, error) {
+func (m *Messenger) EmojiReactionsByChatID(chatID string, threadID string, cursor string, limit int) ([]*EmojiReaction, error) {
 	chat, err := m.persistence.Chat(chatID)
 	if err != nil {
 		return nil, err
@@ -140,7 +140,7 @@ func (m *Messenger) EmojiReactionsByChatID(chatID string, cursor string, limit i
 		})
 		return m.persistence.EmojiReactionsByChatIDs(chatIDs, cursor, limit)
 	}
-	return m.persistence.EmojiReactionsByChatID(chatID, cursor, limit)
+	return m.persistence.EmojiReactionsByChatID(chatID, threadID, cursor, limit, m.featureFlags.Threads)
 }
 
 func (m *Messenger) EmojiReactionsByChatIDMessageID(chatID string, messageID string) ([]*EmojiReaction, error) {

--- a/internal/protocol/persistence_test.go
+++ b/internal/protocol/persistence_test.go
@@ -1168,7 +1168,7 @@ func TestPersistenceEmojiReactions(t *testing.T) {
 		From:        from3,
 	}))
 
-	reactions, err := p.EmojiReactionsByChatID(chatID, "", 1)
+	reactions, err := p.EmojiReactionsByChatID(chatID, "", "", 1, false)
 	require.NoError(t, err)
 	require.Len(t, reactions, 1)
 	require.Equal(t, id3, reactions[0].MessageId)
@@ -1177,11 +1177,65 @@ func TestPersistenceEmojiReactions(t *testing.T) {
 	_, cursor, err := p.MessageByChatID(chatID, "", "", 1, false)
 	require.NoError(t, err)
 
-	reactions, err = p.EmojiReactionsByChatID(chatID, cursor, 2)
+	reactions, err = p.EmojiReactionsByChatID(chatID, "", cursor, 2, false)
 	require.NoError(t, err)
 	require.Len(t, reactions, 2)
 	require.Equal(t, id1, reactions[0].MessageId)
 	require.Equal(t, id1, reactions[1].MessageId)
+}
+
+func TestPersistenceEmojiReactionsThreads(t *testing.T) {
+	db, err := openTestDB()
+	require.NoError(t, err)
+	p := newSQLitePersistence(db)
+
+	chatID := testPublicChatID
+	threadID := "parent-message-id"
+
+	baseMessageID := "base-1"
+	threadMessageID := "thread-1"
+
+	require.NoError(t, insertMinimalMessage(p, baseMessageID))
+	require.NoError(t, insertMinimalThreadMessage(p, threadMessageID, threadID))
+
+	require.NoError(t, p.SaveEmojiReaction(&EmojiReaction{
+		EmojiReaction: &protobuf.EmojiReaction{
+			Clock:     1,
+			MessageId: baseMessageID,
+			ChatId:    chatID,
+			Emoji:     "\U0001F600",
+		},
+		LocalChatID: chatID,
+		From:        "from-1",
+	}))
+
+	require.NoError(t, p.SaveEmojiReaction(&EmojiReaction{
+		EmojiReaction: &protobuf.EmojiReaction{
+			Clock:     2,
+			MessageId: threadMessageID,
+			ChatId:    chatID,
+			Emoji:     "\U0001F601",
+		},
+		LocalChatID: chatID,
+		From:        "from-2",
+	}))
+
+	// A thread query returns only the thread's reactions.
+	reactions, err := p.EmojiReactionsByChatID(chatID, threadID, "", 10, true)
+	require.NoError(t, err)
+	require.Len(t, reactions, 1)
+	require.Equal(t, threadMessageID, reactions[0].MessageId)
+
+	// With threads enabled the base chat excludes thread reactions.
+	reactions, err = p.EmojiReactionsByChatID(chatID, "", "", 10, true)
+	require.NoError(t, err)
+	require.Len(t, reactions, 1)
+	require.Equal(t, baseMessageID, reactions[0].MessageId)
+
+	// With threads disabled thread messages are ordinary messages, so both come back.
+	reactions, err = p.EmojiReactionsByChatID(chatID, "", "", 10, false)
+	require.NoError(t, err)
+	require.Len(t, reactions, 2)
 }
 
 func openTestDB() (*sql.DB, error) {
@@ -1198,6 +1252,15 @@ func insertMinimalMessage(p *sqlitePersistence, id string) error {
 		ID:          id,
 		LocalChatID: testPublicChatID,
 		ChatMessage: &protobuf.ChatMessage{Text: "some-text"},
+		From:        testPK,
+	}})
+}
+
+func insertMinimalThreadMessage(p *sqlitePersistence, id string, threadID string) error {
+	return p.SaveMessages([]*common.Message{{
+		ID:          id,
+		LocalChatID: testPublicChatID,
+		ChatMessage: &protobuf.ChatMessage{Text: "some-text", ThreadId: &threadID},
 		From:        testPK,
 	}})
 }

--- a/pkg/services/ext/api.go
+++ b/pkg/services/ext/api.go
@@ -1023,7 +1023,11 @@ func (api *PublicAPI) SendEmojiReactionRetraction(ctx context.Context, emojiReac
 }
 
 func (api *PublicAPI) EmojiReactionsByChatID(chatID string, cursor string, limit int) ([]*protocol.EmojiReaction, error) {
-	return api.service.messenger.EmojiReactionsByChatID(chatID, cursor, limit)
+	return api.service.messenger.EmojiReactionsByChatID(chatID, "", cursor, limit)
+}
+
+func (api *PublicAPI) EmojiReactionsByChatIDV2(chatID, threadID, cursor string, limit int) ([]*protocol.EmojiReaction, error) {
+	return api.service.messenger.EmojiReactionsByChatID(chatID, threadID, cursor, limit)
 }
 
 func (api *PublicAPI) EmojiReactionsByChatIDMessageID(chatID string, messageID string) ([]*protocol.EmojiReaction, error) {


### PR DESCRIPTION
Needed for https://github.com/status-im/status-app/issues/21900

EmojiReactionsByChatID picked its reaction window with a subquery over user_messages that had no thread_id predicate, unlike MessageByChatID directly above it. Callers therefore had no way to ask for the reactions on a thread's messages.

The same missing predicate degraded the base chat: with threads enabled the subquery's LIMIT was filled from all messages including thread replies, so a busy thread could push base-chat messages out of the reaction window and their reactions silently stopped loading.

Apply the MessageByChatID threadWhere pattern to the subquery and thread threadID plus the Threads feature flag down from the Messenger. No schema change is needed — reactions already reach thread_id through the user_messages join. Expose it as wakuext_emojiReactionsByChatIDV2, mirroring wakuext_chatMessagesV2, and keep v1 delegating with an empty thread ID.
