### PR TITLE
test(functional): migrate the functional-test fleet to a logos-delivery image

### DIFF
--- a/test/functional/README.MD
+++ b/test/functional/README.MD
@@ -287,15 +287,15 @@ If you see some import issues, make sure that you have all requirements installe
 Make sure that you made `test-functional` source folder (Right click > Mark directory as > Source folder)
 
 
-## Apple Silicon (macOS): Waku fleet connection failures — disable Rosetta
+## Apple Silicon (macOS): logos-delivery fleet connection failures — disable Rosetta
 
-The `wakuorg/nwaku` fleet image is `amd64`-only, so on Apple Silicon it runs under emulation.
+The `harbor.status.im/wakuorg/nwaku` logos-delivery fleet image is `amd64`-only, so on Apple Silicon it runs under emulation.
 With Docker Desktop's **Rosetta** emulation enabled, the libp2p Noise handshake between the
-`status-go` nodes (go-libp2p) and the nwaku fleet nodes (nim-libp2p) fails, so the app nodes
+`status-go` nodes (go-libp2p) and the logos-delivery fleet nodes (nim-libp2p) fails, so the app nodes
 never connect to `boot-1`/`store`. Symptoms:
 
 - status-go logs: `failed to negotiate security protocol: ... chacha20poly1305: message authentication failed`
-- nwaku (boot-1/store) logs: `decryptWithAd failed tag authentication.`
+- logos-delivery (boot-1/store) logs: `decryptWithAd failed tag authentication.`
 - Tests that depend on the fleet (store/history sync, communities, anything store-backed) hang
   or fail, and the store node never receives messages.
 

--- a/test/functional/clients/logos_delivery.py
+++ b/test/functional/clients/logos_delivery.py
@@ -3,7 +3,7 @@
 The transport that status-go currently runs on (and that backs the functional
 test fleet) is historically called "waku". The project term going forward is
 "logos delivery", so new code uses that name. The fleet store node exposes the
-nwaku REST API (`/store/v3/messages`); this client queries it so tests can
+logos-delivery REST API (`/store/v3/messages`); this client queries it so tests can
 assert that messages were actually persisted by the store node, instead of
 sleeping and hoping.
 """
@@ -19,7 +19,7 @@ from utils.config import Config
 
 logger = logging.getLogger(__name__)
 
-# Container port the nwaku store node serves its REST API on (mapped to an
+# Container port the logos-delivery store node serves its REST API on (mapped to an
 # ephemeral host port by docker-compose.waku.yml).
 STORE_REST_CONTAINER_PORT = "8645/tcp"
 

--- a/test/functional/docker-compose.waku.yml
+++ b/test/functional/docker-compose.waku.yml
@@ -1,8 +1,8 @@
 services:
   boot-1:
-    image: wakuorg/nwaku:v0.38.1
+    image: harbor.status.im/wakuorg/nwaku:v0.39.0-rc.2
     entrypoint: [
-      "/usr/bin/wakunode",
+      "/usr/local/bin/logosdeliverynode",
       "--discv5-discovery=true",
       "--discv5-enr-auto-update=True",
       "--discv5-udp-port=9000",
@@ -23,7 +23,7 @@ services:
       "--rest-admin",
       "--shard=32",
       "--shard=64",
-      # Lift the per-peer filter/lightpush rate limits well above nwaku's stock
+      # Lift the per-peer filter/lightpush rate limits well above the stock
       # defaults. A light client joining a community fans out many per-content-topic
       # filter subscribe requests at once; the stock filter limit (30/min) returns
       # 429, which go-waku turns into a long subscription backoff.
@@ -41,15 +41,15 @@ services:
       test: ["CMD-SHELL", "curl -X GET -H 'Content-Type: application/json' http://0.0.0.0:8645 || exit 0"]
 
   store:
-    image: wakuorg/nwaku:v0.38.1
-    # Publish the nwaku REST API (incl. Store API) on an ephemeral host port so
+    image: harbor.status.im/wakuorg/nwaku:v0.39.0-rc.2
+    # Publish the logos-delivery REST API (incl. Store API) on an ephemeral host port so
     # tests on the host can query it without colliding on shared CI hosts.
     # The actual host port is discovered at runtime via the Docker API
     # (see clients/logos_delivery.py), mirroring how the Anvil client works.
     ports:
       - "8645"
     entrypoint: [
-      "/usr/bin/wakunode",
+      "/usr/local/bin/logosdeliverynode",
       "--discv5-discovery=true",
       "--discv5-enr-auto-update=True",
       "--discv5-udp-port=9000",
@@ -57,6 +57,8 @@ services:
       # Docker DNS server
       "--dns-addrs-name-server=127.0.0.11",
       "--dns4-domain-name=store",
+      "--filter=false",
+      "--lightpush=false",
       "--log-level=DEBUG",
       "--max-connections=18000",
       "--nodekey=3190bc9b55b18dbc171997a7a67abcd5bbf0c81002ad9617b1cb67f2f15daa64",


### PR DESCRIPTION
Closes #7471

# Description

1. Swapped the `boot-1` and `store` fleet nodes from `wakuorg/nwaku:v0.38.1` to `harbor.status.im/wakuorg/nwaku:v0.39.0-rc.2`.
2. Pointed the entrypoints at `/usr/local/bin/logosdeliverynode` rather than the `/usr/bin/wakunode` compat symlink the image still ships.
3. Pinned `--filter=false --lightpush=false` on the store node. Both default to true in `logosdeliverynode` where they defaulted to false in `wakunode2`, so without this the store node silently starts serving filter and lightpush as well as store.
4. Renamed the remaining `nwaku` references in `README.MD`, `clients/logos_delivery.py` and the compose comments to logos-delivery.

<details>
<summary>AI-made decisions</summary>

- Did not use the `status.prod` preset. It appends its entry nodes to the node's static-node and DNS-discovery lists (`checkAddPresetValueToField` concatenates, it does not override) and no flag removes them, so the fleet dials the real `boot-01.*.status.prod.status.im` nodes and the production enrtree — confirmed by running the image. A local test fleet must not bootstrap into the Status production network.
- Kept the existing `--cluster-id=16 --num-shards-in-network=65 --shard=32 --shard=64`. The preset's auto-sharding with a single shard serves shard 0 only, which would not carry the shard 32/64 traffic status-go publishes.
- Did not pass `--entry-layer`. logos-messaging/logos-delivery#4076 made `kernel` the default, which is the transport-only layer this fleet wants.
- Chose to preserve the v0.38.1 service split (boot-1 serves filter/lightpush, store serves store) rather than adopt the new defaults. The store node already carries filter/lightpush `--rate-limit` flags that were dead config under v0.38.1, so the opposite reading is arguable — drop the two lines if the fleet is meant to serve both from both nodes.
- Left `platform:` unset. The image is amd64-only exactly like the old one, so the Rosetta caveat already in the README still applies unchanged.
- Left `scripts/mc2/run_waku.sh` (`nwaku:v0.36.0`) alone — it is not part of the functional-test fleet.
- The compose healthcheck shells out to `curl`, which is absent from this image, and `|| exit 0` masks the failure so the node always reports healthy. Same on v0.38.1, so not a regression and left alone.
- Watch item, not introduced here: under CPU contention the mutual `--staticnode` pair can dial each other simultaneously, collide on libp2p's per-peer connection limit, and both tear down; the peer then sits in a 120s backoff and did not reconnect within 6 minutes. Seen once on an earlier RC and reproduced on the preceding logos-delivery build, not on v0.38.1; 12/12 subsequent clean starts peered in ~5s.

</details>
