### PR TITLE
test(functional): cover cold-wallet keypair signing and operability

### DIFF
--- a/test/functional/clients/services/accounts.py
+++ b/test/functional/clients/services/accounts.py
@@ -106,6 +106,21 @@ class AccountService(Service):
         response = self.rpc_request("migrateNonProfileColdWalletKeypairToApp", params)
         return response
 
+    def make_seed_phrase_keypair_fully_operable(self, mnemonic, password):
+        params = [mnemonic, password]
+        response = self.rpc_request("makeSeedPhraseKeypairFullyOperable", params)
+        return response
+
+    def make_partially_operable_accouts_fully_operable(self, password):
+        params = [password]
+        response = self.rpc_request("makePartiallyOperableAccoutsFullyOperable", params)
+        return response
+
+    def clean_keystore_files(self, password):
+        params = [password]
+        response = self.rpc_request("cleanKeystoreFiles", params)
+        return response
+
     def get_random_mnemonic(self):
         response = self.rpc_request("getRandomMnemonic", [])
         return response

--- a/test/functional/steps/cold_wallet.py
+++ b/test/functional/steps/cold_wallet.py
@@ -1,0 +1,15 @@
+from resources.constants import keypair_name, user_1, wallet_account_details_derivation
+
+
+def add_seed_keypair(backend, user=user_1, name=keypair_name):
+    """Import a keypair from a seed phrase into the app keystore and return it as the RPC reports it."""
+    response = backend.accounts_service.add_keypair_via_seed_phrase(user.passphrase, backend.password, name, "", wallet_account_details_derivation)
+    assert response.get("key-uid"), "Expected addKeypairViaSeedPhrase to return the created keypair"
+    assert response.get("cold-wallet", "") == "", "Expected a seed-imported keypair to start off any cold wallet"
+    return response
+
+
+def keystore_present(backend, keypair):
+    """Keystore presence per address of the keypair, the master address included."""
+    addresses = [a["address"] for a in keypair["accounts"]] + [keypair["derived-from"]]
+    return {address: backend.accounts_service.verify_keystore_file_for_account(address, backend.password) for address in addresses}

--- a/test/functional/tests/test_cold_keypair_operability.py
+++ b/test/functional/tests/test_cold_keypair_operability.py
@@ -1,21 +1,13 @@
-"""The three operability RPCs that decide whether a keypair's keys are on disk.
-
-makeSeedPhraseKeypairFullyOperable writes keystore files back from a mnemonic,
-makePartiallyOperableAccoutsFullyOperable sweeps accounts that were added without a password, and
-cleanKeystoreFiles deletes files again. All three branch on cold-wallet state and none of them was
-driven anywhere in test/functional; makeSeedPhraseKeypairFullyOperable had no test at any altitude.
-"""
+"""The three operability RPCs that decide whether a keypair's keys are on disk, all of which branch on cold-wallet state:
+makeSeedPhraseKeypairFullyOperable writes keystore files back from a mnemonic, makePartiallyOperableAccoutsFullyOperable
+sweeps accounts that were added without a password, and cleanKeystoreFiles deletes files again."""
 
 import copy
 
 import pytest
 from clients.api import ApiResponseError
-from resources.constants import (
-    keypair_name,
-    user_1,
-    user_mnemonic_12,
-    wallet_account_details_derivation,
-)
+from resources.constants import user_1, user_mnemonic_12
+from steps.cold_wallet import add_seed_keypair, keystore_present
 
 NEXT_PATH = "m/44'/60'/0'/0/1"
 
@@ -27,25 +19,8 @@ class TestColdKeypairOperability:
     def backend(self, backend_new_profile):
         return backend_new_profile("operability")
 
-    def _add_seed_keypair(self, backend, user, name=keypair_name):
-        response = backend.accounts_service.add_keypair_via_seed_phrase(
-            user.passphrase,
-            backend.password,
-            name,
-            "",
-            wallet_account_details_derivation,
-        )
-        key_uid = response.get("key-uid")
-        assert key_uid, "Expected addKeypairViaSeedPhrase to return the created keypair"
-        assert response.get("xpub", "").startswith("xpub"), "Expected the imported keypair to carry an xpub"
-        return key_uid, response
-
-    def _addresses_of(self, backend, key_uid):
-        keypair = backend.accounts_service.get_keypair_by_key_uid(key_uid)
-        return [a["address"] for a in keypair["accounts"]] + [keypair["derived-from"]]
-
-    def _keystore_present(self, backend, addresses):
-        return {address: backend.accounts_service.verify_keystore_file_for_account(address, backend.password) for address in addresses}
+    def _keystore_present(self, backend, key_uid):
+        return keystore_present(backend, backend.accounts_service.get_keypair_by_key_uid(key_uid))
 
     def _add_account_without_a_password(self, backend, key_uid, mnemonic, path=NEXT_PATH):
         """An account added with no password is derived from the stored xpub, so it lands partially operable."""
@@ -72,7 +47,7 @@ class TestColdKeypairOperability:
         return account
 
     def test_the_sweep_promotes_an_account_added_without_a_password(self, backend):
-        key_uid, _ = self._add_seed_keypair(backend, user_1)
+        key_uid = add_seed_keypair(backend)["key-uid"]
         address = self._add_account_without_a_password(backend, key_uid, user_1.passphrase)
 
         assert self._account(backend, key_uid, address)["operable"] == "partially", "Expected an xpub-derived account to start partially operable"
@@ -89,23 +64,22 @@ class TestColdKeypairOperability:
         ), "Expected the sweep to write the keystore file it derived"
 
     def test_the_sweep_skips_cold_wallet_keypairs(self, backend):
-        app_key_uid, _ = self._add_seed_keypair(backend, user_1)
-        cold_key_uid, _ = self._add_seed_keypair(backend, user_mnemonic_12, name="cold-keypair")
+        app_key_uid = add_seed_keypair(backend)["key-uid"]
+        cold_key_uid = add_seed_keypair(backend, user_mnemonic_12, name="cold-keypair")["key-uid"]
         app_address = self._add_account_without_a_password(backend, app_key_uid, user_1.passphrase)
 
         backend.accounts_service.migrate_non_profile_keypair_to_cold_wallet(cold_key_uid, backend.password, "status-keycard")
-        cold_addresses = self._addresses_of(backend, cold_key_uid)
-        assert not any(self._keystore_present(backend, cold_addresses).values()), "Expected migration to have deleted the cold keypair's files"
+        assert not any(self._keystore_present(backend, cold_key_uid).values()), "Expected migration to have deleted the cold keypair's files"
 
         promoted = backend.accounts_service.make_partially_operable_accouts_fully_operable(backend.password)
 
         assert [a.lower() for a in promoted] == [app_address.lower()], "Expected only the app-side account to be promoted"
         assert not any(
-            self._keystore_present(backend, cold_addresses).values()
+            self._keystore_present(backend, cold_key_uid).values()
         ), "Expected the sweep to leave the cold keypair alone, because its key is on the card"
 
     def test_the_sweep_requires_a_password(self, backend):
-        key_uid, _ = self._add_seed_keypair(backend, user_1)
+        key_uid = add_seed_keypair(backend)["key-uid"]
         address = self._add_account_without_a_password(backend, key_uid, user_1.passphrase)
 
         with pytest.raises(ApiResponseError, match="no password provided"):
@@ -114,38 +88,34 @@ class TestColdKeypairOperability:
         assert self._account(backend, key_uid, address)["operable"] == "partially", "Expected the rejected sweep to promote nothing"
 
     def test_make_seed_phrase_keypair_fully_operable_restores_files_but_leaves_the_keypair_cold(self, backend):
-        key_uid, _ = self._add_seed_keypair(backend, user_1)
-        addresses = self._addresses_of(backend, key_uid)
+        key_uid = add_seed_keypair(backend)["key-uid"]
 
         backend.accounts_service.migrate_non_profile_keypair_to_cold_wallet(key_uid, backend.password, "status-keycard")
-        assert not any(self._keystore_present(backend, addresses).values())
+        assert not any(self._keystore_present(backend, key_uid).values())
 
         backend.accounts_service.make_seed_phrase_keypair_fully_operable(user_1.passphrase, backend.password)
 
-        present = self._keystore_present(backend, addresses)
+        present = self._keystore_present(backend, key_uid)
         assert all(present.values()), f"Expected every file back, the master address included: {present}"
-        # The distinction worth pinning: unlike migrateNonProfileColdWalletKeypairToApp, this call
-        # does not clear cold_wallet, so the keypair now claims to be on a card and has its keys on
-        # disk at the same time.
+        # Unlike migrateNonProfileColdWalletKeypairToApp this call does not clear cold_wallet, so the
+        # keypair now claims to be on a card while its keys sit on disk.
         assert (
             backend.accounts_service.get_keypair_by_key_uid(key_uid)["cold-wallet"] == "status-keycard"
-        ), "Expected the cold-wallet flag to survive, because this call only writes keystore files"
+        ), "Characterises current behaviour: this call writes keystore files without clearing cold-wallet"
 
     def test_clean_keystore_files_empties_a_cold_keypair_and_spares_a_regular_one(self, backend):
-        cold_key_uid, _ = self._add_seed_keypair(backend, user_1)
-        app_key_uid, _ = self._add_seed_keypair(backend, user_mnemonic_12, name="app-keypair")
-        app_addresses = self._addresses_of(backend, app_key_uid)
+        cold_key_uid = add_seed_keypair(backend)["key-uid"]
+        app_key_uid = add_seed_keypair(backend, user_mnemonic_12, name="app-keypair")["key-uid"]
 
         backend.accounts_service.migrate_non_profile_keypair_to_cold_wallet(cold_key_uid, backend.password, "status-keycard")
         backend.accounts_service.make_seed_phrase_keypair_fully_operable(user_1.passphrase, backend.password)
-        cold_addresses = self._addresses_of(backend, cold_key_uid)
-        assert any(self._keystore_present(backend, cold_addresses).values()), "Expected files to exist before cleaning"
+        assert any(self._keystore_present(backend, cold_key_uid).values()), "Expected files to exist before cleaning"
 
         backend.accounts_service.clean_keystore_files(backend.password)
 
         assert not any(
-            self._keystore_present(backend, cold_addresses).values()
+            self._keystore_present(backend, cold_key_uid).values()
         ), "Expected every file of a cold keypair to go, the master address included"
         assert all(
-            self._keystore_present(backend, app_addresses).values()
+            self._keystore_present(backend, app_key_uid).values()
         ), "Expected a keypair that is not cold and has no removed accounts to be untouched"

--- a/test/functional/tests/test_cold_keypair_operability.py
+++ b/test/functional/tests/test_cold_keypair_operability.py
@@ -1,0 +1,151 @@
+"""The three operability RPCs that decide whether a keypair's keys are on disk.
+
+makeSeedPhraseKeypairFullyOperable writes keystore files back from a mnemonic,
+makePartiallyOperableAccoutsFullyOperable sweeps accounts that were added without a password, and
+cleanKeystoreFiles deletes files again. All three branch on cold-wallet state and none of them was
+driven anywhere in test/functional; makeSeedPhraseKeypairFullyOperable had no test at any altitude.
+"""
+
+import copy
+
+import pytest
+from clients.api import ApiResponseError
+from resources.constants import (
+    keypair_name,
+    user_1,
+    user_mnemonic_12,
+    wallet_account_details_derivation,
+)
+
+NEXT_PATH = "m/44'/60'/0'/0/1"
+
+
+@pytest.mark.rpc
+class TestColdKeypairOperability:
+
+    @pytest.fixture()
+    def backend(self, backend_new_profile):
+        return backend_new_profile("operability")
+
+    def _add_seed_keypair(self, backend, user, name=keypair_name):
+        response = backend.accounts_service.add_keypair_via_seed_phrase(
+            user.passphrase,
+            backend.password,
+            name,
+            "",
+            wallet_account_details_derivation,
+        )
+        key_uid = response.get("key-uid")
+        assert key_uid, "Expected addKeypairViaSeedPhrase to return the created keypair"
+        assert response.get("xpub", "").startswith("xpub"), "Expected the imported keypair to carry an xpub"
+        return key_uid, response
+
+    def _addresses_of(self, backend, key_uid):
+        keypair = backend.accounts_service.get_keypair_by_key_uid(key_uid)
+        return [a["address"] for a in keypair["accounts"]] + [keypair["derived-from"]]
+
+    def _keystore_present(self, backend, addresses):
+        return {address: backend.accounts_service.verify_keystore_file_for_account(address, backend.password) for address in addresses}
+
+    def _add_account_without_a_password(self, backend, key_uid, mnemonic, path=NEXT_PATH):
+        """An account added with no password is derived from the stored xpub, so it lands partially operable."""
+        keypair = backend.accounts_service.get_keypair_by_key_uid(key_uid)
+        derived = backend.wallet_service.get_derived_addresses_for_mnemonic(mnemonic, [path])[0]
+        template = copy.deepcopy(keypair["accounts"][0])
+        template.update(
+            {
+                "address": derived["address"],
+                "public-key": derived["public-key"],
+                "path": path,
+                "name": "added-without-password",
+                "wallet": False,
+                "chat": False,
+            }
+        )
+        backend.accounts_service.add_account("", template)
+        return derived["address"]
+
+    def _account(self, backend, key_uid, address):
+        keypair = backend.accounts_service.get_keypair_by_key_uid(key_uid)
+        account = next((a for a in keypair["accounts"] if a["address"].lower() == address.lower()), None)
+        assert account is not None, f"Expected {address} to be an account of {key_uid}"
+        return account
+
+    def test_the_sweep_promotes_an_account_added_without_a_password(self, backend):
+        key_uid, _ = self._add_seed_keypair(backend, user_1)
+        address = self._add_account_without_a_password(backend, key_uid, user_1.passphrase)
+
+        assert self._account(backend, key_uid, address)["operable"] == "partially", "Expected an xpub-derived account to start partially operable"
+        assert (
+            backend.accounts_service.verify_keystore_file_for_account(address, backend.password) is False
+        ), "Expected no keystore file, which is what partially operable means"
+
+        promoted = backend.accounts_service.make_partially_operable_accouts_fully_operable(backend.password)
+
+        assert [a.lower() for a in promoted] == [address.lower()], "Expected the sweep to report exactly the account it promoted"
+        assert self._account(backend, key_uid, address)["operable"] == "fully"
+        assert (
+            backend.accounts_service.verify_keystore_file_for_account(address, backend.password) is True
+        ), "Expected the sweep to write the keystore file it derived"
+
+    def test_the_sweep_skips_cold_wallet_keypairs(self, backend):
+        app_key_uid, _ = self._add_seed_keypair(backend, user_1)
+        cold_key_uid, _ = self._add_seed_keypair(backend, user_mnemonic_12, name="cold-keypair")
+        app_address = self._add_account_without_a_password(backend, app_key_uid, user_1.passphrase)
+
+        backend.accounts_service.migrate_non_profile_keypair_to_cold_wallet(cold_key_uid, backend.password, "status-keycard")
+        cold_addresses = self._addresses_of(backend, cold_key_uid)
+        assert not any(self._keystore_present(backend, cold_addresses).values()), "Expected migration to have deleted the cold keypair's files"
+
+        promoted = backend.accounts_service.make_partially_operable_accouts_fully_operable(backend.password)
+
+        assert [a.lower() for a in promoted] == [app_address.lower()], "Expected only the app-side account to be promoted"
+        assert not any(
+            self._keystore_present(backend, cold_addresses).values()
+        ), "Expected the sweep to leave the cold keypair alone, because its key is on the card"
+
+    def test_the_sweep_requires_a_password(self, backend):
+        key_uid, _ = self._add_seed_keypair(backend, user_1)
+        address = self._add_account_without_a_password(backend, key_uid, user_1.passphrase)
+
+        with pytest.raises(ApiResponseError, match="no password provided"):
+            backend.accounts_service.make_partially_operable_accouts_fully_operable("")
+
+        assert self._account(backend, key_uid, address)["operable"] == "partially", "Expected the rejected sweep to promote nothing"
+
+    def test_make_seed_phrase_keypair_fully_operable_restores_files_but_leaves_the_keypair_cold(self, backend):
+        key_uid, _ = self._add_seed_keypair(backend, user_1)
+        addresses = self._addresses_of(backend, key_uid)
+
+        backend.accounts_service.migrate_non_profile_keypair_to_cold_wallet(key_uid, backend.password, "status-keycard")
+        assert not any(self._keystore_present(backend, addresses).values())
+
+        backend.accounts_service.make_seed_phrase_keypair_fully_operable(user_1.passphrase, backend.password)
+
+        present = self._keystore_present(backend, addresses)
+        assert all(present.values()), f"Expected every file back, the master address included: {present}"
+        # The distinction worth pinning: unlike migrateNonProfileColdWalletKeypairToApp, this call
+        # does not clear cold_wallet, so the keypair now claims to be on a card and has its keys on
+        # disk at the same time.
+        assert (
+            backend.accounts_service.get_keypair_by_key_uid(key_uid)["cold-wallet"] == "status-keycard"
+        ), "Expected the cold-wallet flag to survive, because this call only writes keystore files"
+
+    def test_clean_keystore_files_empties_a_cold_keypair_and_spares_a_regular_one(self, backend):
+        cold_key_uid, _ = self._add_seed_keypair(backend, user_1)
+        app_key_uid, _ = self._add_seed_keypair(backend, user_mnemonic_12, name="app-keypair")
+        app_addresses = self._addresses_of(backend, app_key_uid)
+
+        backend.accounts_service.migrate_non_profile_keypair_to_cold_wallet(cold_key_uid, backend.password, "status-keycard")
+        backend.accounts_service.make_seed_phrase_keypair_fully_operable(user_1.passphrase, backend.password)
+        cold_addresses = self._addresses_of(backend, cold_key_uid)
+        assert any(self._keystore_present(backend, cold_addresses).values()), "Expected files to exist before cleaning"
+
+        backend.accounts_service.clean_keystore_files(backend.password)
+
+        assert not any(
+            self._keystore_present(backend, cold_addresses).values()
+        ), "Expected every file of a cold keypair to go, the master address included"
+        assert all(
+            self._keystore_present(backend, app_addresses).values()
+        ), "Expected a keypair that is not cold and has no removed accounts to be untouched"

--- a/test/functional/tests/test_sign_data_cold_wallet_guard.py
+++ b/test/functional/tests/test_sign_data_cold_wallet_guard.py
@@ -1,0 +1,93 @@
+"""wakuext_signData refuses accounts whose key has moved to a cold wallet, because the card has to sign.
+
+The guard sits between the profile/watch-only refusal and the password check
+(internal/protocol/messenger_communities.go:1424-1437), and the suite only ever drove this call with
+regular accounts. These tests pin the refusal, its position in that order, and that one bad account
+fails the whole batch.
+"""
+
+import pytest
+from clients.api import ApiResponseError
+from resources.constants import (
+    keypair_name,
+    user_1,
+    wallet_account_details_derivation,
+)
+
+COLD_WALLET_ERROR = "signing a joining community request for accounts migrated to a cold wallet must be done with the cold wallet"
+PROFILE_OR_WATCH_ERROR = "cannot join a community using profile chat or watch-only account"
+# Any hex payload will do — SignData text-hashes it before signing.
+DATA = "0x" + "11" * 32
+
+
+@pytest.mark.rpc
+class TestSignDataColdWalletGuard:
+
+    @pytest.fixture()
+    def backend(self, backend_new_profile):
+        return backend_new_profile("sign-data-cold")
+
+    def _add_seed_keypair(self, backend):
+        response = backend.accounts_service.add_keypair_via_seed_phrase(
+            user_1.passphrase,
+            backend.password,
+            keypair_name,
+            "",
+            wallet_account_details_derivation,
+        )
+        key_uid = response.get("key-uid")
+        assert key_uid, "Expected addKeypairViaSeedPhrase to return the created keypair"
+        return key_uid, response["accounts"][0]["address"]
+
+    def _profile_account(self, backend, chat):
+        kp = backend.accounts_service.get_keypair_by_key_uid(backend.key_uid)
+        account = next((a for a in kp["accounts"] if bool(a.get("chat")) is chat), None)
+        assert account is not None, f"Expected the profile keypair to own a chat={chat} account"
+        return account["address"]
+
+    def _sign(self, backend, addresses, password=None):
+        params = [{"data": DATA, "account": address, "password": backend.password if password is None else password} for address in addresses]
+        return backend.wakuext_service.sign_data(params)
+
+    def test_sign_data_refuses_a_cold_wallet_account(self, backend):
+        key_uid, address = self._add_seed_keypair(backend)
+
+        before = self._sign(backend, [address])
+        assert len(before) == 1 and before[0].startswith("0x"), "Expected a regular keypair account to sign"
+
+        backend.accounts_service.migrate_non_profile_keypair_to_cold_wallet(key_uid, backend.password, "status-keycard")
+
+        with pytest.raises(ApiResponseError, match=COLD_WALLET_ERROR):
+            self._sign(backend, [address])
+
+        backend.accounts_service.migrate_non_profile_cold_wallet_keypair_to_app(user_1.passphrase, backend.password)
+
+        after = self._sign(backend, [address])
+        assert after == before, "Expected the same key to sign the same payload identically once it is back in the app keystore"
+
+    def test_the_cold_wallet_refusal_precedes_the_password_check(self, backend):
+        key_uid, address = self._add_seed_keypair(backend)
+        backend.accounts_service.migrate_non_profile_keypair_to_cold_wallet(key_uid, backend.password, "status-keycard")
+
+        # A wrong password must still surface the cold-wallet refusal: the guard runs first, so the
+        # caller is told to use the card rather than that their password was wrong.
+        with pytest.raises(ApiResponseError, match=COLD_WALLET_ERROR):
+            self._sign(backend, [address], password="definitely-wrong")
+
+    def test_sign_data_refuses_the_profile_chat_account(self, backend):
+        # The sibling guard, one branch earlier — a different refusal reached through the same call.
+        with pytest.raises(ApiResponseError, match=PROFILE_OR_WATCH_ERROR):
+            self._sign(backend, [self._profile_account(backend, chat=True)])
+
+    def test_one_cold_wallet_account_fails_the_whole_batch(self, backend):
+        key_uid, cold_address = self._add_seed_keypair(backend)
+        profile_address = self._profile_account(backend, chat=False)
+
+        assert len(self._sign(backend, [profile_address, cold_address])) == 2, "Expected both accounts to sign before the migration"
+
+        backend.accounts_service.migrate_non_profile_keypair_to_cold_wallet(key_uid, backend.password, "status-keycard")
+
+        with pytest.raises(ApiResponseError, match=COLD_WALLET_ERROR):
+            self._sign(backend, [profile_address, cold_address])
+
+        assert len(self._sign(backend, [profile_address])) == 1, "Expected the untouched account to keep signing on its own"

--- a/test/functional/tests/test_sign_data_cold_wallet_guard.py
+++ b/test/functional/tests/test_sign_data_cold_wallet_guard.py
@@ -1,18 +1,10 @@
 """wakuext_signData refuses accounts whose key has moved to a cold wallet, because the card has to sign.
-
-The guard sits between the profile/watch-only refusal and the password check
-(internal/protocol/messenger_communities.go:1424-1437), and the suite only ever drove this call with
-regular accounts. These tests pin the refusal, its position in that order, and that one bad account
-fails the whole batch.
-"""
+The guard sits between the profile/watch-only refusal and the password check, and one refused account fails the whole batch."""
 
 import pytest
 from clients.api import ApiResponseError
-from resources.constants import (
-    keypair_name,
-    user_1,
-    wallet_account_details_derivation,
-)
+from resources.constants import user_1
+from steps.cold_wallet import add_seed_keypair
 
 COLD_WALLET_ERROR = "signing a joining community request for accounts migrated to a cold wallet must be done with the cold wallet"
 PROFILE_OR_WATCH_ERROR = "cannot join a community using profile chat or watch-only account"
@@ -28,16 +20,8 @@ class TestSignDataColdWalletGuard:
         return backend_new_profile("sign-data-cold")
 
     def _add_seed_keypair(self, backend):
-        response = backend.accounts_service.add_keypair_via_seed_phrase(
-            user_1.passphrase,
-            backend.password,
-            keypair_name,
-            "",
-            wallet_account_details_derivation,
-        )
-        key_uid = response.get("key-uid")
-        assert key_uid, "Expected addKeypairViaSeedPhrase to return the created keypair"
-        return key_uid, response["accounts"][0]["address"]
+        keypair = add_seed_keypair(backend)
+        return keypair["key-uid"], keypair["accounts"][0]["address"]
 
     def _profile_account(self, backend, chat):
         kp = backend.accounts_service.get_keypair_by_key_uid(backend.key_uid)
@@ -69,13 +53,12 @@ class TestSignDataColdWalletGuard:
         key_uid, address = self._add_seed_keypair(backend)
         backend.accounts_service.migrate_non_profile_keypair_to_cold_wallet(key_uid, backend.password, "status-keycard")
 
-        # A wrong password must still surface the cold-wallet refusal: the guard runs first, so the
-        # caller is told to use the card rather than that their password was wrong.
+        # The guard runs before the password check, so the caller is told to use the card, not that the password is wrong.
         with pytest.raises(ApiResponseError, match=COLD_WALLET_ERROR):
             self._sign(backend, [address], password="definitely-wrong")
 
     def test_sign_data_refuses_the_profile_chat_account(self, backend):
-        # The sibling guard, one branch earlier — a different refusal reached through the same call.
+        # The sibling guard one branch earlier, so the cold-wallet refusal is distinguishable from a blanket rejection.
         with pytest.raises(ApiResponseError, match=PROFILE_OR_WATCH_ERROR):
             self._sign(backend, [self._profile_account(backend, chat=True)])
 

--- a/test/functional/tests/test_sign_on_keycard_flag.py
+++ b/test/functional/tests/test_sign_on_keycard_flag.py
@@ -1,0 +1,107 @@
+"""signOnKeycard tells the client to route signing to the cold wallet instead of asking for a password.
+
+It is derived from the keypair, not the account, and it is set on two different signing surfaces with
+two different wire shapes: buildTransaction omits it when false, the router's signingDetails always
+sends it. These tests pin the true branch of buildTransaction, which nothing else drives.
+"""
+
+import json
+
+import pytest
+from clients.api import ApiResponseError
+from resources.constants import (
+    ANVIL_NETWORK_ID,
+    keypair_name,
+    user_1,
+    wallet_account_details_derivation,
+)
+
+COLD_WALLET_TYPES = ("status-keycard", "ledger", "trezor")
+RECIPIENT = "0x70997970c51812dc3a010c7d01b50e0d17dc79c8"
+# Fully specified so validateAndBuildTransaction never needs a nonce or gas estimate from the chain.
+TX_TEMPLATE = {
+    "to": RECIPIENT,
+    "value": "0x1",
+    "nonce": "0x0",
+    "gas": "0x5208",
+    "gasPrice": "0x3b9aca00",
+}
+
+
+@pytest.mark.rpc
+class TestSignOnKeycardFlag:
+
+    @pytest.fixture()
+    def backend(self, backend_new_profile):
+        return backend_new_profile("sign-on-keycard")
+
+    def _add_seed_keypair(self, backend):
+        response = backend.accounts_service.add_keypair_via_seed_phrase(
+            user_1.passphrase,
+            backend.password,
+            keypair_name,
+            "",
+            wallet_account_details_derivation,
+        )
+        key_uid = response.get("key-uid")
+        assert key_uid, "Expected addKeypairViaSeedPhrase to return the created keypair"
+        assert response.get("cold-wallet", "") == "", "Expected a seed-imported keypair to start off any cold wallet"
+        address = response["accounts"][0]["address"]
+        return key_uid, address
+
+    def _profile_wallet_address(self, backend):
+        kp = backend.accounts_service.get_keypair_by_key_uid(backend.key_uid)
+        wallet = next((a for a in kp["accounts"] if a.get("wallet")), None)
+        assert wallet is not None, "Expected the profile keypair to own a wallet account"
+        return wallet["address"]
+
+    def _build(self, backend, address):
+        args = dict(TX_TEMPLATE, **{"from": address})
+        response = backend.wallet_service.build_transaction(ANVIL_NETWORK_ID, json.dumps(args))
+        assert response.get("messageToSign"), f"Expected buildTransaction to produce a hash to sign for {address}"
+        return response
+
+    def test_sign_on_keycard_follows_the_cold_wallet_round_trip(self, backend):
+        key_uid, address = self._add_seed_keypair(backend)
+
+        before = self._build(backend, address)
+        # TxResponse.SignOnKeycard is `omitempty`, so a regular keypair sends no such key at all.
+        assert "signOnKeycard" not in before, "Expected buildTransaction to omit signOnKeycard for a keypair in the app keystore"
+
+        backend.accounts_service.migrate_non_profile_keypair_to_cold_wallet(key_uid, backend.password, "status-keycard")
+
+        cold = self._build(backend, address)
+        assert cold.get("signOnKeycard") is True, "Expected signOnKeycard once the keypair's key lives on the card"
+        for field in ("keyUid", "address", "addressPath", "chainId", "messageToSign"):
+            assert cold.get(field) == before.get(field), f"Expected {field} to be unchanged by the migration"
+
+        backend.accounts_service.migrate_non_profile_cold_wallet_keypair_to_app(user_1.passphrase, backend.password)
+
+        after = self._build(backend, address)
+        assert "signOnKeycard" not in after, "Expected signOnKeycard to drop again once the keystore files are restored"
+        assert after.get("messageToSign") == before.get("messageToSign")
+
+    @pytest.mark.parametrize("cold_wallet_type", COLD_WALLET_TYPES)
+    def test_sign_on_keycard_is_set_for_every_cold_wallet_type(self, backend, cold_wallet_type):
+        # The field is named for the keycard but MigratedToColdWallet() is true for ledger and trezor too.
+        key_uid, address = self._add_seed_keypair(backend)
+        backend.accounts_service.migrate_non_profile_keypair_to_cold_wallet(key_uid, backend.password, cold_wallet_type)
+
+        assert backend.accounts_service.get_keypair_by_key_uid(key_uid)["cold-wallet"] == cold_wallet_type
+        assert self._build(backend, address).get("signOnKeycard") is True
+
+    def test_sign_on_keycard_is_per_keypair(self, backend):
+        key_uid, cold_address = self._add_seed_keypair(backend)
+        profile_address = self._profile_wallet_address(backend)
+
+        backend.accounts_service.migrate_non_profile_keypair_to_cold_wallet(key_uid, backend.password, "status-keycard")
+
+        assert self._build(backend, cold_address).get("signOnKeycard") is True
+        assert "signOnKeycard" not in self._build(
+            backend, profile_address
+        ), "Expected the profile account to stay password-signed while another keypair is on a card"
+
+    def test_build_transaction_rejects_an_unknown_address(self, backend):
+        # Pins that the flag is read off a resolved account, not defaulted for an address the DB never saw.
+        with pytest.raises(ApiResponseError, match="failed to resolve account"):
+            self._build(backend, "0x" + "ab" * 20)

--- a/test/functional/tests/test_sign_on_keycard_flag.py
+++ b/test/functional/tests/test_sign_on_keycard_flag.py
@@ -1,20 +1,12 @@
 """signOnKeycard tells the client to route signing to the cold wallet instead of asking for a password.
-
-It is derived from the keypair, not the account, and it is set on two different signing surfaces with
-two different wire shapes: buildTransaction omits it when false, the router's signingDetails always
-sends it. These tests pin the true branch of buildTransaction, which nothing else drives.
-"""
+It is derived from the keypair, not the account; buildTransaction omits it when false, the router's signingDetails always sends it."""
 
 import json
 
 import pytest
 from clients.api import ApiResponseError
-from resources.constants import (
-    ANVIL_NETWORK_ID,
-    keypair_name,
-    user_1,
-    wallet_account_details_derivation,
-)
+from resources.constants import ANVIL_NETWORK_ID, user_1
+from steps.cold_wallet import add_seed_keypair
 
 COLD_WALLET_TYPES = ("status-keycard", "ledger", "trezor")
 RECIPIENT = "0x70997970c51812dc3a010c7d01b50e0d17dc79c8"
@@ -36,18 +28,8 @@ class TestSignOnKeycardFlag:
         return backend_new_profile("sign-on-keycard")
 
     def _add_seed_keypair(self, backend):
-        response = backend.accounts_service.add_keypair_via_seed_phrase(
-            user_1.passphrase,
-            backend.password,
-            keypair_name,
-            "",
-            wallet_account_details_derivation,
-        )
-        key_uid = response.get("key-uid")
-        assert key_uid, "Expected addKeypairViaSeedPhrase to return the created keypair"
-        assert response.get("cold-wallet", "") == "", "Expected a seed-imported keypair to start off any cold wallet"
-        address = response["accounts"][0]["address"]
-        return key_uid, address
+        keypair = add_seed_keypair(backend)
+        return keypair["key-uid"], keypair["accounts"][0]["address"]
 
     def _profile_wallet_address(self, backend):
         kp = backend.accounts_service.get_keypair_by_key_uid(backend.key_uid)
@@ -102,6 +84,5 @@ class TestSignOnKeycardFlag:
         ), "Expected the profile account to stay password-signed while another keypair is on a card"
 
     def test_build_transaction_rejects_an_unknown_address(self, backend):
-        # Pins that the flag is read off a resolved account, not defaulted for an address the DB never saw.
         with pytest.raises(ApiResponseError, match="failed to resolve account"):
             self._build(backend, "0x" + "ab" * 20)


### PR DESCRIPTION
# Description

1. `test_sign_on_keycard_flag.py`: `wallet_buildTransaction` reports `signOnKeycard` only while the keypair is on a cold wallet, for all three cold-wallet types, per keypair rather than per profile, and refuses an address the accounts DB has never seen.
2. `test_sign_data_cold_wallet_guard.py`: `wakuext_signData` refuses an account whose keypair is cold, ahead of the password check, and one refused account fails the whole batch.
3. `test_cold_keypair_operability.py`: `makePartiallyOperableAccoutsFullyOperable` promotes an account added without a password and skips cold keypairs; `makeSeedPhraseKeypairFullyOperable` restores keystore files without clearing `cold-wallet`; `cleanKeystoreFiles` empties a cold keypair and spares a regular one.
4. `steps/cold_wallet.py` holds the seed-keypair import and keystore-presence helpers the three modules share; `clients/services/accounts.py` gains wrappers for the three operability RPCs.

All three are behaviours of a non-profile keypair once it is cold, and none was driven before: the suite asserted `signOnKeycard is False` on regular keypairs only, `signData` ran only with regular accounts, and the operability RPCs had no functional caller and no client wrapper. Transaction args are fully specified, so `buildTransaction` needs no nonce or gas estimate from the chain and no funded account.

Run against `develop` at `65e177a4fc`: `15 passed in 145.49s` across the three modules.

<details>
<summary>What each test means for a user</summary>

The keypair is a seed-phrase wallet the user imported next to their profile and then moved onto a Keycard, Ledger or Trezor.

Signing a transaction:

- **`test_sign_on_keycard_follows_the_cold_wallet_round_trip`** — A user prepares a transaction from a wallet before, during and after it lives on a Keycard. Only while it is on the card does the app get told to sign on the card; everything else about the transaction is identical.
- **`test_sign_on_keycard_is_set_for_every_cold_wallet_type`** — The same instruction is given for a Ledger and a Trezor, not only a Keycard.
- **`test_sign_on_keycard_is_per_keypair`** — Moving one wallet onto a card does not make the user's other wallets ask for the card.
- **`test_build_transaction_rejects_an_unknown_address`** — A transaction from an address the profile does not own is refused rather than silently treated as a password-signed one.

Joining a community:

- **`test_sign_data_refuses_a_cold_wallet_account`** — A user tries to join a community and reveal an address that lives on a Keycard. Refused while the wallet is on the card, and the same key signs identically once it is back in the app.
- **`test_the_cold_wallet_refusal_precedes_the_password_check`** — A user with a card-backed wallet mistypes their password. They are told to use the card, not that their password was wrong.
- **`test_sign_data_refuses_the_profile_chat_account`** — The profile's chat account cannot be used to join a community, a separate refusal from the card one.
- **`test_one_cold_wallet_account_fails_the_whole_batch`** — A user reveals several addresses at once and one is card-backed. The whole request is refused, no partial signatures; the others still work on their own.

Key files on the device:

- **`test_the_sweep_promotes_an_account_added_without_a_password`** — A user added a wallet account without a password, so it works for viewing but not signing. Entering the password once brings it fully to life and writes its key file.
- **`test_the_sweep_skips_cold_wallet_keypairs`** — That step never puts key files on the device for a wallet that lives on a card.
- **`test_the_sweep_requires_a_password`** — It refuses to run with an empty password and promotes nothing.
- **`test_make_seed_phrase_keypair_fully_operable_restores_files_but_leaves_the_keypair_cold`** — A user re-enters the seed phrase of a card-backed wallet. Its key files come back, but the wallet still says it is on the card. Recorded as current behaviour.
- **`test_clean_keystore_files_empties_a_cold_keypair_and_spares_a_regular_one`** — Cleaning up removes every key file of a card-backed wallet and leaves a normal wallet alone.

</details>

<details>
<summary>AI-made decisions</summary>

- One PR rather than three because the modules share the fixture shape (import a seed keypair, migrate it, migrate it back) and the helper module; separately each was about a hundred lines.
- The flag is asserted as absent rather than `False` on `buildTransaction`: `TxResponse.SignOnKeycard` is `omitempty`, unlike the router's `SigningDetails`.
- The partially-operable state costs three RPC calls, not a fixture: an account added with an empty password to a keypair that has an xpub is derived from the xpub and lands partially operable.
- `makeSeedPhraseKeypairFullyOperable` leaving `cold-wallet` set is pinned as current behaviour, not filed as a defect, since it may be deliberate.
- Every test was made to fail by breaking the behaviour it covers at the python client boundary, then restored. The `wallet_buildTransactionsFromRoute` true branch is left out: it needs a computed route and a funded cold-wallet account.

</details>
