### PR TITLE
test(functional): extend non-profile cold-wallet guards

### DIFF
--- a/test/functional/tests/test_migrate_non_profile_cold_wallet_keypair_to_app.py
+++ b/test/functional/tests/test_migrate_non_profile_cold_wallet_keypair_to_app.py
@@ -1,3 +1,6 @@
+"""The keycards tables and their RPCs were dropped, so the observable keycard state of a
+non-profile keypair is its cold-wallet type plus the absence of keystore files."""
+
 import copy
 import re
 
@@ -37,6 +40,16 @@ class TestMigrateNonProfileColdWalletKeypairToApp:
         kp = backend.accounts_service.get_keypair_by_key_uid(backend.key_uid)
         assert kp is not None, "Expected the profile keypair to exist"
         return [a.get("address") for a in kp.get("accounts", [])]
+
+    def _keypair_fields(self, kp):
+        return {
+            "key-uid": kp["key-uid"],
+            "type": kp["type"],
+            "name": kp["name"],
+            "derived-from": kp["derived-from"],
+            "xpub": kp["xpub"],
+            "accounts": sorted((a["address"], a["path"]) for a in kp["accounts"] if not a.get("removed")),
+        }
 
     @pytest.mark.parametrize("cold_wallet_type", ["status-keycard", "ledger", "trezor"])
     def test_full_migrate_flow(self, backend, cold_wallet_type):
@@ -153,3 +166,105 @@ class TestMigrateNonProfileColdWalletKeypairToApp:
             assert (
                 resp is False
             ), f"Expected no keystore file for {address} because migrate-to-app with a wrong password must not write keystore files"
+
+    def test_migrate_to_app_preserves_keypair_fields(self, backend):
+        key_uid, addresses = self._add_seed_keypair(backend)
+        profile_xpub0 = backend.accounts_service.get_keypair_by_key_uid(backend.key_uid)["xpub"]
+
+        kp0 = backend.accounts_service.get_keypair_by_key_uid(key_uid)
+        assert kp0["type"] == "seed"
+        assert kp0.get("cold-wallet", "") == ""
+        assert kp0["xpub"] == user_1.wallet_xpub
+        assert kp0["derived-from"]
+        assert kp0["name"] == keypair_name
+        fields0 = self._keypair_fields(kp0)
+
+        backend.accounts_service.migrate_non_profile_keypair_to_cold_wallet(key_uid, backend.password, "status-keycard")
+
+        kp1 = backend.accounts_service.get_keypair_by_key_uid(key_uid)
+        assert self._keypair_fields(kp1) == fields0
+        assert kp1["xpub"] == user_1.wallet_xpub
+        assert kp1.get("cold-wallet") == "status-keycard"
+        for account in kp1["accounts"]:
+            if not account.get("removed"):
+                assert account.get("operable") == "fully"
+
+        keypairs = backend.accounts_service.get_account_keypairs()
+        assert len([kp for kp in keypairs if kp.get("key-uid") == key_uid]) == 1
+        accounts = backend.accounts_service.get_accounts()
+        account_addresses = {account.get("address", "").lower() for account in accounts}
+        assert all(account["address"].lower() in account_addresses for account in kp1["accounts"])
+
+        backend.accounts_service.migrate_non_profile_cold_wallet_keypair_to_app(user_1.passphrase, backend.password)
+
+        kp2 = backend.accounts_service.get_keypair_by_key_uid(key_uid)
+        assert self._keypair_fields(kp2) == fields0
+        assert kp2.get("cold-wallet", "") == ""
+        for account in kp2["accounts"]:
+            if not account.get("removed"):
+                assert account.get("operable") == "fully"
+        accounts = backend.accounts_service.get_accounts()
+        account_addresses = {account.get("address", "").lower() for account in accounts}
+        assert all(account["address"].lower() in account_addresses for account in kp2["accounts"])
+
+        profile_kp = backend.accounts_service.get_keypair_by_key_uid(backend.key_uid)
+        assert profile_kp.get("cold-wallet", "") == ""
+        assert profile_kp["xpub"] == profile_xpub0
+        for address in self._profile_addresses(backend):
+            resp = backend.accounts_service.verify_keystore_file_for_account(address, backend.password)
+            assert resp is True, f"Expected the profile keystore file for {address} to remain present"
+
+    def test_migrate_to_cold_wallet_with_empty_password_is_rejected(self, backend):
+        key_uid, addresses = self._add_seed_keypair(backend)
+
+        with pytest.raises(ApiResponseError, match=re.escape("no password provided")):
+            backend.accounts_service.migrate_non_profile_keypair_to_cold_wallet(key_uid, "", "status-keycard")
+
+        kp = backend.accounts_service.get_keypair_by_key_uid(key_uid)
+        assert kp.get("cold-wallet", "") == ""
+        for address in addresses:
+            resp = backend.accounts_service.verify_keystore_file_for_account(address, backend.password)
+            assert resp is True, f"Expected the keystore file for {address} to remain present"
+
+    def test_migrate_to_cold_wallet_with_wrong_password_is_rejected(self, backend):
+        key_uid, addresses = self._add_seed_keypair(backend)
+
+        with pytest.raises(ApiResponseError, match=re.escape("[keystore] incorrect password provided")):
+            backend.accounts_service.migrate_non_profile_keypair_to_cold_wallet(key_uid, "definitely-wrong-password", "status-keycard")
+
+        kp = backend.accounts_service.get_keypair_by_key_uid(key_uid)
+        assert kp.get("cold-wallet", "") == ""
+        for address in addresses:
+            resp = backend.accounts_service.verify_keystore_file_for_account(address, backend.password)
+            assert resp is True, f"Expected the keystore file for {address} to remain present"
+
+    def test_change_cold_wallet_type_without_password(self, backend):
+        key_uid, addresses = self._add_seed_keypair(backend)
+        backend.accounts_service.migrate_non_profile_keypair_to_cold_wallet(key_uid, backend.password, "status-keycard")
+
+        backend.accounts_service.migrate_non_profile_keypair_to_cold_wallet(key_uid, "", "ledger")
+
+        kp = backend.accounts_service.get_keypair_by_key_uid(key_uid)
+        assert kp.get("cold-wallet") == "ledger"
+        for address in addresses:
+            resp = backend.accounts_service.verify_keystore_file_for_account(address, backend.password)
+            assert resp is False, f"Expected no keystore file for {address} while using a cold wallet"
+
+        backend.accounts_service.migrate_non_profile_cold_wallet_keypair_to_app(user_1.passphrase, backend.password)
+        kp = backend.accounts_service.get_keypair_by_key_uid(key_uid)
+        assert kp.get("cold-wallet", "") == ""
+        for address in addresses:
+            resp = backend.accounts_service.verify_keystore_file_for_account(address, backend.password)
+            assert resp is True, f"Expected the keystore file for {address} to be restored"
+
+    def test_migrate_to_app_twice_is_rejected(self, backend):
+        key_uid, addresses = self._add_seed_keypair(backend)
+        backend.accounts_service.migrate_non_profile_keypair_to_cold_wallet(key_uid, backend.password, "status-keycard")
+        backend.accounts_service.migrate_non_profile_cold_wallet_keypair_to_app(user_1.passphrase, backend.password)
+
+        with pytest.raises(ApiResponseError, match=re.escape("keypair is not a cold wallet keypair")):
+            backend.accounts_service.migrate_non_profile_cold_wallet_keypair_to_app(user_1.passphrase, backend.password)
+
+        for address in addresses:
+            resp = backend.accounts_service.verify_keystore_file_for_account(address, backend.password)
+            assert resp is True, f"Expected the keystore file for {address} to remain present"


### PR DESCRIPTION
# Description

1. Five tests added to `test_migrate_non_profile_cold_wallet_keypair_to_app.py`: a round trip that pins every keypair field (key-uid, type, name, derived-from, xpub, account paths) across migrate-to-keycard and back; a cold-wallet type change with an empty password; and three guards, for an empty password, a wrong password, and migrate-to-app called twice.

The module already drove the happy path for the three cold-wallet types. It did not pin that the migration returns the keypair unchanged, or that the guards hold. The empty-password check is asymmetric, rejected for the first migration and accepted for a type change once the keypair is cold, and nothing recorded that. Keycard rows are not asserted because the `keycards` tables and their RPCs were dropped; the observable state is `cold-wallet` plus keystore presence.

Run against `develop` at `65e177a4fc`, image built from that commit: `15 passed in 145.71s`.

<details>
<summary>What each test means for a user</summary>

The keypair is a second, seed-phrase wallet the user imported alongside their profile.

- **`test_migrate_to_app_preserves_keypair_fields`** — A user moves an imported wallet onto a Keycard and later back to the app. Every detail of that wallet (name, addresses, derivation, public key) is the same at the end as at the start, its accounts are fully usable, and the profile's own keys were never touched.
- **`test_change_cold_wallet_type_without_password`** — A user who keeps a wallet on a Keycard switches it to a Ledger. No password is needed for that, the key files stay off the device while it is on hardware, and moving it back to the app restores them.
- **`test_migrate_to_cold_wallet_with_empty_password_is_rejected`** — A user tries to move a wallet onto hardware without entering a password. Refused, and every key file stays on the device.
- **`test_migrate_to_cold_wallet_with_wrong_password_is_rejected`** — The same with a wrong password. Refused with a clear message, key files intact.
- **`test_migrate_to_app_twice_is_rejected`** — A wallet already back on the app is asked to come back again. Refused with a clear message; nothing is deleted.

</details>

<details>
<summary>AI-made decisions</summary>

- Written by a Devin agent and reshaped in review; the `Assisted-by` trailer on the commit is that agent's.
- Each test was checked by breaking the behaviour it names (the migrate-to-cold-wallet RPC stubbed out, the migrate-to-app RPC stubbed out, the returned xpub corrupted after migration), confirming it fails, then restoring and confirming it passes.
- The nearest existing test, `test_migrate_to_app_rejects_non_cold_keypair`, shares an error string with the called-twice guard but not a scenario (never cold versus already migrated back), so both stay.
- Covers status-im/status-app#21626. The type-change test touches #21637 only incidentally; #21636 is already covered by `test_add_keypair_stored_to_cold_wallet.py`.

</details>
