### PR TITLE
test(functional): cover cold-wallet keypair sync to a second device

### DIFF
--- a/test/functional/steps/multidevice.py
+++ b/test/functional/steps/multidevice.py
@@ -1,0 +1,43 @@
+"""Bootstrapping a second device for the same profile."""
+
+import asyncio
+
+from clients.async_status_backend import AsyncStatusBackend
+from clients.signals import LocalPairingEventAction, LocalPairingEventType, SignalType
+
+
+async def wait_for_pairing_action(backend: AsyncStatusBackend, action, event_type, *, timeout=60):
+    await backend.wait_for_signal(
+        SignalType.LOCAL_PAIRING,
+        predicate=lambda s: s.event.get("action") == action and s.event.get("type") == event_type,
+        timeout=timeout,
+        check_buffer=True,
+    )
+
+
+async def pair_second_device(primary: AsyncStatusBackend, secondary: AsyncStatusBackend):
+    """Bootstrap *secondary* as another device of *primary*, with message syncing enabled."""
+    connection_string = primary.backend.get_connection_string_for_bootstrapping_another_device(message_sync_enabled=True)
+    response = secondary.backend.input_connection_string_for_bootstrapping(connection_string)
+    assert response["error"] is None
+    assert response["keyUID"] == primary.backend.key_uid
+
+    await asyncio.gather(
+        wait_for_pairing_action(
+            primary,
+            LocalPairingEventAction.ACTION_PAIRING_INSTALLATION.value,
+            LocalPairingEventType.EVENT_PROCESS_SUCCESS.value,
+        ),
+        wait_for_pairing_action(
+            secondary,
+            LocalPairingEventAction.ACTION_PAIRING_INSTALLATION.value,
+            LocalPairingEventType.EVENT_TRANSFER_SUCCESS.value,
+        ),
+    )
+
+
+async def login_paired_device(backend: AsyncStatusBackend, key_uid, password):
+    backend.backend.init_status_backend()
+    backend.backend.login(key_uid, password)
+    await backend.wait_for_login(timeout=120.0)
+    backend.backend.wakuext_service.start_messenger()

--- a/test/functional/tests/test_cold_wallet_keypair_device_sync.py
+++ b/test/functional/tests/test_cold_wallet_keypair_device_sync.py
@@ -1,0 +1,92 @@
+"""A cold-wallet migration has to reach the user's other device: the receiving side is handleSyncKeypair,
+driven here over real pairing and sync rather than the single backend the other cold-wallet modules use."""
+
+import asyncio
+import time
+
+import pytest
+from clients.api import ApiResponseError
+from resources.constants import user_1
+from steps.cold_wallet import add_seed_keypair, keystore_present
+from steps.multidevice import login_paired_device, pair_second_device
+
+SYNC_TIMEOUT = 120
+
+
+async def _wait_for_keypair(device, key_uid, predicate, what, timeout=SYNC_TIMEOUT):
+    """Poll the second device until the synced keypair satisfies the predicate."""
+    deadline = time.monotonic() + timeout
+    last = None
+    while time.monotonic() < deadline:
+        try:
+            last = device.backend.accounts_service.get_keypair_by_key_uid(key_uid)
+        except ApiResponseError as error:
+            if "keypair is not found" not in str(error):
+                raise
+            last = None
+        if last is not None and predicate(last):
+            return last
+        await asyncio.sleep(2)
+    raise AssertionError(f"Second device never saw {what} for {key_uid} (last seen: {last})")
+
+
+@pytest.mark.rpc
+@pytest.mark.asyncio
+class TestColdWalletKeypairDeviceSync:
+
+    async def _paired_devices(self, async_backend_new_profile, async_backend_factory):
+        primary, secondary = await asyncio.gather(
+            async_backend_new_profile("cold-sync-primary"),
+            async_backend_factory("cold-sync-secondary"),
+        )
+        secondary.backend.init_status_backend()
+        await pair_second_device(primary, secondary)
+        await login_paired_device(secondary, primary.backend.key_uid, primary.backend.password)
+        # Don't race the second device's Waku subscriptions.
+        await asyncio.to_thread(secondary.backend.wait_for_online, timeout=60)
+        return primary, secondary
+
+    async def test_a_cold_wallet_migration_reaches_the_other_device(self, async_backend_new_profile, async_backend_factory):
+        primary, secondary = await self._paired_devices(async_backend_new_profile, async_backend_factory)
+
+        key_uid = add_seed_keypair(primary.backend)["key-uid"]
+        synced = await _wait_for_keypair(secondary, key_uid, lambda kp: kp.get("key-uid") == key_uid, "the imported keypair")
+        assert synced.get("cold-wallet", "") == "", "Expected the keypair to arrive off any cold wallet"
+        before_xpub = synced["xpub"]
+
+        primary.backend.accounts_service.migrate_non_profile_keypair_to_cold_wallet(key_uid, primary.backend.password, "status-keycard")
+
+        arrived = await _wait_for_keypair(secondary, key_uid, lambda kp: kp.get("cold-wallet") == "status-keycard", "the cold-wallet migration")
+        assert arrived["xpub"] == before_xpub, "Expected the xpub to survive the sync, since the second device cannot derive one"
+        assert arrived["derived-from"] == synced["derived-from"]
+        assert not any(
+            keystore_present(secondary.backend, arrived).values()
+        ), "Expected no keystore files on the second device either, because the key is on the card"
+
+    async def test_migrating_back_to_the_app_reaches_the_other_device(self, async_backend_new_profile, async_backend_factory):
+        primary, secondary = await self._paired_devices(async_backend_new_profile, async_backend_factory)
+
+        key_uid = add_seed_keypair(primary.backend)["key-uid"]
+        await _wait_for_keypair(secondary, key_uid, lambda kp: kp.get("key-uid") == key_uid, "the imported keypair")
+        primary.backend.accounts_service.migrate_non_profile_keypair_to_cold_wallet(key_uid, primary.backend.password, "status-keycard")
+        await _wait_for_keypair(secondary, key_uid, lambda kp: kp.get("cold-wallet") == "status-keycard", "the cold-wallet migration")
+
+        primary.backend.accounts_service.migrate_non_profile_cold_wallet_keypair_to_app(user_1.passphrase, primary.backend.password)
+
+        cleared = await _wait_for_keypair(secondary, key_uid, lambda kp: kp.get("cold-wallet", "") == "", "the migration back to the app")
+        assert not any(
+            keystore_present(secondary.backend, cleared).values()
+        ), "Expected the second device to have no keystore files, because only the first device had the seed"
+
+    async def test_the_exact_cold_wallet_type_survives_the_sync(self, async_backend_new_profile, async_backend_factory):
+        # The handler stores whatever cold_wallet string arrives; an unknown one is not reachable over
+        # RPC, so this drives the nearest case: a known type the receiving device must not normalise.
+        primary, secondary = await self._paired_devices(async_backend_new_profile, async_backend_factory)
+
+        key_uid = add_seed_keypair(primary.backend)["key-uid"]
+        synced = await _wait_for_keypair(secondary, key_uid, lambda kp: kp.get("key-uid") == key_uid, "the imported keypair")
+
+        primary.backend.accounts_service.migrate_non_profile_keypair_to_cold_wallet(key_uid, primary.backend.password, "ledger")
+
+        arrived = await _wait_for_keypair(secondary, key_uid, lambda kp: kp.get("cold-wallet") == "ledger", "the ledger migration")
+        assert arrived["xpub"] == synced["xpub"], "Expected the xpub to survive a ledger migration as it does a keycard one"


### PR DESCRIPTION
Stacked on #7825, for `steps/cold_wallet.py`.

# Description

1. Three tests on two paired devices of one profile: a cold-wallet migration on the first device reaches the second with the xpub and master address unchanged and no keystore files; the migration back to the app reaches it too, still with no files because only the first device had the seed; and a `ledger` migration arrives as `ledger`, not normalised to `status-keycard`.
2. `steps/multidevice.py` lifts the pairing and paired-login helpers out of `test_transport_multidevice_sync.py` so a second module can bootstrap a device. That module keeps its private copies for now.

The receiving side is `handleSyncKeypair`, covered by Go unit tests but never driven over real pairing and sync: every cold-wallet module in the suite uses a single backend. The xpub assertion is the one that matters, since the second device has no seed and could not derive addresses for the keypair without it.

The module takes about five minutes for three tests, all of it pairing and Waku propagation.

Run against `develop` at `65e177a4fc` with the grouped cold-wallet PR applied: `3 passed in 328.95s`.

<details>
<summary>What each test means for a user</summary>

The user has the same profile on two devices, paired, and an imported seed-phrase wallet on the first.

- **`test_a_cold_wallet_migration_reaches_the_other_device`** — The user moves that wallet onto a Keycard on their phone. Their laptop learns it is on a card, still shows the same addresses, and has no key files for it because the seed never went there.
- **`test_migrating_back_to_the_app_reaches_the_other_device`** — The user moves it back to the app on the phone. The laptop sees it is no longer on a card, and still has no key files, because only the phone has the seed. The flag and the keys travel separately.
- **`test_the_exact_cold_wallet_type_survives_the_sync`** — The user moves the wallet onto a Ledger instead. The laptop shows Ledger, not a generic "keycard", and the addresses are unchanged.

</details>

<details>
<summary>AI-made decisions</summary>

- An unknown `cold_wallet` string is not reachable over RPC, so the type test drives the nearest case the handler could get wrong: a known type other than the keycard.
- The second device polls `getKeypairByKeyUID` until the predicate holds rather than waiting on a signal, because keypair sync surfaces no dedicated signal; only `keypair is not found` is treated as "not yet", any other RPC error fails the test.
- `login_paired_device` uses `AsyncStatusBackend.wait_for_login()`; #7823 fixes that helper's stale-signal shape, and this module does not depend on it.
- Switching `test_transport_multidevice_sync.py` to the shared helpers is left for a follow-up.
- Every test was made to fail by breaking the behaviour it covers at the python client boundary, then restored.

</details>
