### PR TITLE
chore: fetch LiFi quote once per swap request

### DIFF
--- a/pkg/services/wallet/router/pathprocessor/processor_lifi.go
+++ b/pkg/services/wallet/router/pathprocessor/processor_lifi.go
@@ -145,7 +145,7 @@ func (s *LiFiProcessor) getOrFetchQuote(params ProcessorInputParams) (*lifi.Quot
 }
 
 func (s *LiFiProcessor) GetContractAddress(params ProcessorInputParams) (common.Address, error) {
-	quote, err := s.fetchAndStoreQuote(params)
+	quote, err := s.getOrFetchQuote(params)
 	if err != nil {
 		return common.Address{}, err
 	}
@@ -175,7 +175,7 @@ func (s *LiFiProcessor) CalculateAmountOut(params ProcessorInputParams) (*big.In
 }
 
 func (s *LiFiProcessor) PackTxInputData(params ProcessorInputParams) ([]byte, error) {
-	quote, err := s.fetchAndStoreQuote(params)
+	quote, err := s.getOrFetchQuote(params)
 	if err != nil {
 		return []byte{}, err
 	}

--- a/pkg/services/wallet/router/pathprocessor/processor_lifi.go
+++ b/pkg/services/wallet/router/pathprocessor/processor_lifi.go
@@ -2,6 +2,7 @@ package pathprocessor
 
 import (
 	"context"
+	"math"
 	"math/big"
 	"strings"
 	"sync"
@@ -160,6 +161,15 @@ func (s *LiFiProcessor) GetProviderTool(params ProcessorInputParams) string {
 		return ""
 	}
 	return quote.Tool
+}
+
+// GetRouteExecutionDuration returns LI.FI's estimated time in seconds once the tx is included.
+func (s *LiFiProcessor) GetRouteExecutionDuration(params ProcessorInputParams) uint {
+	quote, err := s.getOrFetchQuote(params)
+	if err != nil || quote == nil || quote.Estimate.ExecutionDuration <= 0 {
+		return 0
+	}
+	return uint(math.Ceil(quote.Estimate.ExecutionDuration))
 }
 
 func (s *LiFiProcessor) CalculateAmountOut(params ProcessorInputParams) (*big.Int, error) {

--- a/pkg/services/wallet/router/pathprocessor/processor_lifi_test.go
+++ b/pkg/services/wallet/router/pathprocessor/processor_lifi_test.go
@@ -93,13 +93,26 @@ func TestLiFiQuote(t *testing.T) {
 	require.NotNil(t, amountOut)
 	require.Equal(t, testQuote.Estimate.ToAmount.Uint64(), amountOut.Uint64())
 
-	client.EXPECT().FetchQuote(gomock.Any(), gomock.Any()).Return(testQuote, nil)
+	// with a warm cache (an earlier consumer of the same routing round already
+	// fetched), neither call re-quotes — the whole round shares a single fetch
 	contractAddress, err := processor.GetContractAddress(testInputParams)
 	require.NoError(t, err)
 	require.Equal(t, testQuote.Estimate.ApprovalAddress, contractAddress)
 
-	client.EXPECT().FetchQuote(gomock.Any(), gomock.Any()).Return(testQuote, nil)
 	inputData, err := processor.PackTxInputData(testInputParams)
+	assert.NoError(t, err)
+	assert.Equal(t, testQuote.TransactionRequest.Data, hexutil.Encode(inputData))
+
+	// a cleared processor (new routing round, or the post-approval re-pack)
+	// fetches exactly once; the following consumer reuses that fetch
+	processor.Clear()
+	client.EXPECT().FetchQuote(gomock.Any(), gomock.Any()).Return(testQuote, nil).Times(1)
+
+	contractAddress, err = processor.GetContractAddress(testInputParams)
+	require.NoError(t, err)
+	require.Equal(t, testQuote.Estimate.ApprovalAddress, contractAddress)
+
+	inputData, err = processor.PackTxInputData(testInputParams)
 	assert.NoError(t, err)
 	assert.Equal(t, testQuote.TransactionRequest.Data, hexutil.Encode(inputData))
 }

--- a/pkg/services/wallet/router/router.go
+++ b/pkg/services/wallet/router/router.go
@@ -388,6 +388,10 @@ func (r *Router) ReevaluateRouterPath(ctx context.Context, pathTxIdentity *reque
 				continue
 			}
 
+			if clearable, ok := pProcessor.(pathprocessor.PathProcessorClearable); ok {
+				clearable.Clear()
+			}
+
 			r.lastInputParamsMutex.Lock()
 			processorInputParams, err := r.CreateProcessorInputParams(r.lastInputParams, path.FromToken, path.ToToken, 0)
 			r.lastInputParamsMutex.Unlock()
@@ -1250,6 +1254,12 @@ func (r *Router) buildPath(ctx context.Context, input *requests.RouteInputParams
 		ApprovalContractAddress: &contractAddress,
 		ApprovalPackedData:      approvalPackedData,
 		ApprovalGasAmount:       approvalGasLimit,
+	}
+
+	if dp, ok := pathProcessor.(interface {
+		GetRouteExecutionDuration(pathprocessor.ProcessorInputParams) uint
+	}); ok {
+		path.RouteExecutionDuration = dp.GetRouteExecutionDuration(processorInputParams)
 	}
 
 	// processors that route through an underlying tool/exchange (e.g. LI.FI -> "1inch")

--- a/pkg/services/wallet/router/routes/router_path.go
+++ b/pkg/services/wallet/router/routes/router_path.go
@@ -47,6 +47,8 @@ type Path struct {
 	TxTokenFees     *hexutil.Big    // Token fees for the transaction - used for bridges (represent the difference between the amount in and the amount out, in selected token)
 	TxEstimatedTime uint            // Estimated time for the transaction in seconds
 
+	RouteExecutionDuration uint // Provider-reported time (in seconds) the route itself takes to execute once the tx is included (e.g. bridging); 0 when unknown or instant
+
 	TxFee   *hexutil.Big // fee for the transaction (includes tx fee only, doesn't include approval fees, l1 fees, l1 approval fees, token fees or bonders fees, in base unit of the chain eg. WEI for ETH or BNB)
 	TxL1Fee *hexutil.Big // L1 fee for the transaction - used for for transactions placed on L2 chains (in base unit of the chain eg. WEI for ETH or BNB)
 
@@ -110,6 +112,7 @@ func (p *Path) Copy() *Path {
 		TxGasFeeMode:               p.TxGasFeeMode,
 		TxGasAmount:                p.TxGasAmount,
 		TxEstimatedTime:            p.TxEstimatedTime,
+		RouteExecutionDuration:     p.RouteExecutionDuration,
 		ApprovalRequired:           p.ApprovalRequired,
 		ApprovalGasFeeMode:         p.ApprovalGasFeeMode,
 		ApprovalGasAmount:          p.ApprovalGasAmount,

--- a/pkg/services/wallet/thirdparty/lifi/request_quote.go
+++ b/pkg/services/wallet/thirdparty/lifi/request_quote.go
@@ -22,10 +22,11 @@ type TransactionRequest struct {
 }
 
 type Estimate struct {
-	FromAmount      *bigint.BigInt `json:"fromAmount"`
-	ToAmount        *bigint.BigInt `json:"toAmount"`
-	ToAmountMin     *bigint.BigInt `json:"toAmountMin"`
-	ApprovalAddress common.Address `json:"approvalAddress"`
+	FromAmount        *bigint.BigInt `json:"fromAmount"`
+	ToAmount          *bigint.BigInt `json:"toAmount"`
+	ToAmountMin       *bigint.BigInt `json:"toAmountMin"`
+	ApprovalAddress   common.Address `json:"approvalAddress"`
+	ExecutionDuration float64        `json:"executionDuration"`
 }
 
 type Quote struct {


### PR DESCRIPTION
- Each swap request was fetching the LiFi quote twice (GetContractAddress and PackTxInputData both force a fresh fetch),
now stored and reused.
- executionDuration is now parsed in request_quote.go and passed to the client, where it's added to the bridge/route duration when displaying a total time.