### PR TITLE
feat: expose Waku and wallet HTTP byte counters

### DIFF
--- a/internal/metrics/httpbytes/httpbytes.go
+++ b/internal/metrics/httpbytes/httpbytes.go
@@ -1,0 +1,140 @@
+package httpbytes
+
+import (
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+const (
+	unknownHost = "unknown"
+	dirIn       = "in"
+	dirOut      = "out"
+)
+
+var httpBytes = prometheus.NewCounterVec(
+	prometheus.CounterOpts{
+		Name: "status_http_bytes",
+		Help: "Outgoing HTTP request and response body bytes by host.",
+	},
+	[]string{"host", "dir"},
+)
+
+func init() {
+	prometheus.MustRegister(httpBytes)
+}
+
+func Wrap(base http.RoundTripper) http.RoundTripper {
+	if base == nil {
+		base = http.DefaultTransport
+	}
+	if _, ok := base.(*countingTransport); ok {
+		return base
+	}
+	return &countingTransport{base: base}
+}
+
+func WrapClient(client *http.Client) *http.Client {
+	if client == nil {
+		client = &http.Client{}
+	}
+	wrapped := *client
+	wrapped.Transport = Wrap(client.Transport)
+	return &wrapped
+}
+
+func AddResponseBytes(host string, n int) {
+	if n <= 0 {
+		return
+	}
+	if host == "" {
+		host = unknownHost
+	}
+	httpBytes.WithLabelValues(host, dirIn).Add(float64(n))
+}
+
+func HostFromURL(raw string) string {
+	parsed, err := url.Parse(raw)
+	if err != nil {
+		return unknownHost
+	}
+	host := parsed.Host
+	if host == "" {
+		return unknownHost
+	}
+	return stripPort(host)
+}
+
+type countingTransport struct {
+	base http.RoundTripper
+}
+
+func (t *countingTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	host := HostLabel(req)
+	if req.ContentLength > 0 {
+		httpBytes.WithLabelValues(host, dirOut).Add(float64(req.ContentLength))
+	}
+	resp, err := t.base.RoundTrip(req)
+	if err != nil {
+		return resp, err
+	}
+	if resp != nil && resp.Body != nil {
+		resp.Body = &countingReadCloser{inner: resp.Body, host: host}
+	}
+	return resp, nil
+}
+
+func (t *countingTransport) CloseIdleConnections() {
+	type idleCloser interface {
+		CloseIdleConnections()
+	}
+	if closer, ok := t.base.(idleCloser); ok {
+		closer.CloseIdleConnections()
+	}
+}
+
+type countingReadCloser struct {
+	inner io.ReadCloser
+	host  string
+}
+
+func (c *countingReadCloser) Read(p []byte) (int, error) {
+	n, err := c.inner.Read(p)
+	if n > 0 {
+		httpBytes.WithLabelValues(c.host, dirIn).Add(float64(n))
+	}
+	return n, err
+}
+
+func (c *countingReadCloser) Close() error {
+	return c.inner.Close()
+}
+
+func HostLabel(req *http.Request) string {
+	if req == nil {
+		return unknownHost
+	}
+	host := req.URL.Host
+	if host == "" {
+		host = req.Host
+	}
+	return stripPort(host)
+}
+
+func stripPort(host string) string {
+	host = strings.TrimSpace(host)
+	if host == "" {
+		return unknownHost
+	}
+	if h, _, err := net.SplitHostPort(host); err == nil {
+		if h == "" {
+			return unknownHost
+		}
+		return h
+	}
+	return host
+}

--- a/internal/metrics/httpbytes/httpbytes_test.go
+++ b/internal/metrics/httpbytes/httpbytes_test.go
@@ -1,0 +1,108 @@
+package httpbytes
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWrapCountsRequestAndResponseByHost(t *testing.T) {
+	const responseBody = "token-list-payload"
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+		require.Equal(t, "rpc-body", string(body))
+		_, err = io.WriteString(w, responseBody)
+		require.NoError(t, err)
+	}))
+	t.Cleanup(server.Close)
+
+	host := stripPort(strings.TrimPrefix(server.URL, "http://"))
+	before := bytesForHost(t, host)
+
+	client := &http.Client{Transport: Wrap(http.DefaultTransport)}
+	resp, err := client.Post(server.URL+"/tokens", "text/plain", strings.NewReader("rpc-body"))
+	require.NoError(t, err)
+	got, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.NoError(t, resp.Body.Close())
+	require.Equal(t, responseBody, string(got))
+
+	after := bytesForHost(t, host)
+	require.Equal(t, before.in+len(responseBody), after.in)
+	require.Equal(t, before.out+len("rpc-body"), after.out)
+}
+
+func TestWrapIsIdempotent(t *testing.T) {
+	once := Wrap(http.DefaultTransport)
+	require.Equal(t, once, Wrap(once))
+}
+
+func TestHostLabelStripsPort(t *testing.T) {
+	req, err := http.NewRequest(http.MethodGet, "https://prod.market.status.im:443/tokens", nil)
+	require.NoError(t, err)
+	require.Equal(t, "prod.market.status.im", HostLabel(req))
+}
+
+func TestAddResponseBytesCountsInboundBytes(t *testing.T) {
+	host := "prod.market.status.im"
+	before := bytesForHost(t, host)
+	AddResponseBytes(host, 21)
+	after := bytesForHost(t, host)
+	require.Equal(t, before.in+21, after.in)
+}
+
+func TestHostFromURL(t *testing.T) {
+	require.Equal(t, "prod.market.status.im", HostFromURL("https://prod.market.status.im/static/lists.json"))
+	require.Equal(t, unknownHost, HostFromURL("not a url"))
+}
+
+func TestWrapClientIsIdempotentOnTransport(t *testing.T) {
+	client := WrapClient(&http.Client{Transport: http.DefaultTransport})
+	require.Equal(t, client.Transport, WrapClient(client).Transport)
+}
+
+type hostBytes struct {
+	in  int
+	out int
+}
+
+func bytesForHost(t *testing.T, host string) hostBytes {
+	t.Helper()
+	families, err := prometheus.DefaultGatherer.Gather()
+	require.NoError(t, err)
+	var got hostBytes
+	for _, family := range families {
+		if family.GetName() != "status_http_bytes" {
+			continue
+		}
+		for _, metric := range family.GetMetric() {
+			labels := labelMap(metric)
+			if labels["host"] != host {
+				continue
+			}
+			value := int(metric.GetCounter().GetValue())
+			switch labels["dir"] {
+			case dirIn:
+				got.in = value
+			case dirOut:
+				got.out = value
+			}
+		}
+	}
+	return got
+}
+
+func labelMap(metric *dto.Metric) map[string]string {
+	labels := make(map[string]string, len(metric.GetLabel()))
+	for _, label := range metric.GetLabel() {
+		labels[label.GetName()] = label.GetValue()
+	}
+	return labels
+}

--- a/internal/rpc/chain/client_utils.go
+++ b/internal/rpc/chain/client_utils.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/rpc"
 
+	"github.com/status-im/status-go/internal/metrics/httpbytes"
 	"github.com/status-im/status-go/params"
 	"github.com/status-im/status-go/pkg/services/wallet/puzzleauth"
 )
@@ -23,6 +24,8 @@ func CreateEthClientFromProvider(provider params.RpcProvider, rpcUserAgentName s
 	headers := http.Header{}
 	headers.Set("User-Agent", rpcUserAgentName)
 
+	httpClient := httpbytes.WrapClient(&http.Client{})
+
 	// Set up authentication if needed
 	switch provider.AuthType {
 	case params.BasicAuth:
@@ -37,12 +40,11 @@ func CreateEthClientFromProvider(provider params.RpcProvider, rpcUserAgentName s
 		if err != nil {
 			return nil, fmt.Errorf("puzzle auth: invalid provider URL for %s: %w", provider.Name, err)
 		}
-		opts = append(opts, rpc.WithHTTPClient(puzzleauth.NewHTTPClient(origin)))
+		httpClient = puzzleauth.NewHTTPClient(origin)
 	default:
 		return nil, fmt.Errorf("unknown auth type: %s", provider.AuthType)
 	}
-
-	opts = append(opts, rpc.WithHeaders(headers))
+	opts = append(opts, rpc.WithHTTPClient(httpClient), rpc.WithHeaders(headers))
 
 	// Dial the RPC client
 	rpcClient, err := rpc.DialOptions(context.Background(), provider.URL.Reveal(), opts...)

--- a/pkg/messaging/waku/gowaku.go
+++ b/pkg/messaging/waku/gowaku.go
@@ -1751,6 +1751,30 @@ func (w *Waku) FetchMessagesByHashes(ctx context.Context, storenode peer.AddrInf
 	return nil
 }
 
+func clampNonNegative(n int64) uint64 {
+	if n < 0 {
+		return 0
+	}
+	return uint64(n)
+}
+
 func (w *Waku) Metrics() string {
-	return ""
+	if w == nil || w.bandwidthCounter == nil {
+		return formatBandwidthMetrics(0, 0)
+	}
+	totals := w.bandwidthCounter.GetBandwidthTotals()
+	return formatBandwidthMetrics(
+		clampNonNegative(totals.TotalIn),
+		clampNonNegative(totals.TotalOut),
+	)
+}
+
+func formatBandwidthMetrics(bytesIn, bytesOut uint64) string {
+	return fmt.Sprintf(
+		"# HELP waku_libp2p_bandwidth_bytes Cumulative libp2p Waku bytes reported by the process bandwidth counter.\n"+
+			"# TYPE waku_libp2p_bandwidth_bytes counter\n"+
+			"waku_libp2p_bandwidth_bytes{dir=\"in\"} %d\n"+
+			"waku_libp2p_bandwidth_bytes{dir=\"out\"} %d\n",
+		bytesIn, bytesOut,
+	)
 }

--- a/pkg/messaging/waku/gowaku_test.go
+++ b/pkg/messaging/waku/gowaku_test.go
@@ -68,6 +68,38 @@ func TestNewRetrievesInitialDiscV5BootstrapNodes(t *testing.T) {
 	}
 }
 
+func TestBandwidthMetricsEmptyOnNewNode(t *testing.T) {
+	w, err := New(nil, nil, nil, nil)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		w.cancel()
+		w.envelopeCache.Stop()
+		w.wg.Wait()
+	})
+
+	metrics := w.Metrics()
+	require.Contains(t, metrics, `waku_libp2p_bandwidth_bytes{dir="in"} 0`)
+	require.Contains(t, metrics, `waku_libp2p_bandwidth_bytes{dir="out"} 0`)
+}
+
+func TestMetricsRendersBandwidthCounters(t *testing.T) {
+	metrics := formatBandwidthMetrics(2000, 1000)
+	require.Contains(t, metrics, `waku_libp2p_bandwidth_bytes{dir="in"} 2000`)
+	require.Contains(t, metrics, `waku_libp2p_bandwidth_bytes{dir="out"} 1000`)
+}
+
+func TestBandwidthMetricsNilSafe(t *testing.T) {
+	var w *Waku
+	require.Contains(t, w.Metrics(), `waku_libp2p_bandwidth_bytes{dir="in"} 0`)
+	require.Contains(t, (&Waku{}).Metrics(), `waku_libp2p_bandwidth_bytes{dir="out"} 0`)
+}
+
+func TestClampNonNegative(t *testing.T) {
+	require.Equal(t, uint64(0), clampNonNegative(-1))
+	require.Equal(t, uint64(0), clampNonNegative(0))
+	require.Equal(t, uint64(42), clampNonNegative(42))
+}
+
 func TestWakuLifecycleState(t *testing.T) {
 	// New() alone is safe to call with nil params; Start()/Stop() are not used
 	// here because they initialise the SDS library (requires a full node

--- a/pkg/services/wallet/collectibles/manager.go
+++ b/pkg/services/wallet/collectibles/manager.go
@@ -21,6 +21,7 @@ import (
 	"github.com/status-im/status-go/internal/contracts/community-tokens/collectibles"
 	"github.com/status-im/status-go/internal/contracts/ierc1155"
 	"github.com/status-im/status-go/internal/logutils"
+	"github.com/status-im/status-go/internal/metrics/httpbytes"
 	"github.com/status-im/status-go/internal/panics"
 	"github.com/status-im/status-go/internal/rpc"
 	"github.com/status-im/status-go/pkg/services/media"
@@ -101,9 +102,9 @@ func NewManager(
 	return &Manager{
 		ethClientGetter: ethClientGetter,
 		providers:       providers,
-		httpClient: &http.Client{
+		httpClient: httpbytes.WrapClient(&http.Client{
 			Timeout: requestTimeout,
-		},
+		}),
 		collectiblesDataDB: NewCollectibleDataDB(db),
 		collectionsDataDB:  NewCollectionDataDB(db),
 		communityManager:   communityManager,

--- a/pkg/services/wallet/puzzleauth/service.go
+++ b/pkg/services/wallet/puzzleauth/service.go
@@ -14,6 +14,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/status-im/status-go/internal/logutils"
+	"github.com/status-im/status-go/internal/metrics/httpbytes"
 )
 
 // Service manages puzzle authentication tokens
@@ -35,7 +36,7 @@ func NewService(origin string, httpClient *http.Client) *Service {
 	}
 	return &Service{
 		origin:     origin,
-		httpClient: httpClient,
+		httpClient: httpbytes.WrapClient(httpClient),
 	}
 }
 

--- a/pkg/services/wallet/puzzleauth/transport.go
+++ b/pkg/services/wallet/puzzleauth/transport.go
@@ -7,6 +7,8 @@ import (
 	"net/http"
 	"sync"
 	"time"
+
+	"github.com/status-im/status-go/internal/metrics/httpbytes"
 )
 
 var retryStatusCodes = map[int]bool{
@@ -49,7 +51,7 @@ func NewTransport(origin string, base http.RoundTripper) *Transport {
 		base = http.DefaultTransport
 	}
 	return &Transport{
-		base:        base,
+		base:        httpbytes.Wrap(base),
 		authService: sharedAuthServiceForOrigin(origin),
 		maxRetries:  2, // original attempt + 2 retries after auth
 	}

--- a/pkg/services/wallet/thirdparty/auth_transport.go
+++ b/pkg/services/wallet/thirdparty/auth_transport.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/status-im/status-go/internal/metrics/httpbytes"
 	"github.com/status-im/status-go/pkg/security"
 )
 
@@ -40,7 +41,7 @@ func NewAuthTransport(httpClient *http.Client, auth AuthParams, providerID strin
 		httpClient = &http.Client{Timeout: time.Minute}
 	}
 	return &AuthTransport{
-		httpClient: httpClient,
+		httpClient: httpbytes.WrapClient(httpClient),
 		auth:       auth,
 		providerID: providerID,
 	}

--- a/pkg/services/wallet/thirdparty/collectibles/rarible/client.go
+++ b/pkg/services/wallet/thirdparty/collectibles/rarible/client.go
@@ -14,6 +14,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 
 	"github.com/status-im/status-go/internal/logutils"
+	"github.com/status-im/status-go/internal/metrics/httpbytes"
 	"github.com/status-im/status-go/pkg/security"
 	walletCommon "github.com/status-im/status-go/pkg/services/wallet/common"
 	"github.com/status-im/status-go/pkg/services/wallet/connection"
@@ -103,7 +104,7 @@ func NewClient(mainnetAPIKey security.SensitiveString, testnetAPIKey security.Se
 	}
 
 	return &Client{
-		client:           &http.Client{Timeout: time.Minute},
+		client:           httpbytes.WrapClient(&http.Client{Timeout: time.Minute}),
 		mainnetAPIKey:    mainnetAPIKey,
 		testnetAPIKey:    testnetAPIKey,
 		connectionStatus: connection.NewStatus(),

--- a/pkg/services/wallet/thirdparty/decoder/fourbyte/client.go
+++ b/pkg/services/wallet/thirdparty/decoder/fourbyte/client.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/accounts/abi"
 
+	"github.com/status-im/status-go/internal/metrics/httpbytes"
 	"github.com/status-im/status-go/pkg/services/wallet/thirdparty"
 )
 
@@ -38,7 +39,7 @@ type Client struct {
 }
 
 func NewClient() *Client {
-	return &Client{Client: &http.Client{Timeout: time.Minute}, URL: "https://www.4byte.directory"}
+	return &Client{Client: httpbytes.WrapClient(&http.Client{Timeout: time.Minute}), URL: "https://www.4byte.directory"}
 }
 
 func (c *Client) DoQuery(url string) (*http.Response, error) {

--- a/pkg/services/wallet/thirdparty/decoder/fourbytegithub/client.go
+++ b/pkg/services/wallet/thirdparty/decoder/fourbytegithub/client.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/accounts/abi"
 
+	"github.com/status-im/status-go/internal/metrics/httpbytes"
 	"github.com/status-im/status-go/pkg/services/wallet/thirdparty"
 )
 
@@ -32,7 +33,7 @@ type Client struct {
 }
 
 func NewClient() *Client {
-	return &Client{Client: &http.Client{Timeout: time.Minute}, URL: "https://raw.githubusercontent.com"}
+	return &Client{Client: httpbytes.WrapClient(&http.Client{Timeout: time.Minute}), URL: "https://raw.githubusercontent.com"}
 }
 
 func (c *Client) DoQuery(url string) (*http.Response, error) {

--- a/pkg/services/wallet/thirdparty/http_client.go
+++ b/pkg/services/wallet/thirdparty/http_client.go
@@ -18,6 +18,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/status-im/status-go/internal/logutils"
+	"github.com/status-im/status-go/internal/metrics/httpbytes"
 	"github.com/status-im/status-go/pkg/security"
 )
 
@@ -137,6 +138,10 @@ func NewHTTPClient(opts ...Option) *HTTPClient {
 	for _, opt := range opts {
 		opt(client)
 	}
+	if client.client.Transport == nil {
+		client.client.Transport = http.DefaultTransport
+	}
+	client.client.Transport = httpbytes.Wrap(client.client.Transport)
 
 	return client
 }

--- a/pkg/services/wallet/token/httpbytes_fetcher.go
+++ b/pkg/services/wallet/token/httpbytes_fetcher.go
@@ -1,0 +1,31 @@
+package token
+
+import (
+	"context"
+
+	"github.com/status-im/go-wallet-sdk/pkg/tokens/fetcher"
+
+	"github.com/status-im/status-go/internal/metrics/httpbytes"
+)
+
+type countingTokenFetcher struct {
+	inner fetcher.Fetcher
+}
+
+func newCountingTokenFetcher(inner fetcher.Fetcher) fetcher.Fetcher {
+	return &countingTokenFetcher{inner: inner}
+}
+
+func (f *countingTokenFetcher) Fetch(ctx context.Context, details fetcher.FetchDetails) (fetcher.FetchedData, error) {
+	data, err := f.inner.Fetch(ctx, details)
+	httpbytes.AddResponseBytes(httpbytes.HostFromURL(data.SourceURL), len(data.JsonData))
+	return data, err
+}
+
+func (f *countingTokenFetcher) FetchConcurrent(ctx context.Context, details []fetcher.FetchDetails) ([]fetcher.FetchedData, error) {
+	data, err := f.inner.FetchConcurrent(ctx, details)
+	for _, item := range data {
+		httpbytes.AddResponseBytes(httpbytes.HostFromURL(item.SourceURL), len(item.JsonData))
+	}
+	return data, err
+}

--- a/pkg/services/wallet/token/httpbytes_fetcher_test.go
+++ b/pkg/services/wallet/token/httpbytes_fetcher_test.go
@@ -1,0 +1,67 @@
+package token
+
+import (
+	"context"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+	"github.com/status-im/go-wallet-sdk/pkg/tokens/fetcher"
+	"github.com/status-im/go-wallet-sdk/pkg/tokens/types"
+	"github.com/stretchr/testify/require"
+)
+
+type stubFetcher struct {
+	data fetcher.FetchedData
+}
+
+func (s stubFetcher) Fetch(context.Context, fetcher.FetchDetails) (fetcher.FetchedData, error) {
+	return s.data, nil
+}
+
+func (s stubFetcher) FetchConcurrent(context.Context, []fetcher.FetchDetails) ([]fetcher.FetchedData, error) {
+	return []fetcher.FetchedData{s.data}, nil
+}
+
+func TestCountingTokenFetcherAddsResponseBytes(t *testing.T) {
+	const payload = "token-list-json"
+	const host = "prod.market.status.im"
+	before := httpInBytes(t, host)
+
+	inner := stubFetcher{data: fetcher.FetchedData{
+		FetchDetails: fetcher.FetchDetails{
+			ListDetails: types.ListDetails{SourceURL: "https://prod.market.status.im/static/lists.json"},
+		},
+		JsonData: []byte(payload),
+	}}
+	got, err := newCountingTokenFetcher(inner).Fetch(context.Background(), fetcher.FetchDetails{})
+	require.NoError(t, err)
+	require.Equal(t, payload, string(got.JsonData))
+	require.Equal(t, before+len(payload), httpInBytes(t, host))
+}
+
+func httpInBytes(t *testing.T, host string) int {
+	t.Helper()
+	families, err := prometheus.DefaultGatherer.Gather()
+	require.NoError(t, err)
+	for _, family := range families {
+		if family.GetName() != "status_http_bytes" {
+			continue
+		}
+		for _, metric := range family.GetMetric() {
+			if labelValue(metric, "host") == host && labelValue(metric, "dir") == "in" {
+				return int(metric.GetCounter().GetValue())
+			}
+		}
+	}
+	return 0
+}
+
+func labelValue(metric *dto.Metric, name string) string {
+	for _, label := range metric.GetLabel() {
+		if label.GetName() == name {
+			return label.GetValue()
+		}
+	}
+	return ""
+}

--- a/pkg/services/wallet/token/token.go
+++ b/pkg/services/wallet/token/token.go
@@ -207,7 +207,7 @@ func initialListIDsFromEmbedded() []string {
 func setUpTokenListsManager(mng *Manager, walletDB *sql.DB, enabledChains []uint64, lastUpdate time.Time,
 	autoRefreshInterval time.Duration, autoRefreshCheckInterval time.Duration) (manager.Manager, error) {
 
-	wsdkFetcher := fetcher.New(fetcher.DefaultConfig())
+	wsdkFetcher := newCountingTokenFetcher(fetcher.New(fetcher.DefaultConfig()))
 
 	contentStore := NewContentStore(walletDB)
 


### PR DESCRIPTION
Exposes Waku libp2p bandwidth and wallet HTTP byte counters through the existing Prometheus /metrics endpoint. HTTP traffic is grouped by host and direction.

will be present in performance nightly dashboard

<img width="1280" height="893" alt="{74B007D1-4C01-40CA-B344-F5DC9D3512E5}" src="https://github.com/user-attachments/assets/a5550383-fd76-4cc5-8685-84baf4773e06" />
