### PR TITLE
fix(walletconnect): pairing fixes and handshake diagnostics

### DIFF
--- a/internal/protocol/requests/create_account.go
+++ b/internal/protocol/requests/create_account.go
@@ -55,8 +55,11 @@ type CreateAccount struct {
 
 	LogLevel    *string `json:"logLevel"`
 	LogFilePath string  `json:"logFilePath"` // absolute path
-	LogEnabled  bool    `json:"logEnabled"`
-	LogToStderr bool    `json:"logToStderr"`
+
+	// Account creation logs in without a Login request, which carries this too.
+	WalletConnectProjectID string `json:"walletConnectProjectID"`
+	LogEnabled             bool   `json:"logEnabled"`
+	LogToStderr            bool   `json:"logToStderr"`
 
 	PreviewPrivacy bool `json:"previewPrivacy"`
 

--- a/pkg/backend/defaults.go
+++ b/pkg/backend/defaults.go
@@ -300,6 +300,7 @@ func DefaultNodeConfig(installationID, keyUID string, request *requests.CreateAc
 	}
 
 	nodeConfig.WalletConfig = buildWalletConfig(&request.WalletConfig, &request.WalletSecretsConfig)
+	nodeConfig.WalletConnectProjectID = request.WalletConnectProjectID
 
 	if request.TestOverrideNetworks != nil {
 		nodeConfig.Networks = request.TestOverrideNetworks

--- a/pkg/backend/wc_projectid_test.go
+++ b/pkg/backend/wc_projectid_test.go
@@ -1,0 +1,20 @@
+package backend
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/status-im/status-go/internal/protocol/requests"
+)
+
+func TestDefaultNodeConfig_CarriesWalletConnectProjectID(t *testing.T) {
+	request := &requests.CreateAccount{
+		RootDataDir:            t.TempDir(),
+		WalletConnectProjectID: "87815d72a81d739d2a7ce15c2cfdefb3",
+	}
+
+	nodeConfig, err := DefaultNodeConfig("installation-id", "key-uid", request)
+	require.NoError(t, err)
+	require.Equal(t, request.WalletConnectProjectID, nodeConfig.WalletConnectProjectID)
+}

--- a/pkg/services/connector/walletconnect/auth.go
+++ b/pkg/services/connector/walletconnect/auth.go
@@ -25,6 +25,9 @@ const (
 	jwtTTL           = 86400 // 24 hours in seconds
 )
 
+// The relay allows 120s of leeway on iat and rejects a token from a fast clock.
+const jwtClockSkewLeeway = 90 * time.Second
+
 // Auth handles Ed25519 keypair management and DID-JWT signing for relay authentication.
 type Auth struct {
 	privateKey ed25519.PrivateKey
@@ -59,7 +62,7 @@ func (a *Auth) ClientID() string {
 // GenerateJWT creates a signed JWT for relay authentication.
 // aud should be the relay server URL (e.g. "wss://relay.walletconnect.com")
 func (a *Auth) GenerateJWT(aud string) (string, error) {
-	now := time.Now().Unix()
+	now := time.Now().Add(-jwtClockSkewLeeway).Unix()
 
 	// Generate random nonce as subject
 	nonce := make([]byte, 32)

--- a/pkg/services/connector/walletconnect/auth_test.go
+++ b/pkg/services/connector/walletconnect/auth_test.go
@@ -95,8 +95,8 @@ func TestAuth_GenerateJWT_ValidPayload(t *testing.T) {
 
 	iat := int64(payload["iat"].(float64))
 	exp := int64(payload["exp"].(float64))
-	require.GreaterOrEqual(t, iat, before)
-	require.LessOrEqual(t, iat, after)
+	require.GreaterOrEqual(t, iat, before-int64(jwtClockSkewLeeway.Seconds()))
+	require.LessOrEqual(t, iat, after-int64(jwtClockSkewLeeway.Seconds()))
 	require.Equal(t, iat+86400, exp)
 }
 
@@ -193,4 +193,29 @@ func TestEncodeDidKey_DifferentKeys(t *testing.T) {
 	require.NoError(t, err)
 
 	require.NotEqual(t, didKey1, didKey2)
+}
+
+func TestAuth_GenerateJWT_BackdatesIat(t *testing.T) {
+	const wantBackdate = 90 * time.Second
+
+	auth, err := NewAuth()
+	require.NoError(t, err)
+
+	token, err := auth.GenerateJWT("wss://relay.walletconnect.com")
+	require.NoError(t, err)
+
+	parts := strings.Split(token, ".")
+	require.Len(t, parts, 3)
+	raw, err := base64.RawURLEncoding.DecodeString(parts[1])
+	require.NoError(t, err)
+
+	var claims struct {
+		Iat int64 `json:"iat"`
+		Exp int64 `json:"exp"`
+	}
+	require.NoError(t, json.Unmarshal(raw, &claims))
+
+	require.LessOrEqual(t, claims.Iat, time.Now().Unix()-int64(wantBackdate.Seconds())+1,
+		"iat must be backdated to absorb a fast client clock")
+	require.Equal(t, claims.Iat+jwtTTL, claims.Exp)
 }

--- a/pkg/services/connector/walletconnect/client.go
+++ b/pkg/services/connector/walletconnect/client.go
@@ -101,6 +101,12 @@ func (c *Client) Pair(ctx context.Context, uri string) error {
 
 	c.mu.Lock()
 	c.pairingTopics[parsed.Topic] = parsed.SymKey
+	// Forget proposals for this topic so a redelivery is not dropped as a duplicate.
+	for id, pending := range c.pendingProposals {
+		if pending.PairingTopic == parsed.Topic {
+			delete(c.pendingProposals, id)
+		}
+	}
 	c.mu.Unlock()
 
 	c.relay.SetMessageHandler(func(topic, message string, tag int) {

--- a/pkg/services/connector/walletconnect/client_pairing_test.go
+++ b/pkg/services/connector/walletconnect/client_pairing_test.go
@@ -1,0 +1,47 @@
+package walletconnect
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+)
+
+func TestClient_Pair_ResurfacesProposalAfterDismissedModal(t *testing.T) {
+	_, relay, client := newMockClient(t)
+
+	relay.EXPECT().SetMessageHandler(gomock.Any()).Times(2)
+	relay.EXPECT().Connect().Return(nil).Times(2)
+	relay.EXPECT().Subscribe(testPairingTopic).Return("sub-id", nil).Times(2)
+	relay.EXPECT().FetchMessages(testPairingTopic).Return(nil, false, fmt.Errorf("no messages")).Times(2)
+
+	var delivered int32
+	client.SetSessionProposalHandler(func(string) { atomic.AddInt32(&delivered, 1) })
+
+	proposal, _ := json.Marshal(map[string]any{
+		"id":     int64(123),
+		"method": "wc_sessionPropose",
+		"params": map[string]any{"proposer": map[string]any{"publicKey": "abcd1234"}},
+	})
+	encrypted, err := EncryptType0Envelope(testPairingSymKey, proposal)
+	require.NoError(t, err)
+
+	uri := validWCURI(testPairingTopic, testPairingSymKey)
+
+	require.NoError(t, client.Pair(context.Background(), uri))
+	client.handleRelayMessage(testPairingTopic, encrypted, tagSessionPropose)
+	require.Eventually(t, func() bool { return atomic.LoadInt32(&delivered) == 1 },
+		time.Second, 5*time.Millisecond, "first proposal was not delivered")
+
+	// The user dismisses the modal, then pastes the same URI again.
+	require.NoError(t, client.Pair(context.Background(), uri))
+	client.handleRelayMessage(testPairingTopic, encrypted, tagSessionPropose)
+
+	require.Eventually(t, func() bool { return atomic.LoadInt32(&delivered) == 2 },
+		time.Second, 5*time.Millisecond, "proposal was swallowed as a duplicate after re-pairing")
+}

--- a/pkg/services/connector/walletconnect/dialfailure.go
+++ b/pkg/services/connector/walletconnect/dialfailure.go
@@ -1,0 +1,47 @@
+package walletconnect
+
+import "strings"
+
+// Why a handshake was rejected, and whether repeating it could help.
+const (
+	dialFailureClockSkew   = "clock_skew"
+	dialFailureAuth        = "auth"
+	dialFailureProject     = "project"
+	dialFailureRateLimited = "rate_limited"
+	dialFailureServer      = "server"
+	dialFailureProxy       = "proxy"
+	dialFailureNetwork     = "network"
+	dialFailureUnknown     = "unknown"
+)
+
+type dialFailure struct {
+	class     string
+	retryable bool
+}
+
+// status is 0 when the relay never answered.
+func classifyDialFailure(status int, body string) dialFailure {
+	switch {
+	case status == 0:
+		return dialFailure{class: dialFailureNetwork, retryable: true}
+	case status == 401:
+		// The relay names both skew directions in the body.
+		if strings.Contains(body, "not yet valid") || strings.Contains(body, "is expired") {
+			return dialFailure{class: dialFailureClockSkew}
+		}
+		return dialFailure{class: dialFailureAuth}
+	case status == 403:
+		return dialFailure{class: dialFailureProject}
+	case status == 429:
+		return dialFailure{class: dialFailureRateLimited, retryable: true}
+	case status == 407 || status == 502 || status == 504:
+		// The relay answers JSON; anything else came from a proxy.
+		if !strings.HasPrefix(strings.TrimSpace(body), "{") {
+			return dialFailure{class: dialFailureProxy, retryable: true}
+		}
+		return dialFailure{class: dialFailureServer, retryable: true}
+	case status >= 500:
+		return dialFailure{class: dialFailureServer, retryable: true}
+	}
+	return dialFailure{class: dialFailureUnknown}
+}

--- a/pkg/services/connector/walletconnect/relay.go
+++ b/pkg/services/connector/walletconnect/relay.go
@@ -4,6 +4,7 @@ import (
 	cryptorand "crypto/rand"
 	"encoding/json"
 	"fmt"
+	"io"
 	"math/big"
 	"net/url"
 	"sync"
@@ -207,9 +208,27 @@ func (r *RelayClient) dialRelay() (*websocket.Conn, error) {
 	q.Set("projectId", r.projectID)
 	u.RawQuery = q.Encode()
 
-	conn, _, err := websocket.DefaultDialer.Dial(u.String(), nil)
+	conn, resp, err := websocket.DefaultDialer.Dial(u.String(), nil)
 	if err != nil {
-		return nil, fmt.Errorf("dial relay: %w", err)
+		// gorilla collapses every non-101 answer into "bad handshake".
+		status, body := 0, ""
+		if resp != nil {
+			defer resp.Body.Close()
+			raw, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
+			status, body = resp.StatusCode, truncate(string(raw), 256)
+		}
+		failure := classifyDialFailure(status, body)
+		r.logger.Warn("relay handshake rejected",
+			zap.Int("status", status),
+			zap.String("class", failure.class),
+			zap.Bool("retryable", failure.retryable),
+			zap.String("body", body),
+			zap.Int("projectIdLen", len(r.projectID)))
+		if status != 0 {
+			return nil, fmt.Errorf("dial relay: %w (http %d %s, retryable=%t: %s)",
+				err, status, failure.class, failure.retryable, body)
+		}
+		return nil, fmt.Errorf("dial relay: %w (%s, retryable=%t)", err, failure.class, failure.retryable)
 	}
 	return conn, nil
 }

--- a/pkg/services/connector/walletconnect/relay_dial_test.go
+++ b/pkg/services/connector/walletconnect/relay_dial_test.go
@@ -1,0 +1,69 @@
+package walletconnect
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// newRejectingRelay serves status and body instead of upgrading.
+func newRejectingRelay(t *testing.T, status int, body string) *RelayClient {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(status)
+		_, _ = w.Write([]byte(body))
+	}))
+	t.Cleanup(srv.Close)
+
+	r, err := NewRelayClient("test")
+	require.NoError(t, err)
+	r.url = strings.Replace(srv.URL, "http://", "ws://", 1)
+	t.Cleanup(func() { _ = r.Close() })
+	return r
+}
+
+func TestRelayClient_DialError_ReportsHTTPStatus(t *testing.T) {
+	r := newRejectingRelay(t, http.StatusForbidden, `{"error":"Project not found"}`)
+
+	err := r.Connect()
+	require.Error(t, err)
+	require.ErrorContains(t, err, "403")
+	require.ErrorContains(t, err, "Project not found")
+}
+
+func TestRelayClient_DialError_ClassifiesRetryability(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		status int
+		body   string
+		want   string
+	}{
+		{"clock skew", 401, `{"error":"JWT validation error: JWT Token is not yet valid: ..."}`, "clock_skew, retryable=false"},
+		{"expired token", 401, `{"error":"JWT validation error: JWT Token is expired: Some(1)"}`, "clock_skew, retryable=false"},
+		{"missing token", 401, `{"error":"JWT is missing"}`, "auth, retryable=false"},
+		{"unknown project", 403, `{"error":"Project not found"}`, "project, retryable=false"},
+		{"rate limited", 429, `{"error":"Too many requests"}`, "rate_limited, retryable=true"},
+		{"relay down", 503, `{"error":"unavailable"}`, "server, retryable=true"},
+		{"proxy in the way", 502, "<html><title>502 Bad Gateway</title></html>", "proxy, retryable=true"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			err := newRejectingRelay(t, tc.status, tc.body).Connect()
+			require.Error(t, err)
+			require.ErrorContains(t, err, tc.want)
+		})
+	}
+}
+
+func TestRelayClient_DialError_NoResponseIsRetryable(t *testing.T) {
+	r, err := NewRelayClient("test")
+	require.NoError(t, err)
+	r.url = "ws://127.0.0.1:1" // nothing listens here
+	t.Cleanup(func() { _ = r.Close() })
+
+	err = r.Connect()
+	require.Error(t, err)
+	require.ErrorContains(t, err, "network, retryable=true")
+}


### PR DESCRIPTION
Fixes + diagnostic WalletConnect pairing https://github.com/status-im/status-app/issues/22365
- Pass Status ProjectID to the fresh CreateAccount  
- More tolerant to clock mismatch. The relay grants 120s of leeway on the
  auth JWT's `iat` and rejects a token from a fast clock as "not yet valid",
  which surfaces as `websocket: bad handshake`. Backdating iat by 90s takes
  the tolerated skew from 2m to 3m30s. Measured against
  `wss://relay.walletconnect.com`.
- A dismissed proposal made the URI unusable. `pendingProposals` was only
  cleared by `ApproveSession`/`RejectSession`, so closing the connect modal
  without either dropped every later delivery of that proposal as a
  duplicate. Pairing the same topic again now clears it.
- The status code and body are now in the error, plus a class and a
  `retryable` flag (`clock_skew`, `auth`, `project`, `rate_limited`,
  `server`, `proxy`, `network`). Nothing logged the initial dial before, so
  there was no way to tell 401 from 403 from 429 - or to know whether a
  retry would help.
- Tests. Each fix is a red test commit followed by the fix.


https://github.com/user-attachments/assets/6b1c1a0d-89f9-4266-a776-f12320fa6c01

desktop pr https://github.com/status-im/status-app/pull/22367