### PR TITLE
test(functional): cover profile keypair to and from a keycard

### DIFF
--- a/test/functional/clients/services/accounts.py
+++ b/test/functional/clients/services/accounts.py
@@ -91,9 +91,6 @@ class AccountService(Service):
         response = self.rpc_request("getKeypairByKeyUID", params)
         return response
 
-    def get_profile_keypair(self):
-        return next((kp for kp in self.get_account_keypairs() if kp.get("type") == "profile"), None)
-
     def update_account(self, account):
         params = [account]
         response = self.rpc_request("updateAccount", params)

--- a/test/functional/clients/services/accounts.py
+++ b/test/functional/clients/services/accounts.py
@@ -91,6 +91,9 @@ class AccountService(Service):
         response = self.rpc_request("getKeypairByKeyUID", params)
         return response
 
+    def get_profile_keypair(self):
+        return next((kp for kp in self.get_account_keypairs() if kp.get("type") == "profile"), None)
+
     def update_account(self, account):
         params = [account]
         response = self.rpc_request("updateAccount", params)

--- a/test/functional/clients/status_backend.py
+++ b/test/functional/clients/status_backend.py
@@ -450,6 +450,8 @@ class StatusBackend(RpcClient, SignalClient, ApiClient):
         self.password = password
         SignalClient.disconnect(self)
         SignalClient.connect(self)
+        self.wait_until_connected()
+        self._mark_login_signal()
         data = {
             "password": password,
             "keyUid": key_uid,
@@ -465,6 +467,8 @@ class StatusBackend(RpcClient, SignalClient, ApiClient):
     def login_with_mnemonic(self, key_uid, mnemonic: str):
         SignalClient.disconnect(self)
         SignalClient.connect(self)
+        self.wait_until_connected()
+        self._mark_login_signal()
         data = {"password": "", "keyUid": key_uid, "kdfIterations": 0, "mnemonic": mnemonic}
         data = self._set_proxy_credentials(data)
         data = self._set_wallet_secrets(data)

--- a/test/functional/clients/status_backend.py
+++ b/test/functional/clients/status_backend.py
@@ -446,6 +446,53 @@ class StatusBackend(RpcClient, SignalClient, ApiClient):
         data = self._set_wallet_secrets(data)
         return self.api_request_json(method, data)
 
+    def login_with_keycard(self, key_uid, password: str, keycard_whisper_private_key: str, kdf_iterations=0, wallet_xpub=None):
+        self.password = password
+        SignalClient.disconnect(self)
+        SignalClient.connect(self)
+        data = {
+            "password": password,
+            "keyUid": key_uid,
+            "kdfIterations": kdf_iterations,
+            "keycardWhisperPrivateKey": keycard_whisper_private_key,
+        }
+        if wallet_xpub is not None:
+            data["walletXPub"] = wallet_xpub
+        data = self._set_proxy_credentials(data)
+        data = self._set_wallet_secrets(data)
+        return self.api_request_json("LoginAccount", data)
+
+    def login_with_mnemonic(self, key_uid, mnemonic: str):
+        SignalClient.disconnect(self)
+        SignalClient.connect(self)
+        data = {"password": "", "keyUid": key_uid, "kdfIterations": 0, "mnemonic": mnemonic}
+        data = self._set_proxy_credentials(data)
+        data = self._set_wallet_secrets(data)
+        return self.api_request_json("LoginAccount", data)
+
+    def convert_to_keycard_account_v2(self, key_uid, keycard_pairing: str, keycard_uid: str, old_password: str, new_password: str, **kwargs):
+        data = {
+            "account": {"key-uid": key_uid, "keycard-pairing": keycard_pairing, "kdfIterations": 0},
+            "settings": {},
+            "keycardUID": keycard_uid,
+            "oldPassword": old_password,
+            "newPassword": new_password,
+        }
+        response = self.api_request_json("ConvertToKeycardAccountV2", data, **kwargs)
+        self.password = new_password
+        return response
+
+    def convert_to_regular_account_v2(self, mnemonic: str, curr_password: str, new_password: str, **kwargs):
+        data = {"mnemonic": mnemonic, "currPassword": curr_password, "newPassword": new_password}
+        response = self.api_request_json("ConvertToRegularAccountV2", data, **kwargs)
+        self.password = new_password
+        return response
+
+    def reinit_and_get_accounts(self):
+        # InitializeApplication is the only HTTP surface that exposes multiaccounts.keycard-pairing.
+        self.logout()
+        return self.init_status_backend().get("accounts", [])
+
     def logout(self, **kwargs):
         method = "Logout"
         try:

--- a/test/functional/steps/keycard.py
+++ b/test/functional/steps/keycard.py
@@ -1,0 +1,27 @@
+from eth_account import Account
+
+PATH_EIP1581_CHAT = "m/43'/60'/1581'/0'/0"
+PATH_EIP1581_ENCRYPTION = "m/43'/60'/1581'/1'/0"
+
+Account.enable_unaudited_hdwallet_features()
+
+
+def derive_keycard_password(backend, mnemonic: str) -> str:
+    # A keycard profile's password is the encryption public key, the same value the mnemonic login path substitutes.
+    derived = backend.wallet_service.get_derived_addresses_for_mnemonic(mnemonic, [PATH_EIP1581_ENCRYPTION])
+    return derived[0]["public-key"]
+
+
+def derive_chat_private_key(mnemonic: str) -> str:
+    return Account.from_mnemonic(mnemonic, account_path=PATH_EIP1581_CHAT).key.hex()
+
+
+def derive_chat_address(mnemonic: str) -> str:
+    return Account.from_mnemonic(mnemonic, account_path=PATH_EIP1581_CHAT).address.lower()
+
+
+def assert_keystore_state(backend, addresses, password: str, present: bool):
+    for address in addresses:
+        resp = backend.accounts_service.verify_keystore_file_for_account(address, password)
+        expectation = "a keystore file" if present else "no keystore file"
+        assert resp is present, f"Expected {expectation} for {address} with password {password!r}"

--- a/test/functional/steps/keycard.py
+++ b/test/functional/steps/keycard.py
@@ -3,6 +3,9 @@ from eth_account import Account
 PATH_EIP1581_CHAT = "m/43'/60'/1581'/0'/0"
 PATH_EIP1581_ENCRYPTION = "m/43'/60'/1581'/1'/0"
 
+KEYCARD_UID = "mock-keycard-uid"
+KEYPAIR_FIELDS = ("key-uid", "type", "name", "derived-from", "xpub")
+
 Account.enable_unaudited_hdwallet_features()
 
 
@@ -25,3 +28,31 @@ def assert_keystore_state(backend, addresses, password: str, present: bool):
         resp = backend.accounts_service.verify_keystore_file_for_account(address, password)
         expectation = "a keystore file" if present else "no keystore file"
         assert resp is present, f"Expected {expectation} for {address} with password {password!r}"
+
+
+def mock_pairing(key_uid, suffix=""):
+    return f"mock-pairing-{key_uid[:8]}{suffix}"
+
+
+def keypair_addresses(keypair):
+    return [a["address"] for a in keypair["accounts"]] + [keypair["derived-from"]]
+
+
+def account_shape(keypair):
+    return sorted((a["address"], a["path"], a["wallet"], a["chat"]) for a in keypair["accounts"])
+
+
+def keycard_pairing_of(accounts, key_uid):
+    entry = next((a for a in accounts if a.get("key-uid") == key_uid), None)
+    assert entry is not None, f"Expected InitializeApplication to list the account {key_uid}"
+    return entry.get("keycard-pairing", "")
+
+
+def fresh_profile_keypair(backend):
+    """The profile keypair of a freshly created profile, checked to be off any cold wallet with its xpub and master address."""
+    keypair = backend.accounts_service.get_keypair_by_key_uid(backend.key_uid)
+    assert keypair["type"] == "profile"
+    assert keypair.get("cold-wallet", "") == "", "Expected a fresh profile keypair to not be on a cold wallet"
+    assert keypair.get("xpub", "").startswith("xpub"), "Expected a fresh profile keypair to carry its wallet xpub"
+    assert keypair["derived-from"], "Expected the profile keypair to carry its master address"
+    return keypair

--- a/test/functional/tests/test_convert_keycard_profile_to_regular.py
+++ b/test/functional/tests/test_convert_keycard_profile_to_regular.py
@@ -1,0 +1,175 @@
+"""Stop using a keycard for the profile keypair through ConvertToRegularAccountV2, driven with a mock pairing.
+
+The only keycard state observable on this branch is keypair.cold-wallet, keystore presence and
+multiaccounts.keycard-pairing: the keycards tables and their RPCs were dropped, so per-card rows are not assertable.
+"""
+
+import re
+from collections import namedtuple
+
+import pytest
+from clients.api import ApiResponseError
+from resources.constants import user_2
+from steps.keycard import assert_keystore_state, derive_chat_private_key, derive_keycard_password
+from utils import fake
+
+KEYCARD_UID = "mock-keycard-uid"
+KEYPAIR_FIELDS = ("key-uid", "type", "name", "derived-from", "xpub")
+
+KeycardProfile = namedtuple("KeycardProfile", ["key_uid", "mnemonic", "old_password", "keycard_password", "pairing", "kp0"])
+
+
+def _pairing(key_uid, suffix=""):
+    return f"mock-pairing-{key_uid[:8]}{suffix}"
+
+
+def _addresses(keypair):
+    return [a["address"] for a in keypair["accounts"]] + [keypair["derived-from"]]
+
+
+def _account_shape(keypair):
+    return sorted((a["address"], a["path"], a["wallet"], a["chat"]) for a in keypair["accounts"])
+
+
+def _keycard_pairing_of(accounts, key_uid):
+    entry = next((a for a in accounts if a.get("key-uid") == key_uid), None)
+    assert entry is not None, f"Expected InitializeApplication to list the account {key_uid}"
+    return entry.get("keycard-pairing", "")
+
+
+@pytest.mark.rpc
+class TestConvertKeycardProfileToRegular:
+
+    @pytest.fixture()
+    def backend(self, backend_new_profile):
+        return backend_new_profile("keycard-to-regular")
+
+    def _put_profile_on_keycard(self, backend):
+        kp0 = backend.accounts_service.get_keypair_by_key_uid(backend.key_uid)
+        assert kp0 is not None, "Expected the profile keypair to exist"
+        assert kp0["type"] == "profile"
+        assert kp0.get("cold-wallet", "") == "", "Expected a fresh profile keypair to not be on a cold wallet"
+        assert kp0.get("xpub", "").startswith("xpub"), "Expected a fresh profile keypair to carry its wallet xpub"
+        assert kp0["derived-from"], "Expected the profile keypair to carry its master address"
+
+        keycard_password = derive_keycard_password(backend, backend.mnemonic)
+        old_password = backend.password
+        pairing = _pairing(backend.key_uid)
+        backend.convert_to_keycard_account_v2(backend.key_uid, pairing, KEYCARD_UID, old_password, keycard_password)
+
+        kp = backend.accounts_service.get_keypair_by_key_uid(backend.key_uid)
+        assert kp["cold-wallet"] == "status-keycard", "Expected the setup to flag the profile keypair as keycard backed"
+        assert kp["xpub"] == kp0["xpub"], "Expected the setup to keep the wallet xpub"
+        # Keystore files are deleted, not re-encrypted: the keycard password must not resolve them either.
+        assert_keystore_state(backend, _addresses(kp), keycard_password, present=False)
+
+        return KeycardProfile(backend.key_uid, backend.mnemonic, old_password, keycard_password, pairing, kp0)
+
+    def _assert_regular(self, backend, kp0, password):
+        kp = backend.accounts_service.get_keypair_by_key_uid(kp0["key-uid"])
+        assert kp.get("cold-wallet", "") == "", "Expected the profile keypair to be back on the app keystore"
+        for field in KEYPAIR_FIELDS:
+            assert kp.get(field) == kp0.get(field), f"Expected keypair field {field} to survive the reverse migration"
+        assert _account_shape(kp) == _account_shape(kp0), "Expected the profile accounts to be unchanged by the reverse migration"
+        for account in kp["accounts"]:
+            assert account["operable"] == "fully", f"Expected {account['address']} fully operable after the reverse migration"
+        assert_keystore_state(backend, _addresses(kp), password, present=True)
+        assert backend.accounts_service.verify_password(password) is True, "Expected verifyPassword to succeed with the new password"
+        return kp
+
+    def test_stop_using_keycard_for_profile_keypair(self, backend):
+        ctx = self._put_profile_on_keycard(backend)
+        new_password = "NewRegular-" + fake.profile_password()
+
+        backend.convert_to_regular_account_v2(ctx.mnemonic, ctx.keycard_password, new_password)
+
+        self._assert_regular(backend, ctx.kp0, new_password)
+
+        # Keystore files are written with currPassword, then ChangeDatabasePassword re-wraps the DB;
+        # whether the files also answer to the old passwords is a recorded observation, not a contract.
+        probe_address = ctx.kp0["accounts"][0]["address"]
+        keystore_with_keycard_password = backend.accounts_service.verify_keystore_file_for_account(probe_address, ctx.keycard_password)
+        keystore_with_old_password = backend.accounts_service.verify_keystore_file_for_account(probe_address, ctx.old_password)
+        assert keystore_with_keycard_password is False, "Observed: the keycard password no longer resolves the re-created keystore file"
+        assert keystore_with_old_password is False, "Observed: the pre-keycard password does not resolve the re-created keystore file"
+
+        settings = backend.settings_service.get_settings()
+        assert settings.get("profile-migration-needed", False) is False
+        assert not settings.get("mnemonic"), "Expected the mnemonic to stay cleared because the conversion does not restore it"
+
+        accounts = backend.reinit_and_get_accounts()
+        assert _keycard_pairing_of(accounts, ctx.key_uid) == "", "Expected the keycard pairing to be cleared on the multiaccount"
+
+        backend.login(ctx.key_uid, new_password)
+        signal = backend.wait_for_login()
+        assert signal["event"]["account"]["key-uid"] == ctx.key_uid
+        assert signal["event"]["account"].get("keycard-pairing", "") == "", "Expected the login event to carry no keycard pairing"
+        backend.wait_for_wakuext_ready(timeout=30)
+
+        self._assert_regular(backend, ctx.kp0, new_password)
+
+        backend.change_database_password(new_password, new_password + "x")
+        backend.reinit_and_get_accounts()
+        backend.login(ctx.key_uid, new_password + "x")
+        signal = backend.wait_for_login()
+        assert signal["event"]["account"]["key-uid"] == ctx.key_uid, "Expected a normal password profile after the password change"
+
+    def test_stop_using_keycard_rejects_wrong_password(self, backend):
+        ctx = self._put_profile_on_keycard(backend)
+
+        with pytest.raises(ApiResponseError, match="invalid key-encryption key|incorrect password provided"):
+            backend.convert_to_regular_account_v2(ctx.mnemonic, "definitely-wrong", "whatever-new")
+
+        kp = backend.accounts_service.get_keypair_by_key_uid(ctx.key_uid)
+        assert kp["cold-wallet"] == "status-keycard", "Expected the keypair to stay on the keycard after a rejected conversion"
+        assert kp["xpub"] == ctx.kp0["xpub"]
+        assert_keystore_state(backend, _addresses(kp), ctx.keycard_password, present=False)
+        assert_keystore_state(backend, _addresses(kp), ctx.old_password, present=False)
+        assert (
+            _keycard_pairing_of(backend.reinit_and_get_accounts(), ctx.key_uid) == ctx.pairing
+        ), "Expected the pairing kept because the password check runs before it is cleared"
+
+        backend.login_with_keycard(ctx.key_uid, ctx.keycard_password, derive_chat_private_key(ctx.mnemonic))
+        signal = backend.wait_for_login()
+        assert signal["event"]["account"]["key-uid"] == ctx.key_uid, "Expected keycard login to keep working after a rejected conversion"
+
+    def test_stop_using_keycard_rejects_unknown_mnemonic(self, backend):
+        ctx = self._put_profile_on_keycard(backend)
+
+        with pytest.raises(ApiResponseError, match="no rows"):
+            backend.convert_to_regular_account_v2(user_2.passphrase, ctx.keycard_password, "whatever-new")
+
+        kp = backend.accounts_service.get_keypair_by_key_uid(ctx.key_uid)
+        assert kp["cold-wallet"] == "status-keycard", "Expected the keypair untouched by an unknown mnemonic"
+        assert_keystore_state(backend, _addresses(kp), ctx.keycard_password, present=False)
+        assert (
+            _keycard_pairing_of(backend.reinit_and_get_accounts(), ctx.key_uid) == ctx.pairing
+        ), "Expected the pairing kept because the mnemonic lookup fails first"
+
+        backend.login_with_keycard(ctx.key_uid, ctx.keycard_password, derive_chat_private_key(ctx.mnemonic))
+        signal = backend.wait_for_login()
+        assert signal["event"]["account"]["key-uid"] == ctx.key_uid
+
+    def test_stop_using_keycard_accepts_whitespace_padded_mnemonic(self, backend):
+        ctx = self._put_profile_on_keycard(backend)
+        padded = "  " + ctx.mnemonic.replace(" ", "   ") + " \n"
+        new_password = "NewRegular-" + fake.profile_password()
+
+        backend.convert_to_regular_account_v2(padded, ctx.keycard_password, new_password)
+
+        self._assert_regular(backend, ctx.kp0, new_password)
+        assert (
+            _keycard_pairing_of(backend.reinit_and_get_accounts(), ctx.key_uid) == ""
+        ), "Expected the keycard pairing cleared after a padded-mnemonic conversion"
+
+    def test_stop_using_keycard_on_regular_profile_is_rejected(self, backend):
+        kp0 = backend.accounts_service.get_keypair_by_key_uid(backend.key_uid)
+        assert kp0.get("cold-wallet", "") == "", "Expected a fresh profile to not be on a cold wallet"
+
+        with pytest.raises(ApiResponseError, match=re.escape("keypair is not a cold wallet keypair")):
+            backend.convert_to_regular_account_v2(backend.mnemonic, backend.password, "new-pw")
+
+        kp = backend.accounts_service.get_keypair_by_key_uid(backend.key_uid)
+        assert kp.get("cold-wallet", "") == ""
+        assert_keystore_state(backend, _addresses(kp), backend.password, present=True)
+        assert _keycard_pairing_of(backend.reinit_and_get_accounts(), backend.key_uid) == "", "Expected no keycard pairing on a regular profile"

--- a/test/functional/tests/test_convert_keycard_profile_to_regular.py
+++ b/test/functional/tests/test_convert_keycard_profile_to_regular.py
@@ -1,8 +1,5 @@
 """Stop using a keycard for the profile keypair through ConvertToRegularAccountV2, driven with a mock pairing.
-
-The only keycard state observable on this branch is keypair.cold-wallet, keystore presence and
-multiaccounts.keycard-pairing: the keycards tables and their RPCs were dropped, so per-card rows are not assertable.
-"""
+The keycards tables and their RPCs were dropped, so the observable state is cold-wallet, keystore presence and the pairing."""
 
 import re
 from collections import namedtuple
@@ -11,31 +8,22 @@ import pytest
 from clients.api import ApiResponseError
 from clients.signals import SignalType
 from resources.constants import user_2
-from steps.keycard import assert_keystore_state, derive_chat_private_key, derive_keycard_password
+from steps.keycard import (
+    KEYCARD_UID,
+    KEYPAIR_FIELDS,
+    account_shape,
+    assert_keystore_state,
+    derive_chat_private_key,
+    derive_keycard_password,
+    fresh_profile_keypair,
+    keycard_pairing_of,
+    keypair_addresses,
+    mock_pairing,
+)
 from utils import fake
 
-KEYCARD_UID = "mock-keycard-uid"
-KEYPAIR_FIELDS = ("key-uid", "type", "name", "derived-from", "xpub")
 
 KeycardProfile = namedtuple("KeycardProfile", ["key_uid", "mnemonic", "old_password", "keycard_password", "pairing", "kp0"])
-
-
-def _pairing(key_uid, suffix=""):
-    return f"mock-pairing-{key_uid[:8]}{suffix}"
-
-
-def _addresses(keypair):
-    return [a["address"] for a in keypair["accounts"]] + [keypair["derived-from"]]
-
-
-def _account_shape(keypair):
-    return sorted((a["address"], a["path"], a["wallet"], a["chat"]) for a in keypair["accounts"])
-
-
-def _keycard_pairing_of(accounts, key_uid):
-    entry = next((a for a in accounts if a.get("key-uid") == key_uid), None)
-    assert entry is not None, f"Expected InitializeApplication to list the account {key_uid}"
-    return entry.get("keycard-pairing", "")
 
 
 @pytest.mark.rpc
@@ -46,23 +34,18 @@ class TestConvertKeycardProfileToRegular:
         return backend_new_profile("keycard-to-regular")
 
     def _put_profile_on_keycard(self, backend):
-        kp0 = backend.accounts_service.get_keypair_by_key_uid(backend.key_uid)
-        assert kp0 is not None, "Expected the profile keypair to exist"
-        assert kp0["type"] == "profile"
-        assert kp0.get("cold-wallet", "") == "", "Expected a fresh profile keypair to not be on a cold wallet"
-        assert kp0.get("xpub", "").startswith("xpub"), "Expected a fresh profile keypair to carry its wallet xpub"
-        assert kp0["derived-from"], "Expected the profile keypair to carry its master address"
+        kp0 = fresh_profile_keypair(backend)
 
         keycard_password = derive_keycard_password(backend, backend.mnemonic)
         old_password = backend.password
-        pairing = _pairing(backend.key_uid)
+        pairing = mock_pairing(backend.key_uid)
         backend.convert_to_keycard_account_v2(backend.key_uid, pairing, KEYCARD_UID, old_password, keycard_password)
 
         kp = backend.accounts_service.get_keypair_by_key_uid(backend.key_uid)
         assert kp["cold-wallet"] == "status-keycard", "Expected the setup to flag the profile keypair as keycard backed"
         assert kp["xpub"] == kp0["xpub"], "Expected the setup to keep the wallet xpub"
         # Keystore files are deleted, not re-encrypted: the keycard password must not resolve them either.
-        assert_keystore_state(backend, _addresses(kp), keycard_password, present=False)
+        assert_keystore_state(backend, keypair_addresses(kp), keycard_password, present=False)
 
         return KeycardProfile(backend.key_uid, backend.mnemonic, old_password, keycard_password, pairing, kp0)
 
@@ -71,10 +54,10 @@ class TestConvertKeycardProfileToRegular:
         assert kp.get("cold-wallet", "") == "", "Expected the profile keypair to be back on the app keystore"
         for field in KEYPAIR_FIELDS:
             assert kp.get(field) == kp0.get(field), f"Expected keypair field {field} to survive the reverse migration"
-        assert _account_shape(kp) == _account_shape(kp0), "Expected the profile accounts to be unchanged by the reverse migration"
+        assert account_shape(kp) == account_shape(kp0), "Expected the profile accounts to be unchanged by the reverse migration"
         for account in kp["accounts"]:
             assert account["operable"] == "fully", f"Expected {account['address']} fully operable after the reverse migration"
-        assert_keystore_state(backend, _addresses(kp), password, present=True)
+        assert_keystore_state(backend, keypair_addresses(kp), password, present=True)
         assert backend.accounts_service.verify_password(password) is True, "Expected verifyPassword to succeed with the new password"
         return kp
 
@@ -99,7 +82,7 @@ class TestConvertKeycardProfileToRegular:
         assert not settings.get("mnemonic"), "Expected the mnemonic to stay cleared because the conversion does not restore it"
 
         accounts = backend.reinit_and_get_accounts()
-        assert _keycard_pairing_of(accounts, ctx.key_uid) == "", "Expected the keycard pairing to be cleared on the multiaccount"
+        assert keycard_pairing_of(accounts, ctx.key_uid) == "", "Expected the keycard pairing to be cleared on the multiaccount"
 
         with backend.expect_signal(SignalType.NODE_LOGIN, timeout=60) as exp:
             backend.login(ctx.key_uid, new_password)
@@ -127,10 +110,10 @@ class TestConvertKeycardProfileToRegular:
         kp = backend.accounts_service.get_keypair_by_key_uid(ctx.key_uid)
         assert kp["cold-wallet"] == "status-keycard", "Expected the keypair to stay on the keycard after a rejected conversion"
         assert kp["xpub"] == ctx.kp0["xpub"]
-        assert_keystore_state(backend, _addresses(kp), ctx.keycard_password, present=False)
-        assert_keystore_state(backend, _addresses(kp), ctx.old_password, present=False)
+        assert_keystore_state(backend, keypair_addresses(kp), ctx.keycard_password, present=False)
+        assert_keystore_state(backend, keypair_addresses(kp), ctx.old_password, present=False)
         assert (
-            _keycard_pairing_of(backend.reinit_and_get_accounts(), ctx.key_uid) == ctx.pairing
+            keycard_pairing_of(backend.reinit_and_get_accounts(), ctx.key_uid) == ctx.pairing
         ), "Expected the pairing kept because the password check runs before it is cleared"
 
         with backend.expect_signal(SignalType.NODE_LOGIN, timeout=60) as exp:
@@ -147,9 +130,9 @@ class TestConvertKeycardProfileToRegular:
 
         kp = backend.accounts_service.get_keypair_by_key_uid(ctx.key_uid)
         assert kp["cold-wallet"] == "status-keycard", "Expected the keypair untouched by an unknown mnemonic"
-        assert_keystore_state(backend, _addresses(kp), ctx.keycard_password, present=False)
+        assert_keystore_state(backend, keypair_addresses(kp), ctx.keycard_password, present=False)
         assert (
-            _keycard_pairing_of(backend.reinit_and_get_accounts(), ctx.key_uid) == ctx.pairing
+            keycard_pairing_of(backend.reinit_and_get_accounts(), ctx.key_uid) == ctx.pairing
         ), "Expected the pairing kept because the mnemonic lookup fails first"
 
         with backend.expect_signal(SignalType.NODE_LOGIN, timeout=60) as exp:
@@ -167,7 +150,7 @@ class TestConvertKeycardProfileToRegular:
 
         self._assert_regular(backend, ctx.kp0, new_password)
         assert (
-            _keycard_pairing_of(backend.reinit_and_get_accounts(), ctx.key_uid) == ""
+            keycard_pairing_of(backend.reinit_and_get_accounts(), ctx.key_uid) == ""
         ), "Expected the keycard pairing cleared after a padded-mnemonic conversion"
 
     def test_stop_using_keycard_on_regular_profile_is_rejected(self, backend):
@@ -179,5 +162,5 @@ class TestConvertKeycardProfileToRegular:
 
         kp = backend.accounts_service.get_keypair_by_key_uid(backend.key_uid)
         assert kp.get("cold-wallet", "") == ""
-        assert_keystore_state(backend, _addresses(kp), backend.password, present=True)
-        assert _keycard_pairing_of(backend.reinit_and_get_accounts(), backend.key_uid) == "", "Expected no keycard pairing on a regular profile"
+        assert_keystore_state(backend, keypair_addresses(kp), backend.password, present=True)
+        assert keycard_pairing_of(backend.reinit_and_get_accounts(), backend.key_uid) == "", "Expected no keycard pairing on a regular profile"

--- a/test/functional/tests/test_convert_keycard_profile_to_regular.py
+++ b/test/functional/tests/test_convert_keycard_profile_to_regular.py
@@ -9,6 +9,7 @@ from collections import namedtuple
 
 import pytest
 from clients.api import ApiResponseError
+from clients.signals import SignalType
 from resources.constants import user_2
 from steps.keycard import assert_keystore_state, derive_chat_private_key, derive_keycard_password
 from utils import fake
@@ -100,19 +101,22 @@ class TestConvertKeycardProfileToRegular:
         accounts = backend.reinit_and_get_accounts()
         assert _keycard_pairing_of(accounts, ctx.key_uid) == "", "Expected the keycard pairing to be cleared on the multiaccount"
 
-        backend.login(ctx.key_uid, new_password)
-        signal = backend.wait_for_login()
-        assert signal["event"]["account"]["key-uid"] == ctx.key_uid
-        assert signal["event"]["account"].get("keycard-pairing", "") == "", "Expected the login event to carry no keycard pairing"
+        with backend.expect_signal(SignalType.NODE_LOGIN, timeout=60) as exp:
+            backend.login(ctx.key_uid, new_password)
+        assert not exp.result["event"].get("error"), exp.result["event"].get("error")
+        assert exp.result["event"]["account"]["key-uid"] == ctx.key_uid
+        assert exp.result["event"]["account"].get("keycard-pairing", "") == "", "Expected the login event to carry no keycard pairing"
         backend.wait_for_wakuext_ready(timeout=30)
 
         self._assert_regular(backend, ctx.kp0, new_password)
 
         backend.change_database_password(new_password, new_password + "x")
         backend.reinit_and_get_accounts()
-        backend.login(ctx.key_uid, new_password + "x")
-        signal = backend.wait_for_login()
-        assert signal["event"]["account"]["key-uid"] == ctx.key_uid, "Expected a normal password profile after the password change"
+        with backend.expect_signal(SignalType.NODE_LOGIN, timeout=60) as exp:
+            backend.login(ctx.key_uid, new_password + "x")
+        assert not exp.result["event"].get("error"), exp.result["event"].get("error")
+        assert exp.result["event"]["account"]["key-uid"] == ctx.key_uid, "Expected a normal password profile after the password change"
+        assert backend.accounts_service.get_keypair_by_key_uid(ctx.key_uid) is not None
 
     def test_stop_using_keycard_rejects_wrong_password(self, backend):
         ctx = self._put_profile_on_keycard(backend)
@@ -129,9 +133,11 @@ class TestConvertKeycardProfileToRegular:
             _keycard_pairing_of(backend.reinit_and_get_accounts(), ctx.key_uid) == ctx.pairing
         ), "Expected the pairing kept because the password check runs before it is cleared"
 
-        backend.login_with_keycard(ctx.key_uid, ctx.keycard_password, derive_chat_private_key(ctx.mnemonic))
-        signal = backend.wait_for_login()
-        assert signal["event"]["account"]["key-uid"] == ctx.key_uid, "Expected keycard login to keep working after a rejected conversion"
+        with backend.expect_signal(SignalType.NODE_LOGIN, timeout=60) as exp:
+            backend.login_with_keycard(ctx.key_uid, ctx.keycard_password, derive_chat_private_key(ctx.mnemonic))
+        assert not exp.result["event"].get("error"), exp.result["event"].get("error")
+        assert exp.result["event"]["account"]["key-uid"] == ctx.key_uid, "Expected keycard login to keep working after a rejected conversion"
+        assert backend.accounts_service.get_keypair_by_key_uid(ctx.key_uid) is not None
 
     def test_stop_using_keycard_rejects_unknown_mnemonic(self, backend):
         ctx = self._put_profile_on_keycard(backend)
@@ -146,9 +152,11 @@ class TestConvertKeycardProfileToRegular:
             _keycard_pairing_of(backend.reinit_and_get_accounts(), ctx.key_uid) == ctx.pairing
         ), "Expected the pairing kept because the mnemonic lookup fails first"
 
-        backend.login_with_keycard(ctx.key_uid, ctx.keycard_password, derive_chat_private_key(ctx.mnemonic))
-        signal = backend.wait_for_login()
-        assert signal["event"]["account"]["key-uid"] == ctx.key_uid
+        with backend.expect_signal(SignalType.NODE_LOGIN, timeout=60) as exp:
+            backend.login_with_keycard(ctx.key_uid, ctx.keycard_password, derive_chat_private_key(ctx.mnemonic))
+        assert not exp.result["event"].get("error"), exp.result["event"].get("error")
+        assert exp.result["event"]["account"]["key-uid"] == ctx.key_uid
+        assert backend.accounts_service.get_keypair_by_key_uid(ctx.key_uid) is not None
 
     def test_stop_using_keycard_accepts_whitespace_padded_mnemonic(self, backend):
         ctx = self._put_profile_on_keycard(backend)

--- a/test/functional/tests/test_convert_profile_keypair_to_keycard.py
+++ b/test/functional/tests/test_convert_profile_keypair_to_keycard.py
@@ -1,0 +1,199 @@
+"""Profile keypair migration to a keycard through ConvertToKeycardAccountV2, driven with a mock pairing.
+
+Observable keycard state on this branch is keypair.cold-wallet, keystore presence and multiaccounts.keycard-pairing.
+The keycards tables and their RPCs were dropped, so per-card rows are not assertable here.
+"""
+
+import copy
+
+import pytest
+from clients.api import ApiResponseError
+from clients.signals import SignalType
+from resources.constants import user_1
+from steps.keycard import (
+    assert_keystore_state,
+    derive_chat_address,
+    derive_chat_private_key,
+    derive_keycard_password,
+)
+
+KEYCARD_UID = "mock-keycard-uid"
+KEYPAIR_FIELDS = ("key-uid", "type", "name", "derived-from", "xpub")
+
+
+def _pairing(key_uid, suffix=""):
+    return f"mock-pairing-{key_uid[:8]}{suffix}"
+
+
+def _addresses(keypair):
+    return [a["address"] for a in keypair["accounts"]] + [keypair["derived-from"]]
+
+
+def _account_shape(keypair):
+    return sorted((a["address"], a["path"], a["wallet"], a["chat"]) for a in keypair["accounts"])
+
+
+def _keycard_pairing_of(accounts, key_uid):
+    entry = next((a for a in accounts if a.get("key-uid") == key_uid), None)
+    assert entry is not None, f"Expected InitializeApplication to list the account {key_uid}"
+    return entry.get("keycard-pairing", "")
+
+
+@pytest.mark.rpc
+class TestConvertProfileKeypairToKeycard:
+
+    @pytest.fixture()
+    def backend(self, backend_new_profile):
+        return backend_new_profile("keycard-convert")
+
+    def _profile_precondition(self, backend):
+        kp = backend.accounts_service.get_keypair_by_key_uid(backend.key_uid)
+        assert kp is not None, "Expected the profile keypair to exist"
+        assert kp["type"] == "profile"
+        assert kp.get("cold-wallet", "") == "", "Expected a fresh profile keypair to not be on a cold wallet"
+        assert kp.get("xpub", "").startswith("xpub"), "Expected a fresh profile keypair to carry its wallet xpub"
+        assert kp["derived-from"], "Expected the profile keypair to carry its master address"
+        assert derive_chat_address(backend.mnemonic) in [a["address"] for a in kp["accounts"] if a.get("chat")]
+        assert_keystore_state(backend, _addresses(kp), backend.password, present=True)
+        assert backend.settings_service.get_settings().get("mnemonic"), "Expected a new profile to still hold its mnemonic"
+        return kp
+
+    def _assert_on_keycard(self, backend, kp0, old_password, keycard_password):
+        kp1 = backend.accounts_service.get_keypair_by_key_uid(backend.key_uid)
+        assert kp1["cold-wallet"] == "status-keycard", "Expected the profile keypair to be flagged as keycard backed"
+        for field in KEYPAIR_FIELDS:
+            assert kp1.get(field) == kp0.get(field), f"Expected keypair field {field} to survive the keycard migration"
+        assert _account_shape(kp1) == _account_shape(kp0), "Expected the profile accounts to be unchanged by the keycard migration"
+        for account in kp1["accounts"]:
+            assert account["operable"] == "fully", f"Expected {account['address']} fully operable because the keycard now holds the key"
+        # Files must be deleted, not re-encrypted: neither password may resolve them.
+        assert_keystore_state(backend, _addresses(kp1), old_password, present=False)
+        assert_keystore_state(backend, _addresses(kp1), keycard_password, present=False)
+        return kp1
+
+    def _convert(self, backend, pairing):
+        keycard_password = derive_keycard_password(backend, backend.mnemonic)
+        old_password = backend.password
+        backend.convert_to_keycard_account_v2(backend.key_uid, pairing, KEYCARD_UID, old_password, keycard_password)
+        return old_password, keycard_password
+
+    def test_convert_profile_keypair_to_keycard(self, backend):
+        key_uid, mnemonic = backend.key_uid, backend.mnemonic
+        kp0 = self._profile_precondition(backend)
+        pairing = _pairing(key_uid)
+
+        old_password, keycard_password = self._convert(backend, pairing)
+
+        kp1 = self._assert_on_keycard(backend, kp0, old_password, keycard_password)
+        profiles = [kp for kp in backend.accounts_service.get_account_keypairs() if kp.get("type") == "profile"]
+        assert len(profiles) == 1 and profiles[0]["key-uid"] == key_uid, "Expected exactly one profile keypair after the migration"
+        assert profiles[0]["cold-wallet"] == "status-keycard"
+        listed = {a["address"]: a for a in backend.accounts_service.get_accounts()}
+        for account in kp1["accounts"]:
+            assert listed[account["address"]]["wallet"] == account["wallet"]
+            assert listed[account["address"]]["chat"] == account["chat"]
+
+        assert (
+            backend.accounts_service.verify_password(old_password) is False
+        ), "Expected verifyPassword to fail because the chat keystore file is gone"
+        assert backend.accounts_service.verify_password(keycard_password) is False
+
+        settings = backend.settings_service.get_settings()
+        assert not settings.get("mnemonic"), "Expected the mnemonic to be cleared because the keycard now owns the seed"
+        assert settings.get("profile-migration-needed", False) is False
+        assert settings["key-uid"] == key_uid
+
+        accounts = backend.reinit_and_get_accounts()
+        assert _keycard_pairing_of(accounts, key_uid) == pairing, "Expected the keycard pairing stored on the multiaccount"
+
+        backend.login_with_keycard(key_uid, keycard_password, derive_chat_private_key(mnemonic))
+        signal = backend.wait_for_login()
+        assert signal["event"]["account"]["key-uid"] == key_uid
+        backend.wait_for_wakuext_ready(timeout=30)
+
+        kp2 = self._assert_on_keycard(backend, kp0, old_password, keycard_password)
+
+        next_path = "m/44'/60'/0'/0/1"
+        derived = backend.wallet_service.get_derived_addresses_for_mnemonic(mnemonic, [next_path])
+        template = copy.deepcopy(kp2["accounts"][0])
+        template.update(
+            {
+                "address": derived[0]["address"],
+                "public-key": derived[0]["public-key"],
+                "path": next_path,
+                "name": "kc-derived",
+                "wallet": False,
+                "chat": False,
+            }
+        )
+        backend.accounts_service.add_account("", template)
+        kp3 = backend.accounts_service.get_keypair_by_key_uid(key_uid)
+        added = [a for a in kp3["accounts"] if a["path"] == next_path]
+        assert len(added) == 1, "Expected the empty-password add_account to succeed because the keycard migration retains the stored xpub"
+
+    def test_convert_already_on_keycard_is_idempotent(self, backend):
+        key_uid = backend.key_uid
+        kp0 = self._profile_precondition(backend)
+        old_password, keycard_password = self._convert(backend, _pairing(key_uid))
+        pairing2 = _pairing(key_uid, "-repaired")
+
+        backend.convert_to_keycard_account_v2(key_uid, pairing2, KEYCARD_UID, keycard_password, keycard_password)
+
+        self._assert_on_keycard(backend, kp0, old_password, keycard_password)
+        assert _keycard_pairing_of(backend.reinit_and_get_accounts(), key_uid) == pairing2, "Expected a re-convert to store the new pairing"
+
+    def test_convert_rejects_wrong_old_password(self, backend):
+        key_uid = backend.key_uid
+        kp0 = self._profile_precondition(backend)
+        old_password = backend.password
+        keycard_password = derive_keycard_password(backend, backend.mnemonic)
+
+        with pytest.raises(ApiResponseError, match="invalid key-encryption key|incorrect password provided"):
+            backend.convert_to_keycard_account_v2(key_uid, "bad-pairing", KEYCARD_UID, "definitely-wrong", keycard_password)
+
+        kp1 = backend.accounts_service.get_keypair_by_key_uid(key_uid)
+        assert kp1.get("cold-wallet", "") == "", "Expected the keypair to stay off the keycard after a rejected conversion"
+        assert kp1["xpub"] == kp0["xpub"]
+        assert_keystore_state(backend, _addresses(kp1), old_password, present=True)
+        assert backend.accounts_service.verify_password(old_password) is True
+        assert backend.settings_service.get_settings().get("mnemonic"), "Expected the mnemonic kept because the password check failed first"
+        # The pairing is written before the password check (status-im/status-go#7698); this pins the current behaviour.
+        assert _keycard_pairing_of(backend.reinit_and_get_accounts(), key_uid) == "bad-pairing"
+
+        backend.login(key_uid, old_password)
+        signal = backend.wait_for_login()
+        assert signal["event"]["account"]["key-uid"] == key_uid, "Expected password login to keep working because the keystore files still exist"
+
+    def test_convert_unknown_key_uid_is_rejected(self, backend):
+        key_uid = backend.key_uid
+        self._profile_precondition(backend)
+        keycard_password = derive_keycard_password(backend, backend.mnemonic)
+
+        with pytest.raises(ApiResponseError):
+            backend.convert_to_keycard_account_v2("0x" + "ab" * 32, _pairing(key_uid), KEYCARD_UID, backend.password, keycard_password)
+
+        kp1 = backend.accounts_service.get_keypair_by_key_uid(key_uid)
+        assert kp1.get("cold-wallet", "") == ""
+        assert_keystore_state(backend, _addresses(kp1), backend.password, present=True)
+        assert (
+            _keycard_pairing_of(backend.reinit_and_get_accounts(), key_uid) == ""
+        ), "Expected the real account untouched by a request for an unknown key-uid"
+
+    def test_lost_keycard_login_with_mnemonic(self, backend):
+        # Incidental coverage for the lost-keycard recovery flow (status-app#21627).
+        key_uid, mnemonic = backend.key_uid, backend.mnemonic
+        kp0 = self._profile_precondition(backend)
+        pairing = _pairing(key_uid)
+        old_password, keycard_password = self._convert(backend, pairing)
+        backend.reinit_and_get_accounts()
+
+        # LoginAccount reports failures through the node.login signal, not the HTTP response.
+        with backend.expect_signal(SignalType.NODE_LOGIN, timeout=60) as exp:
+            backend.login_with_mnemonic(key_uid, user_1.passphrase)
+        assert "mnemonic does not match this account" in exp.result["event"].get("error", "")
+
+        backend.login_with_mnemonic(key_uid, mnemonic)
+        signal = backend.wait_for_login()
+        assert signal["event"]["account"]["key-uid"] == key_uid
+        backend.wait_for_wakuext_ready(timeout=30)
+        self._assert_on_keycard(backend, kp0, old_password, keycard_password)

--- a/test/functional/tests/test_convert_profile_keypair_to_keycard.py
+++ b/test/functional/tests/test_convert_profile_keypair_to_keycard.py
@@ -1,8 +1,5 @@
-"""Profile keypair migration to a keycard through ConvertToKeycardAccountV2, driven with a mock pairing.
-
-Observable keycard state on this branch is keypair.cold-wallet, keystore presence and multiaccounts.keycard-pairing.
-The keycards tables and their RPCs were dropped, so per-card rows are not assertable here.
-"""
+"""Move the profile keypair onto a keycard through ConvertToKeycardAccountV2, driven with a mock pairing.
+The keycards tables and their RPCs were dropped, so the observable state is cold-wallet, keystore presence and the pairing."""
 
 import copy
 
@@ -11,32 +8,18 @@ from clients.api import ApiResponseError
 from clients.signals import SignalType
 from resources.constants import user_1
 from steps.keycard import (
+    KEYCARD_UID,
+    KEYPAIR_FIELDS,
+    account_shape,
     assert_keystore_state,
     derive_chat_address,
     derive_chat_private_key,
     derive_keycard_password,
+    fresh_profile_keypair,
+    keycard_pairing_of,
+    keypair_addresses,
+    mock_pairing,
 )
-
-KEYCARD_UID = "mock-keycard-uid"
-KEYPAIR_FIELDS = ("key-uid", "type", "name", "derived-from", "xpub")
-
-
-def _pairing(key_uid, suffix=""):
-    return f"mock-pairing-{key_uid[:8]}{suffix}"
-
-
-def _addresses(keypair):
-    return [a["address"] for a in keypair["accounts"]] + [keypair["derived-from"]]
-
-
-def _account_shape(keypair):
-    return sorted((a["address"], a["path"], a["wallet"], a["chat"]) for a in keypair["accounts"])
-
-
-def _keycard_pairing_of(accounts, key_uid):
-    entry = next((a for a in accounts if a.get("key-uid") == key_uid), None)
-    assert entry is not None, f"Expected InitializeApplication to list the account {key_uid}"
-    return entry.get("keycard-pairing", "")
 
 
 @pytest.mark.rpc
@@ -47,14 +30,9 @@ class TestConvertProfileKeypairToKeycard:
         return backend_new_profile("keycard-convert")
 
     def _profile_precondition(self, backend):
-        kp = backend.accounts_service.get_keypair_by_key_uid(backend.key_uid)
-        assert kp is not None, "Expected the profile keypair to exist"
-        assert kp["type"] == "profile"
-        assert kp.get("cold-wallet", "") == "", "Expected a fresh profile keypair to not be on a cold wallet"
-        assert kp.get("xpub", "").startswith("xpub"), "Expected a fresh profile keypair to carry its wallet xpub"
-        assert kp["derived-from"], "Expected the profile keypair to carry its master address"
+        kp = fresh_profile_keypair(backend)
         assert derive_chat_address(backend.mnemonic) in [a["address"] for a in kp["accounts"] if a.get("chat")]
-        assert_keystore_state(backend, _addresses(kp), backend.password, present=True)
+        assert_keystore_state(backend, keypair_addresses(kp), backend.password, present=True)
         assert backend.settings_service.get_settings().get("mnemonic"), "Expected a new profile to still hold its mnemonic"
         return kp
 
@@ -63,12 +41,12 @@ class TestConvertProfileKeypairToKeycard:
         assert kp1["cold-wallet"] == "status-keycard", "Expected the profile keypair to be flagged as keycard backed"
         for field in KEYPAIR_FIELDS:
             assert kp1.get(field) == kp0.get(field), f"Expected keypair field {field} to survive the keycard migration"
-        assert _account_shape(kp1) == _account_shape(kp0), "Expected the profile accounts to be unchanged by the keycard migration"
+        assert account_shape(kp1) == account_shape(kp0), "Expected the profile accounts to be unchanged by the keycard migration"
         for account in kp1["accounts"]:
             assert account["operable"] == "fully", f"Expected {account['address']} fully operable because the keycard now holds the key"
         # Files must be deleted, not re-encrypted: neither password may resolve them.
-        assert_keystore_state(backend, _addresses(kp1), old_password, present=False)
-        assert_keystore_state(backend, _addresses(kp1), keycard_password, present=False)
+        assert_keystore_state(backend, keypair_addresses(kp1), old_password, present=False)
+        assert_keystore_state(backend, keypair_addresses(kp1), keycard_password, present=False)
         return kp1
 
     def _convert(self, backend, pairing):
@@ -80,7 +58,7 @@ class TestConvertProfileKeypairToKeycard:
     def test_convert_profile_keypair_to_keycard(self, backend):
         key_uid, mnemonic = backend.key_uid, backend.mnemonic
         kp0 = self._profile_precondition(backend)
-        pairing = _pairing(key_uid)
+        pairing = mock_pairing(key_uid)
 
         old_password, keycard_password = self._convert(backend, pairing)
 
@@ -104,7 +82,7 @@ class TestConvertProfileKeypairToKeycard:
         assert settings["key-uid"] == key_uid
 
         accounts = backend.reinit_and_get_accounts()
-        assert _keycard_pairing_of(accounts, key_uid) == pairing, "Expected the keycard pairing stored on the multiaccount"
+        assert keycard_pairing_of(accounts, key_uid) == pairing, "Expected the keycard pairing stored on the multiaccount"
 
         with backend.expect_signal(SignalType.NODE_LOGIN, timeout=60) as exp:
             backend.login_with_keycard(key_uid, keycard_password, derive_chat_private_key(mnemonic))
@@ -135,13 +113,13 @@ class TestConvertProfileKeypairToKeycard:
     def test_convert_already_on_keycard_is_idempotent(self, backend):
         key_uid = backend.key_uid
         kp0 = self._profile_precondition(backend)
-        old_password, keycard_password = self._convert(backend, _pairing(key_uid))
-        pairing2 = _pairing(key_uid, "-repaired")
+        old_password, keycard_password = self._convert(backend, mock_pairing(key_uid))
+        pairing2 = mock_pairing(key_uid, "-repaired")
 
         backend.convert_to_keycard_account_v2(key_uid, pairing2, KEYCARD_UID, keycard_password, keycard_password)
 
         self._assert_on_keycard(backend, kp0, old_password, keycard_password)
-        assert _keycard_pairing_of(backend.reinit_and_get_accounts(), key_uid) == pairing2, "Expected a re-convert to store the new pairing"
+        assert keycard_pairing_of(backend.reinit_and_get_accounts(), key_uid) == pairing2, "Expected a re-convert to store the new pairing"
 
     def test_convert_rejects_wrong_old_password(self, backend):
         key_uid = backend.key_uid
@@ -155,11 +133,12 @@ class TestConvertProfileKeypairToKeycard:
         kp1 = backend.accounts_service.get_keypair_by_key_uid(key_uid)
         assert kp1.get("cold-wallet", "") == "", "Expected the keypair to stay off the keycard after a rejected conversion"
         assert kp1["xpub"] == kp0["xpub"]
-        assert_keystore_state(backend, _addresses(kp1), old_password, present=True)
+        assert_keystore_state(backend, keypair_addresses(kp1), old_password, present=True)
         assert backend.accounts_service.verify_password(old_password) is True
         assert backend.settings_service.get_settings().get("mnemonic"), "Expected the mnemonic kept because the password check failed first"
-        # The pairing is written before the password check (status-im/status-go#7698); this pins the current behaviour.
-        assert _keycard_pairing_of(backend.reinit_and_get_accounts(), key_uid) == "bad-pairing"
+        assert (
+            keycard_pairing_of(backend.reinit_and_get_accounts(), key_uid) == "bad-pairing"
+        ), "Characterises current behaviour: the pairing is written before the password check (status-im/status-go#7698)"
 
         with backend.expect_signal(SignalType.NODE_LOGIN, timeout=60) as exp:
             backend.login(key_uid, old_password)
@@ -173,20 +152,19 @@ class TestConvertProfileKeypairToKeycard:
         keycard_password = derive_keycard_password(backend, backend.mnemonic)
 
         with pytest.raises(ApiResponseError):
-            backend.convert_to_keycard_account_v2("0x" + "ab" * 32, _pairing(key_uid), KEYCARD_UID, backend.password, keycard_password)
+            backend.convert_to_keycard_account_v2("0x" + "ab" * 32, mock_pairing(key_uid), KEYCARD_UID, backend.password, keycard_password)
 
         kp1 = backend.accounts_service.get_keypair_by_key_uid(key_uid)
         assert kp1.get("cold-wallet", "") == ""
-        assert_keystore_state(backend, _addresses(kp1), backend.password, present=True)
+        assert_keystore_state(backend, keypair_addresses(kp1), backend.password, present=True)
         assert (
-            _keycard_pairing_of(backend.reinit_and_get_accounts(), key_uid) == ""
+            keycard_pairing_of(backend.reinit_and_get_accounts(), key_uid) == ""
         ), "Expected the real account untouched by a request for an unknown key-uid"
 
     def test_lost_keycard_login_with_mnemonic(self, backend):
-        # Incidental coverage for the lost-keycard recovery flow (status-app#21627).
         key_uid, mnemonic = backend.key_uid, backend.mnemonic
         kp0 = self._profile_precondition(backend)
-        pairing = _pairing(key_uid)
+        pairing = mock_pairing(key_uid)
         old_password, keycard_password = self._convert(backend, pairing)
         backend.reinit_and_get_accounts()
 

--- a/test/functional/tests/test_convert_profile_keypair_to_keycard.py
+++ b/test/functional/tests/test_convert_profile_keypair_to_keycard.py
@@ -106,9 +106,10 @@ class TestConvertProfileKeypairToKeycard:
         accounts = backend.reinit_and_get_accounts()
         assert _keycard_pairing_of(accounts, key_uid) == pairing, "Expected the keycard pairing stored on the multiaccount"
 
-        backend.login_with_keycard(key_uid, keycard_password, derive_chat_private_key(mnemonic))
-        signal = backend.wait_for_login()
-        assert signal["event"]["account"]["key-uid"] == key_uid
+        with backend.expect_signal(SignalType.NODE_LOGIN, timeout=60) as exp:
+            backend.login_with_keycard(key_uid, keycard_password, derive_chat_private_key(mnemonic))
+        assert not exp.result["event"].get("error"), exp.result["event"].get("error")
+        assert exp.result["event"]["account"]["key-uid"] == key_uid
         backend.wait_for_wakuext_ready(timeout=30)
 
         kp2 = self._assert_on_keycard(backend, kp0, old_password, keycard_password)
@@ -160,9 +161,11 @@ class TestConvertProfileKeypairToKeycard:
         # The pairing is written before the password check (status-im/status-go#7698); this pins the current behaviour.
         assert _keycard_pairing_of(backend.reinit_and_get_accounts(), key_uid) == "bad-pairing"
 
-        backend.login(key_uid, old_password)
-        signal = backend.wait_for_login()
-        assert signal["event"]["account"]["key-uid"] == key_uid, "Expected password login to keep working because the keystore files still exist"
+        with backend.expect_signal(SignalType.NODE_LOGIN, timeout=60) as exp:
+            backend.login(key_uid, old_password)
+        assert not exp.result["event"].get("error"), exp.result["event"].get("error")
+        assert exp.result["event"]["account"]["key-uid"] == key_uid, "Expected password login to keep working because the keystore files still exist"
+        assert backend.accounts_service.get_keypair_by_key_uid(key_uid) is not None
 
     def test_convert_unknown_key_uid_is_rejected(self, backend):
         key_uid = backend.key_uid
@@ -192,8 +195,9 @@ class TestConvertProfileKeypairToKeycard:
             backend.login_with_mnemonic(key_uid, user_1.passphrase)
         assert "mnemonic does not match this account" in exp.result["event"].get("error", "")
 
-        backend.login_with_mnemonic(key_uid, mnemonic)
-        signal = backend.wait_for_login()
-        assert signal["event"]["account"]["key-uid"] == key_uid
+        with backend.expect_signal(SignalType.NODE_LOGIN, timeout=60) as exp:
+            backend.login_with_mnemonic(key_uid, mnemonic)
+        assert not exp.result["event"].get("error"), exp.result["event"].get("error")
+        assert exp.result["event"]["account"]["key-uid"] == key_uid
         backend.wait_for_wakuext_ready(timeout=30)
         self._assert_on_keycard(backend, kp0, old_password, keycard_password)


### PR DESCRIPTION
Stacked on #7823, for `_mark_login_signal()`.

# Description

1. Two modules driving both directions of the profile keypair's keycard migration on a fresh profile with a mock pairing. `ConvertToKeycardAccountV2`: flag set, xpub and derived-from kept, keystore files gone under both passwords, mnemonic cleared, pairing exposed through `InitializeApplication`, keycard and mnemonic relogin. `ConvertToRegularAccountV2`: flag cleared, files back, `verifyPassword` with the new password, pairing cleared, password login and a later password change.
2. Guards for both directions: wrong old password, unknown key-uid, wrong current password, unknown mnemonic, conversion of a profile never put on a keycard, plus an idempotent re-convert and a whitespace-padded mnemonic.
3. Client helpers `login_with_keycard`, `login_with_mnemonic`, the two `convert_*_v2` calls and `reinit_and_get_accounts`; derivation, pairing and assertion helpers in `steps/keycard.py`.

Every relogin waits on the `node.login` emitted by its own request with a scoped `expect_signal` and asserts the event carries no error, so a login event retained from earlier in the test cannot satisfy the check. The wrong-old-password guard pins that the pairing is written before the password check (#7698). Keycard rows are not asserted: the `keycards` tables and their RPCs were dropped, so the observable state is `cold-wallet`, keystore presence and `multiaccounts.keycard-pairing`.

Run against `develop` at `65e177a4fc` with #7823 applied: `10 passed in 139.54s`.

<details>
<summary>What each test means for a user</summary>

Moving a profile onto a Keycard:

- **`test_convert_profile_keypair_to_keycard`** — A user with a password-protected profile moves it onto a Keycard. Their wallet accounts and addresses are exactly as before; the seed phrase and every key file are gone from the device, so neither the old password nor the card's unlocks anything locally; they can log in with the card; and they can still add a wallet account without a password, because the device kept the public key material.
- **`test_convert_already_on_keycard_is_idempotent`** — A user pairs the same profile with a second Keycard. The profile does not change; the new card's pairing replaces the old one.
- **`test_convert_rejects_wrong_old_password`** — A user mistypes their current password during the move. It is refused and nothing is lost: keys, seed phrase and password login all still work. The new pairing has already been saved, though, which is #7698 and is recorded here as current behaviour.
- **`test_convert_unknown_key_uid_is_rejected`** — A request names a profile that does not exist. It is refused and the real profile is untouched.
- **`test_lost_keycard_login_with_mnemonic`** — A user has lost their Keycard. The wrong seed phrase is refused with a clear message; the right one logs them in, with the profile still card-backed and no key files on the device.

Moving it back off the Keycard:

- **`test_stop_using_keycard_for_profile_keypair`** — A user stops using their Keycard and sets a new password. Accounts unchanged, key files back on the device, only the new password unlocks them (not the card's, not the pre-card one), the pairing is gone, password login works, and a later password change still works.
- **`test_stop_using_keycard_accepts_whitespace_padded_mnemonic`** — A user pastes their seed phrase with stray spaces and line breaks. It is accepted.
- **`test_stop_using_keycard_rejects_wrong_password`** — A user mistypes the card password while stopping. Refused; the profile stays on the card and the card still logs in.
- **`test_stop_using_keycard_rejects_unknown_mnemonic`** — A user enters someone else's seed phrase. Refused; the profile stays on the card and the card still logs in.
- **`test_stop_using_keycard_on_regular_profile_is_rejected`** — A profile that was never on a Keycard asks to stop using one. Refused with a clear message; nothing changes.

</details>

<details>
<summary>AI-made decisions</summary>

- Written by a Devin agent and reshaped in review; the `Assisted-by` trailers are that agent's. The two modules ship together because the second imports `steps/keycard.py` from the first and, as separate PRs, its copy of the shared module had silently reverted the first's login fix.
- Each test was checked by breaking the behaviour it names (each conversion RPC stubbed out in turn, the pairing exposure corrupted, `addAccount` stubbed, keystore presence forced absent, the mnemonic login corrupted), confirming it fails, then restoring.
- The mnemonic-relogin test incidentally covers status-im/status-app#21627 (lost keycard); #21618 and #21625 are the flows covered on purpose.
- `login_with_keycard` is defined here; the keycard-restore PR depends on this one for it rather than carrying a copy. Both keycard login helpers record the login mark #7823 introduces, so `wait_for_login()` stays correct after them too.

</details>
