### PR TITLE
feat(threads): add batched thread lookup by chat IDs

### DIFF
--- a/cmd/status-backend/API_REFERENCE.md
+++ b/cmd/status-backend/API_REFERENCE.md
@@ -450,6 +450,19 @@ Notes:
 
 ---
 
+### wakuext_chatThreadsByChatIDs
+List threads for several chats at once, so a client opening a section does not have to issue one
+request per chat.
+
+**Params:** `[[chatId, ...]]`
+- `chatIds`: array of strings (communityId + chatUUID)
+
+**Result:** same shape as `wakuext_chatThreads`. Threads from all requested chats are returned in
+one flat list, ordered by `chatId` then `name`; use each thread's `chatId` to group them.
+Requested chats with no threads simply contribute nothing.
+
+---
+
 ### wakuext_leaveCommunity
 
 Leave a community.

--- a/internal/protocol/message_persistence.go
+++ b/internal/protocol/message_persistence.go
@@ -959,6 +959,51 @@ func (db sqlitePersistence) ThreadsByChatID(chatID string) ([]*Thread, error) {
 	return threads, nil
 }
 
+// ThreadsByChatIDs returns the threads of several chats at once, so a client opening a section
+// does not have to issue one query per chat.
+func (db sqlitePersistence) ThreadsByChatIDs(chatIDs []string) ([]*Thread, error) {
+	threads := make([]*Thread, 0)
+	if len(chatIDs) == 0 {
+		return threads, nil
+	}
+
+	args := make([]interface{}, len(chatIDs))
+	for i, v := range chatIDs {
+		args[i] = v
+	}
+
+	// nolint: gosec
+	query := fmt.Sprintf(`
+		SELECT
+			threads.thread_id,
+			threads.chat_id,
+			threads.parent_message_id,
+			threads.name,
+			(SELECT COUNT(1) FROM user_messages WHERE local_chat_id = threads.chat_id AND thread_id = threads.thread_id AND seen = 0),
+			(SELECT COUNT(1) FROM user_messages WHERE local_chat_id = threads.chat_id AND thread_id = threads.thread_id AND seen = 0 AND (mentioned OR replied))
+		FROM threads
+		WHERE chat_id IN (%s)
+		ORDER BY chat_id ASC, name ASC`, strings.Repeat(",?", len(chatIDs))[1:])
+
+	rows, err := db.db.Query(query, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		thread := &Thread{}
+		err = rows.Scan(&thread.ThreadID, &thread.ChatID, &thread.ParentMessageID, &thread.Name, &thread.UnviewedMessagesCount, &thread.UnviewedMentionsCount)
+		if err != nil {
+			return nil, err
+		}
+
+		threads = append(threads, thread)
+	}
+
+	return threads, nil
+}
+
 func (db sqlitePersistence) MessageByChatID(chatID string, threadID string, currCursor string, limit int, threadsEnabled bool) ([]*common.Message, string, error) {
 	cursorWhere := ""
 	if currCursor != "" {

--- a/internal/protocol/messenger_threads.go
+++ b/internal/protocol/messenger_threads.go
@@ -14,6 +14,13 @@ func (m *Messenger) ThreadsByChatID(chatID string) ([]*Thread, error) {
 	return m.persistence.ThreadsByChatID(chatID)
 }
 
+func (m *Messenger) ThreadsByChatIDs(chatIDs []string) ([]*Thread, error) {
+	if !m.featureFlags.Threads {
+		return nil, ErrThreadFeatureDisabled
+	}
+	return m.persistence.ThreadsByChatIDs(chatIDs)
+}
+
 func (m *Messenger) canCreateThread(chat *Chat) error {
 	if !chat.SupportsThreads() {
 		return ErrThreadsNotSupportedForChatType

--- a/internal/protocol/messenger_threads_test.go
+++ b/internal/protocol/messenger_threads_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/stretchr/testify/suite"
 
+	"github.com/status-im/status-go/internal/crypto"
 	"github.com/status-im/status-go/internal/protocol/common"
 )
 
@@ -136,6 +137,59 @@ func (s *MessengerThreadsSuite) TestThreadsByChatID() {
 	s.Require().Contains(threadIDs, "parent-2")
 	s.Require().Equal("First thread", threadIDs["parent-1"].Name)
 	s.Require().Equal("Second thread", threadIDs["parent-2"].Name)
+}
+
+func (s *MessengerThreadsSuite) TestThreadsByChatIDs() {
+	otherKey, err := crypto.GenerateKey()
+	s.Require().NoError(err)
+	thirdKey, err := crypto.GenerateKey()
+	s.Require().NoError(err)
+
+	chat1 := CreateOneToOneChat("test-user-1", &s.m.identity.PublicKey, s.m.getTimesource())
+	s.Require().NoError(s.m.SaveChat(chat1))
+	chat2 := CreateOneToOneChat("test-user-2", &otherKey.PublicKey, s.m.getTimesource())
+	s.Require().NoError(s.m.SaveChat(chat2))
+	chatWithoutThreads := CreateOneToOneChat("test-user-3", &thirdKey.PublicKey, s.m.getTimesource())
+	s.Require().NoError(s.m.SaveChat(chatWithoutThreads))
+
+	parent1 := buildTestMessage(*chat1)
+	parent1.ID = "parent-1"
+	parent1.Text = "First thread"
+	parent1.ChatMessage.Text = "First thread"
+
+	parent2 := buildTestMessage(*chat2)
+	parent2.ID = "parent-2"
+	parent2.Text = "Second thread"
+	parent2.ChatMessage.Text = "Second thread"
+
+	s.Require().NoError(s.m.SaveMessages([]*common.Message{parent1, parent2}))
+
+	_, err = s.m.CreateThread(chat1.ID, "parent-1")
+	s.Require().NoError(err)
+	_, err = s.m.CreateThread(chat2.ID, "parent-2")
+	s.Require().NoError(err)
+
+	threads, err := s.m.ThreadsByChatIDs([]string{chat1.ID, chat2.ID, chatWithoutThreads.ID})
+	s.Require().NoError(err)
+	s.Require().Len(threads, 2)
+
+	byChat := make(map[string]*Thread)
+	for _, thread := range threads {
+		byChat[thread.ChatID] = thread
+	}
+	s.Require().Equal("parent-1", byChat[chat1.ID].ThreadID)
+	s.Require().Equal("parent-2", byChat[chat2.ID].ThreadID)
+	s.Require().NotContains(byChat, chatWithoutThreads.ID)
+
+	// A chat that was never requested must not leak in.
+	threads, err = s.m.ThreadsByChatIDs([]string{chat1.ID})
+	s.Require().NoError(err)
+	s.Require().Len(threads, 1)
+	s.Require().Equal(chat1.ID, threads[0].ChatID)
+
+	threads, err = s.m.ThreadsByChatIDs(nil)
+	s.Require().NoError(err)
+	s.Require().Empty(threads)
 }
 
 func (s *MessengerThreadsSuite) TestThreadsIncludeUnreadCounts() {

--- a/pkg/services/ext/api.go
+++ b/pkg/services/ext/api.go
@@ -573,6 +573,17 @@ func (api *PublicAPI) ChatThreads(chatID string) (*ApplicationThreadsResponse, e
 	}, nil
 }
 
+func (api *PublicAPI) ChatThreadsByChatIDs(chatIDs []string) (*ApplicationThreadsResponse, error) {
+	threads, err := api.service.messenger.ThreadsByChatIDs(chatIDs)
+	if err != nil {
+		return nil, err
+	}
+
+	return &ApplicationThreadsResponse{
+		Threads: threads,
+	}, nil
+}
+
 func (api *PublicAPI) MessageByMessageID(messageID string) (*common.Message, error) {
 	return api.service.messenger.MessageByID(messageID)
 }


### PR DESCRIPTION
Needed for https://github.com/status-im/status-app/issues/21899

ThreadsByChatID only serves one chat and runs two correlated unread COUNT subqueries per thread row, so fetching threads for a whole section costs one request and one query per chat.

Add ThreadsByChatIDs — the same query with WHERE chat_id IN (...), ordered by chat then name so callers can group by each thread's chatId. Exposed as wakuext_chatThreadsByChatIDs; the single-chat API is untouched.
