### PR TITLE
ci: fix github auth by forcing http/1.1 and modify status-app pipeline stages

### DIFF
--- a/_assets/ci/Jenkinsfile.status-app
+++ b/_assets/ci/Jenkinsfile.status-app
@@ -70,21 +70,11 @@ pipeline {
                 windows_x86_64 = triggerJob('windows', 'x86_64')
               } }
             }
-            stage('E2E') {
-              steps { script {
-                triggerE2E('windows', 'x86_64', windows_x86_64)
-              } }
-            }
           }
         }
         stage('MacOS/aarch64') {
           steps { script {
             triggerJob('macos', 'aarch64')
-          } }
-        }
-        stage('iOS/aarch64') {
-          steps { script {
-            triggerJob('ios', 'aarch64')
           } }
         }
         stage('Android/arm64') {

--- a/test/functional/clone_and_run.sh
+++ b/test/functional/clone_and_run.sh
@@ -10,6 +10,11 @@ SENDER_ADDRESS=$6
 
 export GIT_HTTP_LOW_SPEED_LIMIT=1000
 export GIT_HTTP_LOW_SPEED_TIME=30
+# FIXME: hack fix for github asking auth on public resources
+export GIT_CONFIG_COUNT=1
+export GIT_CONFIG_KEY_0=http.version
+export GIT_CONFIG_VALUE_0=HTTP/1.1
+export GIT_TERMINAL_PROMPT=0
 
 retry() {
   local max=$1; shift


### PR DESCRIPTION
This fixes rpc test which otherwise fail with

```
foundry-1            | 2026-09-07T14:11:56.752911588Z fatal: could not
read Username for 'https://github.com': No such device or address
```

nuke windows e2e from status-app job because status devs complained it took too long and agreed that its not needed here, they're okay with just linux e2e.
nuke iOS stage from status-app job because its now built as part of macos job.
