### PR TITLE
[CHERRY-PICK] fix(messaging): fix bridge sendmessage

### DIFF
--- a/internal/protocol/common/message.go
+++ b/internal/protocol/common/message.go
@@ -73,6 +73,13 @@ const (
 
 const EveryoneMentionTag = "0x00001"
 
+// Returned by PrepareContent when the content type declares a payload
+// that is missing, instead of dereferencing nil.
+var (
+	ErrMissingBridgeMessagePayload  = errors.New("bridge message payload is missing")
+	ErrMissingDiscordMessagePayload = errors.New("discord message payload is missing")
+)
+
 // GapParameters is the From and To indicating the missing period in chat history
 type GapParameters struct {
 	From uint32 `json:"from,omitempty"`
@@ -345,6 +352,8 @@ func (m *Message) UnmarshalJSON(data []byte) error {
 		ImageHeight        uint32                           `json:"imageHeight"`
 		AlbumImagesCount   uint32                           `json:"albumImagesCount"`
 		From               string                           `json:"from"`
+		DiscordMessage     *protobuf.DiscordMessage         `json:"discordMessage"`
+		BridgeMessage      *protobuf.BridgeMessage          `json:"bridgeMessage"`
 		PaymentRequestList []*protobuf.PaymentRequest       `json:"paymentRequests"`
 		Deleted            bool                             `json:"deleted,omitempty"`
 		DeletedForMe       bool                             `json:"deletedForMe,omitempty"`
@@ -373,6 +382,15 @@ func (m *Message) UnmarshalJSON(data []byte) error {
 		}
 	}
 
+	if aux.ContentType == protobuf.ChatMessage_DISCORD_MESSAGE && aux.DiscordMessage != nil {
+		m.Payload = &protobuf.ChatMessage_DiscordMessage{DiscordMessage: aux.DiscordMessage}
+	}
+
+	if aux.ContentType == protobuf.ChatMessage_BRIDGE_MESSAGE && aux.BridgeMessage != nil {
+		m.Payload = &protobuf.ChatMessage_BridgeMessage{BridgeMessage: aux.BridgeMessage}
+	}
+
+	m.DiscordMessage = aux.DiscordMessage
 	m.PaymentRequests = aux.PaymentRequestList
 	m.ResponseTo = aux.ResponseTo
 	m.EnsName = aux.EnsName
@@ -559,9 +577,17 @@ func (m *Message) PrepareContent(identity string) error {
 	var parsedText ast.Node
 	switch m.ContentType {
 	case protobuf.ChatMessage_DISCORD_MESSAGE:
-		parsedText = markdown.Parse([]byte(m.GetDiscordMessage().Content), nil)
+		discordMessage := m.GetDiscordMessage()
+		if discordMessage == nil {
+			return ErrMissingDiscordMessagePayload
+		}
+		parsedText = markdown.Parse([]byte(discordMessage.Content), nil)
 	case protobuf.ChatMessage_BRIDGE_MESSAGE:
-		parsedText = markdown.Parse([]byte(m.GetBridgeMessage().Content), nil)
+		bridgeMessage := m.GetBridgeMessage()
+		if bridgeMessage == nil {
+			return ErrMissingBridgeMessagePayload
+		}
+		parsedText = markdown.Parse([]byte(bridgeMessage.Content), nil)
 	default:
 		parsedText = markdown.Parse([]byte(m.Text), nil)
 	}

--- a/internal/protocol/common/message_test.go
+++ b/internal/protocol/common/message_test.go
@@ -679,3 +679,138 @@ func TestMarshalMessageJSON(t *testing.T) {
 
 	assertMarshalAndUnmarshalJSON(t, msg, "message ID='%s'", msg.ID)
 }
+
+// Payload shape sent over messaging_sendChatMessage, see #7774.
+const bridgeMessageJSON = `{
+	"chatId": "0x04c51631b3354242d5a56f044c3b7703bcc001e8c725c4706928b3fac3c2a12ec9019e1e224d487f5c893389405bcec998bc687307f290a569d6a97d24b711bca8",
+	"text": "",
+	"contentType": 18,
+	"bridgeMessage": {
+		"bridgeName": "discord",
+		"userName": "thedatabro",
+		"userAvatar": "",
+		"userID": "123",
+		"content": "Meme here",
+		"messageID": "456",
+		"parentMessageID": "789"
+	}
+}`
+
+const discordMessageJSON = `{
+	"chatId": "0x04c51631b3354242d5a56f044c3b7703bcc001e8c725c4706928b3fac3c2a12ec9019e1e224d487f5c893389405bcec998bc687307f290a569d6a97d24b711bca8",
+	"text": "",
+	"contentType": 12,
+	"discordMessage": {
+		"id": "456",
+		"type": "Default",
+		"timestamp": "2023-01-01T00:00:00Z",
+		"content": "Meme here",
+		"author": {
+			"id": "123",
+			"name": "thedatabro"
+		}
+	}
+}`
+
+func TestUnmarshalBridgeMessageJSON(t *testing.T) {
+	message := NewMessage()
+	require.NoError(t, json.Unmarshal([]byte(bridgeMessageJSON), message))
+
+	require.Equal(t, protobuf.ChatMessage_BRIDGE_MESSAGE, message.ContentType)
+
+	bridgeMessage := message.GetBridgeMessage()
+	require.NotNil(t, bridgeMessage, "bridgeMessage payload must survive JSON unmarshalling")
+	require.Equal(t, "discord", bridgeMessage.BridgeName)
+	require.Equal(t, "thedatabro", bridgeMessage.UserName)
+	require.Equal(t, "", bridgeMessage.UserAvatar)
+	require.Equal(t, "123", bridgeMessage.UserID)
+	require.Equal(t, "Meme here", bridgeMessage.Content)
+	require.Equal(t, "456", bridgeMessage.MessageID)
+	require.Equal(t, "789", bridgeMessage.ParentMessageID)
+}
+
+func TestUnmarshalDiscordMessageJSON(t *testing.T) {
+	message := NewMessage()
+	require.NoError(t, json.Unmarshal([]byte(discordMessageJSON), message))
+
+	require.Equal(t, protobuf.ChatMessage_DISCORD_MESSAGE, message.ContentType)
+
+	discordMessage := message.GetDiscordMessage()
+	require.NotNil(t, discordMessage, "discordMessage payload must survive JSON unmarshalling")
+	require.Equal(t, "456", discordMessage.Id)
+	require.Equal(t, "Meme here", discordMessage.Content)
+	require.NotNil(t, discordMessage.Author)
+	require.Equal(t, "thedatabro", discordMessage.Author.Name)
+}
+
+func TestMarshalBridgeMessageJSON(t *testing.T) {
+	msg := NewMessage()
+	msg.ID = "1"
+	msg.ContentType = protobuf.ChatMessage_BRIDGE_MESSAGE
+	msg.Payload = &protobuf.ChatMessage_BridgeMessage{
+		BridgeMessage: &protobuf.BridgeMessage{
+			BridgeName:      "discord",
+			UserName:        "thedatabro",
+			UserAvatar:      "",
+			UserID:          "123",
+			Content:         "Meme here",
+			MessageID:       "456",
+			ParentMessageID: "789",
+		},
+	}
+
+	assertMarshalAndUnmarshalJSON(t, msg, "message ID='%s'", msg.ID)
+}
+
+// Message also has a standalone DiscordMessage field, so the round trip is
+// not deeply equal; only the payload is asserted.
+func TestMarshalDiscordMessageJSON(t *testing.T) {
+	msg := NewMessage()
+	msg.ID = "1"
+	msg.ContentType = protobuf.ChatMessage_DISCORD_MESSAGE
+	msg.Payload = &protobuf.ChatMessage_DiscordMessage{
+		DiscordMessage: &protobuf.DiscordMessage{
+			Id:        "456",
+			Type:      "Default",
+			Timestamp: "2023-01-01T00:00:00Z",
+			Content:   "Meme here",
+			Author: &protobuf.DiscordMessageAuthor{
+				Id:   "123",
+				Name: "thedatabro",
+			},
+		},
+	}
+
+	rawJSON, err := json.Marshal(msg)
+	require.NoError(t, err)
+
+	var unmarshalled Message
+	require.NoError(t, json.Unmarshal(rawJSON, &unmarshalled))
+	require.Equal(t, msg.ContentType, unmarshalled.ContentType)
+	require.NotNil(t, unmarshalled.GetDiscordMessage())
+	require.Equal(t, msg.GetDiscordMessage().Id, unmarshalled.GetDiscordMessage().Id)
+	require.Equal(t, msg.GetDiscordMessage().Content, unmarshalled.GetDiscordMessage().Content)
+	require.Equal(t, msg.GetDiscordMessage().GetAuthor().Name, unmarshalled.GetDiscordMessage().GetAuthor().Name)
+}
+
+func TestPrepareContentBridgeMessageMissingPayload(t *testing.T) {
+	message := NewMessage()
+	message.ContentType = protobuf.ChatMessage_BRIDGE_MESSAGE
+
+	var err error
+	require.NotPanics(t, func() {
+		err = message.PrepareContent("")
+	}, "PrepareContent must not panic on a BRIDGE_MESSAGE without a payload")
+	require.Error(t, err)
+}
+
+func TestPrepareContentDiscordMessageMissingPayload(t *testing.T) {
+	message := NewMessage()
+	message.ContentType = protobuf.ChatMessage_DISCORD_MESSAGE
+
+	var err error
+	require.NotPanics(t, func() {
+		err = message.PrepareContent("")
+	}, "PrepareContent must not panic on a DISCORD_MESSAGE without a payload")
+	require.Error(t, err)
+}

--- a/internal/protocol/message_persistence.go
+++ b/internal/protocol/message_persistence.go
@@ -2076,16 +2076,20 @@ func (db sqlitePersistence) SaveMessages(messages []*common.Message) (err error)
 		}
 
 		if msg.ContentType == protobuf.ChatMessage_BRIDGE_MESSAGE {
-			// check updates first
+			// Edits re-save the same user_messages.id (PRIMARY KEY ON CONFLICT
+			// REPLACE). The Discord/bridge message_id is not unique — two
+			// distinct Status messages may carry the same foreign id.
 			var hasMessage bool
-			hasMessage, err = db.bridgeMessageExists(tx, msg.GetBridgeMessage().MessageID)
+			hasMessage, err = db.bridgeMessageExists(tx, msg.ID)
 			if err != nil {
 				return
 			}
 			if hasMessage {
-				// bridge message exists, this is edit
-				err = db.updateBridgeMessageContent(tx, msg.GetBridgeMessage().MessageID, msg.GetBridgeMessage().Content)
-				return
+				err = db.updateBridgeMessageContent(tx, msg.ID, msg.GetBridgeMessage().Content)
+				if err != nil {
+					return
+				}
+				continue
 			}
 
 			err = db.saveBridgeMessage(tx, msg.GetBridgeMessage(), msg.ID)
@@ -3546,20 +3550,20 @@ func (db sqlitePersistence) updateStatusMessagesWithResponse(tx *sql.Tx, statusM
 	return err
 }
 
-func (db sqlitePersistence) bridgeMessageExists(tx *sql.Tx, bridgeMessageID string) (exists bool, err error) {
-	err = tx.QueryRow(`SELECT EXISTS(SELECT 1 FROM bridge_messages WHERE message_id = ?)`, bridgeMessageID).Scan(&exists)
+func (db sqlitePersistence) bridgeMessageExists(tx *sql.Tx, userMessageID string) (exists bool, err error) {
+	err = tx.QueryRow(`SELECT EXISTS(SELECT 1 FROM bridge_messages WHERE user_messages_id = ?)`, userMessageID).Scan(&exists)
 	return exists, err
 }
 
-func (db sqlitePersistence) updateBridgeMessageContent(tx *sql.Tx, bridgeMessageID string, content string) error {
-	sql := "UPDATE bridge_messages SET content = ? WHERE message_id = ?"
+func (db sqlitePersistence) updateBridgeMessageContent(tx *sql.Tx, userMessageID string, content string) error {
+	sql := "UPDATE bridge_messages SET content = ? WHERE user_messages_id = ?"
 	stmt, err := tx.Prepare(sql)
 	if err != nil {
 		return err
 	}
 	defer stmt.Close()
 
-	_, err = stmt.Exec(content, bridgeMessageID)
+	_, err = stmt.Exec(content, userMessageID)
 	return err
 }
 

--- a/internal/protocol/message_validator.go
+++ b/internal/protocol/message_validator.go
@@ -220,6 +220,24 @@ func ValidateReceivedChatMessage(message *protobuf.ChatMessage, whisperTimestamp
 		if len(bridgeMessage.Content) == 0 {
 			return errors.New("no bridge message content text")
 		}
+
+	case protobuf.ChatMessage_DISCORD_MESSAGE:
+		if message.Payload == nil {
+			return errors.New("no discord message content")
+		}
+		discordMessage := message.GetDiscordMessage()
+		if discordMessage == nil {
+			return errors.New("no discord message content")
+		}
+		if len(discordMessage.Id) == 0 {
+			return errors.New("no discord message id")
+		}
+		if discordMessage.Author == nil {
+			return errors.New("no discord message author")
+		}
+		if len(discordMessage.Content) == 0 {
+			return errors.New("no discord message content text")
+		}
 	}
 
 	if message.ContentType == protobuf.ChatMessage_AUDIO {

--- a/internal/protocol/message_validator_test.go
+++ b/internal/protocol/message_validator_test.go
@@ -440,6 +440,92 @@ func (s *MessageValidatorSuite) TestValidatePlainTextMessage() {
 				ContentType: protobuf.ChatMessage_BRIDGE_MESSAGE,
 			},
 		},
+		{
+			Name:             "Valid discord message",
+			WhisperTimestamp: 2,
+			Valid:            true,
+			Message: &protobuf.ChatMessage{
+				ChatId:     "a",
+				Text:       "",
+				Clock:      2,
+				Timestamp:  3,
+				ResponseTo: "",
+				EnsName:    "",
+				Payload: &protobuf.ChatMessage_DiscordMessage{
+					DiscordMessage: &protobuf.DiscordMessage{
+						Id:      "456",
+						Content: "some text",
+						Author: &protobuf.DiscordMessageAuthor{
+							Id:   "123",
+							Name: "mike",
+						},
+					},
+				},
+				MessageType: protobuf.MessageType_ONE_TO_ONE,
+				ContentType: protobuf.ChatMessage_DISCORD_MESSAGE,
+			},
+		},
+		{
+			Name:             "Invalid discord message, missing payload",
+			WhisperTimestamp: 2,
+			Valid:            false,
+			Message: &protobuf.ChatMessage{
+				ChatId:      "a",
+				Text:        "",
+				Clock:       2,
+				Timestamp:   3,
+				ResponseTo:  "",
+				EnsName:     "",
+				MessageType: protobuf.MessageType_ONE_TO_ONE,
+				ContentType: protobuf.ChatMessage_DISCORD_MESSAGE,
+			},
+		},
+		{
+			Name:             "Invalid discord message, missing author",
+			WhisperTimestamp: 2,
+			Valid:            false,
+			Message: &protobuf.ChatMessage{
+				ChatId:     "a",
+				Text:       "",
+				Clock:      2,
+				Timestamp:  3,
+				ResponseTo: "",
+				EnsName:    "",
+				Payload: &protobuf.ChatMessage_DiscordMessage{
+					DiscordMessage: &protobuf.DiscordMessage{
+						Id:      "456",
+						Content: "some text",
+					},
+				},
+				MessageType: protobuf.MessageType_ONE_TO_ONE,
+				ContentType: protobuf.ChatMessage_DISCORD_MESSAGE,
+			},
+		},
+		{
+			Name:             "Invalid discord message, empty content and id",
+			WhisperTimestamp: 2,
+			Valid:            false,
+			Message: &protobuf.ChatMessage{
+				ChatId:     "a",
+				Text:       "",
+				Clock:      2,
+				Timestamp:  3,
+				ResponseTo: "",
+				EnsName:    "",
+				Payload: &protobuf.ChatMessage_DiscordMessage{
+					DiscordMessage: &protobuf.DiscordMessage{
+						Id:      "",
+						Content: "",
+						Author: &protobuf.DiscordMessageAuthor{
+							Id:   "123",
+							Name: "mike",
+						},
+					},
+				},
+				MessageType: protobuf.MessageType_ONE_TO_ONE,
+				ContentType: protobuf.ChatMessage_DISCORD_MESSAGE,
+			},
+		},
 	}
 
 	for _, tc := range testCases {

--- a/internal/protocol/messenger_edit_message_test.go
+++ b/internal/protocol/messenger_edit_message_test.go
@@ -679,3 +679,27 @@ func (s *MessengerEditMessageSuite) TestEditMessageWithLinkPreviews() {
 	s.Require().Len(responseMessage.UnfurledStatusLinks.UnfurledStatusLinks, 1)
 	s.Require().False(responseMessage.New)
 }
+
+// A remote EditMessage can declare BRIDGE_MESSAGE while the local message it
+// targets carries no bridge payload, see #7774.
+func (s *MessengerEditMessageSuite) TestEditMessageBridgeContentTypeWithoutPayload() {
+	chat := CreateOneToOneChat("Our 1TO1", &s.privateKey.PublicKey, s.m.getTimesource())
+
+	message := buildTestMessage(*chat)
+	message.ID = "0x1"
+	s.Require().Nil(message.GetBridgeMessage())
+
+	editMessage := &protobuf.EditMessage{
+		Clock:       message.Clock + 1,
+		Text:        "edited text",
+		MessageId:   message.ID,
+		ChatId:      chat.ID,
+		ContentType: protobuf.ChatMessage_BRIDGE_MESSAGE,
+	}
+
+	var err error
+	s.Require().NotPanics(func() {
+		err = s.m.applyEditMessage(editMessage, message)
+	}, "applyEditMessage must not panic on a message without a bridge payload")
+	s.Require().ErrorIs(err, common.ErrMissingBridgeMessagePayload)
+}

--- a/internal/protocol/messenger_messages.go
+++ b/internal/protocol/messenger_messages.go
@@ -381,7 +381,11 @@ func (m *Messenger) applyEditMessage(editMessage *protobuf.EditMessage, message 
 	if editMessage.ContentType != protobuf.ChatMessage_BRIDGE_MESSAGE {
 		message.Text = editMessage.Text
 	} else {
-		message.GetBridgeMessage().Content = editMessage.Text
+		bridgeMessage := message.GetBridgeMessage()
+		if bridgeMessage == nil {
+			return common.ErrMissingBridgeMessagePayload
+		}
+		bridgeMessage.Content = editMessage.Text
 	}
 
 	message.EditedAt = editMessage.Clock

--- a/internal/protocol/persistence_test.go
+++ b/internal/protocol/persistence_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/status-im/status-go/internal/crypto"
@@ -43,6 +44,94 @@ func TestSaveMessages(t *testing.T) {
 		require.NoError(t, err)
 		require.EqualValues(t, id, m.ID)
 	}
+}
+
+// TestBridgeMessageDuplicateMessageID pins down a corruption reproduced against a
+// live status-backend over JSON-RPC: sending two distinct bridge messages that
+// happen to carry the same bridgeMessage.messageID silently destroys both of them.
+//
+// Observed on the wire:
+//
+//	a) send messageID "dup-fixed-id" / content "attempt 1"
+//	   -> message 0x92d6c8c5..., bridgeMessage.content == "attempt 1"   (correct)
+//	b) send messageID "dup-fixed-id" / content "attempt 2"
+//	   -> a NEW message 0x70bdd257... is created, but its bridgeMessage
+//	      comes back as {} (empty)
+//	c) reading the chat back: 0x70bdd257... has contentType 18 and an empty
+//	   bridgeMessage payload (unrenderable), while the ORIGINAL 0x92d6c8c5...
+//	   has been rewritten to content "attempt 2".
+//
+// Mechanism (sqlitePersistence.SaveMessages): the user_messages row for the new
+// message is inserted unconditionally, then bridgeMessageExists(messageID) sees the
+// bridge_messages row belonging to the FIRST message, concludes "this is an edit",
+// runs updateBridgeMessageContent(messageID, content) — which rewrites the first
+// message's payload — and returns early, so saveBridgeMessage never inserts a
+// bridge_messages row for the new user_messages id. The read path's
+// "LEFT JOIN bridge_messages ON m1.id = bm.user_messages_id" then finds nothing and
+// hands back a zero-valued BridgeMessage.
+//
+// The guard is keyed on the wrong column. bridge_messages has
+// user_messages_id as its PRIMARY KEY (one payload per status message) while
+// message_id is a plain column with DEFAULT "" — it is the bridge's own foreign id,
+// used for reply threading, and is not an identity key. The guard was added in
+// c92107976 "fix: handle bridge message edits" to support applyEditMessage, which
+// re-saves the SAME common.Message.ID; distinguishing that case requires comparing
+// user_messages_id, not message_id.
+//
+// Expected behaviour, asserted below: each distinct status message keeps its own
+// bridge payload, and saving a second message never rewrites the first.
+//
+// EXPECTED TO FAIL until the persistence layer is fixed.
+func TestBridgeMessageDuplicateMessageID(t *testing.T) {
+	db, err := openTestDB()
+	require.NoError(t, err)
+	p := newSQLitePersistence(db)
+
+	const duplicateBridgeMessageID = "dup-fixed-id"
+
+	saveBridge := func(statusMessageID, content string) error {
+		return p.SaveMessages([]*common.Message{{
+			ID:          statusMessageID,
+			LocalChatID: testPublicChatID,
+			From:        testPK,
+			ChatMessage: &protobuf.ChatMessage{
+				Text:        content,
+				ContentType: protobuf.ChatMessage_BRIDGE_MESSAGE,
+				ChatId:      testPublicChatID,
+				Payload: &protobuf.ChatMessage_BridgeMessage{
+					BridgeMessage: &protobuf.BridgeMessage{
+						BridgeName: "discord",
+						UserName:   "user1",
+						UserID:     "123",
+						Content:    content,
+						MessageID:  duplicateBridgeMessageID,
+					},
+				},
+			},
+		}})
+	}
+
+	require.NoError(t, saveBridge("status-message-1", "attempt 1"))
+	require.NoError(t, saveBridge("status-message-2", "attempt 2"))
+
+	// (1) the second message must keep its own payload
+	second, err := p.MessageByID("status-message-2")
+	require.NoError(t, err)
+	require.Equal(t, protobuf.ChatMessage_BRIDGE_MESSAGE, second.ContentType)
+	secondPayload := second.GetBridgeMessage()
+	require.NotNil(t, secondPayload, "second bridge message lost its payload entirely")
+	assert.Equal(t, "attempt 2", secondPayload.Content,
+		"second bridge message came back with an empty/incorrect payload; it is unrenderable in the client")
+	assert.Equal(t, "discord", secondPayload.BridgeName)
+	assert.Equal(t, duplicateBridgeMessageID, secondPayload.MessageID)
+
+	// (2) the first message must not be silently rewritten by an unrelated save
+	first, err := p.MessageByID("status-message-1")
+	require.NoError(t, err)
+	firstPayload := first.GetBridgeMessage()
+	require.NotNil(t, firstPayload)
+	assert.Equal(t, "attempt 1", firstPayload.Content,
+		"saving a different status message silently mutated an already-delivered message")
 }
 
 func TestMessagesByIDs(t *testing.T) {

--- a/internal/protocol/persistence_test.go
+++ b/internal/protocol/persistence_test.go
@@ -80,8 +80,6 @@ func TestSaveMessages(t *testing.T) {
 //
 // Expected behaviour, asserted below: each distinct status message keeps its own
 // bridge payload, and saving a second message never rewrites the first.
-//
-// EXPECTED TO FAIL until the persistence layer is fixed.
 func TestBridgeMessageDuplicateMessageID(t *testing.T) {
 	db, err := openTestDB()
 	require.NoError(t, err)
@@ -132,6 +130,49 @@ func TestBridgeMessageDuplicateMessageID(t *testing.T) {
 	require.NotNil(t, firstPayload)
 	assert.Equal(t, "attempt 1", firstPayload.Content,
 		"saving a different status message silently mutated an already-delivered message")
+}
+
+// TestBridgeMessageEditSameStatusID is the counterpart of
+// TestBridgeMessageDuplicateMessageID: applyEditMessage re-saves the same
+// common.Message.ID, and that must still update the existing bridge payload
+// rather than insert a second row (user_messages_id is the PRIMARY KEY).
+func TestBridgeMessageEditSameStatusID(t *testing.T) {
+	db, err := openTestDB()
+	require.NoError(t, err)
+	p := newSQLitePersistence(db)
+
+	saveBridge := func(content string) error {
+		return p.SaveMessages([]*common.Message{{
+			ID:          "status-message-1",
+			LocalChatID: testPublicChatID,
+			From:        testPK,
+			ChatMessage: &protobuf.ChatMessage{
+				Text:        content,
+				ContentType: protobuf.ChatMessage_BRIDGE_MESSAGE,
+				ChatId:      testPublicChatID,
+				Payload: &protobuf.ChatMessage_BridgeMessage{
+					BridgeMessage: &protobuf.BridgeMessage{
+						BridgeName: "discord",
+						UserName:   "user1",
+						UserID:     "123",
+						Content:    content,
+						MessageID:  "bridge-id-1",
+					},
+				},
+			},
+		}})
+	}
+
+	require.NoError(t, saveBridge("original"))
+	require.NoError(t, saveBridge("edited"))
+
+	got, err := p.MessageByID("status-message-1")
+	require.NoError(t, err)
+	payload := got.GetBridgeMessage()
+	require.NotNil(t, payload)
+	assert.Equal(t, "edited", payload.Content)
+	assert.Equal(t, "discord", payload.BridgeName)
+	assert.Equal(t, "bridge-id-1", payload.MessageID)
 }
 
 func TestMessagesByIDs(t *testing.T) {


### PR DESCRIPTION
Cherry-pick of https://github.com/status-im/status-go/pull/7805 onto `release/10.35.x` for Status App 2.39 RC.

Fixes https://github.com/status-im/status-go/issues/7774

`messaging_sendChatMessage` with `contentType: 18` (BRIDGE_MESSAGE) crashed the RPC handler because `Message.UnmarshalJSON` dropped the `bridgeMessage` payload and `PrepareContent` dereferenced nil.

- `UnmarshalJSON` rebuilds the `BridgeMessage` / `DiscordMessage` payload from JSON, same as sticker/audio/image
- `PrepareContent` returns `ErrMissingBridgeMessagePayload` / `ErrMissingDiscordMessagePayload` instead of panicking when the payload is missing
- JSON marshal/unmarshal round trip of a bridge message is now symmetric
- `applyEditMessage` no longer panics on a BRIDGE_MESSAGE edit against a message without a bridge payload
- `ValidateReceivedChatMessage` rejects DISCORD_MESSAGE with a missing payload, id, author or content
- `SaveMessages` keys bridge edits on `user_messages_id` so two Status messages that reuse a Discord `messageID` do not overwrite each other
desktop: https://github.com/status-im/status-app/pull/22405