### PR TITLE
test(functional): cover restoring an account that lives on a keycard

### DIFF
--- a/test/functional/clients/status_backend.py
+++ b/test/functional/clients/status_backend.py
@@ -429,6 +429,21 @@ class StatusBackend(RpcClient, SignalClient, ApiClient):
         self._mark_login_signal()
         return self.api_request_json(method, data)
 
+    def restore_keycard_account_and_login(
+        self, keycard: dict, keycard_instance_uid: str, keycard_pairing_key: str, password: str | None = None, **kwargs
+    ):
+        self._set_display_name(**kwargs)
+        method = "RestoreAccountAndLogin"
+        # The backend replaces whatever password is sent with the card's encryption public key, which
+        # becomes the database password; default to it so the caller's field matches what is stored.
+        data = self._create_account_request(password=keycard["encryptionPublicKey"] if password is None else password, **kwargs)
+        data["keycard"] = keycard
+        data["keycardInstanceUID"] = keycard_instance_uid
+        data["keycardPairingKey"] = keycard_pairing_key
+        self._boot_api_config = copy.deepcopy(data.get("apiConfig", {}))
+        self._mark_login_signal()
+        return self.api_request_json(method, data)
+
     def login(self, key_uid, password: str, kdf_iterations=256000):
         self.password = password
         # Reconnect to signals before login to avoid missing node.login after logout.

--- a/test/functional/tests/test_restore_keycard_account.py
+++ b/test/functional/tests/test_restore_keycard_account.py
@@ -1,0 +1,143 @@
+"""Restoring an existing keycard account through RestoreAccountAndLogin, the path the app uses for keycard login.
+The card's contents are read off a real profile restored from the same seed rather than made up."""
+
+import copy
+
+import pytest
+from clients.api import ApiResponseError
+from clients.signals import SignalType
+from resources.constants import user_1, user_mnemonic_12
+from steps.keycard import PATH_EIP1581_CHAT, PATH_EIP1581_ENCRYPTION, derive_chat_private_key, keycard_pairing_of
+
+PATH_WALLET_ROOT = "m/44'/60'/0'/0"
+PATH_EIP1581_ROOT = "m/43'/60'/1581'"
+PATH_DEFAULT_WALLET = "m/44'/60'/0'/0/0"
+
+KEYCARD_INSTANCE_UID = "mock-keycard-instance-uid"
+KEYCARD_PAIRING_KEY = "mock-keycard-pairing-key"
+
+
+@pytest.mark.rpc
+class TestRestoreKeycardAccount:
+
+    @pytest.fixture()
+    def card(self, backend_factory):
+        origin = backend_factory("card-origin")
+        origin.init_status_backend()
+        with origin.expect_signal(SignalType.NODE_LOGIN, timeout=60) as exp:
+            origin.restore_account_and_login(user=user_1)
+        assert not exp.result["event"].get("error"), exp.result["event"].get("error")
+        key_uid = exp.result["event"]["account"]["key-uid"]
+        origin.wallet_service.start_wallet()
+
+        keypair = origin.accounts_service.get_keypair_by_key_uid(key_uid)
+        # Cross-checked against the recorded constant so a mis-derived payload fails here, not downstream.
+        assert keypair["xpub"] == user_1.wallet_xpub, "Expected the source profile's xpub to match the recorded constant"
+        paths = [PATH_WALLET_ROOT, PATH_EIP1581_ROOT, PATH_EIP1581_CHAT, PATH_DEFAULT_WALLET, PATH_EIP1581_ENCRYPTION]
+        derived = dict(zip(paths, origin.wallet_service.get_derived_addresses_for_mnemonic(user_1.passphrase, paths)))
+
+        data = {
+            "keyUID": key_uid,
+            "address": keypair["derived-from"],
+            "whisperPrivateKey": derive_chat_private_key(user_1.passphrase),
+            "whisperPublicKey": derived[PATH_EIP1581_CHAT]["public-key"],
+            "whisperAddress": derived[PATH_EIP1581_CHAT]["address"],
+            "walletPublicKey": derived[PATH_DEFAULT_WALLET]["public-key"],
+            "walletAddress": derived[PATH_DEFAULT_WALLET]["address"],
+            "walletRootAddress": derived[PATH_WALLET_ROOT]["address"],
+            "eip1581Address": derived[PATH_EIP1581_ROOT]["address"],
+            "encryptionPublicKey": derived[PATH_EIP1581_ENCRYPTION]["public-key"],
+            "walletXPub": keypair["xpub"],
+            "coldWallet": "status-keycard",
+        }
+        origin.logout()
+        return data
+
+    @pytest.fixture()
+    def restoring(self, backend_factory):
+        backend = backend_factory("keycard-restore")
+        backend.init_status_backend()
+        return backend
+
+    def _restore(self, backend, card, pairing_key=KEYCARD_PAIRING_KEY, instance_uid=KEYCARD_INSTANCE_UID):
+        with backend.expect_signal(SignalType.NODE_LOGIN, timeout=60) as exp:
+            backend.restore_keycard_account_and_login(card, instance_uid, pairing_key)
+        return exp.result["event"]
+
+    def test_restore_an_account_that_already_lives_on_a_keycard(self, restoring, card):
+        event = self._restore(restoring, card)
+        assert not event.get("error"), event.get("error")
+        assert event["account"]["key-uid"] == card["keyUID"], "Expected the restored profile to keep the card's key-uid"
+
+        keypair = restoring.accounts_service.get_keypair_by_key_uid(card["keyUID"])
+        assert keypair["type"] == "profile"
+        assert keypair["cold-wallet"] == "status-keycard", "Expected the restored profile keypair to be flagged as card backed"
+        assert keypair["xpub"] == card["walletXPub"], "Expected the card's xpub to be stored, since the seed is not available to derive one"
+        assert keypair["derived-from"].lower() == card["address"].lower()
+
+        addresses = {a["address"].lower() for a in keypair["accounts"]}
+        assert card["whisperAddress"].lower() in addresses, "Expected the chat account to come from the card's whisper key"
+        assert card["walletAddress"].lower() in addresses, "Expected the default wallet account to come from the card"
+
+        for address in [a["address"] for a in keypair["accounts"]] + [keypair["derived-from"]]:
+            assert (
+                restoring.accounts_service.verify_keystore_file_for_account(address, restoring.password) is False
+            ), f"Expected no keystore file for {address} because the key stays on the card"
+
+        settings = restoring.settings_service.get_settings()
+        assert not settings.get("mnemonic"), "Expected no mnemonic stored for a keycard restore"
+        assert settings["key-uid"] == card["keyUID"]
+
+        assert (
+            keycard_pairing_of(restoring.reinit_and_get_accounts(), card["keyUID"]) == KEYCARD_PAIRING_KEY
+        ), "Expected the pairing key to reach the multiaccount"
+
+    def test_the_restored_keycard_profile_logs_in_again(self, restoring, card):
+        self._restore(restoring, card)
+        keycard_password = restoring.password
+        restoring.logout()
+
+        with restoring.expect_signal(SignalType.NODE_LOGIN, timeout=60) as exp:
+            restoring.login_with_keycard(card["keyUID"], keycard_password, card["whisperPrivateKey"])
+        assert not exp.result["event"].get("error"), exp.result["event"].get("error")
+        assert exp.result["event"]["account"]["key-uid"] == card["keyUID"]
+
+        keypair = restoring.accounts_service.get_keypair_by_key_uid(card["keyUID"])
+        assert keypair["cold-wallet"] == "status-keycard", "Expected the card flag to survive a re-login"
+        assert keypair["xpub"] == card["walletXPub"]
+
+    def test_login_accepts_a_chat_key_that_does_not_match_the_profile(self, restoring, card):
+        # Characterises current behaviour, not a contract: the mnemonic login path rejects a seed that
+        # does not derive the account, the keycard path takes the supplied chat key verbatim.
+        event = self._restore(restoring, card)
+        public_key = event["settings"]["public-key"]
+        keycard_password = restoring.password
+        restoring.logout()
+
+        foreign_chat_key = derive_chat_private_key(user_mnemonic_12.passphrase)
+        with restoring.expect_signal(SignalType.NODE_LOGIN, timeout=60) as exp:
+            restoring.login_with_keycard(card["keyUID"], keycard_password, foreign_chat_key)
+
+        assert not exp.result["event"].get("error"), "Characterises current behaviour: a foreign chat key is accepted without error"
+        assert exp.result["event"]["account"]["key-uid"] == card["keyUID"]
+        assert (
+            exp.result["event"]["settings"]["public-key"] == public_key
+        ), "The stored identity does not follow the key that was actually selected, so the two have diverged silently"
+
+    def test_restore_via_keycard_rejects_an_empty_whisper_private_key(self, restoring, card):
+        without_chat_key = copy.deepcopy(card)
+        without_chat_key["whisperPrivateKey"] = ""
+
+        with pytest.raises(ApiResponseError, match="restore-account: chat private key is not set"):
+            restoring.restore_keycard_account_and_login(without_chat_key, KEYCARD_INSTANCE_UID, KEYCARD_PAIRING_KEY)
+
+        assert (restoring.init_status_backend().get("accounts") or []) == [], "Expected a rejected restore to create no account"
+
+    def test_restore_via_keycard_without_a_pairing_key_is_rejected(self, restoring, card):
+        # An empty pairing key sends the backend to a pairings file this device never wrote; the
+        # failure arrives on node.login rather than in the HTTP response.
+        event = self._restore(restoring, card, pairing_key="")
+        assert "failed to prepare for keycard" in event.get("error", ""), event.get("error")
+        assert "keycard pairings" in event.get("error", ""), event.get("error")
+
+        assert (restoring.init_status_backend().get("accounts") or []) == [], "Expected no account to survive a restore that failed the pairings gate"


### PR DESCRIPTION
Stacked on #7826, for its `login_with_keycard` and the `steps/keycard.py` helpers.

# Description

1. Restoring a card-backed profile through `RestoreAccountAndLogin` with `keycard` set: the profile keypair is `status-keycard` with the card's xpub and master address, the chat and wallet accounts come from the card, no keystore file or mnemonic is stored, and the pairing key reaches `multiaccounts.keycard-pairing`.
2. The restored profile logs in again with the card's chat key.
3. The two rejections reachable through this entry point: an empty `whisperPrivateKey`, and a missing pairing key, which fails on the `node.login` signal rather than in the HTTP response.
4. A characterisation test: keycard login accepts a chat key derived from a different seed, where the mnemonic path rejects one.

`RestoreAccountAndLogin` is what the app uses for keycard login; the suite drove it from five places and only one set `keycard`, for the mnemonic-conflict rejection. Two of the four `Validate` rejections cannot be selected here (`restoreViaKeycard` is `request.Keycard != nil`) and are unit-tested on the Go side. The card's contents are read off a real profile restored from the same seed and cross-checked against `user_1.wallet_xpub`, so a mis-derived payload fails in the fixture rather than producing a test that agrees with itself.

Run against `develop` at `65e177a4fc` with #7826 applied: `5 passed in 64.38s`.

<details>
<summary>What each test means for a user</summary>

The user has a profile that lives on a Keycard and sets up a new device with it.

- **`test_restore_an_account_that_already_lives_on_a_keycard`** — A user taps their Keycard on a fresh device. The profile comes back with its identity, chat account and default wallet account exactly as on the card, marked as card-backed, with no seed phrase or key files stored on the device, and the card is remembered as paired.
- **`test_the_restored_keycard_profile_logs_in_again`** — That user logs out and taps the card again. They are back in, and the profile is still card-backed with the same wallet.
- **`test_login_accepts_a_chat_key_that_does_not_match_the_profile`** — Someone presents a different Keycard's chat key against this profile. Today the login is accepted, and the profile keeps advertising its original identity while the running session uses the other key. The seed-phrase path refuses the equivalent. This test records that gap so a fix shows up as a deliberate change.
- **`test_restore_via_keycard_rejects_an_empty_whisper_private_key`** — A card with no chat key on it is presented. Refused with a clear message; no profile is created.
- **`test_restore_via_keycard_without_a_pairing_key_is_rejected`** — A card is presented without its pairing secret on a device that has never paired anything. The restore stops before creating a profile.

</details>

<details>
<summary>AI-made decisions</summary>

- `login_with_keycard` was originally duplicated here byte for byte. The two copies merge without a git conflict and then fail flake8 with F811, so this PR now takes it from #7826.
- `restore_keycard_account_and_login` defaults the password to the card's encryption public key, which is what the backend stores whatever was sent, and records the login mark like the other login methods.
- The foreign-chat-key test pins current behaviour without endorsing it; the stored public key does not move, so what is observable is a silent divergence.
- Every test was made to fail by breaking the behaviour it covers at the python client boundary, then restored.

</details>
