### PR TITLE
test(functional): scope wait_for_login to the login just issued

### DIFF
--- a/test/functional/clients/async_signals.py
+++ b/test/functional/clients/async_signals.py
@@ -112,6 +112,11 @@ class SignalRouter:
         self._cleanup_task: Optional[asyncio.Task[None]] = None
         self._started = False
 
+    @property
+    def seq(self) -> int:
+        """Sequence number of the last published signal."""
+        return self._seq
+
     async def start(self) -> None:
         """Start background cleanup task."""
         if self._started:

--- a/test/functional/clients/async_status_backend.py
+++ b/test/functional/clients/async_status_backend.py
@@ -38,6 +38,11 @@ class AsyncStatusBackend:
         self._backend = backend
         self._router = SignalRouter()
         self._signal_client: Optional[AsyncSignalClient] = None
+        self._login_seq_mark = 0
+        backend._login_issued_hooks.append(self._mark_login)
+
+    def _mark_login(self) -> None:
+        self._login_seq_mark = self._router.seq
 
     # === Proxy properties to sync backend ===
 
@@ -246,8 +251,11 @@ class AsyncStatusBackend:
     async def wait_for_login(self, timeout: float = 60.0) -> dict:
         """Wait until the backend has completed login.
 
-        Async version of StatusBackend.wait_for_login().
+        Async version of StatusBackend.wait_for_login(): only a node.login published after the
+        sync backend issued its login request counts, and a re-login is never confirmed from RPC
+        state an earlier login left behind.
         """
+        mark = self._login_seq_mark
 
         def _apply_login_signal(signal_data: dict) -> None:
             if "error" in signal_data.get("event", {}):
@@ -261,7 +269,7 @@ class AsyncStatusBackend:
 
         # 1) Preferred path: wait for the `node.login` signal
         try:
-            signal = await self.wait_for_signal(SignalType.NODE_LOGIN, timeout=timeout, check_buffer=True)
+            signal = await self.wait_for_signal(SignalType.NODE_LOGIN, timeout=timeout, check_buffer=True, after_seq=mark)
             signal_data = signal.raw
             assert isinstance(signal_data, dict), f"Unexpected NODE_LOGIN signal payload type: {type(signal_data)}"
             _apply_login_signal(signal_data)
@@ -272,6 +280,12 @@ class AsyncStatusBackend:
         except asyncio.TimeoutError:
             logging.warning("NODE_LOGIN signal was not received in time; falling back to RPC polling")
 
+        if self._backend._logins_issued > 1:
+            raise TimeoutError(
+                f"Login did not complete: no new node.login signal arrived within {timeout}s. "
+                "RPC state cannot confirm a re-login, because an earlier login in this session already set it."
+            )
+
         # 2) Fallback path: poll RPC state until it reflects a logged-in account
         deadline = time.monotonic() + timeout
         last_error = None
@@ -279,9 +293,9 @@ class AsyncStatusBackend:
         while time.monotonic() < deadline:
             try:
                 # Check if signal arrived in buffer while we were polling
-                buffered = self._router.get_buffer_signals(SignalType.NODE_LOGIN)
+                buffered = [s for s in self._router.get_buffer_signals(SignalType.NODE_LOGIN) if s.seq > mark]
                 if buffered:
-                    signal_data = buffered[-1].raw
+                    signal_data = buffered[0].raw
                     _apply_login_signal(signal_data)
                     return signal_data
 
@@ -305,6 +319,8 @@ class AsyncStatusBackend:
                     }
                     _apply_login_signal(signal_data)
                     return signal_data
+            except AssertionError:
+                raise
             except Exception as e:
                 last_error = str(e)
 

--- a/test/functional/clients/signals.py
+++ b/test/functional/clients/signals.py
@@ -185,6 +185,7 @@ class SignalClient:
         # Global ordered stream: (seq, signal_type, signal_dict)
         self._received_all: list[tuple[int, SignalType, dict]] = []
         self._should_stop = False
+        self._ws_open = threading.Event()
 
         # Public attribute for debugging/inspection in tests if needed.
         # Do NOT mutate it directly.
@@ -252,6 +253,7 @@ class SignalClient:
 
     def _on_open(self, ws):
         logging.debug(f"SignalClient [{self.url}]: websocket connection opened")
+        self._ws_open.set()
 
     def _connect(self):
         retry_delay = 0.5
@@ -276,9 +278,16 @@ class SignalClient:
 
     def connect(self):
         self._should_stop = False
+        self._ws_open.clear()
         websocket_thread = threading.Thread(target=self._connect)
         websocket_thread.daemon = True
         websocket_thread.start()
+
+    def wait_until_connected(self, timeout: float = 10.0):
+        # A signal emitted before the websocket is open is never delivered, so a caller that
+        # reconnects right before a request must not send it until the connection is up.
+        if not self._ws_open.wait(timeout):
+            raise TimeoutError(f"SignalClient [{self.url}]: websocket did not open within {timeout}s")
 
     def disconnect(self):
         self._should_stop = True

--- a/test/functional/clients/status_backend.py
+++ b/test/functional/clients/status_backend.py
@@ -45,11 +45,14 @@ NANOSECONDS_PER_SECOND = 1_000_000_000
 class StatusBackend(RpcClient, SignalClient, ApiClient):
     name: str = ""
     container: StatusBackendContainer | None = None
+    _login_signal_mark = 0
+    _logins_issued = 0
     _media_server_port_gen = itertools.count(constants.STATUS_MEDIA_SERVER_PORT, 1)
     _connector_ws_port_gen = itertools.count(constants.STATUS_CONNECTOR_WS_PORT, 1)
 
     def __init__(self, privileged=False, ipv6=USE_IPV6, **kwargs):
         self.temp_dir = None
+        self._login_issued_hooks = []
         self.ipv6 = True if ipv6 == "Yes" else False
         logging.debug(f"Flag USE_IPV6 is: {self.ipv6}")
 
@@ -400,11 +403,21 @@ class StatusBackend(RpcClient, SignalClient, ApiClient):
         data = self._set_custom_tokens(data, kwargs)
         return data
 
+    def _mark_login_signal(self):
+        # node.login signals are never dropped from the signal buffer, so wait_for_login() has to know
+        # which ones predate this login: without the mark it matches an earlier one and reports a
+        # failed login as successful. The async waiter marks its own router through the hooks.
+        self._login_signal_mark = len(self.received_signals.get(SignalType.NODE_LOGIN, []))
+        self._logins_issued += 1
+        for hook in self._login_issued_hooks:
+            hook()
+
     def create_account_and_login(self, password: str, **kwargs):
         self._set_display_name(**kwargs)
         method = "CreateAccountAndLogin"
         data = self._create_account_request(password=password, **kwargs)
         self._boot_api_config = copy.deepcopy(data.get("apiConfig", {}))
+        self._mark_login_signal()
         return self.api_request_json(method, data)
 
     def restore_account_and_login(self, user=user_1, **kwargs):
@@ -413,6 +426,7 @@ class StatusBackend(RpcClient, SignalClient, ApiClient):
         data = self._create_account_request(password=user.password, **kwargs)
         data["mnemonic"] = user.passphrase
         self._boot_api_config = copy.deepcopy(data.get("apiConfig", {}))
+        self._mark_login_signal()
         return self.api_request_json(method, data)
 
     def login(self, key_uid, password: str, kdf_iterations=256000):
@@ -420,6 +434,8 @@ class StatusBackend(RpcClient, SignalClient, ApiClient):
         # Reconnect to signals before login to avoid missing node.login after logout.
         SignalClient.disconnect(self)
         SignalClient.connect(self)
+        self.wait_until_connected()
+        self._mark_login_signal()
         method = "LoginAccount"
         data = {
             "password": self.password,
@@ -452,6 +468,10 @@ class StatusBackend(RpcClient, SignalClient, ApiClient):
         occasionally missed by the websocket client. To keep tests stable we:
         - try to wait for `node.login` first
         - if it doesn't arrive, fall back to polling RPC state and extracting the same fields
+
+        Only signals and state produced by the login the caller just triggered count. Every login
+        method records the signal backlog depth first, and a re-login cannot be confirmed from RPC
+        state an earlier login left behind.
         """
 
         def _apply_login_signal(signal: dict):
@@ -465,14 +485,20 @@ class StatusBackend(RpcClient, SignalClient, ApiClient):
             self.key_uid = self.node_login_event.get("event", {}).get("account", {}).get("key-uid", "")
 
         # 1) Preferred path: wait for the `node.login` signal (race-safe with backlog).
+        mark = self._login_signal_mark
         try:
-            with self.expect_signal(SignalType.NODE_LOGIN, timeout=60, start="beginning") as exp:
+            with self.expect_signal(SignalType.NODE_LOGIN, timeout=60, start=mark) as exp:
                 pass
             signal = exp.result
             assert isinstance(signal, dict), f"Unexpected NODE_LOGIN signal payload type: {type(signal)}"
             _apply_login_signal(signal)
             return signal
         except TimeoutError:
+            if self._logins_issued > 1:
+                raise TimeoutError(
+                    "Login did not complete: no new node.login signal arrived within 60s. "
+                    "RPC state cannot confirm a re-login, because an earlier login in this session already set it."
+                )
             logging.warning("NODE_LOGIN signal was not received in time; falling back to RPC polling to confirm login")
 
         # 2) Fallback path: poll RPC state until it reflects a logged-in account.
@@ -485,9 +511,9 @@ class StatusBackend(RpcClient, SignalClient, ApiClient):
         while time.monotonic() < deadline:
             try:
                 # If the signal arrived late while we were falling back, prefer it.
-                buffered = self.received_signals.get(SignalType.NODE_LOGIN, [])
+                buffered = self.received_signals.get(SignalType.NODE_LOGIN, [])[mark:]
                 if buffered:
-                    signal = buffered[-1]
+                    signal = buffered[0]
                     assert isinstance(signal, dict), f"Unexpected buffered NODE_LOGIN payload type: {type(signal)}"
                     _apply_login_signal(signal)
                     return signal
@@ -517,6 +543,8 @@ class StatusBackend(RpcClient, SignalClient, ApiClient):
                     }
                     _apply_login_signal(signal)
                     return signal
+            except AssertionError:
+                raise
             except Exception as e:
                 last_error = str(e)
 

--- a/test/functional/tests/test_login_signal_freshness.py
+++ b/test/functional/tests/test_login_signal_freshness.py
@@ -1,0 +1,36 @@
+import pytest
+
+
+@pytest.mark.rpc
+class TestLoginSignalFreshness:
+
+    @pytest.fixture()
+    def backend(self, backend_new_profile):
+        return backend_new_profile("account-backend")
+
+    def test_wait_for_login_rejects_a_failed_relogin(self, backend):
+        key_uid = backend.key_uid
+        backend.logout()
+        backend.login(key_uid, "not-the-password")
+
+        with pytest.raises(AssertionError, match="Unexpected error during login"):
+            backend.wait_for_login()
+
+
+@pytest.mark.rpc
+@pytest.mark.asyncio
+class TestAsyncLoginSignalFreshness:
+
+    async def test_wait_for_login_rejects_a_failed_relogin(self, async_backend_new_profile):
+        device = await async_backend_new_profile("account-backend")
+        key_uid, password = device.backend.key_uid, device.backend.password
+
+        device.backend.logout()
+        device.backend.login(key_uid, password)
+        await device.wait_for_login()
+
+        device.backend.logout()
+        device.backend.login(key_uid, "not-the-password")
+
+        with pytest.raises(AssertionError, match="Unexpected error during login"):
+            await device.wait_for_login()


### PR DESCRIPTION
# Description

1. `wait_for_login()` now waits only for a `node.login` emitted after the login request it is confirming. The login methods record a mark before sending: the signal backlog depth for the sync waiter, the router sequence number (via a hook, passed as `after_seq`) for `AsyncStatusBackend.wait_for_login()`.
2. The RPC-polling fallback in both waiters runs only for a backend's first login. A re-login that produces no fresh signal raises instead of being confirmed from state an earlier login left behind.
3. Two regression tests, one per waiter: log out, log in with a wrong password, the waiter must raise.

Both waiters could confirm a login that was not the one under test: the sync one returned the first `node.login` the client ever buffered (`start="beginning"`), the async one scans its buffer newest-first. Neither buffer is ever cleared and every fixture logs in before the test body runs, so on a re-login the helper answered with the fixture's signal and never read the one carrying `failed to open database: [keystore] incorrect password provided`. Fifteen call sites in ten files use the sync helper; the five that re-login after a logout were affected, and now fail when no fresh signal arrives instead of passing on the old one.

Verified against `develop` at `65e177a4fc`: both new tests fail with `DID NOT RAISE` without the change and pass with it; with it, the two new tests, the async waiter's two call-site modules, the three login-method modules and `test_transport_store_history_sync.py` `12 passed in 381.79s`.

<details>
<summary>What each test means for a user</summary>

The user here is a test author relying on `wait_for_login()` to tell them whether a login worked.

- **`TestLoginSignalFreshness::test_wait_for_login_rejects_a_failed_relogin`** — A test logs a profile out and back in with the wrong password. The helper must report that failure, not the earlier successful login it saw when the profile was created. Before this change it returned the old success and the test passed.
- **`TestAsyncLoginSignalFreshness::test_wait_for_login_rejects_a_failed_relogin`** — The same, through the async wrapper used by the multi-device tests: one good re-login leaves a success in its buffer, then a wrong-password re-login must still be reported as a failure.

</details>

<details>
<summary>AI-made decisions</summary>

- The async mark comes from a hook the wrapper registers on the sync backend, because the request goes through the sync `StatusBackend.login()` and the call sites stay as they are. The re-login gate is a count of logins issued, not the buffer: the router expires signals after five minutes.
- The fallback stays for a first login, the missed-websocket case it was added for; on a re-login its check (a public key in settings, a keypair row) is already satisfied, so it cannot tell a missed signal from a failed login. Removing it there exposed a race it hid: `login()` reconnected the websocket and sent the request before the socket was open. `SignalClient` now records when the connection opens and the login helpers wait for it.
- An `AssertionError` from the error check is no longer swallowed by the fallback's `except Exception`, which turned a failed login into a timeout.
- The async waiter was not live-broken at its two call sites: a wrong-password paired login in `test_transport_multidevice_sync.py` on unpatched `develop` found no earlier `node.login` in the router. The regression test builds the stale case deliberately.

</details>
